### PR TITLE
Feature/inputview

### DIFF
--- a/docs/MessageInput.md
+++ b/docs/MessageInput.md
@@ -87,6 +87,7 @@ The following listeners can be set
 
 * setOnSendMessageListener
 * setOpenCameraViewListener
+* setPermissionRequestListener
 
 #### Send a message with attachments
 
@@ -94,13 +95,29 @@ The following listeners can be set
 
 You can send messages with attachments like images, videos and other files.
 To upload an attachment, you must allow proper permissions to access the camera and storage on your device.
+If your own application has already granted the permissions, ignore this part and `setPermissionRequestListener`.
 So you need to add the following code to ChannelActivity:
 
+* Set PermissionRequestListener
+
+```java
+...
+binding.messageInput.setPermissionRequestListener(this);
+...
+
+@Override
+public void openPermissionRequest() {
+    PermissionChecker.permissionCheck(this, null);
+    // If you are writing a Channel Screen in a Fragment, use the code below instead of the code above.
+    //   PermissionChecker.permissionCheck(getActivity(), this);
+}
+```
+
+* Request Permissions Result
 ```java
 @Override
 public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions,
                                        @NonNull int[] grantResults) {
-    // If you are using own MessageInputView please comment this line.
     binding.messageInput.permissionResult(requestCode, permissions, grantResults);
 }
 ```

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/Client.java
@@ -487,6 +487,7 @@ public class Client implements WSResponseHandler {
 
     @Override
     public void onWSEvent(Event event) {
+        builtinHandler.dispatchEvent(this, event);
         for (int i = eventSubscribers.size() - 1; i >= 0; i--) {
             ChatEventHandler handler = eventSubscribers.get(i);
             handler.dispatchEvent(this, event);
@@ -496,8 +497,6 @@ public class Client implements WSResponseHandler {
         if (channel != null) {
             channel.handleChannelEvent(event);
         }
-
-        builtinHandler.dispatchEvent(this, event);
     }
 
     /**

--- a/library/src/main/java/com/getstream/sdk/chat/utils/MessageInputClient.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/MessageInputClient.java
@@ -1,10 +1,13 @@
 package com.getstream.sdk.chat.utils;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.database.Cursor;
 import android.net.Uri;
 import android.os.AsyncTask;
+import android.os.Build;
 import android.os.Environment;
 import android.provider.MediaStore;
 import android.text.TextUtils;
@@ -97,6 +100,13 @@ public class MessageInputClient {
         }
         binding.tvTitle.setText(type.label);
         messageInputType = type;
+        // Check Camera Permission is allowed or not.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M){
+            int hasCameraPermission = context.checkSelfPermission(Manifest.permission.CAMERA);
+            if (hasCameraPermission != PackageManager.PERMISSION_GRANTED) {
+                binding.llCamera.setVisibility(View.GONE);
+            }
+        }
     }
 
 

--- a/library/src/main/java/com/getstream/sdk/chat/utils/PermissionChecker.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/PermissionChecker.java
@@ -2,14 +2,8 @@ package com.getstream.sdk.chat.utils;
 
 import android.Manifest;
 import android.app.Activity;
-import android.content.Context;
-import android.content.DialogInterface;
 import android.content.pm.PackageManager;
 import android.os.Build;
-import android.view.View;
-import android.widget.Button;
-
-import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
@@ -35,8 +29,7 @@ public class PermissionChecker {
                 permissions.add(Manifest.permission.READ_EXTERNAL_STORAGE);
             }
             if (hasCameraPermission != PackageManager.PERMISSION_GRANTED) {
-                permissions.add(Manifest.permission.CAMERA);
-            }
+                permissions.add(Manifest.permission.CAMERA);            }
 
             if (!permissions.isEmpty()) {
                 if (fragment == null)
@@ -49,20 +42,4 @@ public class PermissionChecker {
         }
     }
 
-    public static void showRationalDialog(Context context, Fragment fragment) {
-        final AlertDialog alertDialog = new AlertDialog.Builder(context)
-                .setTitle("You must allow these permissions to use the Attachments feature!")
-                .setPositiveButton(android.R.string.ok, null)
-                .create();
-
-        alertDialog.setOnShowListener((DialogInterface dialog) -> {
-
-            Button button = alertDialog.getButton(AlertDialog.BUTTON_POSITIVE);
-            button.setOnClickListener((View view) -> {
-                permissionCheck((Activity) context, fragment);
-                alertDialog.dismiss();
-            });
-        });
-        alertDialog.show();
-    }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/utils/PermissionChecker.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/PermissionChecker.java
@@ -4,13 +4,17 @@ import android.Manifest;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.os.Build;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 
 import java.util.ArrayList;
 import java.util.List;
 
 public class PermissionChecker {
-    public static void permissionCheck(Activity activity, Fragment fragment) {
+    public static void permissionCheck(@NonNull Activity activity, @Nullable Fragment fragment) {
+
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 (activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED
                         || activity.checkSelfPermission(Manifest.permission.CAMERA) != PackageManager.PERMISSION_GRANTED
@@ -19,7 +23,6 @@ public class PermissionChecker {
             int hasStoragePermission = activity.checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
             int hasReadPermission = activity.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
             int hasCameraPermission = activity.checkSelfPermission(Manifest.permission.CAMERA);
-
 
             List<String> permissions = new ArrayList<>();
             if (hasStoragePermission != PackageManager.PERMISSION_GRANTED) {

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputStyle.java
@@ -22,7 +22,7 @@ import com.getstream.sdk.chat.R;
 public class MessageInputStyle extends BaseStyle {
 
     private boolean showAttachmentButton;
-
+    private boolean permissionSet;
     private int attachmentButtonIcon;
     private int attachmentButtonDefaultIconColor;
     private int attachmentButtonDefaultIconPressedColor;
@@ -132,7 +132,7 @@ public class MessageInputStyle extends BaseStyle {
     // Attachment Button
     private SharedPreferences prefs; // Used for write/read showAttachmentButton from Request permissions
     private final String showAttachmentButtonKey = "showAttachmentButton";
-
+    private final String permissionSetKey = "permissionSetKey";
     public boolean showAttachmentButton() {
         return prefs.getBoolean(showAttachmentButtonKey, showAttachmentButton);
     }
@@ -140,6 +140,11 @@ public class MessageInputStyle extends BaseStyle {
     public void setShowAttachmentButton(boolean showAttachmentButton) {
         this.showAttachmentButton = showAttachmentButton;
         prefs.edit().putBoolean(showAttachmentButtonKey, showAttachmentButton).apply();
+        prefs.edit().putBoolean(permissionSetKey, true).apply();
+    }
+
+    public boolean isPermissionSet() {
+        return prefs.getBoolean(permissionSetKey, false);
     }
 
     public Drawable getAttachmentButtonIcon(boolean isSelected) {

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -424,7 +424,7 @@ public class MessageInputView extends RelativeLayout
             binding.setIsAttachFile(true);
             if (style.isPermissionSet() || isGrantedPermissions())
                 messageInputClient.onClickOpenBackGroundView(MessageInputType.ADD_FILE);
-            else
+            else if(permissionRequestListener != null)
                 permissionRequestListener.openPermissionRequest();
         }
     }

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Typeface;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.provider.MediaStore;
@@ -378,6 +379,18 @@ public class MessageInputView extends RelativeLayout
         }
     }
 
+    private boolean isGrantedPermissions() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            int hasStoragePermission = getContext().checkSelfPermission(Manifest.permission.WRITE_EXTERNAL_STORAGE);
+            int hasReadPermission = getContext().checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE);
+            int hasCameraPermission = getContext().checkSelfPermission(Manifest.permission.CAMERA);
+            return (hasStoragePermission == PackageManager.PERMISSION_GRANTED)
+                    && (hasReadPermission == PackageManager.PERMISSION_GRANTED)
+                    && (hasCameraPermission == PackageManager.PERMISSION_GRANTED);
+        } else
+            return true;
+    }
+
     public Message getEditMessage() {
         return viewModel.getEditMessage().getValue();
     }
@@ -409,7 +422,7 @@ public class MessageInputView extends RelativeLayout
             this.onSendMessage(binding.etMessage.getText().toString(), viewModel.isEditing());
         } else if (id == R.id.iv_openAttach) {
             binding.setIsAttachFile(true);
-            if (style.isPermissionSet())
+            if (style.isPermissionSet() || isGrantedPermissions())
                 messageInputClient.onClickOpenBackGroundView(MessageInputType.ADD_FILE);
             else
                 permissionRequestListener.openPermissionRequest();

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -1,5 +1,6 @@
 package com.getstream.sdk.chat.view;
 
+import android.Manifest;
 import android.app.Activity;
 import android.content.ContentValues;
 import android.content.Context;
@@ -43,7 +44,6 @@ import com.getstream.sdk.chat.rest.response.MessageResponse;
 import com.getstream.sdk.chat.utils.Constant;
 import com.getstream.sdk.chat.utils.GridSpacingItemDecoration;
 import com.getstream.sdk.chat.utils.MessageInputClient;
-import com.getstream.sdk.chat.utils.PermissionChecker;
 import com.getstream.sdk.chat.utils.Utils;
 import com.getstream.sdk.chat.viewmodel.ChannelViewModel;
 
@@ -84,6 +84,8 @@ public class MessageInputView extends RelativeLayout
     private MessageInputStyle style;
     /** Fired when a message is sent */
     private SendMessageListener sendMessageListener;
+    /** Permission Request listener */
+    private PermissionRequestListener permissionRequestListener;
     /** Camera view listener */
     private OpenCameraViewListener openCameraViewListener;
     /**
@@ -357,16 +359,22 @@ public class MessageInputView extends RelativeLayout
                                  @NonNull int[] grantResults) {
         if (requestCode == Constant.PERMISSIONS_REQUEST) {
             boolean granted = true;
-            for (int grantResult : grantResults)
-                if (grantResult != PackageManager.PERMISSION_GRANTED) {
+            for (int i = 0; i < permissions.length; i++) {
+                String permission = permissions[i];
+                int grantResult = grantResults[i];
+                if (!permission.equals(Manifest.permission.CAMERA)
+                        && grantResult != PackageManager.PERMISSION_GRANTED) {
                     granted = false;
                     break;
                 }
-            if (!granted) {
-                style.setShowAttachmentButton(granted);
-                messageInputClient.onClickCloseBackGroundView();
-                binding.ivOpenAttach.setVisibility(GONE);
             }
+
+            style.setShowAttachmentButton(granted);
+            if (granted)
+                messageInputClient.onClickOpenBackGroundView(MessageInputType.ADD_FILE);
+            else
+                binding.ivOpenAttach.setVisibility(GONE);
+
         }
     }
 
@@ -401,8 +409,10 @@ public class MessageInputView extends RelativeLayout
             this.onSendMessage(binding.etMessage.getText().toString(), viewModel.isEditing());
         } else if (id == R.id.iv_openAttach) {
             binding.setIsAttachFile(true);
-            PermissionChecker.permissionCheck((Activity) v.getContext(), null);
-            messageInputClient.onClickOpenBackGroundView(MessageInputType.ADD_FILE);
+            if (style.isPermissionSet())
+                messageInputClient.onClickOpenBackGroundView(MessageInputType.ADD_FILE);
+            else
+                permissionRequestListener.openPermissionRequest();
         }
     }
 
@@ -503,6 +513,10 @@ public class MessageInputView extends RelativeLayout
         this.sendMessageListener = l;
     }
 
+    public void setPermissionRequestListener(PermissionRequestListener l) {
+        this.permissionRequestListener = l;
+    }
+
     public void setOpenCameraViewListener(OpenCameraViewListener l) {
         this.openCameraViewListener = l;
     }
@@ -525,7 +539,12 @@ public class MessageInputView extends RelativeLayout
     public interface AttachmentListener {
         void onAddAttachments();
     }
-
+    /**
+     * Interface for Permission request
+     */
+    public interface PermissionRequestListener {
+        void openPermissionRequest();
+    }
     /**
      * Interface for opening the camera view
      */

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -15,6 +15,7 @@ import com.getstream.sdk.chat.model.Channel;
 import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.User;
 import com.getstream.sdk.chat.rest.core.Client;
+import com.getstream.sdk.chat.utils.PermissionChecker;
 import com.getstream.sdk.chat.view.Dialog.MoreActionDialog;
 import com.getstream.sdk.chat.view.MessageInputView;
 import com.getstream.sdk.chat.view.MessageListView;
@@ -31,7 +32,7 @@ public class ChannelActivity extends AppCompatActivity
         MessageListView.AttachmentClickListener,
         MessageListView.HeaderOptionsClickListener,
         MessageListView.HeaderAvatarGroupClickListener,
-        MessageListView.UserClickListener,
+        MessageListView.UserClickListener, MessageInputView.PermissionRequestListener,
         MessageInputView.OpenCameraViewListener {
 
     static final String TAG = ChannelActivity.class.getSimpleName();
@@ -70,7 +71,7 @@ public class ChannelActivity extends AppCompatActivity
         binding.messageList.setAttachmentClickListener(this);
         // If you are using own MessageInputView please comment this line.
         binding.messageInput.setOpenCameraViewListener(this);
-
+        binding.messageInput.setPermissionRequestListener(this);
         binding.messageList.setViewHolderFactory(new MyMessageViewHolderFactory());
 
         // connect the view model
@@ -111,6 +112,12 @@ public class ChannelActivity extends AppCompatActivity
                                            @NonNull int[] grantResults) {
         // If you are using own MessageInputView please comment this line.
         binding.messageInput.permissionResult(requestCode, permissions, grantResults);
+    }
+
+
+    @Override
+    public void openPermissionRequest() {
+        PermissionChecker.permissionCheck(this, null);
     }
 
     @Override

--- a/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/ChannelActivity.java
@@ -118,6 +118,8 @@ public class ChannelActivity extends AppCompatActivity
     @Override
     public void openPermissionRequest() {
         PermissionChecker.permissionCheck(this, null);
+        // If you are writing a Channel Screen in a Fragment, use the code below instead of the code above.
+        //   PermissionChecker.permissionCheck(getActivity(), this);
     }
 
     @Override


### PR DESCRIPTION
# Submit a pull request(close #99)

* Added `setPermissionRequestListener` in ChannelActivity for on Activity or Fragment

```java
...
binding.messageInput.setPermissionRequestListener(this);
...
    @Override
    public void openPermissionRequest() {
        PermissionChecker.permissionCheck(this, null);
        // If you are writing a Channel Screen in a Fragment, use the code below instead of the code above.
        //   PermissionChecker.permissionCheck(getActivity(), this);
    }
```
* updated ReadMe
https://github.com/GetStream/stream-chat-android/blob/feature/inputview/docs/MessageInput.md#send-a-message-with-attachments