### PR TITLE
made it easier to customize the message

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.java
@@ -443,6 +443,18 @@ public class MessageInputView extends RelativeLayout
             Utils.hideSoftKeyboard((Activity) getContext());
     }
 
+    /**
+     Prepare message takes the message input string and returns a message object
+     You can overwrite this method in case you want to attach more custom properties to the message
+     */
+    public Message prepareMessage(String input) {
+        Message m = new Message();
+        m.setStatus(null);
+        m.setText(input);
+        m.setAttachments(messageInputClient.getSelectedAttachments());
+        return m;
+    }
+
     private void onSendMessage(String input, boolean isEdit) {
         binding.ivSend.setEnabled(false);
 
@@ -465,10 +477,7 @@ public class MessageInputView extends RelativeLayout
                 }
             });
         } else {
-            Message m = new Message();
-            m.setStatus(null);
-            m.setText(input);
-            m.setAttachments(messageInputClient.getSelectedAttachments());
+            Message m = prepareMessage(input);
             viewModel.sendMessage(m, new MessageCallback() {
                 @Override
                 public void onSuccess(MessageResponse response) {

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -21,8 +21,8 @@ android {
         applicationId "io.getstream.chat.sdk"
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 2
-        versionName "1.0"
+        versionCode 6
+        versionName "6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     buildTypes {

--- a/sample/src/main/java/io/getstream/chat/example/CustomMessageInputView2.java
+++ b/sample/src/main/java/io/getstream/chat/example/CustomMessageInputView2.java
@@ -1,0 +1,31 @@
+package io.getstream.chat.example;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import com.getstream.sdk.chat.rest.Message;
+import com.getstream.sdk.chat.view.MessageInputView;
+
+import java.util.HashMap;
+
+public class CustomMessageInputView2 extends MessageInputView {
+    public CustomMessageInputView2(Context context) {
+        super(context);
+    }
+
+    public CustomMessageInputView2(Context context, AttributeSet attrs) {
+        super(context, attrs);
+    }
+
+    @Override
+    public Message prepareMessage(String input) {
+        Message m = super.prepareMessage(input);
+        // note that you typically want to use custom fields on attachments instead of messages
+        // attachment UI is easier to customize than the message UI
+        HashMap<String, Object> extraData = new HashMap<>();
+        extraData.put("mycustomfield", "123");
+        m.setExtraData(extraData);
+
+        return m;
+    }
+}


### PR DESCRIPTION
adds the prepareMessage function to the MessageInputView, solves 
https://github.com/GetStream/stream-chat-android/issues/28

example usage

```
public class CustomMessageInputView2 extends MessageInputView {
    public CustomMessageInputView2(Context context) {
        super(context);
    }

    public CustomMessageInputView2(Context context, AttributeSet attrs) {
        super(context, attrs);
    }

    @Override
    public Message prepareMessage(String input) {
        Message m = super.prepareMessage(input);
        // note that you typically want to use custom fields on attachments instead of messages
        // attachment UI is easier to customize than the message UI
        HashMap<String, Object> extraData = new HashMap<>();
        extraData.put("mycustomfield", "123");
        m.setExtraData(extraData);

        return m;
    }
}

```