### PR TITLE
Change RecyclerView dependency configuration to api

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     implementation Dependencies.appCompat
     implementation Dependencies.constraintLayout
     implementation Dependencies.androidLegacySupport
-    implementation Dependencies.recyclerview
+    api Dependencies.recyclerview
     implementation Dependencies.activityKtx
     implementation Dependencies.lifecycleExtension
     implementation Dependencies.lifecycleViewModelKTX


### PR DESCRIPTION
Adding RecyclerView with `implementation` configuration results  crash in `MessageView`  unless RecyclerView dependency is manually added to the project