### PR TITLE
Hotfix/avatar view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Jun 3rd, 2020 - 4.2.11-beta
+
+- Fix `AvatarView` crash when the view is not attached
+
+## May 15th, 2020 - 4.2.10-beta
+
+- Update to the latest livedata: 0.6.1
+
 ## May 29th, 2020 - 4.2.9-beta-3
 
 - Fix AttachmentViewHolder crash when user sends message with plain/no-media url

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -22,7 +22,7 @@ android {
 
     defaultConfig {
 
-        versionName "4.2.10-beta"
+        versionName "4.2.11-beta"
 
         buildConfigField "String", "DEFAULT_API_ENDPOINT", "\"$DEFAULT_API_ENDPOINT\""
         buildConfigField "int", "DEFAULT_API_TIMEOUT", "$DEFAULT_API_TIMEOUT"

--- a/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
@@ -47,7 +47,7 @@ class AvatarView @JvmOverloads constructor(
 			layoutParams?.apply {
 				width = style.getAvatarWidth()
 				height = style.getAvatarHeight()
-			}?.let { layoutParams = it }
+			}
 			setImageDrawable(generateAvatarDrawable())
 		}
 	}

--- a/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/AvatarView.kt
@@ -43,11 +43,11 @@ class AvatarView @JvmOverloads constructor(
 	}
 
 	private fun configUIs(style: BaseStyle, generateAvatarDrawable: suspend () -> AvatarDrawable) {
-		layoutParams = layoutParams.apply {
-			width = style.getAvatarWidth()
-			height = style.getAvatarHeight()
-		}
 		GlobalScope.launch(Dispatchers.Main) {
+			layoutParams?.apply {
+				width = style.getAvatarWidth()
+				height = style.getAvatarHeight()
+			}?.let { layoutParams = it }
 			setImageDrawable(generateAvatarDrawable())
 		}
 	}


### PR DESCRIPTION
Handle nullability of the `LayoutParams`, it could be null if the view is not attached.
Fix #511 
