### PR TITLE
[CAS-176] Add ChannelsView.setViewHolderFactory() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Jun 4th, 2020 - 4.2.11-beta-8
+
+- Add `ChannelsView.setViewHolderFactory(factory: ChannelViewHolderFactory)` function
+
 ## Jun 4th, 2020 - 4.2.11-beta-7
 
 - Fix channel name validation in CreateChannelViewModel

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,7 +23,7 @@ android {
 
     defaultConfig {
 
-        versionName "4.2.11-beta-7"
+        versionName "4.2.11-beta-8"
 
         buildConfigField "String", "DEFAULT_API_ENDPOINT", "\"$DEFAULT_API_ENDPOINT\""
         buildConfigField "int", "DEFAULT_API_TIMEOUT", "$DEFAULT_API_TIMEOUT"

--- a/library/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
@@ -8,6 +8,7 @@ import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.TextView
 import com.getstream.sdk.chat.R
+import com.getstream.sdk.chat.adapter.ChannelViewHolderFactory
 import com.getstream.sdk.chat.view.channels.ChannelListView.ChannelClickListener
 import com.getstream.sdk.chat.view.common.visible
 import io.getstream.chat.android.client.models.Channel
@@ -47,6 +48,10 @@ class ChannelsView @JvmOverloads constructor(
         removeView(this.loadingView)
         this.loadingView = view.apply { id = LOADING_VIEW_ID }
         addView(loadingView, layoutParams)
+    }
+
+    fun setViewHolderFactory(factory: ChannelViewHolderFactory) {
+        this.channelListView.setViewHolderFactory(factory)
     }
 
     fun setOnChannelClickListener(listener: (Channel) -> Unit) {


### PR DESCRIPTION
Jira link: 
https://stream-io.atlassian.net/browse/CAS-176

Adds missing `ChannelsView.setViewHolderFactory(factory: ChannelViewHolderFactory)` function to `ChannelsView`.

Related: https://github.com/GetStream/stream-chat-android/issues/571