### PR TITLE
Fix crash on pressing image in chat

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -10,6 +10,7 @@ import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 
+import com.facebook.drawee.backends.pipeline.Fresco;
 import com.getstream.sdk.chat.Chat;
 import com.getstream.sdk.chat.DefaultBubbleHelper;
 import com.getstream.sdk.chat.adapter.MessageListItem;
@@ -119,6 +120,15 @@ public class MessageListView extends RecyclerView {
         setBubbleHelper(DefaultBubbleHelper.initDefaultBubbleHelper(style, context));
         setHasFixedSize(true);
         setItemViewCacheSize(20);
+
+        initFresco();
+    }
+
+    private void initFresco() {
+        try {
+            Fresco.initialize(getContext());
+        } catch (Exception e) {
+        }
     }
 
     // region Init


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request

Fresco is not being initialised anywhere (probably removed by mistake at some point), which means a crash will happen when pressing an image in the chat.

