### PR TITLE
Feature/inputview

### DIFF
--- a/docs/MessageInput.md
+++ b/docs/MessageInput.md
@@ -1,4 +1,8 @@
 ### Message Input
+The MessageInput is used to enter a message with text, attachments(images & videos and the other files).
+Typically it will show:
+
+- Attachment Button
 
 Here's an example message input view
 
@@ -75,6 +79,45 @@ You must use the following properties in your XML to change your MessageInputVie
 | `app:streamInputBackground`         | reference   | -       |
 | `app:streamInputSelectedBackground` | reference   | -       |
 | `app:streamInputEditBackground`     | reference   | -       |
+
+
+#### Listeners
+
+The following listeners can be set
+
+* setOnSendMessageListener
+* setOpenCameraViewListener
+
+#### Send a message with attachments
+
+* Permission Request
+
+You can send messages with attachments like images, videos and other files.
+To upload an attachment, you must allow proper permissions to access the camera and storage on your device.
+So you need to add the following code to ChannelActivity:
+
+```java
+@Override
+public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
+                                       @NonNull int[] grantResults) {
+    // If you are using own MessageInputView please comment this line.
+    binding.messageInput.permissionResult(requestCode, permissions, grantResults);
+}
+```
+
+* Send Images and Videos from camera
+
+After capturing an image or video from the device's camera, it should be processed by `ChannelActivity`.
+
+```java
+@Override
+public void onActivityResult(int requestCode, int resultCode, Intent data) {
+    super.onActivityResult(requestCode, resultCode, data);
+    // If you are using own MessageInputView please comment this line.
+    binding.messageInput.captureMedia(requestCode, resultCode, data);
+}
+```
+
 
 ### Writing your own message input view
 

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
@@ -1,6 +1,7 @@
 package com.getstream.sdk.chat.view;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.res.ColorStateList;
 import android.content.res.TypedArray;
 import android.graphics.Color;
@@ -50,9 +51,9 @@ public class MessageInputStyle extends BaseStyle {
     private Drawable inputSelectedBackground;
     private Drawable inputEditBackground;
 
-
     public MessageInputStyle(Context context, AttributeSet attrs) {
         setContext(context);
+
         TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.MessageInputView);
         // Attachment Button
         showAttachmentButton = a.getBoolean(R.styleable.MessageInputView_streamShowAttachmentButton, true);
@@ -106,6 +107,9 @@ public class MessageInputStyle extends BaseStyle {
         avatarInitialTextColor = a.getColor(R.styleable.MessageInputView_streamAvatarTextColor, Color.WHITE);
         avatarInitialTextStyle = a.getInt(R.styleable.MessageInputView_streamAvatarTextStyle, Typeface.BOLD);
         a.recycle();
+
+        prefs = context.getSharedPreferences(
+                "MessageInputStyle", Context.MODE_PRIVATE);
     }
 
     private Drawable getSelector(@ColorInt int normalColor, @ColorInt int pressedColor,
@@ -126,12 +130,16 @@ public class MessageInputStyle extends BaseStyle {
     }
 
     // Attachment Button
+    private SharedPreferences prefs; // Used for write/read showAttachmentButton from Request permissions
+    private final String showAttachmentButtonKey = "showAttachmentButton";
+
     public boolean showAttachmentButton() {
-        return showAttachmentButton;
+        return prefs.getBoolean(showAttachmentButtonKey, showAttachmentButton);
     }
 
     public void setShowAttachmentButton(boolean showAttachmentButton) {
         this.showAttachmentButton = showAttachmentButton;
+        prefs.edit().putBoolean(showAttachmentButtonKey, showAttachmentButton).apply();
     }
 
     public Drawable getAttachmentButtonIcon(boolean isSelected) {

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
@@ -130,6 +130,10 @@ public class MessageInputStyle extends BaseStyle {
         return showAttachmentButton;
     }
 
+    public void setShowAttachmentButton(boolean showAttachmentButton) {
+        this.showAttachmentButton = showAttachmentButton;
+    }
+
     public Drawable getAttachmentButtonIcon(boolean isSelected) {
         if (attachmentButtonIcon == -1) {
             return getSelector(isSelected ? attachmentButtonSelectedIconColor : attachmentButtonDefaultIconColor,

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.net.Uri;
 import android.os.Bundle;
@@ -20,6 +21,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.RelativeLayout;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.os.BuildCompat;
 import androidx.core.view.inputmethod.InputConnectionCompat;
@@ -320,7 +322,7 @@ public class MessageInputView extends RelativeLayout
 
     // endregion
     // TODO: the name of this method is weird (progres..)? perhaps captureMedia?
-    public void progressCapturedMedia(int requestCode, int resultCode, Intent data) {
+    public void captureMedia(int requestCode, int resultCode, Intent data) {
         if (requestCode == Constant.CAPTURE_IMAGE_REQUEST_CODE && resultCode == Activity.RESULT_OK) {
             if (data == null) {
                 File file = null;
@@ -347,6 +349,23 @@ public class MessageInputView extends RelativeLayout
                 }
             } catch (Exception e) {
                 e.printStackTrace();
+            }
+        }
+    }
+    /*Used for handling requestPermissionsResult*/
+    public void permissionResult(int requestCode, @NonNull String[] permissions,
+                                 @NonNull int[] grantResults) {
+        if (requestCode == Constant.PERMISSIONS_REQUEST) {
+            boolean granted = true;
+            for (int grantResult : grantResults)
+                if (grantResult != PackageManager.PERMISSION_GRANTED) {
+                    granted = false;
+                    break;
+                }
+            if (!granted) {
+                style.setShowAttachmentButton(granted);
+                messageInputClient.onClickCloseBackGroundView();
+                binding.ivOpenAttach.setVisibility(GONE);
             }
         }
     }

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -1,7 +1,6 @@
 package io.getstream.chat.example;
 
 import android.content.Intent;
-import android.content.pm.PackageManager;
 import android.os.Bundle;
 
 import androidx.annotation.NonNull;
@@ -16,8 +15,6 @@ import com.getstream.sdk.chat.model.Channel;
 import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.User;
 import com.getstream.sdk.chat.rest.core.Client;
-import com.getstream.sdk.chat.utils.Constant;
-import com.getstream.sdk.chat.utils.PermissionChecker;
 import com.getstream.sdk.chat.view.Dialog.MoreActionDialog;
 import com.getstream.sdk.chat.view.MessageInputView;
 import com.getstream.sdk.chat.view.MessageListView;

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -106,22 +106,14 @@ public class ChannelActivity extends AppCompatActivity
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         super.onActivityResult(requestCode, resultCode, data);
         // If you are using own MessageInputView please comment this line.
-        binding.messageInput.progressCapturedMedia(requestCode, resultCode, data);
+        binding.messageInput.captureMedia(requestCode, resultCode, data);
     }
 
     @Override
 
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
-        if (requestCode == Constant.PERMISSIONS_REQUEST) {
-            boolean granted = true;
-            for (int grantResult : grantResults)
-                if (grantResult != PackageManager.PERMISSION_GRANTED) {
-                    granted = false;
-                    break;
-                }
-            if (!granted) PermissionChecker.showRationalDialog(this, null);
-        }
+        binding.messageInput.permissionResult(requestCode, permissions, grantResults);
     }
 
     @Override

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -107,9 +107,9 @@ public class ChannelActivity extends AppCompatActivity
     }
 
     @Override
-
     public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                            @NonNull int[] grantResults) {
+        // If you are using own MessageInputView please comment this line.
         binding.messageInput.permissionResult(requestCode, permissions, grantResults);
     }
 


### PR DESCRIPTION
# Submit a pull request (close #78 )

## MessageInputView
- rename 
  ` progressCapturedMedia(...)` to` captureMedia(...)`
- add new function 
   `permissionResult(...)`

## ChannelActivity

- Before

```java
    @Override
    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                           @NonNull int[] grantResults) {
        if (requestCode == Constant.PERMISSIONS_REQUEST) {
            boolean granted = true;
            for (int grantResult : grantResults)
                if (grantResult != PackageManager.PERMISSION_GRANTED) {
                    granted = false;
                    break;
                }
            if (!granted) PermissionChecker.showRationalDialog(this, null);
        }
    }
```
- After
```java
    @Override
    public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                           @NonNull int[] grantResults) {
        binding.messageInput.permissionResult(requestCode, permissions, grantResults);
    }
```

## Update ReadMe

* Listeners 
https://github.com/GetStream/stream-chat-android/blob/feature/inputview/docs/MessageInput.md#listeners

* Send a message with attachments
https://github.com/GetStream/stream-chat-android/blob/feature/inputview/docs/MessageInput.md#send-a-message-with-attachments

## Result

After deny permission requests, hides attachment drawer.

![20191005_190838](https://user-images.githubusercontent.com/11132956/66258401-26e9fe00-e7a5-11e9-8120-774429af0297.gif)

   