### PR TITLE
Close app on back press at home screen

### DIFF
--- a/sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
+++ b/sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.sample.feature.channels
 
 import android.os.Bundle
 import android.view.View
+import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.getstream.sdk.chat.Chat
@@ -46,6 +47,14 @@ class ChannelsFragment : Fragment(R.layout.fragment_channels) {
 
         addNewChannelButton.setOnClickListener {
             findNavController().navigate(R.id.action_to_create_channel)
+        }
+
+        activity?.apply {
+            onBackPressedDispatcher.addCallback(viewLifecycleOwner, object : OnBackPressedCallback(true) {
+                override fun handleOnBackPressed() {
+                    activity?.finish()
+                }
+            })
         }
     }
 }


### PR DESCRIPTION
## PR description:

* Using navigation component requires a manual call to `activity.finish()` in order to close the app on back press. This PR handles back press in ChannelsFragment 
