### PR TITLE
Catch error body parsing errors

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/rest/response/ErrorResponse.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/response/ErrorResponse.java
@@ -50,11 +50,10 @@ public class ErrorResponse extends IOException {
         try {
             // avoid consuming the response body stream (might crash other readers)
             message = response.peekBody(Long.MAX_VALUE).string();
-        } catch (IOException e) {
+            return parseError(message);
+        } catch (Throwable e) {
             return new ErrorResponse("", -1, "", 0,"");
         }
-
-        return parseError(message);
     }
 
     public int getCode() {


### PR DESCRIPTION
`ErrorResponse.parseError` might throw exception if response doesn't contain proper body. That's the case for >=4xx errors.