### PR TITLE
include channel to event handler and do the null checks in the handler

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/enums/EventType.java
+++ b/library/src/main/java/com/getstream/sdk/chat/enums/EventType.java
@@ -14,7 +14,6 @@ public enum EventType {
     MESSAGE_UPDATED("message.updated"),
     MESSAGE_DELETED("message.deleted"),
     MESSAGE_READ("message.read"),
-    MESSAGE_REACTION("message.reaction"),
     REACTION_NEW("reaction.new"),
     REACTION_DELETED("reaction.deleted"),
     MEMBER_ADDED("member.added"),

--- a/library/src/main/java/com/getstream/sdk/chat/model/Channel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/model/Channel.java
@@ -541,10 +541,10 @@ public class Channel {
         });
     }
 
-    public void handleChannelUpdated(Event event){
-        name = event.getChannel().name;
-        image = event.getChannel().image;
-        extraData = event.getChannel().extraData;
+    public void handleChannelUpdated(Channel channel, Event event){
+        name = channel.name;
+        image = channel.image;
+        extraData = channel.extraData;
     }
 
     public void handleWatcherStart(Event event) {

--- a/library/src/main/java/com/getstream/sdk/chat/model/Event.java
+++ b/library/src/main/java/com/getstream/sdk/chat/model/Event.java
@@ -49,10 +49,6 @@ public class Event implements UserEntity {
     @Expose
     private Reaction reaction;
 
-    public void setChannel(Channel channel) {
-        this.channel = channel;
-    }
-
     @SerializedName("channel")
     @Expose
     private Channel channel;

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/ChatChannelEventHandler.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/ChatChannelEventHandler.java
@@ -10,7 +10,6 @@ public abstract class ChatChannelEventHandler {
     public void onMessageUpdated(Event event) {}
     public void onMessageDeleted(Event event) {}
     public void onMessageRead(Event event) {}
-    public void onMessageReaction(Event event) {}
     public void onReactionNew(Event event) {}
     public void onReactionDeleted(Event event) {}
     public void onMemberAdded(Event event) {}
@@ -40,9 +39,6 @@ public abstract class ChatChannelEventHandler {
                 break;
             case MESSAGE_READ:
                 onMessageRead(event);
-                break;
-            case MESSAGE_REACTION:
-                onMessageReaction(event);
                 break;
             case REACTION_NEW:
                 onReactionNew(event);

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
@@ -106,76 +106,53 @@ public class Client implements WSResponseHandler {
                 }
             }
 
-            private void updateChannelMessage(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleMessageUpdatedOrDeleted(event);
-                }
+            private void updateChannelMessage(Channel channel, Event event) {
+                channel.handleMessageUpdatedOrDeleted(event);
             }
 
             @Override
-            public void onUserWatchingStart(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleWatcherStart(event);
-                }
+            public void onUserWatchingStart(Channel channel, Event event) {
+                channel.handleWatcherStart(event);
             }
 
             @Override
-            public void onUserWatchingStop(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleWatcherStop(event);
-                }
+            public void onUserWatchingStop(Channel channel, Event event) {
+                channel.handleWatcherStop(event);
             }
 
             @Override
-            public void onMessageNew(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleNewMessage(event);
-                }
+            public void onMessageNew(Channel channel, Event event) {
+                channel.handleNewMessage(event);
             }
 
             @Override
-            public void onMessageUpdated(Event event) {
-                this.updateChannelMessage(event);
+            public void onMessageUpdated(Channel channel, Event event) {
+                this.updateChannelMessage(channel, event);
             }
 
             @Override
-            public void onMessageDeleted(Event event) {
-                this.updateChannelMessage(event);
+            public void onMessageDeleted(Channel channel, Event event) {
+                this.updateChannelMessage(channel, event);
             }
 
             @Override
-            public void onMessageRead(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleReadEvent(event);
-                }
+            public void onMessageRead(Channel channel, Event event) {
+                channel.handleReadEvent(event);
             }
 
             @Override
-            public void onReactionNew(Event event) {
-                this.updateChannelMessage(event);
+            public void onReactionNew(Channel channel, Event event) {
+                this.updateChannelMessage(channel, event);
             }
 
             @Override
-            public void onReactionDeleted(Event event) {
-                this.updateChannelMessage(event);
+            public void onReactionDeleted(Channel channel, Event event) {
+                this.updateChannelMessage(channel, event);
             }
 
             @Override
-            public void onChannelUpdated(Event event) {
-                Channel channel = getChannelByCid(event.getCid());
-                if (channel != null) {
-                    channel.handleChannelUpdated(event);
-                }
-            }
-
-            @Override
-            public void onChannelDeleted(Event event) {
-                //TODO: remove channel from client activeChannels
+            public void onChannelUpdated(Channel channel, Event event) {
+                channel.handleChannelUpdated(channel, event);
             }
 
             @Override
@@ -395,18 +372,14 @@ public class Client implements WSResponseHandler {
 
     @Override
     public void onWSEvent(Event event) {
-        builtinHandler.dispatchEvent(event);
-
-        Channel channel = getChannelByCid(event.getCid());
-        if (channel != null){
-            event.setChannel(channel);
-        }
+        builtinHandler.dispatchEvent(this, event);
 
         for (int i = eventSubscribers.size() - 1; i >= 0 ; i--) {
             ChatEventHandler handler = eventSubscribers.get(i);
-            handler.dispatchEvent(event);
+            handler.dispatchEvent(this, event);
         }
 
+        Channel channel = getChannelByCid(event.getCid());
         if (channel != null) {
             channel.handleChannelEvent(event);
         }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -173,51 +173,40 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
         subscriptionId = client().addEventHandler(new ChatEventHandler() {
 
             @Override
-            public void onNotificationMessageNew(Event event) {
-                Channel channel = client().getChannelByCid(event.getCid());
-                if (channel == null) return;
+            public void onNotificationMessageNew(Channel channel, Event event) {
                 Message lastMessage = channel.getChannelState().getLastMessage();
                 Log.i(TAG, "onMessageNew Event: Received a new message with text: " + event.getMessage().getText());
                 Log.i(TAG, "onMessageNew State: Last message is: " + lastMessage.getText());
-                Log.i(TAG, "onMessageNew Unread Count " + event.getChannel().getChannelState().getCurrentUserUnreadMessageCount());
-                upsertChannel(event.getChannel());
+                Log.i(TAG, "onMessageNew Unread Count " + channel.getChannelState().getCurrentUserUnreadMessageCount());
+                upsertChannel(channel);
             }
 
             @Override
-            public void onMessageNew(Event event) {
-                Channel channel = client().getChannelByCid(event.getCid());
-                if (channel == null) return;
+            public void onMessageNew(Channel channel, Event event) {
                 Message lastMessage = channel.getChannelState().getLastMessage();
                 Log.i(TAG, "onMessageNew Event: Received a new message with text: " + event.getMessage().getText());
                 Log.i(TAG, "onMessageNew State: Last message is: " + lastMessage.getText());
-                Log.i(TAG, "onMessageNew Unread Count " + event.getChannel().getChannelState().getCurrentUserUnreadMessageCount());
-                updateChannel(event.getChannel(), true);
+                Log.i(TAG, "onMessageNew Unread Count " + channel.getChannelState().getCurrentUserUnreadMessageCount());
+                updateChannel(channel, true);
             }
 
             @Override
-            public void onChannelDeleted(Event event) {
-                deleteChannel(event.getChannel());
+            public void onChannelDeleted(Channel channel, Event event) {
+                deleteChannel(channel);
             }
 
             @Override
-            public void onChannelUpdated(Event event) {
-                updateChannel(event.getChannel(), false);
+            public void onChannelUpdated(Channel channel, Event event) {
+                updateChannel(channel, false);
             }
 
             @Override
-            public void onMessageRead(Event event) {
-                Log.i(TAG, "Event: Message read by user " + event.getUser().getName());
-                Channel channel = client().getChannelByCid(event.getCid());
-                if (channel == null) return;
+            public void onMessageRead(Channel channel, Event event) {
                 List<ChannelUserRead> reads = channel.getChannelState().getLastMessageReads();
                 if (reads.size() > 0) {
                     Log.i(TAG, "State: Message read by user " + reads.get(0).getUser().getName());
                 }
-                updateChannel(event.getChannel(),false);
-            }
-            @Override
-            public void onUserWatchingStart(Event event){
-                Channel channel = client().getChannelByCid(event.getCid());
+                updateChannel(channel,false);
             }
         });
     }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
@@ -237,17 +237,17 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
 
             @Override
             public void onUserWatchingStart(Event event) {
-                channelState.postValue(event.getChannel().getChannelState());
+                channelState.postValue(channel.getChannelState());
             }
 
             @Override
             public void onUserWatchingStop(Event event) {
-                channelState.postValue(event.getChannel().getChannelState());
+                channelState.postValue(channel.getChannelState());
             }
 
             @Override
             public void onChannelUpdated(Event event) {
-                channelState.postValue(event.getChannel().getChannelState());
+                channelState.postValue(channel.getChannelState());
             }
 
             @Override


### PR DESCRIPTION
# Submit a pull request

Channel events handlers include the channel as parameter; the client does all the magic and makes sure the channel is known (queuing up to solve races is left as TODO).

This should make handlers safer and remove lot of boilerplate code

Before:

```java
private void updateChannelMessage(Event event) {
    Channel channel = getChannelByCid(event.getCid());
    if (channel != null) {
        channel.handleMessageUpdatedOrDeleted(event);
    }
}
```

After:

```java
private void updateChannelMessage(Channel channel, Event event) {
    channel.handleMessageUpdatedOrDeleted(event);
}
```