### PR TITLE
Make ChannelItemPayloadDiff public

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelItemPayloadDiff.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ChannelItemPayloadDiff.java
@@ -1,6 +1,6 @@
 package com.getstream.sdk.chat.adapter;
 
-class ChannelItemPayloadDiff {
+public class ChannelItemPayloadDiff {
     boolean name = true;
     boolean avatarView = true;
     boolean lastMessage = true;


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
I want to have a custom implementation extended from BaseChannelListItemViewHolder
For it I need to have public ChannelItemPayloadDiff