### PR TITLE
Apply KtLint Plugin to Root of the Project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ import com.getstream.sdk.chat.Dependencies
 
 apply plugin: 'com.pascalwelsch.gitversioner'
 apply plugin: "com.github.ben-manes.versions"
+apply plugin: "org.jlleitschuh.gradle.ktlint"
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
 


### PR DESCRIPTION
Apply KtLint Plugin to Root of the Project to add some extra gradle tasks like `ktlintApplyToIdea` that help us to apply Kotlin CheckStyle into our AndroidStudio configuration