### PR TITLE
fix message input lines(max 7) and image select with text message

### DIFF
--- a/library/src/main/res/layout/stream_view_message_input.xml
+++ b/library/src/main/res/layout/stream_view_message_input.xml
@@ -333,7 +333,7 @@
                     android:layout_gravity="center"
                     android:layout_weight="1"
                     android:background="@null"
-                    android:maxLines="100"
+                    android:maxLines="7"
                     android:padding="17dp"
                     android:textSize="15sp"
                     app:layout_constraintBottom_toBottomOf="parent"

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -16,7 +16,7 @@
     <color name="stream_input_message_send_button">#0076FF</color>
     <color name="stream_input_message_box_stroke_select">#0076FF</color>
     <color name="stream_input_message_box_stroke_edit">#0DD25E</color>
-    <color name="stream_input_message_box_background">#0D000000</color>
+    <color name="stream_input_message_box_background">#EDEDED</color>
     <color name="stream_chat_no_connection">#1AD0021B</color>
 
     <!--Message Item-->


### PR DESCRIPTION
# Submit a pull request

- Maxlines 7 for Input text.

- Uploading an image + text

![image](https://user-images.githubusercontent.com/11132956/66497170-5efe8300-eabc-11e9-9fd8-c6e173497f19.png)

