### PR TITLE
Add requesting for legacy external storage

### DIFF
--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
+        android:requestLegacyExternalStorage="true"
         android:networkSecurityConfig="@xml/network_security_config">
         <activity android:name=".view.activity.UsersActivity"/>
         <activity android:name=".view.activity.AttachmentMediaActivity" />


### PR DESCRIPTION
Android 10 introduced a new storage paradigm - scoped storage and this requires changes for getting media and files. On Android 10 we can request for legacy external storage, but this is only a temporary solution because this flag won't work on Android 11