### PR TITLE
Move KeyboardEventListener initialization to onFocusChangeListener

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
@@ -56,6 +56,8 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
      */
     private var permissionRequestListener: PermissionRequestListener? = null
 
+    private var isKeyboardEventListenerInitialized = false
+
     var messageSendHandler: MessageSendHandler = object : MessageSendHandler {
         override fun sendMessage(messageText: String) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
@@ -149,11 +151,15 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
 
     private fun configInputEditText() {
         binding.etMessage.onFocusChangeListener =
-            OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-                if (hasFocus) {
-                    Utils.showSoftKeyboard(context as Activity)
-                } else Utils.hideSoftKeyboard(context as Activity)
-            }
+                OnFocusChangeListener { _: View?, hasFocus: Boolean ->
+                    if (hasFocus) {
+                        Utils.showSoftKeyboard(context as Activity)
+                    } else Utils.hideSoftKeyboard(context as Activity)
+                    if (!isKeyboardEventListenerInitialized) {
+                        isKeyboardEventListenerInitialized = true
+                        setKeyboardEventListener()
+                    }
+                }
         TextViewUtils.afterTextChanged(binding.etMessage) { editable: Editable -> keyStroke(editable.toString()) }
         binding.etMessage.setCallback { inputContentInfo: InputContentInfoCompat, flags: Int, opts: Bundle ->
             sendGiphyFromKeyboard(
@@ -365,6 +371,5 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         configOnClickListener()
         configInputEditText()
         configAttachmentUI()
-        setKeyboardEventListener()
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
@@ -151,15 +151,15 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
 
     private fun configInputEditText() {
         binding.etMessage.onFocusChangeListener =
-                OnFocusChangeListener { _: View?, hasFocus: Boolean ->
-                    if (hasFocus) {
-                        Utils.showSoftKeyboard(context as Activity)
-                    } else Utils.hideSoftKeyboard(context as Activity)
-                    if (!isKeyboardEventListenerInitialized) {
-                        isKeyboardEventListenerInitialized = true
-                        setKeyboardEventListener()
-                    }
+            OnFocusChangeListener { _: View?, hasFocus: Boolean ->
+                if (hasFocus) {
+                    Utils.showSoftKeyboard(context as Activity)
+                } else Utils.hideSoftKeyboard(context as Activity)
+                if (!isKeyboardEventListenerInitialized) {
+                    isKeyboardEventListenerInitialized = true
+                    setKeyboardEventListener()
                 }
+            }
         TextViewUtils.afterTextChanged(binding.etMessage) { editable: Editable -> keyStroke(editable.toString()) }
         binding.etMessage.setCallback { inputContentInfo: InputContentInfoCompat, flags: Int, opts: Bundle ->
             sendGiphyFromKeyboard(


### PR DESCRIPTION
Setting KeyboardEventListener inside `init` block is not safe, because it's initialization looks for host Activity under the hood and `init` is being called before Activity `onCreate` method. 