### PR TITLE
fix reusable reactionInputView

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ReactionDialogAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ReactionDialogAdapter.java
@@ -6,6 +6,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
+import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.getstream.sdk.chat.R;
@@ -69,6 +70,12 @@ public class ReactionDialogAdapter extends RecyclerView.Adapter<ReactionDialogAd
 
     private void applyStyle(final MyViewHolder holder) {
         holder.tv_emoji.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getReactionInputEmojiSize());
+        ConstraintLayout.LayoutParams params = (ConstraintLayout.LayoutParams) holder.tv_emoji.getLayoutParams();
+        params.leftMargin = style.getReactionInputEmojiMargin();
+        params.rightMargin = style.getReactionInputEmojiMargin();
+        params.topMargin = style.getReactionInputEmojiMargin();
+        params.bottomMargin = style.getReactionInputEmojiMargin();
+        holder.tv_emoji.setLayoutParams(params);
     }
 
     @Override

--- a/library/src/main/java/com/getstream/sdk/chat/view/Dialog/MoreActionDialog.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/Dialog/MoreActionDialog.java
@@ -4,7 +4,6 @@ import android.app.Dialog;
 import android.content.ClipData;
 import android.content.ClipboardManager;
 import android.content.Context;
-import android.graphics.Color;
 import android.text.TextUtils;
 import android.view.MotionEvent;
 import android.view.View;
@@ -130,11 +129,14 @@ public class MoreActionDialog extends Dialog {
 
         // set style
         if (canReactOnMessage()) {
-            rl_wrap.setBackground(new DrawableBuilder()
-                    .rectangle()
-                    .solidColor(Color.BLACK)
-                    .cornerRadii(Utils.dpToPx(25), Utils.dpToPx(25), 0, 0)
-                    .build());
+            rl_wrap.post(() ->
+                    rl_wrap.setBackground(new DrawableBuilder()
+                            .rectangle()
+                            .solidColor(style.getReactionInputBgColor())
+                            .cornerRadii(rl_wrap.getHeight() / 2, rl_wrap.getHeight() / 2, 0, 0)
+                            .build())
+            );
+
             RecyclerView rv_reaction = findViewById(com.getstream.sdk.chat.R.id.rv_reaction);
             RecyclerView.LayoutManager mLayoutManager;
             mLayoutManager = new LinearLayoutManager(getContext(), LinearLayoutManager.HORIZONTAL, false);

--- a/library/src/main/res/layout/stream_dialog_moreaction.xml
+++ b/library/src/main/res/layout/stream_dialog_moreaction.xml
@@ -9,6 +9,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:gravity="center"
+        android:paddingStart="10dp"
+        android:paddingEnd="10dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">

--- a/library/src/main/res/layout/stream_item_dialog_reaction.xml
+++ b/library/src/main/res/layout/stream_item_dialog_reaction.xml
@@ -12,8 +12,6 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="3dp"
             android:gravity="center_vertical"
-            android:paddingStart="5dp"
-            android:paddingEnd="5dp"
             android:textColor="@color/stream_white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
# Submit a pull request

I have noticed that the attrs of _ReactionInput_ didn't work at all.

~~~xml
        <com.getstream.sdk.chat.view.MessageListView
            android:id="@+id/messageList"
           ...
            app:streamReactionInputEmojiSize="50dp"
            app:streamReactionInputEmojiMargin="20sp"
            app:streamReactionInputbgColor="#001DC4"
           ...
           " />
~~~

![Screenshot_1569262590](https://user-images.githubusercontent.com/11132956/65451463-83612b00-de3f-11e9-93e6-009883396b00.png)
