### PR TITLE
Update/Reusable attachment title and description for incoming and outgoing message

### DIFF
--- a/docs/MessageList.md
+++ b/docs/MessageList.md
@@ -225,17 +225,26 @@ You must use the following properties in your XML to change your MessageListView
 
 - **AttachmentView**
 
-| Properties                                | Type                 | Default          |
-| ----------------------------------------- | -------------------- | ---------------- |
-| `app:streamAttachmentTitleTextSize`       | dimension            | 13sp             |
-| `app:streamAttachmentTitleTextColor`      | color                | #026DFE          |
-| `app:streamAttachmentTitleTextStyle`      | normal, bold, italic | bold             |
-| `app:streamAttachmentDescriptionTextSize` | dimension            | 11sp             |
-| `app:streamAttachmentDescriptionTextColor`| color                | stream_gray_dark |
-| `app:streamAttachmentDescriptionTextStyle`| normal, bold, italic | normal           |
-| `app:streamAttachmentFileSizeTextSize`    | dimension            | 12sp             |
-| `app:streamAttachmentFileSizeTextColor`   | color                | stream_gray_dark |
-| `app:streamAttachmentFileSizeTextStyle`   | normal, bold, italic | bold             |
+| Properties                                      | Type                 | Default          |
+| ----------------------------------------------- | -------------------- | ---------------- |
+| `app:streamAttachmentTitleTextSizeMine`         | dimension            | 13sp             |
+| `app:streamAttachmentTitleTextSizeTheirs`       | dimension            | 13sp             |
+| `app:streamAttachmentTitleTextColorMine`        | color                | #026DFE          |
+| `app:streamAttachmentTitleTextColorTheirs`      | color                | #026DFE          |
+| `app:streamAttachmentTitleTextStyleMine`        | normal, bold, italic | bold             |
+| `app:streamAttachmentTitleTextStyleTheirs`      | normal, bold, italic | bold             |
+| `app:streamAttachmentDescriptionTextSizeMine`   | dimension            | 11sp             |
+| `app:streamAttachmentDescriptionTextSizeTheirs` | dimension            | 11sp             |
+| `app:streamAttachmentDescriptionTextColorMine`  | color                | stream_gray_dark |
+| `app:streamAttachmentDescriptionTextColorTheirs`| color                | stream_gray_dark |
+| `app:streamAttachmentDescriptionTextStyleMine`  | normal, bold, italic | normal           |
+| `app:streamAttachmentDescriptionTextStyleTheirs`| normal, bold, italic | normal           |
+| `app:streamAttachmentFileSizeTextSizeMine`      | dimension            | 12sp             |
+| `app:streamAttachmentFileSizeTextSizeTheirs`    | dimension            | 12sp             |
+| `app:streamAttachmentFileSizeTextColorMine`     | color                | stream_gray_dark |
+| `app:streamAttachmentFileSizeTextColorTheirs`   | color                | stream_gray_dark |
+| `app:streamAttachmentFileSizeTextStyleMine`     | normal, bold, italic | bold             |
+| `app:streamAttachmentFileSizeTextStyleTheirs`   | normal, bold, italic | bold             |
 
 - **Date Separator**
 

--- a/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
+++ b/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
@@ -80,7 +80,6 @@ public class DefaultBubbleHelper {
                             bottomRightRadius = context.getResources().getDimensionPixelSize(R.dimen.stream_message_corner_radius2);
                     }
                 }
-                bgColor = Color.WHITE;
                 return getBubbleDrawable();
             }
 

--- a/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
+++ b/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
@@ -52,8 +52,7 @@ public class DefaultBubbleHelper {
             @Override
             public Drawable getDrawableForAttachment(Message message, Boolean mine, List<MessageViewHolderFactory.Position> positions, Attachment attachment) {
                 if (attachment == null
-                        || attachment.getType().equals(ModelType.attach_unknown)
-                        || attachment.getType().equals(ModelType.attach_file))
+                        || attachment.getType().equals(ModelType.attach_unknown))
                     return null;
 
                 if (mine) {

--- a/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
+++ b/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
@@ -60,9 +60,6 @@ public class DefaultBubbleHelper {
                     configParamsMine(style);
                     if (isDefaultBubble(style, context)) {
                         applyStyleDefaultMine(positions, context);
-                        // set corner radius if the attachment has title or description
-                        if (!TextUtils.isEmpty(attachment.getTitle()) && !attachment.getType().equals(ModelType.attach_file))
-                            bottomRightRadius = bottomLeftRadius = 0;
                         // set corner radius if message has multi attachments
                         if (message.getAttachments().indexOf(attachment) > 0)
                             topRightRadius = context.getResources().getDimensionPixelSize(R.dimen.stream_message_corner_radius2);
@@ -74,14 +71,14 @@ public class DefaultBubbleHelper {
                     configParamsTheirs(style);
                     if (isDefaultBubble(style, context)) {
                         applyStyleDefaultTheirs(positions, context);
-                        // set corner radius if the attachment has title or description
-                        if (!TextUtils.isEmpty(attachment.getTitle()) && !attachment.getType().equals(ModelType.attach_file))
-                            bottomRightRadius = bottomLeftRadius = 0;
                         // set corner radius if message has multi attachments
                         if (message.getAttachments().indexOf(attachment) > 0)
                             topLeftRadius = context.getResources().getDimensionPixelSize(R.dimen.stream_message_corner_radius2);
                     }
                 }
+                // set corner radius if the attachment has title or description
+                if (!TextUtils.isEmpty(attachment.getTitle()) && !attachment.getType().equals(ModelType.attach_file))
+                    bottomRightRadius = bottomLeftRadius = 0;
                 return getBubbleDrawable();
             }
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolder.java
@@ -225,12 +225,13 @@ public class AttachmentViewHolder extends BaseAttachmentViewHolder {
     }
 
     private void applyStyle() {
-        tv_media_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize());
-        tv_media_title.setTextColor(style.getAttachmentTitleTextColor());
-        tv_media_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle());
+        boolean isMine = getMessageListItem().isMine();
+        tv_media_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize(isMine));
+        tv_media_title.setTextColor(style.getAttachmentTitleTextColor(isMine));
+        tv_media_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle(isMine));
 
-        tv_media_des.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentDescriptionTextSize());
-        tv_media_des.setTextColor(style.getAttachmentDescriptionTextColor());
-        tv_media_des.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentDescriptionTextStyle());
+        tv_media_des.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentDescriptionTextSize(isMine));
+        tv_media_des.setTextColor(style.getAttachmentDescriptionTextColor(isMine));
+        tv_media_des.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentDescriptionTextStyle(isMine));
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
@@ -47,13 +47,14 @@ public class AttachmentViewHolderFile extends BaseAttachmentViewHolder {
     }
 
     private void applyStyle() {
-        tv_file_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize());
-        tv_file_title.setTextColor(style.getAttachmentTitleTextColor());
-        tv_file_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle());
+        boolean isMine = getMessageListItem().isMine();
+        tv_file_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize(isMine));
+        tv_file_title.setTextColor(style.getAttachmentTitleTextColor(isMine));
+        tv_file_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle(isMine));
 
-        tv_file_size.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentFileSizeTextSize());
-        tv_file_size.setTextColor(style.getAttachmentFileSizeTextColor());
-        tv_file_size.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentFileSizeTextStyle());
+        tv_file_size.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentFileSizeTextSize(isMine));
+        tv_file_size.setTextColor(style.getAttachmentFileSizeTextColor(isMine));
+        tv_file_size.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentFileSizeTextStyle(isMine));
     }
 
     private void configAttachment() {

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderMedia.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderMedia.java
@@ -155,13 +155,14 @@ public class AttachmentViewHolderMedia extends BaseAttachmentViewHolder {
     }
 
     private void applyStyle() {
-        tv_media_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize());
-        tv_media_title.setTextColor(style.getAttachmentTitleTextColor());
-        tv_media_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle());
+        boolean isMine = getMessageListItem().isMine();
+        tv_media_title.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentTitleTextSize(isMine));
+        tv_media_title.setTextColor(style.getAttachmentTitleTextColor(isMine));
+        tv_media_title.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentTitleTextStyle(isMine));
 
-        tv_media_des.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentDescriptionTextSize());
-        tv_media_des.setTextColor(style.getAttachmentDescriptionTextColor());
-        tv_media_des.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentDescriptionTextStyle());
+        tv_media_des.setTextSize(TypedValue.COMPLEX_UNIT_PX, style.getAttachmentDescriptionTextSize(isMine));
+        tv_media_des.setTextColor(style.getAttachmentDescriptionTextColor(isMine));
+        tv_media_des.setTypeface(Typeface.DEFAULT_BOLD, style.getAttachmentDescriptionTextStyle(isMine));
     }
 
     public void setGiphySendListener(MessageListView.GiphySendListener giphySendListener) {

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.java
@@ -37,17 +37,29 @@ public class MessageListViewStyle extends BaseStyle {
     private int messageBorderWidthMine;
     private int messageBorderWidthTheirs;
     // Attachment
-    private int attachmentTitleTextSize;
-    private int attachmentTitleTextColor;
-    private int attachmentTitleTextStyle;
+    private int attachmentTitleTextSizeMine;
+    private int attachmentTitleTextColorMine;
+    private int attachmentTitleTextStyleMine;
 
-    private int attachmentDescriptionTextSize;
-    private int attachmentDescriptionTextColor;
-    private int attachmentDescriptionTextStyle;
+    private int attachmentTitleTextSizeTheirs;
+    private int attachmentTitleTextColorTheirs;
+    private int attachmentTitleTextStyleTheirs;
 
-    private int attachmentFileSizeTextSize;
-    private int attachmentFileSizeTextColor;
-    private int attachmentFileSizeTextStyle;
+    private int attachmentDescriptionTextSizeMine;
+    private int attachmentDescriptionTextColorMine;
+    private int attachmentDescriptionTextStyleMine;
+
+    private int attachmentDescriptionTextSizeTheirs;
+    private int attachmentDescriptionTextColorTheirs;
+    private int attachmentDescriptionTextStyleTheirs;
+
+    private int attachmentFileSizeTextSizeMine;
+    private int attachmentFileSizeTextColorMine;
+    private int attachmentFileSizeTextStyleMine;
+
+    private int attachmentFileSizeTextSizeTheirs;
+    private int attachmentFileSizeTextColorTheirs;
+    private int attachmentFileSizeTextStyleTheirs;
     // Reaction
     private boolean reactionEnabled;
     // ReactionView
@@ -109,17 +121,29 @@ public class MessageListViewStyle extends BaseStyle {
         messageBorderWidthMine = a.getDimensionPixelSize(R.styleable.MessageListView_streamMessageBorderWidthMine, getDimension(R.dimen.stream_message_stroke));
         messageBorderWidthTheirs = a.getDimensionPixelSize(R.styleable.MessageListView_streamMessageBorderWidthTheirs, getDimension(R.dimen.stream_message_stroke));
         // Attachment
-        attachmentTitleTextSize = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentTitleTextSize, getDimension(R.dimen.stream_attach_title_text));
-        attachmentTitleTextColor = a.getColor(R.styleable.MessageListView_streamAttachmentTitleTextColor, getColor(R.color.stream_attach_title_text));
-        attachmentTitleTextStyle = a.getInt(R.styleable.MessageListView_streamAttachmentTitleTextStyle, Typeface.BOLD);
+        attachmentTitleTextSizeMine = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentTitleTextSizeMine, getDimension(R.dimen.stream_attach_title_text));
+        attachmentTitleTextColorMine = a.getColor(R.styleable.MessageListView_streamAttachmentTitleTextColorMine, getColor(R.color.stream_attach_title_text));
+        attachmentTitleTextStyleMine = a.getInt(R.styleable.MessageListView_streamAttachmentTitleTextStyleMine, Typeface.BOLD);
 
-        attachmentDescriptionTextSize = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentDescriptionTextSize, getDimension(R.dimen.stream_attach_description_text));
-        attachmentDescriptionTextColor = a.getColor(R.styleable.MessageListView_streamAttachmentDescriptionTextColor, getColor(R.color.stream_gray_dark));
-        attachmentDescriptionTextStyle = a.getInt(R.styleable.MessageListView_streamAttachmentDescriptionTextStyle, Typeface.NORMAL);
+        attachmentTitleTextSizeTheirs = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentTitleTextSizeTheirs, getDimension(R.dimen.stream_attach_title_text));
+        attachmentTitleTextColorTheirs = a.getColor(R.styleable.MessageListView_streamAttachmentTitleTextColorTheirs, getColor(R.color.stream_attach_title_text));
+        attachmentTitleTextStyleTheirs = a.getInt(R.styleable.MessageListView_streamAttachmentTitleTextStyleTheirs, Typeface.BOLD);
 
-        attachmentFileSizeTextSize = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentFileSizeTextSize, getDimension(R.dimen.stream_attach_file_size_text));
-        attachmentFileSizeTextColor = a.getColor(R.styleable.MessageListView_streamAttachmentFileSizeTextColor, getColor(R.color.stream_gray_dark));
-        attachmentFileSizeTextStyle = a.getInt(R.styleable.MessageListView_streamAttachmentFileSizeTextStyle, Typeface.BOLD);
+        attachmentDescriptionTextSizeMine = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentDescriptionTextSizeMine, getDimension(R.dimen.stream_attach_description_text));
+        attachmentDescriptionTextColorMine = a.getColor(R.styleable.MessageListView_streamAttachmentDescriptionTextColorMine, getColor(R.color.stream_gray_dark));
+        attachmentDescriptionTextStyleMine = a.getInt(R.styleable.MessageListView_streamAttachmentDescriptionTextStyleMine, Typeface.NORMAL);
+
+        attachmentDescriptionTextSizeTheirs = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentDescriptionTextSizeTheirs, getDimension(R.dimen.stream_attach_description_text));
+        attachmentDescriptionTextColorTheirs = a.getColor(R.styleable.MessageListView_streamAttachmentDescriptionTextColorTheirs, getColor(R.color.stream_gray_dark));
+        attachmentDescriptionTextStyleTheirs = a.getInt(R.styleable.MessageListView_streamAttachmentDescriptionTextStyleTheirs, Typeface.NORMAL);
+
+        attachmentFileSizeTextSizeMine = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentFileSizeTextSizeMine, getDimension(R.dimen.stream_attach_file_size_text));
+        attachmentFileSizeTextColorMine = a.getColor(R.styleable.MessageListView_streamAttachmentFileSizeTextColorMine, getColor(R.color.stream_gray_dark));
+        attachmentFileSizeTextStyleMine = a.getInt(R.styleable.MessageListView_streamAttachmentFileSizeTextStyleMine, Typeface.BOLD);
+
+        attachmentFileSizeTextSizeTheirs = a.getDimensionPixelSize(R.styleable.MessageListView_streamAttachmentFileSizeTextSizeTheirs, getDimension(R.dimen.stream_attach_file_size_text));
+        attachmentFileSizeTextColorTheirs = a.getColor(R.styleable.MessageListView_streamAttachmentFileSizeTextColorTheirs, getColor(R.color.stream_gray_dark));
+        attachmentFileSizeTextStyleTheirs = a.getInt(R.styleable.MessageListView_streamAttachmentFileSizeTextStyleTheirs, Typeface.BOLD);
         // Reaction
         reactionEnabled = a.getBoolean(R.styleable.MessageListView_streamReactionEnabled, true);
 
@@ -257,40 +281,40 @@ public class MessageListViewStyle extends BaseStyle {
     }
 
     // Attachment
-    public int getAttachmentTitleTextSize() {
-        return attachmentTitleTextSize;
+    public int getAttachmentTitleTextSize(boolean isMine) {
+        return isMine ? attachmentTitleTextSizeMine : attachmentTitleTextSizeTheirs;
     }
 
-    public int getAttachmentTitleTextColor() {
-        return attachmentTitleTextColor;
+    public int getAttachmentTitleTextColor(boolean isMine) {
+        return isMine ? attachmentTitleTextColorMine : attachmentTitleTextColorTheirs;
     }
 
-    public int getAttachmentTitleTextStyle() {
-        return attachmentTitleTextStyle;
+    public int getAttachmentTitleTextStyle(boolean isMine) {
+        return isMine ? attachmentTitleTextStyleMine : attachmentTitleTextStyleTheirs;
     }
 
-    public int getAttachmentDescriptionTextSize() {
-        return attachmentDescriptionTextSize;
+    public int getAttachmentDescriptionTextSize(boolean isMine) {
+        return isMine ? attachmentDescriptionTextSizeMine : attachmentDescriptionTextSizeTheirs;
     }
 
-    public int getAttachmentDescriptionTextColor() {
-        return attachmentDescriptionTextColor;
+    public int getAttachmentDescriptionTextColor(boolean isMine) {
+        return isMine ? attachmentDescriptionTextColorMine : attachmentDescriptionTextColorTheirs;
     }
 
-    public int getAttachmentDescriptionTextStyle() {
-        return attachmentDescriptionTextStyle;
+    public int getAttachmentDescriptionTextStyle(boolean isMine) {
+        return isMine ? attachmentDescriptionTextStyleMine : attachmentDescriptionTextStyleTheirs;
     }
 
-    public int getAttachmentFileSizeTextSize() {
-        return attachmentFileSizeTextSize;
+    public int getAttachmentFileSizeTextSize(boolean isMine) {
+        return isMine ? attachmentFileSizeTextSizeMine : attachmentFileSizeTextSizeTheirs;
     }
 
-    public int getAttachmentFileSizeTextColor() {
-        return attachmentFileSizeTextColor;
+    public int getAttachmentFileSizeTextColor(boolean isMine) {
+        return isMine ? attachmentFileSizeTextColorMine : attachmentFileSizeTextColorTheirs;
     }
 
-    public int getAttachmentFileSizeTextStyle() {
-        return attachmentFileSizeTextStyle;
+    public int getAttachmentFileSizeTextStyle(boolean isMine) {
+        return isMine ? attachmentFileSizeTextStyleMine : attachmentFileSizeTextStyleTheirs;
     }
 
     // Reaction Dialog

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -187,30 +187,54 @@
         <attr name="streamMessageBorderWidthMine" format="dimension|reference" />
         <attr name="streamMessageBorderWidthTheirs" format="dimension|reference" />
         <!-- Attachment-->
-        <attr name="streamAttachmentTitleTextSize" format="dimension|reference" />
-        <attr name="streamAttachmentTitleTextColor" format="color" />
-        <attr name="streamAttachmentTitleTextStyle">
+        <attr name="streamAttachmentTitleTextSizeMine" format="dimension|reference" />
+        <attr name="streamAttachmentTitleTextColorMine" format="color" />
+        <attr name="streamAttachmentTitleTextStyleMine">
             <flag name="normal" value="0" />
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
 
-        <attr name="streamAttachmentDescriptionTextSize" format="dimension|reference" />
-        <attr name="streamAttachmentDescriptionTextColor" format="color" />
-        <attr name="streamAttachmentDescriptionTextStyle">
+        <attr name="streamAttachmentTitleTextSizeTheirs" format="dimension|reference" />
+        <attr name="streamAttachmentTitleTextColorTheirs" format="color" />
+        <attr name="streamAttachmentTitleTextStyleTheirs">
             <flag name="normal" value="0" />
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
 
-        <attr name="streamAttachmentFileSizeTextSize" format="dimension|reference" />
-        <attr name="streamAttachmentFileSizeTextColor" format="color" />
-        <attr name="streamAttachmentFileSizeTextStyle">
+        <attr name="streamAttachmentDescriptionTextSizeMine" format="dimension|reference" />
+        <attr name="streamAttachmentDescriptionTextColorMine" format="color" />
+        <attr name="streamAttachmentDescriptionTextStyleMine">
             <flag name="normal" value="0" />
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
-        
+
+        <attr name="streamAttachmentDescriptionTextSizeTheirs" format="dimension|reference" />
+        <attr name="streamAttachmentDescriptionTextColorTheirs" format="color" />
+        <attr name="streamAttachmentDescriptionTextStyleTheirs">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamAttachmentFileSizeTextSizeMine" format="dimension|reference" />
+        <attr name="streamAttachmentFileSizeTextColorMine" format="color" />
+        <attr name="streamAttachmentFileSizeTextStyleMine">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamAttachmentFileSizeTextSizeTheirs" format="dimension|reference" />
+        <attr name="streamAttachmentFileSizeTextColorTheirs" format="color" />
+        <attr name="streamAttachmentFileSizeTextStyleTheirs">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
         <attr name="streamThreadEnabled" format="boolean" />
         <!--Date Separator-->
         <attr name="streamDateSeparatorDateTextSize" format="dimension|reference" />

--- a/library/src/main/res/values/colors.xml
+++ b/library/src/main/res/values/colors.xml
@@ -21,8 +21,8 @@
     <color name="stream_chat_no_connection">#1AD0021B</color>
     <!--Message Item-->
     <color name="stream_message_background_incoming">#FFFFFF</color>
-    <color name="stream_message_background_outgoing">#0D000000</color>
-    <color name="stream_message_stroke">#14000000</color>
+    <color name="stream_message_background_outgoing">#EDEDED</color>
+    <color name="stream_message_stroke">#E6E6E6</color>
     <color name="stream_message_failed">#1AD0021B</color>
     <color name="stream_message_reply_text">#006CFF</color>
     <color name="stream_reaction_input_background">#292929</color>


### PR DESCRIPTION
# Submit a pull request

- **AttachmentView**

| Properties                                      | Type                 | Default          |
| ----------------------------------------------- | -------------------- | ---------------- |
| `app:streamAttachmentTitleTextSizeMine`         | dimension            | 13sp             |
| `app:streamAttachmentTitleTextSizeTheirs`       | dimension            | 13sp             |
| `app:streamAttachmentTitleTextColorMine`        | color                | #026DFE          |
| `app:streamAttachmentTitleTextColorTheirs`      | color                | #026DFE          |
| `app:streamAttachmentTitleTextStyleMine`        | normal, bold, italic | bold             |
| `app:streamAttachmentTitleTextStyleTheirs`      | normal, bold, italic | bold             |
| `app:streamAttachmentDescriptionTextSizeMine`   | dimension            | 11sp             |
| `app:streamAttachmentDescriptionTextSizeTheirs` | dimension            | 11sp             |
| `app:streamAttachmentDescriptionTextColorMine`  | color                | stream_gray_dark |
| `app:streamAttachmentDescriptionTextColorTheirs`| color                | stream_gray_dark |
| `app:streamAttachmentDescriptionTextStyleMine`  | normal, bold, italic | normal           |
| `app:streamAttachmentDescriptionTextStyleTheirs`| normal, bold, italic | normal           |
| `app:streamAttachmentFileSizeTextSizeMine`      | dimension            | 12sp             |
| `app:streamAttachmentFileSizeTextSizeTheirs`    | dimension            | 12sp             |
| `app:streamAttachmentFileSizeTextColorMine`     | color                | stream_gray_dark |
| `app:streamAttachmentFileSizeTextColorTheirs`   | color                | stream_gray_dark |
| `app:streamAttachmentFileSizeTextStyleMine`     | normal, bold, italic | bold             |
| `app:streamAttachmentFileSizeTextStyleTheirs`   | normal, bold, italic | bold             |



