### PR TITLE
Message input view

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -319,6 +319,7 @@ public class MessageInputView extends RelativeLayout
     }
 
     // endregion
+    // TODO: the name of this method is weird (progres..)? perhaps captureMedia?
     public void progressCapturedMedia(int requestCode, int resultCode, Intent data) {
         if (requestCode == Constant.CAPTURE_IMAGE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             if (data == null) {

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -33,8 +33,6 @@ import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.databinding.StreamViewMessageInputBinding;
 import com.getstream.sdk.chat.enums.InputType;
 import com.getstream.sdk.chat.enums.MessageInputType;
-import com.getstream.sdk.chat.utils.PermissionChecker;
-import com.getstream.sdk.chat.utils.MessageInputClient;
 import com.getstream.sdk.chat.model.Attachment;
 import com.getstream.sdk.chat.model.ModelType;
 import com.getstream.sdk.chat.rest.Message;
@@ -42,6 +40,8 @@ import com.getstream.sdk.chat.rest.interfaces.MessageCallback;
 import com.getstream.sdk.chat.rest.response.MessageResponse;
 import com.getstream.sdk.chat.utils.Constant;
 import com.getstream.sdk.chat.utils.GridSpacingItemDecoration;
+import com.getstream.sdk.chat.utils.MessageInputClient;
+import com.getstream.sdk.chat.utils.PermissionChecker;
 import com.getstream.sdk.chat.utils.Utils;
 import com.getstream.sdk.chat.viewmodel.ChannelViewModel;
 
@@ -66,26 +66,35 @@ import java.util.Arrays;
 public class MessageInputView extends RelativeLayout
         implements View.OnClickListener, TextWatcher, View.OnFocusChangeListener {
 
+    /**
+     * Tag for logging purposes
+     */
     final String TAG = MessageInputView.class.getSimpleName();
+    /** Store the image if you take a picture */
     Uri imageUri;
-    // our connection to the channel scope
-    private ChannelViewModel viewModel;
-    // binding for this view
-    private StreamViewMessageInputBinding binding;
-    private MessageInputStyle style;
-    // listeners
-    private SendMessageListener sendMessageListener;
-    private OpenCameraViewListener openCameraViewListener;
+    /** If you are allowed to scroll up or not */
+    boolean lockScrollUp = false;
 
-    // TODO Rename, it's not a function
+    private StreamViewMessageInputBinding binding;
+    /**
+     * Styling class for the MessageInput
+     */
+    private MessageInputStyle style;
+    /** Fired when a message is sent */
+    private SendMessageListener sendMessageListener;
+    /** Camera view listener */
+    private OpenCameraViewListener openCameraViewListener;
+    /**
+     * The viewModel for handling typing etc.
+     */
+    private ChannelViewModel viewModel;
+    // TODO Rename, totally not clear what this does
     private MessageInputClient messageInputClient;
 
-    // region Constructor
     public MessageInputView(Context context) {
         super(context);
         binding = initBinding(context);
     }
-    // endregion
 
     public MessageInputView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -94,7 +103,6 @@ public class MessageInputView extends RelativeLayout
         applyStyle();
     }
 
-    // region Init
     private StreamViewMessageInputBinding initBinding(Context context) {
         LayoutInflater inflater = LayoutInflater.from(context);
         return StreamViewMessageInputBinding.inflate(inflater, this, true);
@@ -138,7 +146,7 @@ public class MessageInputView extends RelativeLayout
         binding.etMessage.setOnFocusChangeListener(this);
         binding.etMessage.addTextChangedListener(this);
         binding.etMessage.setCallback((InputContentInfoCompat inputContentInfo,
-                                       int flags, Bundle opts)-> {
+                                       int flags, Bundle opts) -> {
             if (BuildCompat.isAtLeastQ()
                     && (flags & InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION) != 0) {
                 try {
@@ -161,7 +169,6 @@ public class MessageInputView extends RelativeLayout
         });
 
         onBackPressed();
-        setOnSendMessageListener(viewModel);
         initAttachmentUI();
         KeyboardVisibilityEvent.setEventListener(
                 (Activity) getContext(), (boolean isOpen) -> {
@@ -231,7 +238,7 @@ public class MessageInputView extends RelativeLayout
             if (messageListScrollup && !lockScrollUp)
                 Utils.hideSoftKeyboard((Activity) getContext());
         });
-        viewModel.getThreadParentMessage().observe(lifecycleOwner, threadParentMessage ->{
+        viewModel.getThreadParentMessage().observe(lifecycleOwner, threadParentMessage -> {
             if (threadParentMessage == null) {
                 initSendMessage();
                 Utils.hideSoftKeyboard((Activity) getContext());
@@ -281,7 +288,7 @@ public class MessageInputView extends RelativeLayout
         binding.rvMedia.addItemDecoration(new GridSpacingItemDecoration(spanCount, spacing, includeEdge));
         binding.tvClose.setOnClickListener(v -> {
             messageInputClient.onClickCloseBackGroundView();
-            if (viewModel.isEditing()){
+            if (viewModel.isEditing()) {
                 initSendMessage();
                 clearFocus();
             }
@@ -317,7 +324,7 @@ public class MessageInputView extends RelativeLayout
             if (data == null) {
                 File file = null;
                 try {
-                    String path  = imageUri.getPath();
+                    String path = imageUri.getPath();
                     file = new File(path);
                 } catch (Exception e) {
                     e.printStackTrace();
@@ -351,7 +358,6 @@ public class MessageInputView extends RelativeLayout
         binding.etMessage.setEnabled(true);
     }
 
-
     public void clearFocus() {
         binding.etMessage.clearFocus();
     }
@@ -360,12 +366,12 @@ public class MessageInputView extends RelativeLayout
         return binding.etMessage.requestFocus();
     }
 
-    public void setMessageText(String t) {
-        binding.etMessage.setText(t);
-    }
-
     public String getMessageText() {
         return binding.etMessage.getText().toString();
+    }
+
+    public void setMessageText(String t) {
+        binding.etMessage.setText(t);
     }
 
     @Override
@@ -390,7 +396,6 @@ public class MessageInputView extends RelativeLayout
         //noop
     }
 
-
     @Override
     public void afterTextChanged(Editable s) {
         String messageText = this.getMessageText();
@@ -402,15 +407,15 @@ public class MessageInputView extends RelativeLayout
         messageInputClient.checkCommand(messageText);
         binding.setActiveMessageSend(!(messageText.length() == 0));
     }
-    boolean lockScrollUp = false;
+
     @Override
     public void onFocusChange(View v, boolean hasFocus) {
         viewModel.setInputType(hasFocus ? InputType.SELECT : InputType.DEFAULT);
-        if (hasFocus){
+        if (hasFocus) {
             lockScrollUp = true;
-            new Handler().postDelayed(()->lockScrollUp = false, 500);
+            new Handler().postDelayed(() -> lockScrollUp = false, 500);
             Utils.showSoftKeyboard((Activity) getContext());
-        }else
+        } else
             Utils.hideSoftKeyboard((Activity) getContext());
     }
 
@@ -440,22 +445,27 @@ public class MessageInputView extends RelativeLayout
             m.setStatus(null);
             m.setText(input);
             m.setAttachments(messageInputClient.getSelectedAttachments());
-            if (sendMessageListener != null) {
-                sendMessageListener.onSendMessage(m, new MessageCallback() {
-                    @Override
-                    public void onSuccess(MessageResponse response) {
-                        binding.ivSend.setEnabled(true);
-                        initSendMessage();
+            viewModel.sendMessage(m, new MessageCallback() {
+                @Override
+                public void onSuccess(MessageResponse response) {
+                    binding.ivSend.setEnabled(true);
+                    initSendMessage();
+                    if (sendMessageListener != null) {
+                        sendMessageListener.onSendMessageSuccess(response.getMessage());
                     }
+                }
 
-                    @Override
-                    public void onError(String errMsg, int errCode) {
-                        initSendMessage();
-                        binding.ivSend.setEnabled(true);
+                @Override
+                public void onError(String errMsg, int errCode) {
+                    initSendMessage();
+                    binding.ivSend.setEnabled(true);
+                    if (sendMessageListener != null) {
+                        sendMessageListener.onSendMessageError(errMsg, errCode);
+                    } else {
                         Utils.showMessage(getContext(), errMsg);
                     }
-                });
-            }
+                }
+            });
         }
     }
 
@@ -481,7 +491,9 @@ public class MessageInputView extends RelativeLayout
      * Used for listening to the sendMessage event
      */
     public interface SendMessageListener {
-        void onSendMessage(Message message, MessageCallback callback);
+        void onSendMessageSuccess(Message message);
+        void onSendMessageError(String errMsg, int errCod);
+
     }
 
     /**
@@ -491,6 +503,9 @@ public class MessageInputView extends RelativeLayout
         void onAddAttachments();
     }
 
+    /**
+     * Interface for opening the camera view
+     */
     public interface OpenCameraViewListener {
         void openCameraView(Intent intent, int REQUEST_CODE);
     }

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -464,7 +464,7 @@ public class MessageListView extends RecyclerView {
         } else {
             adapter.setMessageClickListener((message, position) -> {
                 if (message.getStatus() == MessageStatus.FAILED) {
-                    viewModel.onSendMessage(message, null);
+                    viewModel.sendMessage(message, null);
                 } else if (message.getReplyCount() > 0) {
                     viewModel.setThreadParentMessage(message);
                 }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -355,7 +355,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
                 queryChannelDone = true;
                 setLoadingDone();
 
-                Log.i(TAG, "onSuccess for loading the channels");
+                Log.i(TAG, "onSendMessageSuccess for loading the channels");
                 // remove the offline channels before adding the new ones
                 setChannels(response.getChannelStates());
 
@@ -437,7 +437,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
         client().queryChannels(request, new QueryChannelListCallback() {
             @Override
             public void onSuccess(QueryChannelsResponse response) {
-                Log.i(TAG, "onSuccess for loading more channels");
+                Log.i(TAG, "onSendMessageSuccess for loading more channels");
                 setLoadingMoreDone();
                 addChannels(response.getChannelStates());
 

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
@@ -42,7 +42,6 @@ import com.getstream.sdk.chat.storage.Storage;
 import com.getstream.sdk.chat.storage.Sync;
 import com.getstream.sdk.chat.utils.Constant;
 import com.getstream.sdk.chat.utils.MessageListItemLiveData;
-import com.getstream.sdk.chat.view.MessageInputView;
 
 import java.util.ArrayList;
 import java.util.Date;
@@ -60,7 +59,7 @@ import static java.util.UUID.randomUUID;
  * - load more data
  * -
  */
-public class ChannelViewModel extends AndroidViewModel implements MessageInputView.SendMessageListener, LifecycleHandler {
+public class ChannelViewModel extends AndroidViewModel implements LifecycleHandler {
     private static final String TAG = ChannelViewModel.class.getSimpleName();
 
     private Channel channel;
@@ -696,10 +695,11 @@ public class ChannelViewModel extends AndroidViewModel implements MessageInputVi
         }
     }
 
-    @Override
-    public void onSendMessage(final Message message, @Nullable final MessageCallback callback) {
+    public void sendMessage(final Message message, @Nullable final MessageCallback callback) {
         // send typing.stop immediately
         stopTyping();
+
+        // TODO: this should be a method at the channel level
 
         if (message.getStatus() == null) {
             message.setUser(client().getUser());

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -83,6 +83,17 @@ public class ChannelActivity extends AppCompatActivity
         binding.channelHeader.setHeaderAvatarGroupClickListener(this);
         binding.messageList.setViewModel(viewModel, this);
         binding.messageInput.setViewModel(viewModel, this);
+        binding.messageInput.setOnSendMessageListener(new MessageInputView.SendMessageListener() {
+            @Override
+            public void onSendMessageSuccess(Message message) {
+                // good place to track analytics events...
+            }
+
+            @Override
+            public void onSendMessageError(String errMsg, int errCod) {
+                // show an error message
+            }
+        });
     }
 
     @Override

--- a/sample/src/main/java/io/getstream/chat/example/CustomMessageInputView.java
+++ b/sample/src/main/java/io/getstream/chat/example/CustomMessageInputView.java
@@ -116,7 +116,7 @@ public class CustomMessageInputView extends RelativeLayout {
             });
         } else {
             message.setStatus(null);
-            viewModel.onSendMessage(message, new MessageCallback() {
+            viewModel.sendMessage(message, new MessageCallback() {
                 @Override
                 public void onSuccess(MessageResponse response) {
                     Log.i(TAG, "Sent message successfully!");


### PR DESCRIPTION
For analytics and toast/UI purposes its nice if you can set a SendMessage listener on the MessageInputView. 

This pull request adds support for that by removing this line:

```
setOnSendMessageListener(viewModel);
```

That line was overwriting listeners set by users of this library.

It also simplifies the listener system from a double listener system to a single listener setup, making the code easier to read. 