### PR TITLE
Fix / Update livedata dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Jun 4th, 2020 - 4.2.11-beta-5
+
+- Update livedata dependency to fix crash when NotificationMarkReadEvent received
+- Add mavenLocal() repository
+
 ## Jun 4th, 2020 - 4.2.11-beta-4
 
 - Fix crash when command (`/`) is typed.

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ allprojects {
         google()
         jcenter()
         maven { url "https://jitpack.io" }
+        mavenLocal()
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -119,7 +119,7 @@ dependencies {
 
 
     //api project(path: ':livedata')
-    api 'com.github.GetStream:stream-chat-android-livedata:0.6.1'
+    api 'com.github.GetStream:stream-chat-android-livedata:0.6.5'
 
     implementation "io.coil-kt:coil:0.10.1"
 


### PR DESCRIPTION
* Updates livedata to 0.6.5 version which fixes NotificationMarkReadEvent crash
* Adds mavenLocal() repository
* Fixes: https://github.com/GetStream/stream-chat-android/issues/536