### PR TITLE
Fix default avatar with an empty name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## Upcoming
 
+## May 15th, 2020 - 4.2.6
+
+- Fix Avatar crash if channel/user initials are empty
+
+## May 13th, 2020 - 4.2.5
+
+- Create new `AvatarView`
+- Glide Redirect issues resolved
+- Bugfix release for livedata, updated to 0.4.2
+
 ## March 11th, 2020 - 3.6.5
 
 - Fix reaction score parser casting exception

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
 
-        versionName "4.2.5"
+        versionName "4.2.6"
 
         buildConfigField "String", "DEFAULT_API_ENDPOINT", "\"$DEFAULT_API_ENDPOINT\""
         buildConfigField "int", "DEFAULT_API_TIMEOUT", "$DEFAULT_API_TIMEOUT"

--- a/library/src/main/java/com/getstream/sdk/chat/utils/LlcMigrationUtils.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/LlcMigrationUtils.java
@@ -3,7 +3,6 @@ package com.getstream.sdk.chat.utils;
 
 import android.text.TextUtils;
 
-import com.getstream.sdk.chat.Chat;
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.model.AttachmentMetaData;
 import com.getstream.sdk.chat.model.ModelType;
@@ -11,12 +10,24 @@ import com.getstream.sdk.chat.model.ModelType;
 import java.text.DateFormat;
 import java.text.DecimalFormat;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TimeZone;
 
 import androidx.annotation.Nullable;
 import io.getstream.chat.android.client.events.ChatEvent;
 import io.getstream.chat.android.client.logger.ChatLogger;
-import io.getstream.chat.android.client.models.*;
+import io.getstream.chat.android.client.models.Attachment;
+import io.getstream.chat.android.client.models.Channel;
+import io.getstream.chat.android.client.models.ChannelUserRead;
+import io.getstream.chat.android.client.models.Member;
+import io.getstream.chat.android.client.models.Message;
+import io.getstream.chat.android.client.models.User;
 import io.getstream.chat.android.livedata.ChatDomain;
 
 import static com.getstream.sdk.chat.enums.Dates.TODAY;
@@ -26,8 +37,8 @@ public class LlcMigrationUtils {
 
     private static Map<String, String> reactionTypes;
 
+    @Nullable
     public static String getInitials(User user) {
-
         String name = (String) user.getExtraData().get("name");
 
         if (name == null) {
@@ -342,9 +353,8 @@ public class LlcMigrationUtils {
         return result;
     }
 
+    @Nullable
     public static String getInitials(Channel channel) {
-
-
         String name = (String) channel.getExtraData().get("name");
         if (name == null) {
             return "";

--- a/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
@@ -82,7 +82,7 @@ class AvatarView @JvmOverloads constructor(
 		}
 		val textBounds = Rect()
 		paintText.getTextBounds(initials, 0, initials.length, textBounds);
-		val radius = max(textBounds.width(), textBounds.height()).takeUnless { it <= 0 } ?: MIN_RADIO_SIZE
+		val radius = max(textBounds.width(), textBounds.height()).takeUnless { it <= 0 } ?: MIN_RADIUS_SIZE
 		val bitmapSize = (radius * 2)
 		val output = Bitmap.createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_8888)
 		val canvas = Canvas(output)
@@ -95,7 +95,7 @@ class AvatarView @JvmOverloads constructor(
 	}
 }
 
-private const val MIN_RADIO_SIZE = 100
+private const val MIN_RADIUS_SIZE = 100
 private const val FACTOR = 1.7
 private class AvatarDrawable(bitmaps: List<Bitmap>) : Drawable() {
 	private val avatarBitmaps = bitmaps.take(3)

--- a/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
@@ -82,7 +82,7 @@ class AvatarView @JvmOverloads constructor(
 		}
 		val textBounds = Rect()
 		paintText.getTextBounds(initials, 0, initials.length, textBounds);
-		val radius = max(textBounds.width(), textBounds.height())
+		val radius = max(textBounds.width(), textBounds.height()).takeUnless { it <= 0 } ?: MIN_RADIO_SIZE
 		val bitmapSize = (radius * 2)
 		val output = Bitmap.createBitmap(bitmapSize, bitmapSize, Bitmap.Config.ARGB_8888)
 		val canvas = Canvas(output)
@@ -95,6 +95,7 @@ class AvatarView @JvmOverloads constructor(
 	}
 }
 
+private const val MIN_RADIO_SIZE = 100
 private const val FACTOR = 1.7
 private class AvatarDrawable(bitmaps: List<Bitmap>) : Drawable() {
 	private val avatarBitmaps = bitmaps.take(3)

--- a/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
@@ -56,7 +56,7 @@ class AvatarView @JvmOverloads constructor(
 		ImageLoader.getBitmap(context,
 				getExtraValue("image", ""),
 				ImageLoader.ImageTransformation.Circle)
-				?: createImageRounded(LlcMigrationUtils.getInitials(this), style)
+				?: createImageRounded(LlcMigrationUtils.getInitials(this) ?: "", style)
 
 	private suspend fun List<User>.createBitmaps(style: BaseStyle): List<Bitmap> =
 			take(3).mapNotNull { it.createBitmap(style) }
@@ -65,7 +65,7 @@ class AvatarView @JvmOverloads constructor(
 			ImageLoader.getBitmap(context,
 					getExtraValue("image", ""),
 					ImageLoader.ImageTransformation.Circle)
-					?: createImageRounded(LlcMigrationUtils.getInitials(this), style)
+					?: LlcMigrationUtils.getInitials(this)?.let { createImageRounded(it, style) }
 
 	private fun createImageRounded(initials: String, baseStyle: BaseStyle): Bitmap {
 		val paintText = Paint(Paint.ANTI_ALIAS_FLAG).apply {


### PR DESCRIPTION
When a channel or user has an empty name, the text to be rendered on the bitmap that contains the initials of the name has a size of 0. This size was used as the radio of the bitmap be center the name on it, but a bitmap can't have a size of 0, so it needs to have a default value on the case that user/channel doesn't have an associated name.

Fix #478 