### PR TITLE
Init Fresco library

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -43,6 +43,12 @@
                 android:resource="@xml/stream_filepaths"
                 />
         </provider>
+        <provider
+            android:authorities="${applicationId}.FrescoContentProvider"
+            android:name=".utils.frescoimageviewer.FrescoContentProvider"
+            android:enabled="true"
+            android:exported="false"
+            />
     </application>
 
 </manifest>

--- a/library/src/main/java/com/getstream/sdk/chat/utils/frescoimageviewer/FrescoContentProvider.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/frescoimageviewer/FrescoContentProvider.kt
@@ -1,0 +1,20 @@
+package com.getstream.sdk.chat.utils.frescoimageviewer
+
+import android.content.ContentProvider
+import android.content.ContentValues
+import android.database.Cursor
+import android.net.Uri
+import com.facebook.drawee.backends.pipeline.Fresco
+
+class FrescoContentProvider : ContentProvider() {
+    override fun insert(uri: Uri, values: ContentValues?): Uri? = null
+    override fun query(uri: Uri, projection: Array<String>?, selection: String?, selectionArgs: Array<String>?, sortOrder: String?): Cursor? = null
+    override fun update(uri: Uri, values: ContentValues?, selection: String?, selectionArgs: Array<String>?): Int = 0
+    override fun delete(uri: Uri, selection: String?, selectionArgs: Array<String>?): Int = 0
+    override fun getType(uri: Uri): String? = null
+
+    override fun onCreate(): Boolean {
+        Fresco.initialize(context)
+        return true
+    }
+}

--- a/versions.gradle
+++ b/versions.gradle
@@ -41,7 +41,7 @@ ext {
     retrofitVersion = "2.8.1"
     gsonVersion = "2.8.1"
 
-    frescoVersion = "1.2.0"
+    frescoVersion = "2.3.0"
     photodraweeviewVersion = "1.1.0"
     keyboardvisibilityeventVersion = "2.3.0"
     dexterVersion = "6.1.2"


### PR DESCRIPTION
Fresco library needs to be initialized before starting to use the views they provide.
I'm using a ContentProvider to start it because it is instantiated before any other part of the code