### PR TITLE
Feature/Update Default QuerySort for querying Channels

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelListViewModel.java
@@ -86,7 +86,7 @@ public class ChannelListViewModel extends AndroidViewModel implements LifecycleH
 
         channels = new LazyQueryChannelLiveData<>();
         channels.viewModel = this;
-        sort = new QuerySort().desc("last_message_at");
+        sort = new QuerySort().desc("last_message_at").desc("created_at");
 
         setupConnectionRecovery();
         setEventHandler(new EventHandler((event, channel) -> false));

--- a/sample/src/main/java/io/getstream/chat/example/MainActivity.java
+++ b/sample/src/main/java/io/getstream/chat/example/MainActivity.java
@@ -227,7 +227,8 @@ public class MainActivity extends AppCompatActivity {
                 intent.putExtra(EXTRA_CHANNEL_TYPE, channel.getType());
                 intent.putExtra(EXTRA_CHANNEL_ID, channel.getId());
                 startActivity(intent);
-                viewModel.addChannels(Arrays.asList(channel.getChannelState()));
+                // If you query channels without `created_at` sort option, please uncomment the line below.
+//                viewModel.addChannels(Arrays.asList(channel.getChannelState()));
                 viewModel.setLoadingDone();
             }
 


### PR DESCRIPTION
# Submit a pull request

We need to add `created_at` sort option as the default  as well as `last_message_at` unless customer sets custom sort up.
Then we can prevent the problem for non adding new channel to channel list in case no post message in the channel.(or query channels has no message)