### PR TITLE
CAS-45/Giphy: send and shuffle buttons do not work

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -25,6 +25,7 @@ import com.getstream.sdk.chat.model.Channel;
 import com.getstream.sdk.chat.model.ModelType;
 import com.getstream.sdk.chat.rest.Message;
 import com.getstream.sdk.chat.rest.User;
+import com.getstream.sdk.chat.rest.interfaces.MessageCallback;
 import com.getstream.sdk.chat.rest.response.ChannelUserRead;
 import com.getstream.sdk.chat.storage.Sync;
 import com.getstream.sdk.chat.utils.Utils;
@@ -61,7 +62,6 @@ public class MessageListView extends RecyclerView {
     private MessageClickListener messageClickListener;
     private MessageLongClickListener messageLongClickListener;
     private AttachmentClickListener attachmentClickListener;
-    private GiphySendListener giphySendListener;
     private ReactionViewClickListener reactionViewClickListener;
     private UserClickListener userClickListener;
     private ReadStateClickListener readStateClickListener;
@@ -109,7 +109,6 @@ public class MessageListView extends RecyclerView {
             Fresco.initialize(getContext());
         } catch (Exception e) {
         }
-        giphySendListener = viewModel::sendGiphy;
     }
 
     // set the adapter and apply the style.
@@ -121,7 +120,7 @@ public class MessageListView extends RecyclerView {
     public void setAdapterWithStyle(MessageListItemAdapter adapter) {
 
         adapter.setStyle(style);
-        adapter.setGiphySendListener(giphySendListener);
+        adapter.setGiphySendListener(viewModel::sendGiphy);
         setMessageClickListener(messageClickListener);
         setMessageLongClickListener(messageLongClickListener);
         setAttachmentClickListener(attachmentClickListener);
@@ -521,7 +520,7 @@ public class MessageListView extends RecyclerView {
     }
 
     public interface GiphySendListener {
-        void onGiphySend(Message message, GiphyAction action);
+        void onGiphySend(Message message, GiphyAction action, MessageCallback callback);
     }
 
     public interface UserClickListener {

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelViewModel.java
@@ -1059,7 +1059,7 @@ public class ChannelViewModel extends AndroidViewModel implements LifecycleHandl
      */
     public void sendGiphy(Message message,
                           GiphyAction action,
-                          MessageCallback callback) {
+                          @NonNull MessageCallback callback) {
         Map<String, String> map = new HashMap<>();
         switch (action) {
             case SEND:

--- a/library/src/main/res/layout/stream_item_attach_media.xml
+++ b/library/src/main/res/layout/stream_item_attach_media.xml
@@ -35,6 +35,16 @@
         app:layout_constraintStart_toStartOf="@+id/iv_media_thumb"
         app:layout_constraintTop_toTopOf="@+id/iv_media_thumb" />
 
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/iv_media_thumb"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/iv_media_thumb" />
+
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/cl_des"
         android:layout_width="match_parent"


### PR DESCRIPTION
# Submit a pull request

https://stream-io.atlassian.net/browse/CAS-45

- add progressBar/ disable buttons while giphy send API response
- if error response, shows error message

## Result
![20191128_171313](https://user-images.githubusercontent.com/11132956/69820878-70355780-1202-11ea-8e34-a50939d5c71a.gif)

