### PR TITLE
Feature/message list view

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/BaseMessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/BaseMessageListItemViewHolder.java
@@ -21,13 +21,7 @@ public abstract class BaseMessageListItemViewHolder extends RecyclerView.ViewHol
     public abstract void bind(Context context,
                               ChannelState channelState,
                               @NonNull MessageListItem messageListItem,
-                              int position,
-                              boolean isThread,
-                              MessageListView.MessageClickListener messageClickListener,
-                              MessageListView.MessageLongClickListener messageLongClickListener,
-                              MessageListView.AttachmentClickListener attachmentClickListener,
-                              MessageListView.UserClickListener userClickListener,
-                              MessageListView.ReadStateClickListener readStateClickListener);
+                              int position);
 
     public abstract void setStyle(MessageListViewStyle style);
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/DateSeparatorViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/DateSeparatorViewHolder.java
@@ -6,7 +6,6 @@ import android.widget.TextView;
 
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 
 import static android.text.format.DateUtils.getRelativeTimeSpanString;
@@ -26,13 +25,7 @@ public class DateSeparatorViewHolder extends BaseMessageListItemViewHolder {
     public void bind(Context context,
                      ChannelState channelState,
                      MessageListItem messageListItem,
-                     int position,
-                     boolean isThread,
-                     MessageListView.MessageClickListener l1,
-                     MessageListView.MessageLongClickListener messageLongClickListener,
-                     MessageListView.AttachmentClickListener l2,
-                     MessageListView.UserClickListener userClickListener,
-                     MessageListView.ReadStateClickListener readStateClickListener) {
+                     int position) {
 
         String humanizedDate = getRelativeTimeSpanString(messageListItem.getDate().getTime()).toString();
         tv_header_date.setText(humanizedDate);

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.java
@@ -19,12 +19,12 @@ import java.util.List;
 
 public class MessageListItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
 
-
     private final String TAG = MessageListItemAdapter.class.getSimpleName();
     private ChannelState channelState;
     private MessageListView.MessageClickListener messageClickListener;
     private MessageListView.MessageLongClickListener messageLongClickListener;
     private MessageListView.AttachmentClickListener attachmentClickListener;
+    private MessageListView.ReactionViewClickListener reactionViewClickListener;
     private MessageListView.UserClickListener userClickListener;
     private MessageListView.ReadStateClickListener readStateClickListener;
     private MessageListView.GiphySendListener giphySendListener;
@@ -36,6 +36,7 @@ public class MessageListItemAdapter extends RecyclerView.Adapter<RecyclerView.Vi
     private int itemLayoutId;
     private MessageViewHolderFactory viewHolderFactory;
     private MessageListView.BubbleHelper bubbleHelper;
+
     public MessageListItemAdapter(Context context, ChannelState channelState, @NonNull List<MessageListItem> messageListItemList) {
         this.context = context;
         this.viewHolderFactory = new MessageViewHolderFactory();
@@ -120,15 +121,7 @@ public class MessageListItemAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         ((BaseMessageListItemViewHolder) holder).bind(this.context,
                 this.channelState,
                 messageListItem,
-                position,
-                isThread,
-                messageClickListener,
-                messageLongClickListener,
-                attachmentClickListener,
-                userClickListener,
-                readStateClickListener);
-
-
+                position);
     }
 
     public void setChannelState(ChannelState channelState) {
@@ -143,21 +136,49 @@ public class MessageListItemAdapter extends RecyclerView.Adapter<RecyclerView.Vi
         isThread = thread;
     }
 
+    public MessageListView.MessageClickListener getMessageClickListener() {
+        return messageClickListener;
+    }
+
     public void setMessageClickListener(MessageListView.MessageClickListener messageClickListener) {
         if (style.isReactionEnabled())
             this.messageClickListener = messageClickListener;
+    }
+
+    public MessageListView.MessageLongClickListener getMessageLongClickListener() {
+        return messageLongClickListener;
     }
 
     public void setMessageLongClickListener(MessageListView.MessageLongClickListener messageLongClickListener) {
         this.messageLongClickListener = messageLongClickListener;
     }
 
+    public MessageListView.AttachmentClickListener getAttachmentClickListener() {
+        return attachmentClickListener;
+    }
+
     public void setAttachmentClickListener(MessageListView.AttachmentClickListener attachmentClickListener) {
         this.attachmentClickListener = attachmentClickListener;
     }
 
+    public MessageListView.ReactionViewClickListener getReactionViewClickListener() {
+        return reactionViewClickListener;
+    }
+
+    public void setReactionViewClickListener(MessageListView.ReactionViewClickListener l) {
+        this.reactionViewClickListener = l;
+    }
+
+    public MessageListView.UserClickListener getUserClickListener() {
+        return userClickListener;
+    }
+
     public void setUserClickListener(MessageListView.UserClickListener userClickListener) {
         this.userClickListener = userClickListener;
+    }
+
+    public MessageListView.ReadStateClickListener getReadStateClickListener() {
+        return readStateClickListener;
     }
 
     public void setReadStateClickListener(MessageListView.ReadStateClickListener readStateClickListener) {
@@ -166,7 +187,6 @@ public class MessageListItemAdapter extends RecyclerView.Adapter<RecyclerView.Vi
 
     @Override
     public int getItemCount() {
-
         return messageListItemList.size();
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
@@ -1,5 +1,6 @@
 package com.getstream.sdk.chat.adapter;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.Color;
 import android.graphics.Typeface;
@@ -7,6 +8,7 @@ import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.TypedValue;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.ImageView;
@@ -444,6 +446,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         alv_attachments.setBackgroundResource(0);
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     private void configReactionView() {
         if (isDeletedOrFailedMessage()
                 || !style.isReactionEnabled()
@@ -463,8 +466,10 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
                 message.getReactionCounts(),
                 channelState.getChannel().getReactionTypes(),
                 style));
-        rv_reaction.setOnClickListener(view -> {
-            reactionViewClickListener.onReactionViewClick(message);
+        rv_reaction.setOnTouchListener((View v, MotionEvent event) -> {
+            if (event.getAction() == MotionEvent.ACTION_UP)
+                reactionViewClickListener.onReactionViewClick(message);
+            return false;
         });
     }
 
@@ -559,8 +564,8 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         else
             params.startToEnd = layoutId;
         tv_reaction_space.setLayoutParams(params);
-        rv_reaction.post(()->{
-            params.width = rv_reaction.getHeight()/3;
+        rv_reaction.post(() -> {
+            params.width = rv_reaction.getHeight() / 3;
             tv_reaction_space.setLayoutParams(params);
         });
     }
@@ -577,11 +582,11 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
             params.startToStart = tv_reaction_space.getId();
         else
             params.endToEnd = tv_reaction_space.getId();
-        rv_reaction.post(()->{
-           params.height = rv_reaction.getHeight();
-           params.width = rv_reaction.getHeight();
-           params.topMargin = rv_reaction.getHeight()/3;
-           iv_tail.setLayoutParams(params);
+        rv_reaction.post(() -> {
+            params.height = rv_reaction.getHeight();
+            params.width = rv_reaction.getHeight();
+            params.topMargin = rv_reaction.getHeight() / 3;
+            iv_tail.setLayoutParams(params);
         });
     }
 
@@ -703,8 +708,9 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         params.rightMargin = Utils.dpToPx(8);
         read_state.setLayoutParams(params);
     }
-    private void configStyleReactionView(){
-        if (style.getReactionViewBgDrawable() == -1){
+
+    private void configStyleReactionView() {
+        if (style.getReactionViewBgDrawable() == -1) {
             rv_reaction.setBackground(new DrawableBuilder()
                     .rectangle()
                     .rounded()
@@ -718,7 +724,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
                 iv_tail.setImageDrawable(context.getResources().getDrawable(R.drawable.stream_tail_incoming));
 
             DrawableCompat.setTint(iv_tail.getDrawable(), style.getReactionViewBgColor());
-        }else{
+        } else {
             int drawable = style.getReactionViewBgDrawable();
             rv_reaction.setBackground(context.getDrawable(drawable));
             iv_tail.setVisibility(View.GONE);

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
@@ -2,9 +2,11 @@ package com.getstream.sdk.chat.adapter;
 
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.content.Intent;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.graphics.drawable.Drawable;
+import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
 import android.util.TypedValue;
@@ -356,6 +358,8 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         }
     }
 
+    boolean isLongClick = false;
+    @SuppressLint("ClickableViewAccessibility")
     private void configMessageText() {
         if (message.getStatus() == MessageStatus.FAILED
                 || message.getType().equals(ModelType.message_error)
@@ -410,13 +414,27 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
                 messageClickListener.onMessageClick(message, position);
             }
         });
+
         tv_text.setOnLongClickListener(view -> {
+            isLongClick = true;
             if (this.messageLongClickListener != null)
                 this.messageLongClickListener.onMessageLongClick(message);
-
             return true;
         });
+
+        tv_text.setMovementMethod(new Utils.TextViewLinkHandler() {
+            @Override
+            public void onLinkClick(String url) {
+                if (isLongClick){
+                    isLongClick = false;
+                    return;
+                }
+                Intent browserIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
+                context.startActivity(browserIntent);
+            }
+        });
     }
+
 
     private void configAttachmentView() {
         if (isDeletedOrFailedMessage()

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
@@ -76,6 +76,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
     private MessageListView.MessageClickListener messageClickListener;
     private MessageListView.MessageLongClickListener messageLongClickListener;
     private MessageListView.AttachmentClickListener attachmentClickListener;
+    private MessageListView.ReactionViewClickListener reactionViewClickListener;
     private MessageListView.UserClickListener userClickListener;
     private MessageListView.ReadStateClickListener readStateClickListener;
 
@@ -88,10 +89,6 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
     private MessageListView.GiphySendListener giphySendListener;
     private List<MessageViewHolderFactory.Position> positions;
     private ConstraintSet set;
-    public MessageListItemViewHolder(int resId, ViewGroup viewGroup, MessageListViewStyle s) {
-        this(resId, viewGroup);
-        style = s;
-    }
 
     public MessageListItemViewHolder(int resId, ViewGroup viewGroup) {
         super(resId, viewGroup);
@@ -135,24 +132,12 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
     public void bind(Context context,
                      ChannelState channelState,
                      MessageListItem messageListItem,
-                     int position,
-                     boolean isThread,
-                     MessageListView.MessageClickListener messageClickListener,
-                     MessageListView.MessageLongClickListener messageLongClickListener,
-                     MessageListView.AttachmentClickListener attachmentClickListener,
-                     MessageListView.UserClickListener userClickListener,
-                     MessageListView.ReadStateClickListener readStateClickListener) {
+                     int position) {
 
         // set binding
         this.context = context;
         this.channelState = channelState;
         this.position = position;
-        this.isThread = isThread;
-        this.messageClickListener = messageClickListener;
-        this.messageLongClickListener = messageLongClickListener;
-        this.attachmentClickListener = attachmentClickListener;
-        this.userClickListener = userClickListener;
-        this.readStateClickListener = readStateClickListener;
 
         this.messageListItem = messageListItem;
         this.message = messageListItem.getMessage();
@@ -161,6 +146,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         init();
     }
 
+    // region Init
     private void init() {
         // Configure UIs
         configSendFailed();
@@ -185,16 +171,47 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         configParamsReadIndicator();
     }
 
-    // endregion
+
     public void setStyle(MessageListViewStyle style) {
         this.style = style;
         avatarWidth = style.getAvatarWidth();
+    }
+
+    public void setThread(boolean thread) {
+        isThread = thread;
+    }
+
+    public void setMessageClickListener(MessageListView.MessageClickListener messageClickListener) {
+        this.messageClickListener = messageClickListener;
+    }
+
+    public void setMessageLongClickListener(MessageListView.MessageLongClickListener messageLongClickListener) {
+        this.messageLongClickListener = messageLongClickListener;
+    }
+
+    public void setAttachmentClickListener(MessageListView.AttachmentClickListener attachmentClickListener) {
+        this.attachmentClickListener = attachmentClickListener;
+    }
+
+    public void setReactionViewClickListener(MessageListView.ReactionViewClickListener reactionViewClickListener) {
+        this.reactionViewClickListener = reactionViewClickListener;
+    }
+
+    public void setUserClickListener(MessageListView.UserClickListener userClickListener) {
+        this.userClickListener = userClickListener;
+    }
+
+    public void setReadStateClickListener(MessageListView.ReadStateClickListener readStateClickListener) {
+        this.readStateClickListener = readStateClickListener;
     }
 
     public void setGiphySendListener(MessageListView.GiphySendListener giphySendListener) {
         this.giphySendListener = giphySendListener;
     }
 
+    // endregion
+
+    // region Config
     private void configPositionsStyle() {
         // TOP position has a rounded top left corner and extra spacing
         // BOTTOM position shows the user avatar & message time
@@ -442,7 +459,13 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder {
         rv_reaction.setVisibility(View.VISIBLE);
         iv_tail.setVisibility(View.VISIBLE);
         tv_reaction_space.setVisibility(View.VISIBLE);
-        rv_reaction.setAdapter(new ReactionListItemAdapter(context, message.getReactionCounts(), channelState.getChannel().getReactionTypes(), style));
+        rv_reaction.setAdapter(new ReactionListItemAdapter(context,
+                message.getReactionCounts(),
+                channelState.getChannel().getReactionTypes(),
+                style));
+        rv_reaction.setOnClickListener(view -> {
+            reactionViewClickListener.onReactionViewClick(message);
+        });
     }
 
     private void configReplyView() {

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.java
@@ -72,9 +72,15 @@ public class MessageViewHolderFactory {
             MessageListItemViewHolder holder = new MessageListItemViewHolder(R.layout.stream_item_message, parent);
             holder.setViewHolderFactory(this);
             holder.setStyle(adapter.getStyle());
+            holder.setThread(adapter.isThread());
+            holder.setMessageClickListener(adapter.getMessageClickListener());
+            holder.setMessageLongClickListener(adapter.getMessageLongClickListener());
+            holder.setAttachmentClickListener(adapter.getAttachmentClickListener());
+            holder.setReactionViewClickListener(adapter.getReactionViewClickListener());
+            holder.setUserClickListener(adapter.getUserClickListener());
+            holder.setReadStateClickListener(adapter.getReadStateClickListener());
             holder.setGiphySendListener(adapter.getGiphySendListener());
             return holder;
-
         } else if (viewType == MessageListItemType.TYPING) {
             TypingIndicatorViewHolder holder = new TypingIndicatorViewHolder(R.layout.stream_item_type_indicator, parent);
             holder.setStyle(adapter.getStyle());

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/NoConnectionViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/NoConnectionViewHolder.java
@@ -6,7 +6,6 @@ import android.widget.TextView;
 
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 
 public class NoConnectionViewHolder extends BaseMessageListItemViewHolder {
@@ -22,13 +21,7 @@ public class NoConnectionViewHolder extends BaseMessageListItemViewHolder {
     public void bind(Context context,
                      ChannelState channelState,
                      MessageListItem messageListItem,
-                     int position,
-                     boolean isThread,
-                     MessageListView.MessageClickListener l1,
-                     MessageListView.MessageLongClickListener messageLongClickListener,
-                     MessageListView.AttachmentClickListener l2,
-                     MessageListView.UserClickListener userClickListener,
-                     MessageListView.ReadStateClickListener readStateClickListener) {
+                     int position) {
 
 //        tv_text.setText();
     }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ThreadSeparatorViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ThreadSeparatorViewHolder.java
@@ -6,7 +6,6 @@ import android.widget.TextView;
 
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 
 public class ThreadSeparatorViewHolder extends BaseMessageListItemViewHolder {
@@ -22,14 +21,7 @@ public class ThreadSeparatorViewHolder extends BaseMessageListItemViewHolder {
     public void bind(Context context,
                      ChannelState channelState,
                      MessageListItem messageListItem,
-                     int position,
-                     boolean isThread,
-                     MessageListView.MessageClickListener l1,
-                     MessageListView.MessageLongClickListener messageLongClickListener,
-                     MessageListView.AttachmentClickListener l2,
-                     MessageListView.UserClickListener userClickListener,
-                     MessageListView.ReadStateClickListener readStateClickListener) {
-
+                     int position) {
 //        tv_text.setText();
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/TypingIndicatorViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/TypingIndicatorViewHolder.java
@@ -11,7 +11,6 @@ import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.rest.User;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 import com.getstream.sdk.chat.view.AvatarGroupView;
-import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 
 public class TypingIndicatorViewHolder extends BaseMessageListItemViewHolder {
@@ -35,12 +34,7 @@ public class TypingIndicatorViewHolder extends BaseMessageListItemViewHolder {
     public void bind(Context context,
                      ChannelState channelState,
                      MessageListItem messageListItem,
-                     int position, boolean isThread,
-                     MessageListView.MessageClickListener l1,
-                     MessageListView.MessageLongClickListener messageLongClickListener,
-                     MessageListView.AttachmentClickListener l2,
-                     MessageListView.UserClickListener userClickListener,
-                     MessageListView.ReadStateClickListener readStateClickListener) {
+                     int position) {
 
         ll_typingusers.setVisibility(View.VISIBLE);
         iv_typing_indicator.setVisibility(View.VISIBLE);

--- a/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
@@ -9,14 +9,20 @@ import android.graphics.Bitmap;
 import android.net.Uri;
 import android.os.Handler;
 import android.provider.MediaStore;
+import android.text.Layout;
+import android.text.Spannable;
 import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
+import android.text.style.URLSpan;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.Display;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.WindowManager;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ImageView;
+import android.widget.TextView;
 import android.widget.Toast;
 
 import androidx.core.graphics.drawable.RoundedBitmapDrawable;
@@ -250,5 +256,32 @@ public class Utils {
             }
         }
         return mentionedUserIDs;
+    }
+
+    public static abstract class TextViewLinkHandler extends LinkMovementMethod {
+        public boolean onTouchEvent(TextView widget, Spannable buffer, MotionEvent event) {
+            if (event.getAction() != MotionEvent.ACTION_UP)
+                return super.onTouchEvent(widget, buffer, event);
+
+            int x = (int) event.getX();
+            int y = (int) event.getY();
+
+            x -= widget.getTotalPaddingLeft();
+            y -= widget.getTotalPaddingTop();
+
+            x += widget.getScrollX();
+            y += widget.getScrollY();
+
+            Layout layout = widget.getLayout();
+            int line = layout.getLineForVertical(y);
+            int off = layout.getOffsetForHorizontal(line, x);
+
+            URLSpan[] link = buffer.getSpans(off, off, URLSpan.class);
+            if (link.length != 0) {
+                onLinkClick(link[0].getURL());
+            }
+            return true;
+        }
+        abstract public void onLinkClick(String url);
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -64,6 +64,7 @@ public class MessageListView extends RecyclerView {
     private MessageLongClickListener messageLongClickListener;
     private AttachmentClickListener attachmentClickListener;
     private GiphySendListener giphySendListener;
+    private ReactionViewClickListener reactionViewClickListener;
     private UserClickListener userClickListener;
     private ReadStateClickListener readStateClickListener;
     private boolean hasScrolledUp;
@@ -273,6 +274,7 @@ public class MessageListView extends RecyclerView {
         setMessageClickListener(messageClickListener);
         setMessageLongClickListener(messageLongClickListener);
         setAttachmentClickListener(attachmentClickListener);
+        setReactionViewClickListener(reactionViewClickListener);
         setUserClickListener(userClickListener);
         setReadStateClickListener(readStateClickListener);
         setMessageLongClickListener(messageLongClickListener);
@@ -503,6 +505,23 @@ public class MessageListView extends RecyclerView {
         }
     }
 
+    public void setReactionViewClickListener(ReactionViewClickListener l) {
+        this.reactionViewClickListener = l;
+        if (adapter == null) return;
+
+        if (this.reactionViewClickListener != null) {
+            adapter.setReactionViewClickListener(this.reactionViewClickListener);
+        } else {
+            adapter.setReactionViewClickListener(message -> {
+                new MoreActionDialog(getContext())
+                        .setChannelViewModel(viewModel)
+                        .setMessage(message)
+                        .setStyle(style)
+                        .show();
+            });
+        }
+    }
+
     public void setUserClickListener(UserClickListener userClickListener) {
         this.userClickListener = userClickListener;
 
@@ -649,7 +668,9 @@ public class MessageListView extends RecyclerView {
     public interface ReadStateClickListener {
         void onReadStateClick(List<ChannelUserRead> reads);
     }
-
+    public interface ReactionViewClickListener {
+        void onReactionViewClick(Message message);
+    }
     public interface BubbleHelper {
         Drawable getDrawableForMessage(Message message, Boolean mine, List<MessageViewHolderFactory.Position> positions);
 


### PR DESCRIPTION
# Submit a pull request
- Disable Web clickable for LongClick event

- Once tapping reactionView. shows up MoreActionView

- Remove listeners from bind of BaseMessageListItemViewHolder

We don't need to set these on all subclasses of `BaseMessageListItemViewHolder`
(`TypingIndicatorViewHolder`, `ThreadSeparatorViewHolder` and `NoConnectionViewHolder`)

Instead, we can set the listeners on `MessageListItemViewHolder` from `MessageViewHolderFactory`

```java
 public BaseMessageListItemViewHolder createMessageViewHolder(MessageListItemAdapter adapter, ViewGroup parent, MessageListItemType viewType) {
        if (viewType == MessageListItemType.DATE_SEPARATOR) {
          ...
        } else if (viewType == MessageListItemType.MESSAGE) {
            MessageListItemViewHolder holder = new MessageListItemViewHolder(R.layout.stream_item_message, parent);
            holder.setViewHolderFactory(this);
            holder.setStyle(adapter.getStyle());
            holder.setThread(adapter.isThread());
            holder.setMessageClickListener(adapter.getMessageClickListener());
            holder.setMessageLongClickListener(adapter.getMessageLongClickListener());
            holder.setAttachmentClickListener(adapter.getAttachmentClickListener());
            holder.setReactionViewClickListener(adapter.getReactionViewClickListener());
            holder.setUserClickListener(adapter.getUserClickListener());
            holder.setReadStateClickListener(adapter.getReadStateClickListener());
            holder.setGiphySendListener(adapter.getGiphySendListener());
            return holder;
        } else if (viewType == MessageListItemType.TYPING) {
           ...
```