### PR TITLE
Add delete channel feature

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/rest/adapter/ChannelGsonAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/adapter/ChannelGsonAdapter.java
@@ -46,11 +46,11 @@ public class ChannelGsonAdapter extends TypeAdapter<Channel> {
         Channel channel = new Channel();
         HashMap<String, Object> extraData = new HashMap<>();
 
-        for (HashMap.Entry<String, Object> set : value.entrySet()) {   
-            String json = gson.toJson(set.getValue());      
+        for (HashMap.Entry<String, Object> set : value.entrySet()) {
+            String json = gson.toJson(set.getValue());
             // Set Reserved Data
             switch (set.getKey()) {
-                case "id":              
+                case "id":
                     channel.setId((String) set.getValue());
                     continue;
                 case "cid":
@@ -67,6 +67,9 @@ public class ChannelGsonAdapter extends TypeAdapter<Channel> {
                     continue;
                 case "created_at":
                     channel.setCreatedAt(gson.fromJson(json, Date.class));
+                    continue;
+                case "deleted_at":
+                    channel.setDeletedAt(gson.fromJson(json, Date.class));
                     continue;
                 case "updated_at":
                     channel.setUpdatedAt(gson.fromJson(json, Date.class));

--- a/library/src/main/java/com/getstream/sdk/chat/rest/controller/APIService.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/controller/APIService.java
@@ -9,7 +9,8 @@ import com.getstream.sdk.chat.rest.request.SendActionRequest;
 import com.getstream.sdk.chat.rest.request.SendEventRequest;
 import com.getstream.sdk.chat.rest.request.SendMessageRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.rest.response.DevicesResponse;
+import com.getstream.sdk.chat.rest.response.CompletableResponse;
+import com.getstream.sdk.chat.rest.response.DeleteChannelResponse;
 import com.getstream.sdk.chat.rest.response.EventResponse;
 import com.getstream.sdk.chat.rest.response.FileSendResponse;
 import com.getstream.sdk.chat.rest.response.FlagResponse;
@@ -19,7 +20,6 @@ import com.getstream.sdk.chat.rest.response.MessageResponse;
 import com.getstream.sdk.chat.rest.response.MuteUserResponse;
 import com.getstream.sdk.chat.rest.response.QueryChannelsResponse;
 import com.getstream.sdk.chat.rest.response.QueryUserListResponse;
-import com.getstream.sdk.chat.rest.response.CompletableResponse;
 
 import org.json.JSONObject;
 
@@ -48,7 +48,7 @@ public interface APIService {
     Call<ChannelState> queryChannel(@Path("type") String channelType, @Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String clientID, @Body ChannelQueryRequest request);
 
     @DELETE("/channels/{type}/{id}")
-    Call<ChannelState> deleteChannel(@Path("type") String channelType, @Path("id") String channelId, @Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String clientID);
+    Call<DeleteChannelResponse> deleteChannel(@Path("type") String channelType, @Path("id") String channelId, @Query("api_key") String apiKey, @Query("client_id") String clientID);
 
     @POST("/channels/{type}/{id}/stop-watching")
     Call<ChannelState> stopWatching(@Path("type") String channelType, @Path("id") String channelId, @Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String clientID, @Body Map<String, String> body);
@@ -143,9 +143,9 @@ public interface APIService {
     Call<GetDevicesResponse> getDevices(@Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String connectionId, @Query("userID") Map body);
 
     @POST("devices")
-    Call<DevicesResponse> addDevices(@Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String connectionId, @Body AddDeviceRequest request);
+    Call<CompletableResponse> addDevices(@Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String connectionId, @Body AddDeviceRequest request);
 
     @DELETE("/devices")
-    Call<DevicesResponse> deleteDevice(@Query("id") String deviceId, @Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String connectionId);
+    Call<CompletableResponse> deleteDevice(@Query("id") String deviceId, @Query("api_key") String apiKey, @Query("user_id") String userId, @Query("client_id") String connectionId);
     // endregion
 }

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
@@ -27,14 +27,13 @@ import com.getstream.sdk.chat.rest.codecs.GsonConverter;
 import com.getstream.sdk.chat.rest.controller.APIService;
 import com.getstream.sdk.chat.rest.controller.RetrofitClient;
 import com.getstream.sdk.chat.rest.interfaces.CompletableCallback;
-import com.getstream.sdk.chat.rest.interfaces.DeviceCallback;
+import com.getstream.sdk.chat.rest.interfaces.DeleteChannelCallback;
 import com.getstream.sdk.chat.rest.interfaces.EventCallback;
 import com.getstream.sdk.chat.rest.interfaces.FlagCallback;
 import com.getstream.sdk.chat.rest.interfaces.GetDevicesCallback;
 import com.getstream.sdk.chat.rest.interfaces.GetRepliesCallback;
 import com.getstream.sdk.chat.rest.interfaces.MessageCallback;
 import com.getstream.sdk.chat.rest.interfaces.MuteUserCallback;
-import com.getstream.sdk.chat.rest.interfaces.QueryChannelCallback;
 import com.getstream.sdk.chat.rest.interfaces.QueryChannelListCallback;
 import com.getstream.sdk.chat.rest.interfaces.QueryUserListCallback;
 import com.getstream.sdk.chat.rest.interfaces.SendFileCallback;
@@ -48,7 +47,7 @@ import com.getstream.sdk.chat.rest.request.SendEventRequest;
 import com.getstream.sdk.chat.rest.request.SendMessageRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 import com.getstream.sdk.chat.rest.response.CompletableResponse;
-import com.getstream.sdk.chat.rest.response.DevicesResponse;
+import com.getstream.sdk.chat.rest.response.DeleteChannelResponse;
 import com.getstream.sdk.chat.rest.response.ErrorResponse;
 import com.getstream.sdk.chat.rest.response.EventResponse;
 import com.getstream.sdk.chat.rest.response.FileSendResponse;
@@ -168,7 +167,11 @@ public class Client implements WSResponseHandler {
                     channel.handleChannelUpdated(channel);
                 }
 
-                // TODO: what about deleted channels?
+                @Override
+                public void onChannelDeleted(Channel channel, Event event) {
+                    storage().deleteChannel(channel);
+                }
+
                 // TODO: what about user update events?
 
                 @Override
@@ -557,26 +560,36 @@ public class Client implements WSResponseHandler {
     }
 
     /**
-     * deleteChannel - Delete the given channel
+     * removes the channel. Messages are permanently removed.
      *
-     * @param channelId the Channel id needs to be specified
-     * @return {object} Response that includes the channel
+     * @param channel  the channel needs to delete
+     * @param callback the result callback
      */
-    public void deleteChannel(@NonNull String channelType, @NonNull String channelId, QueryChannelCallback callback) {
-
-        mService.deleteChannel(channelType, channelId, apiKey, user.getId(), clientID).enqueue(new Callback<ChannelState>() {
+    public void deleteChannel(@NonNull Channel channel, @NotNull DeleteChannelCallback callback) {
+        onSetUserCompleted(new ClientConnectionCallback() {
             @Override
-            public void onResponse(Call<ChannelState> call, Response<ChannelState> response) {
-                callback.onSuccess(response.body());
+            public void onSuccess(User user) {
+                mService.deleteChannel(channel.getType(), channel.getId(), apiKey, clientID)
+                        .enqueue(new Callback<DeleteChannelResponse>() {
+                            @Override
+                            public void onResponse(Call<DeleteChannelResponse> call, Response<DeleteChannelResponse> response) {
+                                callback.onSuccess(response.body());
+                            }
+
+                            @Override
+                            public void onFailure(Call call, Throwable t) {
+                                if (t instanceof ErrorResponse) {
+                                    callback.onError(t.getMessage(), ((ErrorResponse) t).getCode());
+                                } else {
+                                    callback.onError(t.getLocalizedMessage(), -1);
+                                }
+                            }
+                        });
             }
 
             @Override
-            public void onFailure(Call call, Throwable t) {
-                if (t instanceof ErrorResponse) {
-                    callback.onError(t.getMessage(), ((ErrorResponse) t).getCode());
-                } else {
-                    callback.onError(t.getLocalizedMessage(), -1);
-                }
+            public void onError(String errMsg, int errCode) {
+                callback.onError(errMsg, errCode);
             }
         });
     }
@@ -651,6 +664,7 @@ public class Client implements WSResponseHandler {
             }
         });
     }
+
 
     // region Message
 
@@ -1261,21 +1275,21 @@ public class Client implements WSResponseHandler {
      * addDevice - Adds a push device for a user.
      */
     public void addDevice(@NonNull String deviceId,
-                          DeviceCallback callback) {
+                          CompletableCallback callback) {
         AddDeviceRequest request = new AddDeviceRequest(deviceId);
         onSetUserCompleted(
                 new ClientConnectionCallback() {
 
                     @Override
                     public void onSuccess(User user) {
-                        mService.addDevices(apiKey, user.getId(), clientID, request).enqueue(new Callback<DevicesResponse>() {
+                        mService.addDevices(apiKey, user.getId(), clientID, request).enqueue(new Callback<CompletableResponse>() {
                             @Override
-                            public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
+                            public void onResponse(Call<CompletableResponse> call, Response<CompletableResponse> response) {
                                 callback.onSuccess(response.body());
                             }
 
                             @Override
-                            public void onFailure(Call<DevicesResponse> call, Throwable t) {
+                            public void onFailure(Call<CompletableResponse> call, Throwable t) {
                                 if (t instanceof ErrorResponse) {
                                     callback.onError(t.getMessage(), ((ErrorResponse) t).getCode());
                                 } else {
@@ -1331,19 +1345,19 @@ public class Client implements WSResponseHandler {
      * removeDevice - Removes the device with the given id. Clientside users can only delete their own devices
      */
     public void removeDevice(@NonNull String deviceId,
-                             DeviceCallback callback) {
+                             CompletableCallback callback) {
         onSetUserCompleted(
                 new ClientConnectionCallback() {
                     @Override
                     public void onSuccess(User user) {
-                        mService.deleteDevice(deviceId, apiKey, user.getId(), clientID).enqueue(new Callback<DevicesResponse>() {
+                        mService.deleteDevice(deviceId, apiKey, user.getId(), clientID).enqueue(new Callback<CompletableResponse>() {
                             @Override
-                            public void onResponse(Call<DevicesResponse> call, Response<DevicesResponse> response) {
+                            public void onResponse(Call<CompletableResponse> call, Response<CompletableResponse> response) {
                                 callback.onSuccess(response.body());
                             }
 
                             @Override
-                            public void onFailure(Call<DevicesResponse> call, Throwable t) {
+                            public void onFailure(Call<CompletableResponse> call, Throwable t) {
                                 if (t instanceof ErrorResponse) {
                                     callback.onError(t.getMessage(), ((ErrorResponse) t).getCode());
                                 } else {

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
@@ -170,6 +170,7 @@ public class Client implements WSResponseHandler {
                 @Override
                 public void onChannelDeleted(Channel channel, Event event) {
                     storage().deleteChannel(channel);
+                    activeChannels.remove(channel);
                 }
 
                 // TODO: what about user update events?
@@ -411,8 +412,6 @@ public class Client implements WSResponseHandler {
 
     @Override
     public void onWSEvent(Event event) {
-        builtinHandler.dispatchEvent(this, event);
-
         for (int i = eventSubscribers.size() - 1; i >= 0; i--) {
             ChatEventHandler handler = eventSubscribers.get(i);
             handler.dispatchEvent(this, event);
@@ -422,6 +421,8 @@ public class Client implements WSResponseHandler {
         if (channel != null) {
             channel.handleChannelEvent(event);
         }
+
+        builtinHandler.dispatchEvent(this, event);
     }
 
     @Override

--- a/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/DeleteChannelCallback.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/DeleteChannelCallback.java
@@ -1,0 +1,9 @@
+package com.getstream.sdk.chat.rest.interfaces;
+
+import com.getstream.sdk.chat.rest.response.DeleteChannelResponse;
+
+public interface DeleteChannelCallback {
+    void onSuccess(DeleteChannelResponse response);
+
+    void onError(String errMsg, int errCode);
+}

--- a/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/DeviceCallback.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/interfaces/DeviceCallback.java
@@ -1,9 +1,0 @@
-package com.getstream.sdk.chat.rest.interfaces;
-
-import com.getstream.sdk.chat.rest.response.DevicesResponse;
-
-public interface DeviceCallback {
-    void onSuccess(DevicesResponse response);
-
-    void onError(String errMsg, int errCode);
-}

--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/DeleteChannelResponse.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/DeleteChannelResponse.java
@@ -1,0 +1,32 @@
+package com.getstream.sdk.chat.rest.response;
+
+import com.getstream.sdk.chat.model.Channel;
+import com.google.gson.annotations.Expose;
+import com.google.gson.annotations.SerializedName;
+
+/*
+ * Created by Anton Bevza on 2019-10-03.
+ */
+public class DeleteChannelResponse {
+
+    @SerializedName("duration")
+    @Expose
+    private String duration;
+
+    @SerializedName("channel")
+    @Expose
+    private Channel channel;
+
+    public DeleteChannelResponse(String duration, Channel channel) {
+        this.duration = duration;
+        this.channel = channel;
+    }
+
+    public String getDuration() {
+        return duration;
+    }
+
+    public Channel getChannel() {
+        return channel;
+    }
+}

--- a/library/src/main/java/com/getstream/sdk/chat/storage/ChannelsDao.java
+++ b/library/src/main/java/com/getstream/sdk/chat/storage/ChannelsDao.java
@@ -23,7 +23,6 @@ public interface ChannelsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertChannels(List<Channel> channels);
 
-
     @Query("SELECT * FROM stream_channel " +
             "WHERE stream_channel.cid IN (:cids)")
     List<Channel> getChannels(final List<String> cids);
@@ -32,4 +31,6 @@ public interface ChannelsDao {
             "WHERE stream_channel.cid IN (:cid)")
     Channel getChannel(final String cid);
 
+    @Query("DELETE FROM stream_channel WHERE stream_channel.cid IN (:cid)")
+    void deleteChannel(final String cid);
 }

--- a/library/src/main/java/com/getstream/sdk/chat/storage/Storage.java
+++ b/library/src/main/java/com/getstream/sdk/chat/storage/Storage.java
@@ -17,6 +17,9 @@ import com.getstream.sdk.chat.rest.User;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 import com.getstream.sdk.chat.rest.response.ChannelUserRead;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -89,7 +92,7 @@ public class Storage {
     public void insertChannels(List<Channel> channels) {
         if (!enabled) return;
 
-        for (Channel c: channels) {
+        for (Channel c : channels) {
             c.preStorage();
             c.getLastState().preStorage();
         }
@@ -234,6 +237,17 @@ public class Storage {
         channels.add(channel);
 
         insertChannels(channels);
+    }
+
+    /**
+     * delete channel from database
+     *
+     * @param channel the channel needs to delete
+     */
+    public void deleteChannel(@NotNull Channel channel) {
+        if (!enabled) return;
+
+        new DeleteChannelAsyncTask(channelsDao).execute(channel.getCid());
     }
 
     public void insertQuery(QueryChannelsQ query) {
@@ -511,6 +525,20 @@ public class Storage {
                     mCallBack.onFailure(mException);
                 }
             }
+        }
+    }
+
+    public static class DeleteChannelAsyncTask extends AsyncTask<String, Void, Void> {
+        private WeakReference<ChannelsDao> channelsDao;
+
+        private DeleteChannelAsyncTask(ChannelsDao channelsDao) {
+            this.channelsDao = new WeakReference<>(channelsDao);
+        }
+
+        @Override
+        protected Void doInBackground(String... params) {
+            channelsDao.get().deleteChannel(params[0]); // params[0] - channel cid
+            return null;
         }
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -20,12 +20,14 @@ import com.getstream.sdk.chat.model.Event;
 import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.core.ChatEventHandler;
 import com.getstream.sdk.chat.rest.core.Client;
-import com.getstream.sdk.chat.rest.interfaces.QueryChannelListCallback;
 import com.getstream.sdk.chat.rest.interfaces.CompletableCallback;
+import com.getstream.sdk.chat.rest.interfaces.DeleteChannelCallback;
+import com.getstream.sdk.chat.rest.interfaces.QueryChannelListCallback;
 import com.getstream.sdk.chat.rest.request.QueryChannelsRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
-import com.getstream.sdk.chat.rest.response.QueryChannelsResponse;
 import com.getstream.sdk.chat.rest.response.CompletableResponse;
+import com.getstream.sdk.chat.rest.response.DeleteChannelResponse;
+import com.getstream.sdk.chat.rest.response.QueryChannelsResponse;
 import com.getstream.sdk.chat.storage.Storage;
 import com.getstream.sdk.chat.utils.ResultCallback;
 
@@ -160,7 +162,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
     /**
      * hides the channel from queryChannels for the user until a message is added and remove from the current list of channels
      *
-     * @param channel the channel needs to hide
+     * @param channel  the channel needs to hide
      * @param callback the result callback
      */
     public void hideChannel(@NotNull Channel channel, @Nullable ResultCallback<Void, String> callback) {
@@ -186,7 +188,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
     /**
      * removes the hidden status for a channel and remove from the current list of channels
      *
-     * @param channel the channel needs to show
+     * @param channel  the channel needs to show
      * @param callback the result callback
      */
     public void showChannel(@NotNull Channel channel, @Nullable ResultCallback<Void, String> callback) {
@@ -196,6 +198,32 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
                 deleteChannel(channel); // remove the channel from the list of hidden channels
                 if (callback != null) {
                     callback.onSuccess(null);
+                }
+            }
+
+            @Override
+            public void onError(String errMsg, int errCode) {
+                Log.e(TAG, errMsg);
+                if (callback != null) {
+                    callback.onError(errMsg);
+                }
+            }
+        });
+    }
+
+    /**
+     * removes the channel. Messages are permanently removed.
+     *
+     * @param channel  the channel needs to delete
+     * @param callback the result callback
+     */
+    public void deleteChannel(@NotNull Channel channel, @Nullable ResultCallback<Channel, String> callback) {
+        channel.delete(new DeleteChannelCallback() {
+            @Override
+            public void onSuccess(DeleteChannelResponse response) {
+                deleteChannel(channel);
+                if (callback != null) {
+                    callback.onSuccess(response.getChannel());
                 }
             }
 

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -21,12 +21,10 @@ import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.core.ChatEventHandler;
 import com.getstream.sdk.chat.rest.core.Client;
 import com.getstream.sdk.chat.rest.interfaces.CompletableCallback;
-import com.getstream.sdk.chat.rest.interfaces.DeleteChannelCallback;
 import com.getstream.sdk.chat.rest.interfaces.QueryChannelListCallback;
 import com.getstream.sdk.chat.rest.request.QueryChannelsRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 import com.getstream.sdk.chat.rest.response.CompletableResponse;
-import com.getstream.sdk.chat.rest.response.DeleteChannelResponse;
 import com.getstream.sdk.chat.rest.response.QueryChannelsResponse;
 import com.getstream.sdk.chat.storage.Storage;
 import com.getstream.sdk.chat.utils.ResultCallback;
@@ -203,31 +201,6 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
                 deleteChannel(channel); // remove the channel from the list of hidden channels
                 if (callback != null) {
                     callback.onSuccess(null);
-                }
-            }
-
-            @Override
-            public void onError(String errMsg, int errCode) {
-                Log.e(TAG, errMsg);
-                if (callback != null) {
-                    callback.onError(errMsg);
-                }
-            }
-        });
-    }
-
-    /**
-     * removes the channel. Messages are permanently removed. //TODO I am not sure this method is needed. Client can call Channel.delete or Client.deleteChannel directly.
-     *
-     * @param channel  the channel needs to delete
-     * @param callback the result callback
-     */
-    public void deleteChannel(@NotNull Channel channel, @Nullable ResultCallback<Channel, String> callback) {
-        channel.delete(new DeleteChannelCallback() {
-            @Override
-            public void onSuccess(DeleteChannelResponse response) {
-                if (callback != null) {
-                    callback.onSuccess(response.getChannel());
                 }
             }
 

--- a/sample/src/main/java/io/getstream/chat/example/BaseApplication.java
+++ b/sample/src/main/java/io/getstream/chat/example/BaseApplication.java
@@ -5,8 +5,8 @@ import android.app.Application;
 import com.crashlytics.android.Crashlytics;
 import com.getstream.sdk.chat.StreamChat;
 import com.getstream.sdk.chat.rest.core.ApiClientOptions;
-import com.getstream.sdk.chat.rest.interfaces.DeviceCallback;
-import com.getstream.sdk.chat.rest.response.DevicesResponse;
+import com.getstream.sdk.chat.rest.interfaces.CompletableCallback;
+import com.getstream.sdk.chat.rest.response.CompletableResponse;
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.iid.FirebaseInstanceId;
 
@@ -21,21 +21,22 @@ public class BaseApplication extends Application {
         FirebaseApp.initializeApp(getApplicationContext());
         StreamChat.init("qk4nn7rpcn75", new ApiClientOptions.Builder().Timeout(6666).build(), getApplicationContext());
         FirebaseInstanceId.getInstance().getInstanceId()
-            .addOnCompleteListener(task -> {
-                if (!task.isSuccessful()) {
-                    return;
-                }
-                StreamChat.getInstance(getApplicationContext()).addDevice(task.getResult().getToken(), new DeviceCallback() {
-                    @Override
-                    public void onSuccess(DevicesResponse response) {
-                        // device is now registered!
-                    }
-                    @Override
-                    public void onError(String errMsg, int errCode) {
-                        // something went wrong registering this device, ouch!
-                    }
-                });
-            }
-        );
+                .addOnCompleteListener(task -> {
+                            if (!task.isSuccessful()) {
+                                return;
+                            }
+                            StreamChat.getInstance(getApplicationContext()).addDevice(task.getResult().getToken(), new CompletableCallback() {
+                                @Override
+                                public void onSuccess(CompletableResponse response) {
+                                    // device is now registered!
+                                }
+
+                                @Override
+                                public void onError(String errMsg, int errCode) {
+                                    // something went wrong registering this device, ouch!
+                                }
+                            });
+                        }
+                );
     }
 }


### PR DESCRIPTION
# Submit a pull request

## Description of the pull request
- add field `deletedAt` to Channel model. Also, add it to gson adapter.
- add API method to `Client` to delete a channel.
- add method to `Channel` to delete this channel.
- add method to `ChannelListViewModel` to delete channel. _I am not sure this method is needed. Client can call Channel.delete or Client.deleteChannel directly._
- add handling of the event `channel.deleted`. 
- add method to `Storage` to delete the channel from local DB. 

