### PR TITLE
Feature/take picture

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -90,6 +90,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.0.0-beta4'
     implementation 'androidx.legacy:legacy-support-v4:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.2.0-alpha03'
+    implementation 'androidx.activity:activity-ktx:1.2.0-alpha06'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
 

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -32,6 +32,17 @@
                 <action android:name="com.getstream.sdk.chat.REPLY" />
             </intent-filter>
         </receiver>
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.streamfileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true"
+            >
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/stream_filepaths"
+                />
+        </provider>
     </application>
 
 </manifest>

--- a/library/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
@@ -1,0 +1,56 @@
+package com.getstream.sdk.chat
+
+import android.app.Activity
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.provider.MediaStore
+import androidx.activity.result.contract.ActivityResultContract
+import androidx.core.content.FileProvider
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+private val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
+class CaptureMediaContract : ActivityResultContract<Unit, File>() {
+
+	private var pictureFile: File? = null
+	private var videoFile: File? = null
+
+	override fun createIntent(context: Context, input: Unit?): Intent {
+		val takePictureIntents = File(context.externalCacheDir, createFileName("STREAM_IMG","jpg")).let {
+			pictureFile = it
+			createIntentList(context, MediaStore.ACTION_IMAGE_CAPTURE, it)
+		}
+		val recordVideoIntents = File(context.externalCacheDir, createFileName("STREAM_VID","mp4")).let	{
+			videoFile = it
+			createIntentList(context, MediaStore.ACTION_VIDEO_CAPTURE, it)
+		}
+		return Intent.createChooser(Intent(), context.getString(R.string.stream_input_camera_title)).apply {
+			putExtra(Intent.EXTRA_INITIAL_INTENTS, (takePictureIntents + recordVideoIntents).toTypedArray())
+		}
+	}
+
+	private fun createFileName(prefix: String, extension: String) = "${prefix}_${dateFormat.format(Date().time)}.$extension"
+
+	private fun createIntentList(context: Context, action: String, destinationFile: File): List<Intent> {
+		val destinationUri = FileProvider.getUriForFile(context, "${context.packageName}.streamfileprovider", destinationFile)
+		val actionIntent = Intent(action)
+		return context.packageManager.queryIntentActivities(actionIntent, PackageManager.MATCH_DEFAULT_ONLY).map {
+			Intent(actionIntent).apply {
+				putExtra(MediaStore.EXTRA_OUTPUT, destinationUri)
+				flags = Intent.FLAG_GRANT_WRITE_URI_PERMISSION
+				component = ComponentName(it.activityInfo.packageName, it.activityInfo.name)
+				`package` = it.activityInfo.packageName
+			}
+		}
+	}
+
+	override fun parseResult(resultCode: Int, intent: Intent?): File? =
+			(pictureFile?.takeIf { it.exists() && it.length() > 0 }
+					?: videoFile?.takeIf { it.exists() && it.length() > 0 })
+					.takeIf { resultCode == Activity.RESULT_OK }
+
+}

--- a/library/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
@@ -49,8 +49,8 @@ class CaptureMediaContract : ActivityResultContract<Unit, File>() {
 	}
 
 	override fun parseResult(resultCode: Int, intent: Intent?): File? =
-			(pictureFile?.takeIf { it.exists() && it.length() > 0 }
-					?: videoFile?.takeIf { it.exists() && it.length() > 0 })
+			(pictureFile.takeIfCaptured() ?: videoFile.takeIfCaptured())
 					.takeIf { resultCode == Activity.RESULT_OK }
-
 }
+
+private fun File?.takeIfCaptured(): File? = this?.takeIf { it.exists() && it.length() > 0 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MediaAttachmentSelectedAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MediaAttachmentSelectedAdapter.java
@@ -106,7 +106,7 @@ public class MediaAttachmentSelectedAdapter extends RecyclerView.Adapter<MediaAt
                 }
             }
 
-            if (attachment.type.equals(ModelType.attach_file)) {
+            if (ModelType.attach_file.equals(attachment.type)) {
                 binding.tvLength.setText(StringUtility.convertVideoLength(attachment.videoLength));
             } else {
                 binding.tvLength.setText("");

--- a/library/src/main/res/xml/stream_filepaths.xml
+++ b/library/src/main/res/xml/stream_filepaths.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <external-cache-path name="picturesext" path="/" />
+</paths>


### PR DESCRIPTION
Implement behavior to take a picture or record a video by another installed app on the device.
To be able to share File/Uri between different apps we need to declare a `FileProvider`, it is using the final `packageName` as part of the `android:authorities` attribute to be able to use the one defined on the Stream library into multiple apps.
With the new method `registerForActivityResult()` we are able to register callbacks that handles the "Activity Result" without needed to add logic to the activity/fragment where the activity was started