### PR TITLE
Fix score double casting error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Upcoming
 
+## March 11th, 2020 - 3.6.5
+
+- Fix reaction score parser casting exception
+
 ## March 3rd, 2020 - 3.6.5
 
 - Fix crash on sending Google gif

--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ buildscript {
 allprojects {
 
     ext {
-        releaseSdkVersion = '3.6.5'
+        releaseSdkVersion = '3.6.6'
     }
 
     repositories {

--- a/library/src/main/java/com/getstream/sdk/chat/rest/adapter/ReactionGsonAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/rest/adapter/ReactionGsonAdapter.java
@@ -84,7 +84,8 @@ public class ReactionGsonAdapter extends TypeAdapter<Reaction> {
                     reaction.setCreatedAt(gson.fromJson(json, Date.class));
                     continue;
                 case "score":
-                    reaction.setScore((Integer) set.getValue());
+                    int score = ((Number) set.getValue()).intValue();
+                    reaction.setScore(score);
                     continue;
             }
             // Set Extra Data


### PR DESCRIPTION
Double can't be casted to Integer.
```
java.lang.ClassCastException: java.lang.Double cannot be cast to java.lang.Integer
```