### PR TITLE
Feature/channellist

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
@@ -2,6 +2,7 @@ package com.getstream.sdk.chat.adapter;
 
 import android.content.Context;
 import android.graphics.Color;
+import android.graphics.Typeface;
 import android.os.Handler;
 import android.util.TypedValue;
 import android.view.View;
@@ -88,19 +89,19 @@ public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
     public void applyUnreadStyle() {
         // channel name
         tv_name.setTextColor(style.getUnreadTitleTextColor());
-        tv_name.setTypeface(tv_name.getTypeface(), style.getUnreadTitleTextStyle());
+        tv_name.setTypeface(Typeface.DEFAULT, style.getUnreadTitleTextStyle());
 
         // last message
-        tv_last_message.setTypeface(tv_last_message.getTypeface(), style.getUnreadMessageTextStyle());
+        tv_last_message.setTypeface(Typeface.DEFAULT, style.getUnreadMessageTextStyle());
         tv_last_message.setTextColor(style.getUnreadMessageTextColor());
     }
 
     public void applyReadStyle() {
         // channel name
         tv_name.setTextColor(style.getTitleTextColor());
-        tv_name.setTypeface(tv_name.getTypeface(), style.getTitleTextStyle());
+        tv_name.setTypeface(Typeface.DEFAULT, style.getTitleTextStyle());
         // last messsage
-        tv_last_message.setTypeface(tv_last_message.getTypeface(), style.getMessageTextStyle());
+        tv_last_message.setTypeface(Typeface.DEFAULT, style.getMessageTextStyle());
         tv_last_message.setTextColor(style.getMessageTextColor());
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
@@ -12,6 +12,7 @@ import androidx.annotation.NonNull;
 import androidx.constraintlayout.widget.ConstraintLayout;
 
 import com.getstream.sdk.chat.R;
+import com.getstream.sdk.chat.StreamChat;
 import com.getstream.sdk.chat.model.Channel;
 import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.User;
@@ -25,6 +26,7 @@ import com.getstream.sdk.chat.view.ChannelListViewStyle;
 import com.getstream.sdk.chat.view.ReadStateView;
 
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 
 import io.noties.markwon.Markwon;
@@ -145,14 +147,14 @@ public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
 
         // read indicators
         read_state.setReads(lastMessageReads, true, style);
-
-        // apply unread style or read style
-        if (unreadCount == 0) {
-            this.applyReadStyle();
-        } else {
-            this.applyUnreadStyle();
+        Date myReadDate = channelState.getReadDateOfChannelLastMessage(StreamChat.getInstance(context).getUserId());
+        if (myReadDate == null){
+            applyUnreadStyle();
+        }else if (channelState.getLastMessage() == null){
+            applyReadStyle();
+        }else if (myReadDate.getTime() > channelState.getLastMessage().getCreatedAt().getTime()){
+            applyReadStyle();
         }
-
         // click listeners
         avatarGroupView.setOnClickListener(view -> {
             // if there is 1 user

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
@@ -118,7 +118,6 @@ public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
         // - unread count
         // - read state for this channel
         Message lastMessage = channelState.getLastMessage();
-        int unreadCount = channelState.getCurrentUserUnreadMessageCount();
         List<ChannelUserRead> lastMessageReads = channelState.getLastMessageReads();
         List<User> otherUsers = channelState.getOtherUsers();
         String channelName = channelState.getChannelNameOrMembers();
@@ -147,14 +146,12 @@ public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
 
         // read indicators
         read_state.setReads(lastMessageReads, true, style);
-        Date myReadDate = channelState.getReadDateOfChannelLastMessage(StreamChat.getInstance(context).getUserId());
-        if (myReadDate == null){
+
+        if (channelState.readLastMessage())
+            applyReadStyle();
+        else
             applyUnreadStyle();
-        }else if (channelState.getLastMessage() == null){
-            applyReadStyle();
-        }else if (myReadDate.getTime() > channelState.getLastMessage().getCreatedAt().getTime()){
-            applyReadStyle();
-        }
+
         // click listeners
         avatarGroupView.setOnClickListener(view -> {
             // if there is 1 user

--- a/library/src/main/java/com/getstream/sdk/chat/model/Channel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/model/Channel.java
@@ -732,7 +732,6 @@ public class Channel {
 
     public void handleReadEvent(Event event) {
         channelState.setReadDateOfChannelLastMessage(event.getUser(), event.getCreatedAt());
-        channelState.getChannel().setLastMessageDate(event.getCreatedAt());
     }
 
     /**
@@ -767,7 +766,7 @@ public class Channel {
         client.markRead(this, new MarkReadRequest(null), new EventCallback() {
             @Override
             public void onSuccess(EventResponse response) {
-                Log.i(TAG, "mark read successful");
+                Log.i(TAG, "mark read successful: " + response.getEvent().getUserId());
             }
 
             @Override

--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
@@ -481,5 +481,20 @@ public class ChannelState {
         ChannelUserRead channelUserRead = new ChannelUserRead(user, readDate);
         reads.add(channelUserRead);
     }
+    // if user read the last message returns true, else false.
+    public boolean readLastMessage(){
+        Client client = this.getChannel().getClient();
+        String userID = client.getUserId();
+        Date myReadDate = getReadDateOfChannelLastMessage(userID);
+        if (myReadDate == null){
+            return false;
+        }else if (getLastMessage() == null){
+            return true;
+        }else if (myReadDate.getTime() > getLastMessage().getCreatedAt().getTime()){
+            return true;
+        }else{
+            return false;
+        }
+    }
 }
 

--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
@@ -11,6 +11,7 @@ import androidx.room.PrimaryKey;
 import androidx.room.RoomWarnings;
 import androidx.room.TypeConverters;
 
+import com.getstream.sdk.chat.StreamChat;
 import com.getstream.sdk.chat.model.Channel;
 import com.getstream.sdk.chat.model.Member;
 import com.getstream.sdk.chat.model.ModelType;
@@ -82,9 +83,6 @@ public class ChannelState {
     }
 
     // endregion
-    private static void sortUserReads(List<ChannelUserRead> reads) {
-        Collections.sort(reads, (ChannelUserRead o1, ChannelUserRead o2) -> o1.getLastRead().compareTo(o2.getLastRead()));
-    }
 
     public String getCid() {
         return cid;
@@ -295,7 +293,11 @@ public class ChannelState {
         Message lastMessage = this.getLastMessage();
         List<ChannelUserRead> readLastMessage = new ArrayList<>();
         if (reads == null || lastMessage == null) return readLastMessage;
+        Client client = this.getChannel().getClient();
+        String userID = client.getUserId();
         for (ChannelUserRead r : reads) {
+            if (r.getUserId().equals(userID))
+                continue;
             if (r.getLastRead().compareTo(lastMessage.getCreatedAt()) > -1) {
                 readLastMessage.add(r);
             }
@@ -364,7 +366,6 @@ public class ChannelState {
     public User getLastReader() {
         if (this.reads == null || this.reads.isEmpty()) return null;
         User lastReadUser = null;
-        sortUserReads(this.reads);
         for (int i = reads.size() - 1; i >= 0; i--) {
             ChannelUserRead channelUserRead = reads.get(i);
             if (!channel.getClient().fromCurrentUser(channelUserRead)) {
@@ -435,10 +436,10 @@ public class ChannelState {
 
     public int getUnreadMessageCount(String userId) {
         int unreadMessageCount = 0;
-        if (this.reads == null || this.reads.isEmpty()) return unreadMessageCount;
+        if (this.reads == null || this.reads.isEmpty()) return 1;
 
         Date lastReadDate = getReadDateOfChannelLastMessage(userId);
-        if (lastReadDate == null) return unreadMessageCount;
+        if (lastReadDate == null) return 1;
         for (int i = messages.size() - 1; i >= 0; i--) {
             Message message = messages.get(i);
             if (!message.getUser().getId().equals(userId)) continue;
@@ -452,8 +453,6 @@ public class ChannelState {
     public Date getReadDateOfChannelLastMessage(String userId) {
         if (this.reads == null || this.reads.isEmpty()) return null;
         Date lastReadDate = null;
-        sortUserReads(this.reads);
-
         try {
             for (int i = reads.size() - 1; i >= 0; i--) {
                 ChannelUserRead channelUserRead = reads.get(i);
@@ -479,7 +478,6 @@ public class ChannelState {
                 return;
             }
         }
-
         ChannelUserRead channelUserRead = new ChannelUserRead(user, readDate);
         reads.add(channelUserRead);
     }

--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelState.java
@@ -436,10 +436,10 @@ public class ChannelState {
 
     public int getUnreadMessageCount(String userId) {
         int unreadMessageCount = 0;
-        if (this.reads == null || this.reads.isEmpty()) return 1;
+        if (this.reads == null || this.reads.isEmpty()) return unreadMessageCount;
 
         Date lastReadDate = getReadDateOfChannelLastMessage(userId);
-        if (lastReadDate == null) return 1;
+        if (lastReadDate == null) return unreadMessageCount;
         for (int i = messages.size() - 1; i >= 0; i--) {
             Message message = messages.get(i);
             if (!message.getUser().getId().equals(userId)) continue;

--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelStateGsonAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/ChannelStateGsonAdapter.java
@@ -6,6 +6,7 @@ import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
 
 import java.io.IOException;
+import java.util.Collections;
 
 public class ChannelStateGsonAdapter extends TypeAdapter<ChannelState> {
     @Override
@@ -18,6 +19,9 @@ public class ChannelStateGsonAdapter extends TypeAdapter<ChannelState> {
         TypeAdapter adapter = new Gson().getAdapter(ChannelState.class);
         ChannelState value = (ChannelState) adapter.read(in);
         value.getChannel().setChannelState(value);
+        if (value.getReads() != null && !value.getReads().isEmpty()){
+            Collections.sort(value.getReads(), (ChannelUserRead o1, ChannelUserRead o2) -> o1.getLastRead().compareTo(o2.getLastRead()));
+        }
         return value;
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/view/ChannelListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/ChannelListView.java
@@ -6,6 +6,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.util.AttributeSet;
 import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.Nullable;
 import androidx.lifecycle.LifecycleOwner;
@@ -135,6 +136,12 @@ public class ChannelListView extends RecyclerView {
         throw new IllegalArgumentException("Use setAdapterWithStyle instead please");
     }
 
+    @Override
+    public void onVisibilityChanged(View view, int visibility){
+        super.onVisibilityChanged(view, visibility);
+        if (visibility == 0 && adapter != null)
+            adapter.notifyDataSetChanged();
+    }
     // set the adapter and apply the style.
     public void setAdapterWithStyle(ChannelListItemAdapter adapter) {
         super.setAdapter(adapter);

--- a/library/src/main/java/com/getstream/sdk/chat/view/ReadStateView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/ReadStateView.java
@@ -48,9 +48,6 @@ public class ReadStateView<STYLE extends BaseStyle> extends RelativeLayout {
                 || reads == null
                 || reads.isEmpty()) return;
 
-        // Show the icon of the user who was last to read...
-        Collections.sort(reads, (ChannelUserRead o1, ChannelUserRead o2) -> o2.getLastRead().compareTo(o1.getLastRead()));
-
         User user = reads.get(0).getUser();
         String image = user.getImage();
         // Avatar

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -22,7 +22,6 @@ import com.getstream.sdk.chat.rest.core.Client;
 import com.getstream.sdk.chat.rest.interfaces.QueryChannelListCallback;
 import com.getstream.sdk.chat.rest.request.QueryChannelsRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.rest.response.ChannelUserRead;
 import com.getstream.sdk.chat.rest.response.QueryChannelsResponse;
 import com.getstream.sdk.chat.storage.Storage;
 
@@ -235,10 +234,6 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
 
             @Override
             public void onMessageRead(Channel channel, Event event) {
-                List<ChannelUserRead> reads = channel.getChannelState().getLastMessageReads();
-                if (reads.size() > 0) {
-                    Log.i(TAG, "State: Message read by user " + reads.get(0).getUser().getName());
-                }
                 updateChannel(channel, false);
             }
         });

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
@@ -459,6 +459,7 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
                 messagesCopy.add(message);
             }
             messages.postValue(messagesCopy);
+            markLastMessageRead();
         }
 
 //        Log.d(TAG,"New messages Count:" + messages.getValue().size());
@@ -715,7 +716,7 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
                 callback.onError("no internet", -1);
             return;
         }
-
+        channel.getChannelState().setReadDateOfChannelLastMessage(client().getUser(), message.getCreatedAt());
         // afterwards send the request
         channel.sendMessage(message,
                 new MessageCallback() {


### PR DESCRIPTION
# Submit a pull request

## Fix channels unread mark
- remove `sortUserReads()` from `ChannelState`
- add `sort` to `ChannelStateGsonAdapter ` instead.
```java
public class ChannelStateGsonAdapter extends TypeAdapter<ChannelState> {
   ...
    @Override
    public ChannelState read(JsonReader in) throws IOException {
        ...
        if (value.getReads() != null && !value.getReads().isEmpty()){
            Collections.sort(value.getReads(), (ChannelUserRead o1, ChannelUserRead o2) -> o1.getLastRead().compareTo(o2.getLastRead()));
        }
        return value;
    }
}
```

**Result**
![20190926_112528](https://user-images.githubusercontent.com/11132956/65677152-61d78d80-e051-11e9-8400-af4c68abb9a7.gif)
