### PR TITLE
Client robustness WIP

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/EventSubscriberRegistry.java
+++ b/library/src/main/java/com/getstream/sdk/chat/EventSubscriberRegistry.java
@@ -1,0 +1,68 @@
+package com.getstream.sdk.chat;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * A thread safe registry of subscribers.
+ * This ensures that you can't miss a message event while a handler is being added
+ *
+ * As an example:
+ * - You add a handler, which does something slow and takes 3ms ---
+ * - Next an event is fired on a different thread in 2ms        --
+ * Without locking the handler would never receive the event
+ */
+public class EventSubscriberRegistry<T> {
+    // the mapping of subscriberID to chat event handler
+    private Map<Number, T> subscribers;
+    // subscriberSequence, starts at 1
+    private int subscriberSequence;
+    // the lock used to make sure you cant read while someone else is adding a handler
+    private ReentrantLock lock;
+
+    public EventSubscriberRegistry() {
+        this.subscribers = new HashMap<>();
+        this.lock = new ReentrantLock();
+    }
+
+    /**
+     * Gets the list of subscribers
+     * @return
+     */
+    public List<T> getSubscribers() {
+        lock.lock();
+        List<T> subs = new ArrayList<>();
+        for (int i = subscriberSequence; i >= 1; i--) {
+            T sub = subscribers.get(i);
+            subs.add(sub);
+        }
+        lock.unlock();
+        return subs;
+    }
+
+    /**
+     * Adds a subscription
+     * @param handler the chat event handler
+     * @return
+     */
+    public final int addSubscription(T handler) {
+        lock.lock();
+        int id = ++subscriberSequence;
+        subscribers.put(id, handler);
+        lock.unlock();
+        return id;
+    }
+
+    /**
+     * Removed the subscription by the subscription id returned by the addSubscription call
+     * @param subId
+     */
+    public final void removeSubscription(int subId) {
+        lock.lock();
+        subscribers.remove(subId);
+        lock.unlock();
+    }
+}

--- a/library/src/main/java/com/getstream/sdk/chat/EventSubscriberRegistry.java
+++ b/library/src/main/java/com/getstream/sdk/chat/EventSubscriberRegistry.java
@@ -48,7 +48,7 @@ public class EventSubscriberRegistry<T> {
      * @param handler the chat event handler
      * @return
      */
-    public final int addSubscription(T handler) {
+    public int addSubscription(T handler) {
         lock.lock();
         int id = ++subscriberSequence;
         subscribers.put(id, handler);
@@ -60,9 +60,19 @@ public class EventSubscriberRegistry<T> {
      * Removed the subscription by the subscription id returned by the addSubscription call
      * @param subId
      */
-    public final void removeSubscription(int subId) {
+    public void removeSubscription(int subId) {
         lock.lock();
         subscribers.remove(subId);
+        lock.unlock();
+    }
+
+    /**
+     * Resets the list of subscribers and the subscriber sequence
+     */
+    public void clear() {
+        lock.lock();
+        this.subscribers = new HashMap<>();
+        subscriberSequence = 0;
         lock.unlock();
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/rest/EventHandler.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/EventHandler.java
@@ -1,0 +1,20 @@
+package com.getstream.sdk.chat.rest;
+
+import android.os.Handler;
+import android.os.Message;
+import com.getstream.sdk.chat.model.Event;
+
+
+public class EventHandler extends Handler {
+    private WebSocketService webSocketService;
+
+    public EventHandler(WebSocketService webSocketService) {
+        this.webSocketService = webSocketService;
+    }
+
+    @Override
+    public void handleMessage(Message msg) {
+        super.handleMessage(msg);
+        webSocketService.webSocketListener.onWSEvent((Event) msg.obj);
+    }
+}

--- a/library/src/main/java/com/getstream/sdk/chat/rest/EventHandlerThread.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/EventHandlerThread.java
@@ -1,0 +1,11 @@
+package com.getstream.sdk.chat.rest;
+
+class EventHandlerThread extends Thread {
+    EventHandler mHandler;
+
+    public EventHandlerThread(WebSocketService webSocketService) {
+        mHandler = new EventHandler(webSocketService);
+    }
+
+
+}

--- a/library/src/main/java/com/getstream/sdk/chat/rest/WebSocketService.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/WebSocketService.java
@@ -1,8 +1,5 @@
 package com.getstream.sdk.chat.rest;
 
-import android.annotation.SuppressLint;
-import android.os.Handler;
-import android.os.Looper;
 import android.os.Message;
 import android.util.Log;
 
@@ -27,7 +24,7 @@ public class WebSocketService extends WebSocketListener {
     private static final int NORMAL_CLOSURE_STATUS = 1000;
     private final String TAG = WebSocketService.class.getSimpleName();
     protected EchoWebSocketListener listener;
-    private WSResponseHandler webSocketListener;
+    public WSResponseHandler webSocketListener;
     private String wsURL;
     private OkHttpClient httpClient;
     private WebSocket webSocket;
@@ -171,12 +168,18 @@ public class WebSocketService extends WebSocketListener {
         wsId = 0;
         setConnecting(true);
         resetConsecutiveFailures();
+
+        // start the thread before setting up the websocket connection
+        eventThread = new EventHandlerThread(this);
+        eventThread.setName("WSS - event handler thread");
+        eventThread.start();
+
+        // WS connection
         setupWS();
 
         shuttingDown = false;
-        eventThread = new EventHandlerThread();
-        eventThread.start();
-        eventThread.setName("WSS - event handler thread");
+
+
     }
 
     public void disconnect() {
@@ -269,6 +272,7 @@ public class WebSocketService extends WebSocketListener {
 
         @Override
         public synchronized void onMessage(WebSocket webSocket, String text) {
+            // TODO: synchronized onMessage is not great for performance when receiving many messages at once
             Log.d(TAG, "WebSocket # " + wsId + " Response : " + text);
 
             if (isShuttingDown()) return;
@@ -336,23 +340,6 @@ public class WebSocketService extends WebSocketListener {
             setConnecting(false);
             setHealth(false);
             reconnect(true);
-        }
-    }
-
-    class EventHandlerThread extends Thread {
-        Handler mHandler;
-
-        @SuppressLint("HandlerLeak")
-        public void run() {
-            Looper.prepare();
-
-            mHandler = new Handler() {
-                public void handleMessage(Message msg) {
-                    webSocketListener.onWSEvent((Event) msg.obj);
-                }
-            };
-
-            Looper.loop();
         }
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/rest/WebSocketService.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/WebSocketService.java
@@ -23,6 +23,7 @@ import okhttp3.WebSocketListener;
 public class WebSocketService extends WebSocketListener {
     private static final int NORMAL_CLOSURE_STATUS = 1000;
     private final String TAG = WebSocketService.class.getSimpleName();
+
     protected EchoWebSocketListener listener;
     public WSResponseHandler webSocketListener;
     private String wsURL;


### PR DESCRIPTION
We have Client, Channel, WebsocketService, ChannelState, ClientState
Threads are used for websocket events `EventHandlerThread` and the `onSetUserCompleted`
There are some possible race conditions:

- code that adds/calls event handlers (currently done using synchronized methods, which is not entirely right since it only affects the individual method)
- reading and writing on the channel/channelState objects

Looks like https://github.com/GetStream/stream-chat-android/issues/106 is related

FIXED:

- websocket events could be received before the thread was ready to receive them
-- start the thread before connecting the websocket
-- setup the handler logic on thread creation instead of thread start
(Possibly related: https://github.com/GetStream/stream-chat-android/issues/105)
- Thread safety for event handlers (both channel and client)
- onSetUserCompleted thread safety
- Use ConcurrentHashMap for knownUsers (clientState)


TODO:

- ChannelState doesn't look thread safe. On the other hand EchoWebSocketListener.onMessage is synchronized, so maybe that's ok?

