### PR TITLE
Fix/Channel Header Title position issue when Last active is hidden

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/ChannelHeaderView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/ChannelHeaderView.java
@@ -132,7 +132,7 @@ public class ChannelHeaderView extends RelativeLayout {
         binding.tvActive.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getLastActiveTextSize());
         binding.tvActive.setTextColor(style.getLastActiveTextColor());
         binding.tvActive.setTypeface(Typeface.DEFAULT, style.getLastActiveTextStyle());
-        binding.tvActive.setVisibility(style.isLastActiveShow() ? VISIBLE : INVISIBLE);
+        binding.tvActive.setVisibility(style.isLastActiveShow() ? VISIBLE : GONE);
         // Back Button
         binding.tvBack.setVisibility(style.isBackButtonShow() ? VISIBLE : INVISIBLE);
         binding.tvBack.setBackground(style.getBackButtonBackground());


### PR DESCRIPTION
# Submit a pull request

- Fixed the position issue of channel Header Title when Last active is hidden
