### PR TITLE
Add missing fragment ktx dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     implementation Dependencies.androidLegacySupport
     api Dependencies.recyclerview
     implementation Dependencies.activityKtx
+    implementation Dependencies.fragmentKtx
     implementation Dependencies.lifecycleExtension
     implementation Dependencies.lifecycleViewModelKTX
 


### PR DESCRIPTION
Missing fragmentKtx library causes `java.lang.IllegalArgumentException: Can only use lower 16 bits for requestCode` crash on some Android devices when trying to open the camera from MessageInputView