### PR TITLE
Feature/channel list vm event interceptor

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/rest/User.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/User.java
@@ -274,6 +274,20 @@ public class User implements UserEntity {
         this.invisible = invisible;
     }
 
+
+    /**
+     * Returns true if the other user is muted
+     */
+    public boolean hasMuted(User user) {
+        if (mutes == null || mutes.size() == 0)
+            return false;
+        for (Mute mute : getMutes()) {
+            if (mute.getTarget().getId().equals(user.getId()))
+                return true;
+        }
+        return false;
+    }
+
     public List<Mute> getMutes() {
         return mutes;
     }

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/ChatEventHandler.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/ChatEventHandler.java
@@ -6,6 +6,8 @@ import com.getstream.sdk.chat.rest.interfaces.QueryChannelCallback;
 import com.getstream.sdk.chat.rest.request.ChannelQueryRequest;
 import com.getstream.sdk.chat.rest.response.ChannelState;
 
+import static com.getstream.sdk.chat.enums.EventType.NOTIFICATION_MESSAGE_NEW;
+
 public abstract class ChatEventHandler {
 
     public void onUserDisconnected() {}
@@ -189,9 +191,6 @@ public abstract class ChatEventHandler {
             case CONNECTION_RECOVERED:
                 onConnectionRecovered(event);
                 break;
-            case NOTIFICATION_MESSAGE_NEW:
-                dispatchChannelEvent(client, event, this::onNotificationMessageNew);
-                break;
             case NOTIFICATION_MARK_READ:
                 dispatchChannelEvent(client, event, this::onNotificationMarkRead);
                 break;
@@ -204,12 +203,17 @@ public abstract class ChatEventHandler {
             case NOTIFICATION_INVITE_REJECTED:
                 dispatchChannelEvent(client, event, this::onNotificationInviteRejected);
                 break;
+            case NOTIFICATION_MESSAGE_NEW:
             case NOTIFICATION_ADDED_TO_CHANNEL:
                 Channel channel = client.channel(event.getChannel().getCid());
                 channel.query(new ChannelQueryRequest(), new QueryChannelCallback() {
                     @Override
                     public void onSuccess(ChannelState response) {
-                        onNotificationAddedToChannel(channel, event);
+                        if (event.getType() == NOTIFICATION_MESSAGE_NEW) {
+                            onNotificationMessageNew(channel, event);
+                        } else {
+                            onNotificationAddedToChannel(channel, event);
+                        }
                     }
 
                     @Override

--- a/library/src/main/java/com/getstream/sdk/chat/rest/core/ClientState.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/core/ClientState.java
@@ -48,7 +48,6 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 public class ClientState {
 
-
     private static final String TAG = ClientState.class.getSimpleName();
 
     @NotNull

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -89,7 +89,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
         sort = new QuerySort().desc("last_message_at");
 
         setupConnectionRecovery();
-        setEventHandler(new EventHandler((event, channel) -> EventInterceptorAction.CONTINUE));
+        setEventHandler(new EventHandler((event, channel) -> false));
 
         new StreamLifecycleObserver(this);
         retryLooper = new Handler();
@@ -307,21 +307,17 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
     }
 
     /*
-    * EventInterceptor implementations will receive all events (and channel when applicable) to add
-    * custom behavior.
-    *
-    * handleEvent return type tells the view model what to do next: continue with event handling or
-    * stop any processing.
-    *
-    * This allows the developer to disable some built-in mechanism like automatically add a new
-    * channel to the list.
-    */
+     * EventInterceptor implementations will receive all events (and channel when applicable) to add
+     * custom behavior.
+     *
+     * shouldDiscard informs the view model what to do next: continue with event handling or
+     * ignore the event.
+     *
+     * This allows the developer to disable some built-in mechanism like automatically add a new
+     * channel to the list.
+     */
     public interface EventInterceptor {
-        EventInterceptorAction handleEvent(Event event, @Nullable Channel channel);
-    }
-
-    public enum EventInterceptorAction {
-        CONTINUE, STOP
+        boolean shouldDiscard(Event event, @Nullable Channel channel);
     }
 
     public class EventHandler extends ChatEventHandler {
@@ -345,73 +341,73 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
 
         @Override
         public void onNotificationMessageNew(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             upsertChannel(channel);
         }
 
         @Override
         public void onNotificationAddedToChannel(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             upsertChannel(channel);
         }
 
         @Override
         public void onNotificationRemovedFromChannel(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             deleteChannel(channel);
         }
 
         @Override
         public void onMessageNew(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, true);
         }
 
         @Override
         public void onMessageUpdated(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, true);
         }
 
         @Override
         public void onMessageDeleted(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
 
         @Override
         public void onChannelDeleted(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             deleteChannel(channel);
         }
 
         @Override
         public void onChannelUpdated(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
 
         @Override
         public void onMessageRead(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
 
         @Override
         public void onMemberAdded(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
 
         @Override
         public void onMemberUpdated(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
 
         @Override
         public void onMemberRemoved(Channel channel, Event event) {
-            if (interceptor.handleEvent(event, channel) == EventInterceptorAction.STOP) return;
+            if (interceptor.shouldDiscard(event, channel)) return;
             updateChannel(channel, false);
         }
     }

--- a/sample/src/main/java/io/getstream/chat/example/MainActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/MainActivity.java
@@ -125,11 +125,9 @@ public class MainActivity extends AppCompatActivity {
         // Example on how to ignore some events handled by the VM
         //    viewModel.setEventInterceptor((event, channel) -> {
         //        if (event.getType() == EventType.NOTIFICATION_MESSAGE_NEW && event.getMessage() != null) {
-        //            if (client.getUser().hasMuted(event.getMessage().getUser())) {
-        //                return ChannelListViewModel.EventInterceptorAction.STOP;
-        //            }
+        //            return client.getUser().hasMuted(event.getMessage().getUser());
         //        }
-        //        return ChannelListViewModel.EventInterceptorAction.CONTINUE;
+        //        return false;
         //    });
 
         // set the viewModel data for the activity_main.xml layout

--- a/sample/src/main/java/io/getstream/chat/example/MainActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/MainActivity.java
@@ -37,6 +37,7 @@ import io.getstream.chat.example.databinding.ActivityMainBinding;
 
 import static com.getstream.sdk.chat.enums.Filters.and;
 import static com.getstream.sdk.chat.enums.Filters.eq;
+import static java.util.UUID.randomUUID;
 
 
 /**
@@ -61,7 +62,6 @@ public class MainActivity extends AppCompatActivity {
         }
         Crashlytics.setBool("offlineEnabled", offlineEnabled);
 
-
         HashMap<String, Object> extraData = new HashMap<>();
         extraData.put("name", BuildConfig.USER_NAME);
         extraData.put("image", BuildConfig.USER_IMAGE);
@@ -80,6 +80,15 @@ public class MainActivity extends AppCompatActivity {
         });
         return client;
     }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        viewModel = ViewModelProviders.of(this).get(randomUUID().toString(), ChannelListViewModel.class);
+        FilterObject filter = and(eq("type", "messaging"));
+        viewModel.setChannelFilter(filter);
+    }
+
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -111,6 +120,18 @@ public class MainActivity extends AppCompatActivity {
         // ChannelViewHolderFactory factory = new ChannelViewHolderFactory();
         //binding.channelList.setViewHolderFactory(factory);
         viewModel.setChannelFilter(filter);
+
+
+        // Example on how to ignore some events handled by the VM
+        //    viewModel.setEventInterceptor((event, channel) -> {
+        //        if (event.getType() == EventType.NOTIFICATION_MESSAGE_NEW && event.getMessage() != null) {
+        //            if (client.getUser().hasMuted(event.getMessage().getUser())) {
+        //                return ChannelListViewModel.EventInterceptorAction.STOP;
+        //            }
+        //        }
+        //        return ChannelListViewModel.EventInterceptorAction.CONTINUE;
+        //    });
+
         // set the viewModel data for the activity_main.xml layout
         binding.setViewModel(viewModel);
 


### PR DESCRIPTION
Adds a event interceptor interface to allow users to customize ChannelListViewModel event handling.

Example: ignore message notifications from muted users (default behavior is to add the channel to the list automatically)

```java
viewModel.setEventInterceptor((event, channel) -> {
    if (event.getType() == EventType.NOTIFICATION_MESSAGE_NEW && event.getMessage() != null) {
        return client.getUser().hasMuted(event.getMessage().getUser());
    }
    return false;
});
```

Minor fixes:
- we had NPE when the channel list is empty and we get a notification event (adding the channel would crash then)
- NOTIFICATION_MESSAGE_NEW was sent to channel handlers, that does not make sense since the event is sent if the user is not watching the channel