### PR TITLE
Feature/ease of use

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
@@ -357,14 +357,18 @@ public class Client implements WSResponseHandler {
 
     public Channel channel(String cid) {
         String[] parts = cid.split(":", 2);
-        return new Channel(this, parts[0], parts[1]);
+        return channel(parts[0], parts[1], new HashMap<>());
     }
 
     public Channel channel(String type, String id) {
-        return new Channel(this, type, id);
+        return channel(type, id, new HashMap<>());
     }
 
     public Channel channel(String type, String id, HashMap<String, Object> extraData) {
+        Channel channel = getChannelByCid(type, id);
+        if (channel != null) {
+            return channel;
+        }
         return new Channel(this, type, id, extraData);
     }
 
@@ -441,7 +445,11 @@ public class Client implements WSResponseHandler {
 
     // endregion
 
-    public Channel getChannelByCid(String cid) {
+    private Channel getChannelByCid(String type, String id) {
+        return getChannelByCid(type + ":" + id);
+    }
+
+    Channel getChannelByCid(String cid) {
         if (cid == null) {
             return null;
         }
@@ -478,6 +486,9 @@ public class Client implements WSResponseHandler {
                                 addToActiveChannels(channel);
                             }
                             channel.mergeWithState(channelState);
+                            if (request.isWatch()) {
+                                channel.setInitialized(true);
+                            }
                         }
 
                         // store the results of the query
@@ -860,19 +871,30 @@ public class Client implements WSResponseHandler {
      */
     public void addDevice(@NonNull String deviceId,
                           DeviceCallback callback) {
-
         AddDeviceRequest request = new AddDeviceRequest(deviceId);
-        mService.addDevices(apiKey, user.getId(), clientID, request).enqueue(new Callback<DevicesResponse>() {
-            @Override
-            public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
-                callback.onSuccess(response.body());
-            }
+        onSetUserCompleted(
+            new ClientConnectionCallback() {
 
-            @Override
-            public void onFailure(Call<DevicesResponse> call, Throwable t) {
-                callback.onError(t.getLocalizedMessage(), -1);
-            }
-        });
+                @Override
+                public void onSuccess(User user) {
+                    mService.addDevices(apiKey, user.getId(), clientID, request).enqueue(new Callback<DevicesResponse>() {
+                        @Override
+                        public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
+                            callback.onSuccess(response.body());
+                        }
+
+                        @Override
+                        public void onFailure(Call<DevicesResponse> call, Throwable t) {
+                            callback.onError(t.getLocalizedMessage(), -1);
+                        }
+                    });
+                }
+
+                @Override
+                public void onError(String errMsg, int errCode) {
+
+                }
+            });
     }
 
     /**
@@ -882,17 +904,29 @@ public class Client implements WSResponseHandler {
     public void getDevices(@NonNull Map<String, String> payload,
                            GetDevicesCallback callback) {
 
-        mService.getDevices(apiKey, user.getId(), clientID, payload).enqueue(new Callback<GetDevicesResponse>() {
-            @Override
-            public void onResponse(Call<GetDevicesResponse> call, Response<GetDevicesResponse> response) {
-                callback.onSuccess(response.body());
-            }
+        onSetUserCompleted(
+            new ClientConnectionCallback() {
+                @Override
+                public void onSuccess(User user) {
+                    mService.getDevices(apiKey, user.getId(), clientID, payload).enqueue(new Callback<GetDevicesResponse>() {
+                        @Override
+                        public void onResponse(Call<GetDevicesResponse> call, Response<GetDevicesResponse> response) {
+                            callback.onSuccess(response.body());
+                        }
 
-            @Override
-            public void onFailure(Call<GetDevicesResponse> call, Throwable t) {
-                callback.onError(t.getLocalizedMessage(), -1);
+                        @Override
+                        public void onFailure(Call<GetDevicesResponse> call, Throwable t) {
+                            callback.onError(t.getLocalizedMessage(), -1);
+                        }
+                    });
+                }
+
+                @Override
+                public void onError(String errMsg, int errCode) {
+
+                }
             }
-        });
+        );
     }
 
     /**
@@ -901,18 +935,29 @@ public class Client implements WSResponseHandler {
      */
     public void removeDevice(@NonNull String deviceId,
                              DeviceCallback callback) {
+        onSetUserCompleted(
+            new ClientConnectionCallback() {
+                @Override
+                public void onSuccess(User user) {
+                    mService.deleteDevice(deviceId, apiKey, user.getId(), clientID).enqueue(new Callback<DevicesResponse>() {
+                        @Override
+                        public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
+                            callback.onSuccess(response.body());
+                        }
 
-        mService.deleteDevice(deviceId, apiKey, user.getId(), clientID).enqueue(new Callback<DevicesResponse>() {
-            @Override
-            public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
-                callback.onSuccess(response.body());
-            }
+                        @Override
+                        public void onFailure(Call<DevicesResponse> call, Throwable t) {
+                            callback.onError(t.getLocalizedMessage(), -1);
+                        }
+                    });
+                }
 
-            @Override
-            public void onFailure(Call<DevicesResponse> call, Throwable t) {
-                callback.onError(t.getLocalizedMessage(), -1);
+                @Override
+                public void onError(String errMsg, int errCode) {
+
+                }
             }
-        });
+        );
     }
 
     // endregion

--- a/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/QueryWatchCallback.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/QueryWatchCallback.java
@@ -1,8 +1,8 @@
 package com.getstream.sdk.chat.rest.interfaces;
 
-        import com.getstream.sdk.chat.rest.response.ChannelState;
+import com.getstream.sdk.chat.rest.response.ChannelState;
 
-public interface QueryChannelCallback {
+public interface QueryWatchCallback {
     void onSuccess(ChannelState response);
 
     void onError(String errMsg, int errCode);

--- a/library/src/main/java/com/getstream/sdk/chat/rest/request/BaseQueryChannelRequest.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/request/BaseQueryChannelRequest.java
@@ -16,6 +16,10 @@ public abstract class BaseQueryChannelRequest<T extends BaseQueryChannelRequest<
 
     protected abstract T cloneOpts();
 
+    public boolean isWatch() {
+        return watch;
+    }
+
     public T withWatch() {
         BaseQueryChannelRequest clone = this.cloneOpts();
         clone.watch = true;

--- a/library/src/main/java/com/getstream/sdk/chat/rest/request/ChannelWatchRequest.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/request/ChannelWatchRequest.java
@@ -6,21 +6,21 @@ import com.google.gson.annotations.SerializedName;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ChannelQueryRequest extends BaseQueryChannelRequest<ChannelQueryRequest> {
+public class ChannelWatchRequest extends ChannelQueryRequest {
 
     @SerializedName("messages")
     protected Map<String, Object> messages;
     @SerializedName("data")
     private Map<String, Object> data;
 
-    public ChannelQueryRequest() {
-        this.watch = false;
+    public ChannelWatchRequest() {
+        this.watch = true;
         this.presence = false;
         this.state = true;
     }
 
-    protected ChannelQueryRequest cloneOpts() {
-        ChannelQueryRequest _this = new ChannelQueryRequest();
+    protected ChannelWatchRequest cloneOpts() {
+        ChannelWatchRequest _this = new ChannelWatchRequest();
         _this.state = this.state;
         _this.watch = this.watch;
         _this.presence = this.presence;
@@ -33,26 +33,27 @@ public class ChannelQueryRequest extends BaseQueryChannelRequest<ChannelQueryReq
         return _this;
     }
 
-    public ChannelQueryRequest withData(Map<String, Object> data) {
-        ChannelQueryRequest clone = this.cloneOpts();
+    public ChannelWatchRequest withData(Map<String, Object> data) {
+        ChannelWatchRequest clone = this.cloneOpts();
         clone.data = data;
         return clone;
     }
 
-    public ChannelQueryRequest withMessages(int limit) {
-        ChannelQueryRequest clone = this.cloneOpts();
+    public ChannelWatchRequest withMessages(int limit) {
+        ChannelWatchRequest clone = this.cloneOpts();
         Map<String, Object> messages = new HashMap<>();
         messages.put("limit", limit);
         clone.messages = messages;
         return clone;
     }
 
-    public ChannelQueryRequest withMessages(Pagination direction, String messageId, int limit) {
-        ChannelQueryRequest clone = this.cloneOpts();
+    public ChannelWatchRequest withMessages(Pagination direction, String messageId, int limit) {
+        ChannelWatchRequest clone = this.cloneOpts();
         Map<String, Object> messages = new HashMap<>();
         messages.put("limit", limit);
         messages.put(direction.toString(), messageId);
         clone.messages = messages;
         return clone;
     }
+
 }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -294,7 +294,6 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
                 .withLimit(pageSize)
                 .withMessageLimit(20);
 
-
         QueryChannelListCallback queryCallback = new QueryChannelListCallback() {
             @Override
             public void onSuccess(QueryChannelsResponse response) {

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
@@ -29,7 +29,9 @@ import com.getstream.sdk.chat.rest.interfaces.EventCallback;
 import com.getstream.sdk.chat.rest.interfaces.GetRepliesCallback;
 import com.getstream.sdk.chat.rest.interfaces.MessageCallback;
 import com.getstream.sdk.chat.rest.interfaces.QueryChannelCallback;
+import com.getstream.sdk.chat.rest.interfaces.QueryWatchCallback;
 import com.getstream.sdk.chat.rest.request.ChannelQueryRequest;
+import com.getstream.sdk.chat.rest.request.ChannelWatchRequest;
 import com.getstream.sdk.chat.rest.request.SendActionRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 import com.getstream.sdk.chat.rest.response.ChannelUserRead;
@@ -589,15 +591,15 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
         channelState.postValue(channel.getChannelState());
     }
 
-    private void queryChannel() {
+    private void watchChannel() {
         int limit = 10; // Constant.DEFAULT_LIMIT
         if (!setLoading()) return;
 
-        ChannelQueryRequest request = new ChannelQueryRequest().withMessages(limit);
+        ChannelWatchRequest request = new ChannelWatchRequest().withMessages(limit);
 
-        channel.query(
+        channel.watch(
                 request,
-                new QueryChannelCallback() {
+                new QueryWatchCallback() {
                     @Override
                     public void onSuccess(ChannelState response) {
                         if (response.getMessages().size() < limit) {
@@ -936,10 +938,10 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
         protected void onActive() {
             super.onActive();
             if (viewModel.initialized.compareAndSet(false, true)) {
-                if (channel.getChannelState().getLastMessage() == null) {
-                    viewModel.queryChannel();
-                } else {
+                if (channel.isInitialized()) {
                     channelLoadingDone();
+                } else {
+                    viewModel.watchChannel();
                 }
             }
         }

--- a/sample/src/main/java/io/getstream/chat/example/BaseApplication.java
+++ b/sample/src/main/java/io/getstream/chat/example/BaseApplication.java
@@ -2,10 +2,14 @@ package io.getstream.chat.example;
 
 import android.app.Application;
 
+import com.crashlytics.android.Crashlytics;
 import com.getstream.sdk.chat.StreamChat;
 import com.getstream.sdk.chat.rest.core.ApiClientOptions;
+import com.getstream.sdk.chat.rest.interfaces.DeviceCallback;
+import com.getstream.sdk.chat.rest.response.DevicesResponse;
 import com.google.firebase.FirebaseApp;
-import com.crashlytics.android.Crashlytics;
+import com.google.firebase.iid.FirebaseInstanceId;
+
 import io.fabric.sdk.android.Fabric;
 
 
@@ -15,6 +19,23 @@ public class BaseApplication extends Application {
         super.onCreate();
         Fabric.with(this, new Crashlytics());
         FirebaseApp.initializeApp(getApplicationContext());
-        StreamChat.init("u4nadyhunvhz", new ApiClientOptions.Builder().Timeout(6666).build(), getApplicationContext());
+        StreamChat.init("qk4nn7rpcn75", new ApiClientOptions.Builder().Timeout(6666).build(), getApplicationContext());
+        FirebaseInstanceId.getInstance().getInstanceId()
+            .addOnCompleteListener(task -> {
+                if (!task.isSuccessful()) {
+                    return;
+                }
+                StreamChat.getInstance(getApplicationContext()).addDevice(task.getResult().getToken(), new DeviceCallback() {
+                    @Override
+                    public void onSuccess(DevicesResponse response) {
+                        // device is now registered!
+                    }
+                    @Override
+                    public void onError(String errMsg, int errCode) {
+                        // something went wrong registering this device, ouch!
+                    }
+                });
+            }
+        );
     }
 }

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -62,9 +62,7 @@ public class ChannelActivity extends AppCompatActivity
             binding.messageInput.setMessageText(messageText);
         }
 
-        Channel channel = client.getChannelByCid(channelType + ":" + channelID);
-        if (channel == null)
-            channel = client.channel(channelType, channelID);
+        Channel channel = client.channel(channelType, channelID);
         viewModel = ViewModelProviders.of(this,
                 new ChannelViewModelFactory(this.getApplication(), channel)
         ).get(ChannelViewModel.class);

--- a/sample/src/main/java/io/getstream/chat/example/MainActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/MainActivity.java
@@ -48,9 +48,9 @@ public class MainActivity extends AppCompatActivity {
     private static final String TAG = MainActivity.class.getSimpleName();
     public static final String EXTRA_CHANNEL_TYPE = "io.getstream.chat.example.CHANNEL_TYPE";
     public static final String EXTRA_CHANNEL_ID = "io.getstream.chat.example.CHANNEL_ID";
-    final String USER_ID = "dark-brook-5";
+    final String USER_ID = "bender";
     // User token is typically provided by your server when the user authenticates
-    final String USER_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiZGFyay1icm9vay01In0.DQo_SCAfFVLqGZHm_f1I1oNmgrbeOcTTw4LS18dpljo";
+    final String USER_TOKEN = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYmVuZGVyIn0.3KYJIoYvSPgTURznP8nWvsA2Yj2-vLqrm-ubqAeOlcQ";
     private ChannelListViewModel viewModel;
 
     // establish a websocket connection to stream
@@ -59,8 +59,8 @@ public class MainActivity extends AppCompatActivity {
         //client.enableOfflineStorage();
 
         HashMap<String, Object> extraData = new HashMap<>();
-        extraData.put("name", "Paranoid Android");
-        extraData.put("image", "https://bit.ly/2TIt8NR");
+        extraData.put("name", "Bender");
+        extraData.put("image", "https://bit.ly/321RmWb");
         User user = new User(USER_ID, extraData);
         client.setUser(user, USER_TOKEN);
         return client;


### PR DESCRIPTION
# Submit a pull request

- Fixes #67 
- Hide client.getChannelByCID behind `client.channel`
- Add channel initialized state
- Channel View Model can be used to open a channel directly (ie. from a notification)
- Let device client's methods wait for `setUser`
