### PR TITLE
Feature/retry

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/utils/RetryPolicy.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/RetryPolicy.java
@@ -1,6 +1,28 @@
 package com.getstream.sdk.chat.utils;
 
+import com.getstream.sdk.chat.rest.core.Client;
+
 public interface RetryPolicy {
-    boolean shouldRetry(Integer attempt, String errMsg, int errCode);
-    Integer retryTimeout(Integer attempt, String errMsg, int errCode);
+    /**
+     * Should Retry evaluates if we should retry the failure
+     *
+     * @param client
+     * @param attempt
+     * @param errMsg
+     * @param errCode
+     * @return
+     */
+    boolean shouldRetry(Client client, Integer attempt, String errMsg, int errCode);
+
+    /**
+     * In the case that we want to retry a failed request the retryTimeout method is called
+     * to determine the timeout
+     *
+     * @param client
+     * @param attempt
+     * @param errMsg
+     * @param errCode
+     * @return
+     */
+    Integer retryTimeout(Client client, Integer attempt, String errMsg, int errCode);
 }

--- a/library/src/main/java/com/getstream/sdk/chat/utils/RetryPolicy.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/RetryPolicy.java
@@ -1,0 +1,6 @@
+package com.getstream.sdk.chat.utils;
+
+public interface RetryPolicy {
+    boolean shouldRetry(Integer attempt, String errMsg, int errCode);
+    Integer retryTimeout(Integer attempt, String errMsg, int errCode);
+}


### PR DESCRIPTION
Make the retry policy configurable. You might want to change the retry behaviour based on:

- if the user is online
- the error type
- how many retries you've made

```
        // default retry policy is to retry the request 100 times
        retryPolicy = new RetryPolicy() {
            @Override
            public boolean shouldRetry(Client client, Integer attempt, String errMsg, int errCode) {
                return attempt < 100;
            }

            @Override
            public Integer retryTimeout(Client client, Integer attempt, String errMsg, int errCode) {
                return Math.min(500 * (attempt * attempt + 1), 30000);
            }
        };
```