### PR TITLE
Update/ReadMe for Custom Font

### DIFF
--- a/docs/ChannelHeader.md
+++ b/docs/ChannelHeader.md
@@ -206,6 +206,8 @@ You must use the following properties in your XML to change your ChannelHeaderVi
 | `app:streamAvatarTextSize`                       | dimension            | 14sp       |
 | `app:streamAvatarTextColor`                      | color                | WHITE      |
 | `app:streamAvatarTextStyle`                      | normal, bold, italic | bold       |
+| `app:streamAvatarTextFont`                       | reference            | -          |
+| `app:streamAvatarTextFontAssets`                 | string               | -          |
 
 - **Header Title**
 
@@ -215,17 +217,20 @@ You must use the following properties in your XML to change your ChannelHeaderVi
 | `app:streamChannelHeaderTitleTextSize`           | dimension            | 16sp                 |
 | `app:streamChannelHeaderTitleTextColor`          | color                | BLACK                |
 | `app:streamChannelHeaderTitleTextStyle`          | normal, bold, italic | bold                 |
+| `app:streamChannelHeaderTitleTextFont`           | reference            | -                    |
+| `app:streamChannelHeaderTitleTextFontAssets`     | string               | -                    |
 		
 - **Last Active**
 
-| Properties                                       | Type                 | Default                |
-| ------------------------------------------------ | -------------------- | ---------------------- |
-| `app:streamChannelHeaderOfflineText`             | string               | Waiting for network... |
-| `app:streamChannelHeaderLastActiveShow`          | boolean              | true                   |
-| `app:streamChannelHeaderLastActiveTextSize`      | dimension            | 11sp                   |
-| `app:streamChannelHeaderLastActiveTextColor`     | color                | stream_gray_dark       |
-| `app:streamChannelHeaderLastActiveTextStyle`     | normal, bold, italic | normal                 |
-
+| Properties                                        | Type                 | Default                |
+| ------------------------------------------------- | -------------------- | ---------------------- |
+| `app:streamChannelHeaderOfflineText`              | string               | Waiting for network... |
+| `app:streamChannelHeaderLastActiveShow`           | boolean              | true                   |
+| `app:streamChannelHeaderLastActiveTextSize`       | dimension            | 11sp                   |
+| `app:streamChannelHeaderLastActiveTextColor`      | color                | stream_gray_dark       |
+| `app:streamChannelHeaderLastActiveTextStyle`      | normal, bold, italic | normal                 |
+| `app:streamChannelHeaderLastActiveTextFont`       | reference            | -                      |
+| `app:streamChannelHeaderLastActiveTextFontAssets` | string               | -                      |
 
 - **Back Button**
 

--- a/docs/ChannelList.md
+++ b/docs/ChannelList.md
@@ -154,16 +154,18 @@ You must use the following properties in your XML to change your ChannelListView
 
 - **AvatarView**
 
-| Properties                          | Type                  | Default          |
-| ----------------------------------- | --------------------- | ---------------- |
-| `app:streamAvatarWidth`             | dimension             | 40dp             |
-| `app:streamAvatarHeight`            | dimension             | 40dp             |
-| `app:streamAvatarBorderWidth`       | dimension             | 3dp              |
-| `app:streamAvatarBorderColor`       | color                 | WHITE            |
-| `app:streamAvatarBackGroundColor`   | color                 | stream_gray_dark |
-| `app:streamAvatarTextSize`          | dimension             | 14sp             |
-| `app:streamAvatarTextColor`         | color                 | WHITE            |
-| `app:streamAvatarTextStyle`         | normal, bold, italic  | bold             |
+| Properties                         | Type                  | Default          |
+| ---------------------------------- | --------------------- | ---------------- |
+| `app:streamAvatarWidth`            | dimension             | 40dp             |
+| `app:streamAvatarHeight`           | dimension             | 40dp             |
+| `app:streamAvatarBorderWidth`      | dimension             | 3dp              |
+| `app:streamAvatarBorderColor`      | color                 | WHITE            |
+| `app:streamAvatarBackGroundColor`  | color                 | stream_gray_dark |
+| `app:streamAvatarTextSize`         | dimension             | 14sp             |
+| `app:streamAvatarTextColor`        | color                 | WHITE            |
+| `app:streamAvatarTextStyle`        | normal, bold, italic  | bold             |
+| `app:streamAvatarTextFont`         | reference             | -                |
+| `app:streamAvatarTextFontAssets`   | string                | -                |
 
 - **ReadStateView**
 
@@ -175,44 +177,43 @@ You must use the following properties in your XML to change your ChannelListView
 | `app:streamReadStateTextSize`       | dimension             | 8sp     |
 | `app:streamReadStateTextColor`      | color                 | BLACK   |
 | `app:streamReadStateTextStyle`      | normal, bold, italic  | bold    |
+| `app:streamReadStateTextFont`       | reference             | -       |
+| `app:streamReadStateTextFontAssets` | string                | -       |
 
 - **Channel Title**
 
 | Properties                                 | Type                  | Default              |
 | ------------------------------------------ | --------------------- | -------------------- |
-| `app:streamTitleTextSize`                  | dimension             | 15sp                 |
-| `app:streamTitleTextColor`                 | color                 | BLACK                |
-| `app:streamTitleTextStyle`                 | normal, bold, italic  | bold                 |
+| `app:streamChannelTitleTextSize`           | dimension             | 15sp                 |
+| `app:streamChannelTitleTextColor`          | color                 | BLACK                |
+| `app:streamChannelTitleUnreadTextColor`    | color                 | BLACK                |
+| `app:streamChannelTitleTextStyle`          | normal, bold, italic  | bold                 |
+| `app:streamChannelTitleUnreadTextStyle`    | normal, bold, italic  | bold                 |
 | `app:streamChannelWithOutNameTitleText`    | string                | Channel without name |
 
 - **Last Message**
 
-| Properties                          | Type                  | Default          |
-| ----------------------------------- | --------------------- | ---------------- |
-| `app:streamMessageTextSize`         | dimension             | 13sp             |
-| `app:streamMessageTextColor`        | color                 | stream_gray_dark |
-| `app:streamMessageTextStyle`        | normal, bold, italic  | normal           |
+| Properties                              | Type                  | Default          |
+| --------------------------------------- | --------------------- | ---------------- |
+| `app:streamLastMessageTextSize`         | dimension             | 13sp             |
+| `app:streamLastMessageTextColor`        | color                 | stream_gray_dark |
+| `app:streamLastMessageUnreadTextColor`  | color                 | BLACK            |
+| `app:streamLastMessageTextStyle`        | normal, bold, italic  | normal           |
+| `app:streamLastMessageUnreadTextStyle`  | normal, bold, italic  | bold             |
+| `app:streamLastMessageTextFont`         | reference             | -                |
+| `app:streamLastMessageTextFontAssets`   | string                | -                |
 
 - **Last Message Date**
 
-| Properties                          | Type                  | Default          |
-| ----------------------------------- | --------------------- | ---------------- |
-| `app:streamLastMessageDateTextSize` | dimension             | 11sp             |
-| `app:streamLastMessageDateTextColor`| color                 | stream_gray_dark |
-
-- **Unread Channel Title**
-
-| Properties                          | Type                  | Default |
-| ----------------------------------- | --------------------- | ------- |
-| `app:streamUnreadTitleTextColor`    | color                 | BLACK   |
-| `app:streamUnreadTitleTextStyle`    | normal, bold, italic  | bold    |
-
-- **Unread Last Message**
-
-| Properties                          | Type                  | Default |
-| ----------------------------------- | --------------------- | ------- |
-| `app:streamUnreadMessageTextColor`  | color                 | BLACK   |
-| `app:streamUnreadMessageTextStyle`  | normal, bold, italic  | bold    |
+| Properties                                 | Type                  | Default          |
+| ------------------------------------------ | --------------------- | ---------------- |
+| `app:streamLastMessageDateTextSize`        | dimension             | 11sp             |
+| `app:streamLastMessageDateTextColor`       | color                 | stream_gray_dark |
+| `app:streamLastMessageDateUnreadTextColor` | color                 | BLACK            |
+| `app:streamLastMessageDateTextStyle`       | normal, bold, italic  | normal           |
+| `app:streamLastMessageDateUnreadTextStyle` | normal, bold, italic  | bold             |
+| `app:streamLastMessageDateTextFont`        | reference             | -                |
+| `app:streamLastMessageDateTextFontAssets`  | string                | -                |
 
 - **Custom Layout**
 

--- a/docs/MessageInput.md
+++ b/docs/MessageInput.md
@@ -33,6 +33,8 @@ You must use the following properties in your XML to change your MessageInputVie
 | `app:streamAvatarTextSize`         | dimension              | 14sp    |
 | `app:streamAvatarTextColor`        | color                  | WHITE   |
 | `app:streamAvatarTextStyle`        | normal, bold, italic   | bold    |
+| `app:streamAvatarTextFont`         | reference              | -       |
+| `app:streamAvatarTextFontAssets`   | string                 | -       |
 
 - **Attachment Button**
 
@@ -62,23 +64,29 @@ You must use the following properties in your XML to change your MessageInputVie
 		
 - **Input Text**
 
-| Properties                  | Type                  | Default          |
-| --------------------------- | --------------------- | ---------------- |
-| `app:streamInputHint`       | string                | Write a message  |
-| `app:streamInputTextSize`   | dimension             | 15sp             |
-| `app:streamInputTextColor`  | color                 | BLACK            |
-| `app:streamInputHintColor`  | color                 | stream_gray_dark |
-| `app:streamInputTextStyle`  | normal, bold, italic  | normal           |
-
+| Properties                      | Type                  | Default          |
+| ------------------------------- | --------------------- | ---------------- |
+| `app:streamInputHint`           | string                | Write a message  |
+| `app:streamInputTextSize`       | dimension             | 15sp             |
+| `app:streamInputTextColor`      | color                 | BLACK            |
+| `app:streamInputHintColor`      | color                 | stream_gray_dark |
+| `app:streamInputTextStyle`      | normal, bold, italic  | normal           |
+| `app:streamInputTextFont`       | reference             | -                |
+| `app:streamInputTextFontAssets` | string                | -                |
 
 
 - **Input Background**
 
-| Properties                          | Type        | Default |
-| ----------------------------------- | ----------- | ------- |
-| `app:streamInputBackground`         | reference   | -       |
-| `app:streamInputSelectedBackground` | reference   | -       |
-| `app:streamInputEditBackground`     | reference   | -       |
+| Properties                                | Type                  | Default |
+| ----------------------------------------- | --------------------- | ------- |
+| `app:streamInputBackground`               | reference             | -       |
+| `app:streamInputSelectedBackground`       | reference             | -       |
+| `app:streamInputEditBackground`           | reference             | -       |
+| `app:streamInputBackgroundTextSize`       | dimension             | 15sp    |
+| `app:streamInputBackgroundTextColor`      | color                 | BLACK   |
+| `app:streamInputBackgroundTextStyle`      | normal, bold, italic  | normal  |
+| `app:streamInputBackgroundTextFont`       | reference             | -       |
+| `app:streamInputBackgroundTextFontAssets` | string                | -       |
 
 
 #### Listeners

--- a/docs/MessageList.md
+++ b/docs/MessageList.md
@@ -171,17 +171,21 @@ You must use the following properties in your XML to change your MessageListView
 | `app:streamAvatarTextSize`         | dimension              | 14sp             |
 | `app:streamAvatarTextColor`        | color                  | WHITE            |
 | `app:streamAvatarTextStyle`        | normal, bold, italic   | bold             |
+| `app:streamAvatarTextFont`         | reference              | -                |
+| `app:streamAvatarTextFontAssets`   | string                 | -                |
 
 - **ReadStateView**
 
-| Properties                         | Type                   | Default |
-| ---------------------------------- | ---------------------- | ------- |
-| `app:streamShowReadState`          | boolean                | true    |
-| `app:streamReadStateAvatarWidth`   | dimension              | 14dp    |
-| `app:streamReadStateAvatarHeight`  | dimension              | 14dp    |
-| `app:streamReadStateTextSize`      | dimension              | 8sp     |
-| `app:streamReadStateTextColor`     | color                  | BLACK   |
-| `app:streamReadStateTextStyle`     | normal, bold, italic   | bold    |
+| Properties                          | Type                   | Default |
+| ----------------------------------- | ---------------------- | ------- |
+| `app:streamShowReadState`           | boolean                | true    |
+| `app:streamReadStateAvatarWidth`    | dimension              | 14dp    |
+| `app:streamReadStateAvatarHeight`   | dimension              | 14dp    |
+| `app:streamReadStateTextSize`       | dimension              | 8sp     |
+| `app:streamReadStateTextColor`      | color                  | BLACK   |
+| `app:streamReadStateTextStyle`      | normal, bold, italic   | bold    |
+| `app:streamReadStateTextFont`       | reference              | -       |
+| `app:streamReadStateTextFontAssets` | string                 | -       |
 
 - **Reaction**
 
@@ -206,6 +210,10 @@ You must use the following properties in your XML to change your MessageListView
 | `app:streamMessageTextColorTheirs`              | color                | BLACK     |
 | `app:streamMessageTextStyleMine`                | normal, bold, italic | normal    |
 | `app:streamMessageTextStyleTheirs`              | normal, bold, italic | normal    |
+| `app:streamMessageTextFontMine`                 | reference            | -         |
+| `app:streamMessageTextFontTheirs`               | reference            | -         |
+| `app:streamMessageTextFontMineAssets`           | string               | -         |
+| `app:streamMessageTextFontTheirsAssets`         | string               | -         |
 | `app:streamMessageBubbleDrawableMine`           | reference            | -         |
 | `app:streamMessageBubbleDrawableTheirs`         | reference            | -         |
 | `app:streamMessageTopLeftCornerRadiusMine`      | dimension            | 16dp      |
@@ -225,55 +233,73 @@ You must use the following properties in your XML to change your MessageListView
 
 - **AttachmentView**
 
-| Properties                                      | Type                 | Default                            |
-| ----------------------------------------------- | -------------------- | ---------------------------------- |
-| `app:streamAttachmentBackgroundColorMine`       | color                | streamMessageBackgroundColorMine   |
-| `app:streamAttachmentBackgroundColorTheirs`     | color                | streamMessageBackgroundColorTheirs |
-| `app:streamAttachmentTitleTextSizeMine`         | dimension            | 13sp                               |
-| `app:streamAttachmentTitleTextSizeTheirs`       | dimension            | 13sp                               |
-| `app:streamAttachmentTitleTextColorMine`        | color                | #026DFE                            |
-| `app:streamAttachmentTitleTextColorTheirs`      | color                | #026DFE                            |
-| `app:streamAttachmentTitleTextStyleMine`        | normal, bold, italic | bold                               |
-| `app:streamAttachmentTitleTextStyleTheirs`      | normal, bold, italic | bold                               |
-| `app:streamAttachmentDescriptionTextSizeMine`   | dimension            | 11sp                               |
-| `app:streamAttachmentDescriptionTextSizeTheirs` | dimension            | 11sp                               |
-| `app:streamAttachmentDescriptionTextColorMine`  | color                | stream_gray_dark                   |
-| `app:streamAttachmentDescriptionTextColorTheirs`| color                | stream_gray_dark                   |
-| `app:streamAttachmentDescriptionTextStyleMine`  | normal, bold, italic | normal                             |
-| `app:streamAttachmentDescriptionTextStyleTheirs`| normal, bold, italic | normal                             |
-| `app:streamAttachmentFileSizeTextSizeMine`      | dimension            | 12sp                               |
-| `app:streamAttachmentFileSizeTextSizeTheirs`    | dimension            | 12sp                               |
-| `app:streamAttachmentFileSizeTextColorMine`     | color                | stream_gray_dark                   |
-| `app:streamAttachmentFileSizeTextColorTheirs`   | color                | stream_gray_dark                   |
-| `app:streamAttachmentFileSizeTextStyleMine`     | normal, bold, italic | bold                               |
-| `app:streamAttachmentFileSizeTextStyleTheirs`   | normal, bold, italic | bold                               |
+| Properties                                            | Type                 | Default                            |
+| ----------------------------------------------------- | -------------------- | ---------------------------------- |
+| `app:streamAttachmentBackgroundColorMine`             | color                | streamMessageBackgroundColorMine   |
+| `app:streamAttachmentBackgroundColorTheirs`           | color                | streamMessageBackgroundColorTheirs |
+| `app:streamAttachmentTitleTextSizeMine`               | dimension            | 13sp                               |
+| `app:streamAttachmentTitleTextSizeTheirs`             | dimension            | 13sp                               |
+| `app:streamAttachmentTitleTextColorMine`              | color                | #026DFE                            |
+| `app:streamAttachmentTitleTextColorTheirs`            | color                | #026DFE                            |
+| `app:streamAttachmentTitleTextStyleMine`              | normal, bold, italic | bold                               |
+| `app:streamAttachmentTitleTextStyleTheirs`            | normal, bold, italic | bold                               |
+| `app:streamAttachmentTitleTextFontMine`               | reference            | -                                  |
+| `app:streamAttachmentTitleTextFontTheirs`             | reference            | -                                  |
+| `app:streamAttachmentTitleTextFontAssetsMine`         | string               | -                                  |
+| `app:streamAttachmentTitleTextFontAssetsTheirs`       | string               | -                                  |
+| `app:streamAttachmentDescriptionTextSizeMine`         | dimension            | 11sp                               |
+| `app:streamAttachmentDescriptionTextSizeTheirs`       | dimension            | 11sp                               |
+| `app:streamAttachmentDescriptionTextColorMine`        | color                | stream_gray_dark                   |
+| `app:streamAttachmentDescriptionTextColorTheirs`      | color                | stream_gray_dark                   |
+| `app:streamAttachmentDescriptionTextStyleMine`        | normal, bold, italic | normal                             |
+| `app:streamAttachmentDescriptionTextStyleTheirs`      | normal, bold, italic | normal                             |
+| `app:streamAttachmentDescriptionTextFontMine`         | reference            | -                                  |
+| `app:streamAttachmentDescriptionTextFontTheirs`       | reference            | -                                  |
+| `app:streamAttachmentDescriptionTextFontAssetsMine`   | string               | -                                  |
+| `app:streamAttachmentDescriptionTextFontAssetsTheirs` | string               | -                                  |
+| `app:streamAttachmentFileSizeTextSizeMine`            | dimension            | 12sp                               |
+| `app:streamAttachmentFileSizeTextSizeTheirs`          | dimension            | 12sp                               |
+| `app:streamAttachmentFileSizeTextColorMine`           | color                | stream_gray_dark                   |
+| `app:streamAttachmentFileSizeTextColorTheirs`         | color                | stream_gray_dark                   |
+| `app:streamAttachmentFileSizeTextStyleMine`           | normal, bold, italic | bold                               |
+| `app:streamAttachmentFileSizeTextStyleTheirs`         | normal, bold, italic | bold                               |
+| `app:streamAttachmentFileSizeTextFontMine`            | reference            | -                                  |
+| `app:streamAttachmentFileSizeTextFontTheirs`          | reference            | -                                  |
+| `app:streamAttachmentFileSizeTextFontAssetsMine`      | string               | -                                  |
+| `app:streamAttachmentFileSizeTextFontAssetsTheirs`    | string               | -                                  |
 
 - **Date Separator**
 
-| Properties                                | Type                   | Default           |
-| ----------------------------------------- | ---------------------- | ----------------- |
-| `app:streamDateSeparatorDateTextSize`     | dimension              | 12sp              |
-| `app:streamDateSeparatorDateTextColor`    | color                  | stream_gray_dark  |
-| `app:streamDateSeparatorDateTextStyle`    | normal, bold, italic   | bold              |
-| `app:streamDateSeparatorLineWidth`        | dimension              | 1dp               |
-| `app:streamDateSeparatorLineColor`        | color                  | stream_gray_dark  |
-| `app:streamDateSeparatorLineDrawable`     | reference              | -                 |
+| Properties                                  | Type                   | Default           |
+| ------------------------------------------- | ---------------------- | ----------------- |
+| `app:streamDateSeparatorDateTextSize`       | dimension              | 12sp              |
+| `app:streamDateSeparatorDateTextColor`      | color                  | stream_gray_dark  |
+| `app:streamDateSeparatorDateTextStyle`      | normal, bold, italic   | bold              |
+| `app:streamDateSeparatorDateTextFont`       | reference              | -                 |
+| `app:streamDateSeparatorDateTextFontAssets` | string                 | -                 |
+| `app:streamDateSeparatorLineWidth`          | dimension              | 1dp               |
+| `app:streamDateSeparatorLineColor`          | color                  | stream_gray_dark  |
+| `app:streamDateSeparatorLineDrawable`       | reference              | -                 |
 
 - **User name and message date**
 
-| Properties                             | Type                   | Default          |
-| -------------------------------------- | ---------------------- | ---------------- |
-| `app:streamMessageUserNameTextSize`    | dimension              | 11sp             |
-| `app:streamMessageUserNameTextColor`   | color                  | stream_gray_dark |
-| `app:streamMessageUserNameTextStyle`   | normal, bold, italic   | normal           |
-| `app:streamMessageDateTextSizeMine`    | dimension              | 11sp             |
-| `app:streamMessageDateTextSizeTheirs`  | dimension              | 11sp             |
-| `app:streamMessageDateTextColorMine`   | color                  | stream_gray_dark |
-| `app:streamMessageDateTextColorTheirs` | color                  | stream_gray_dark |
-| `app:streamMessageDateTextStyleMine`   | normal, bold, italic   | normal           |
-| `app:streamMessageDateTextStyleTheirs` | normal, bold, italic   | normal           |
-| `app:streamUserNameShow`               |   boolean              | true             |
-| `app:streamMessageDateShow`            |   boolean              | true             |
+| Properties                                | Type                   | Default          |
+| ----------------------------------------- | ---------------------- | ---------------- |
+| `app:streamMessageUserNameTextSize`       | dimension              | 11sp             |
+| `app:streamMessageUserNameTextColor`      | color                  | stream_gray_dark |
+| `app:streamMessageUserNameTextStyle`      | normal, bold, italic   | normal           |
+| `app:streamMessageUserNameTextFont`       | reference              | -                |
+| `app:streamMessageUserNameTextFontAssets` | string                 | -                |
+| `app:streamMessageDateTextSizeMine`       | dimension              | 11sp             |
+| `app:streamMessageDateTextSizeTheirs`     | dimension              | 11sp             |
+| `app:streamMessageDateTextColorMine`      | color                  | stream_gray_dark |
+| `app:streamMessageDateTextColorTheirs`    | color                  | stream_gray_dark |
+| `app:streamMessageDateTextStyleMine`      | normal, bold, italic   | normal           |
+| `app:streamMessageDateTextStyleTheirs`    | normal, bold, italic   | normal           |
+| `app:streamMessageDateTextFontMine`       | reference              | -                |
+| `app:streamMessageDateTextFontAssetsMine` | string                 | -                |
+| `app:streamUserNameShow`                  | boolean                | true             |
+| `app:streamMessageDateShow`               | boolean                | true             |
 
 - **Thread**
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
@@ -50,12 +50,11 @@ public class AttachmentViewHolderFile extends BaseAttachmentViewHolder {
 
         if(getMessageListItem().isMine()) {
             style.attachmentTitleTextMine.apply(tv_file_title);
+            style.attachmentFileSizeTextMine.apply(tv_file_size);
         } else {
             style.attachmentTitleTextTheirs.apply(tv_file_title);
+            style.attachmentFileSizeTextTheirs.apply(tv_file_size);
         }
-
-
-        style.attachmentFileSizeText.apply(tv_file_size);
     }
 
     private void configAttachment() {

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
@@ -3,7 +3,6 @@ package com.getstream.sdk.chat.adapter;
 
 import android.content.Context;
 import android.graphics.drawable.Drawable;
-import android.util.TypedValue;
 import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -12,7 +11,6 @@ import androidx.constraintlayout.widget.ConstraintLayout;
 
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.model.Attachment;
-import com.getstream.sdk.chat.utils.TextViewUtils;
 import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.java
@@ -43,7 +43,8 @@ public class MessageListViewStyle extends BaseStyle {
 
     public TextStyle attachmentDescriptionTextMine;
     public TextStyle attachmentDescriptionTextTheirs;
-    public TextStyle attachmentFileSizeText;
+    public TextStyle attachmentFileSizeTextMine;
+    public TextStyle attachmentFileSizeTextTheirs;
     private int attachmentBackgroundColorMine;
     private int attachmentBackgroundColorTheirs;
 
@@ -167,11 +168,18 @@ public class MessageListViewStyle extends BaseStyle {
                 .style(R.styleable.MessageListView_streamAttachmentDescriptionTextStyleTheirs, Typeface.NORMAL)
                 .build();
 
-        attachmentFileSizeText = new TextStyle.Builder(a)
-                .size(R.styleable.MessageListView_streamAttachmentFileSizeTextSize, getDimension(R.dimen.stream_attach_file_size_text))
-                .color(R.styleable.MessageListView_streamAttachmentFileSizeTextColor, getColor(R.color.stream_gray_dark))
-                .font(R.styleable.MessageListView_streamAttachmentFileSizeTextFontAssets, R.styleable.MessageListView_streamAttachmentFileSizeTextFont)
-                .style(R.styleable.MessageListView_streamAttachmentFileSizeTextStyle, Typeface.BOLD)
+        attachmentFileSizeTextMine = new TextStyle.Builder(a)
+                .size(R.styleable.MessageListView_streamAttachmentFileSizeTextSizeMine, getDimension(R.dimen.stream_attach_file_size_text))
+                .color(R.styleable.MessageListView_streamAttachmentFileSizeTextColorMine, getColor(R.color.stream_gray_dark))
+                .font(R.styleable.MessageListView_streamAttachmentFileSizeTextFontAssetsMine, R.styleable.MessageListView_streamAttachmentFileSizeTextFontMine)
+                .style(R.styleable.MessageListView_streamAttachmentFileSizeTextStyleMine, Typeface.BOLD)
+                .build();
+
+        attachmentFileSizeTextTheirs = new TextStyle.Builder(a)
+                .size(R.styleable.MessageListView_streamAttachmentFileSizeTextSizeTheirs, getDimension(R.dimen.stream_attach_file_size_text))
+                .color(R.styleable.MessageListView_streamAttachmentFileSizeTextColorTheirs, getColor(R.color.stream_gray_dark))
+                .font(R.styleable.MessageListView_streamAttachmentFileSizeTextFontAssetsTheirs, R.styleable.MessageListView_streamAttachmentFileSizeTextFontTheirs)
+                .style(R.styleable.MessageListView_streamAttachmentFileSizeTextStyleTheirs, Typeface.BOLD)
                 .build();
 
         // Reaction

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -314,21 +314,21 @@
             <flag name="italic" value="2" />
         </attr>
 
-        <attr name="streamAttachmentDescriptionTextSize" format="dimension|reference"/>
-        <attr name="streamAttachmentDescriptionTextColor" format="color"/>
-        <attr name="streamAttachmentDescriptionTextFont" format="reference"/>
-        <attr name="streamAttachmentDescriptionTextFontAssets" format="string"/>
-        <attr name="streamAttachmentDescriptionTextStyle">
+        <attr name="streamAttachmentFileSizeTextSizeMine" format="dimension|reference"/>
+        <attr name="streamAttachmentFileSizeTextColorMine" format="color"/>
+        <attr name="streamAttachmentFileSizeTextFontMine" format="reference"/>
+        <attr name="streamAttachmentFileSizeTextFontAssetsMine" format="string"/>
+        <attr name="streamAttachmentFileSizeTextStyleMine">
             <flag name="normal" value="0"/>
             <flag name="bold" value="1"/>
             <flag name="italic" value="2"/>
         </attr>
 
-        <attr name="streamAttachmentFileSizeTextSize" format="dimension|reference"/>
-        <attr name="streamAttachmentFileSizeTextColor" format="color"/>
-        <attr name="streamAttachmentFileSizeTextFont" format="reference"/>
-        <attr name="streamAttachmentFileSizeTextFontAssets" format="string"/>
-        <attr name="streamAttachmentFileSizeTextStyle">
+        <attr name="streamAttachmentFileSizeTextSizeTheirs" format="dimension|reference"/>
+        <attr name="streamAttachmentFileSizeTextColorTheirs" format="color"/>
+        <attr name="streamAttachmentFileSizeTextFontTheirs" format="reference"/>
+        <attr name="streamAttachmentFileSizeTextFontAssetsTheirs" format="string"/>
+        <attr name="streamAttachmentFileSizeTextStyleTheirs">
             <flag name="normal" value="0"/>
             <flag name="bold" value="1"/>
             <flag name="italic" value="2"/>


### PR DESCRIPTION
# Submit a pull request

## Setup custom font
You can set custom fonts for the entire library or for specific UI components.

1. First of all you have to put your own font file(s) (.ttf, .otf,…) in your `assets` folder or `res`.

2. Setup custom font for whole library
You can register your custom font by `StreamChat.initStyle(StreamChatStyle style)`
```
StreamChat.initStyle(
        new StreamChatStyle.Builder()
                .setDefaultFont(R.font.your_custom_font)                
               //.setDefaultFont("fonts/your_custom_font.ttf")
                .build()
``` 
3. Setup custom font to specific UI components

You can setup custom fonts specific UI components of `ChannelListView` , `ChannelHeaderView`, `MessageListView` and `MessageInputView`
For example, if you want to set custom font of message text, you can follow the code below
```xml
<com.getstream.sdk.chat.view.MessageListView
     … 
      app:streamAttachmentFileSizeTextFontMine="@font/your_custom_font"
      // Or if you put custom font in `assets/fonts` folder
      app: streamAttachmentFileSizeTextFontMine ="fonts/your_custom_font.ttf"
     … 
/>
```
*Note:*  If you put your font to `assets` folder, you must provide file type correctly.
