### PR TITLE
Move Primives files to another package to avoid duplicate class error

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/ChatSocketListener.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatSocketListener.kt
@@ -1,7 +1,6 @@
 package com.getstream.sdk.chat
 
 import com.getstream.sdk.chat.enums.OnlineStatus
-import exhaustive
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChannelCreatedEvent
 import io.getstream.chat.android.client.events.ChannelDeletedEvent

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -1,6 +1,6 @@
 package com.getstream.sdk.chat.adapter
 
-import exhaustive
+import com.getstream.sdk.chat.exhaustive
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User

--- a/library/src/main/java/com/getstream/sdk/chat/utils/MessageInputController.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/MessageInputController.kt
@@ -11,12 +11,12 @@ import com.getstream.sdk.chat.adapter.MediaAttachmentAdapter
 import com.getstream.sdk.chat.adapter.MediaAttachmentSelectedAdapter
 import com.getstream.sdk.chat.databinding.StreamViewMessageInputBinding
 import com.getstream.sdk.chat.enums.MessageInputType
+import com.getstream.sdk.chat.exhaustive
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.view.MessageInputStyle
 import com.getstream.sdk.chat.view.MessageInputView
 import com.getstream.sdk.chat.view.PreviewMessageView
 import com.getstream.sdk.chat.view.common.visible
-import exhaustive
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message

--- a/library/src/main/java/com/getstream/sdk/chat/utils/UploadManager.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/UploadManager.kt
@@ -1,8 +1,8 @@
 package com.getstream.sdk.chat.utils
 
+import com.getstream.sdk.chat.exhaustive
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
-import exhaustive
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.models.Attachment

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageInputView.kt
@@ -32,14 +32,14 @@ import com.getstream.sdk.chat.utils.PermissionChecker
 import com.getstream.sdk.chat.utils.StringUtility
 import com.getstream.sdk.chat.utils.TextViewUtils
 import com.getstream.sdk.chat.utils.Utils
+import com.getstream.sdk.chat.whenFalse
+import com.getstream.sdk.chat.whenTrue
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent
-import whenFalse
-import whenTrue
 import java.io.File
 
 class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(context, attrs) {

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
@@ -6,9 +6,9 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations.map
 import androidx.lifecycle.ViewModel
 import com.getstream.sdk.chat.Chat
+import com.getstream.sdk.chat.exhaustive
 import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModel.Companion.DEFAULT_FILTER
 import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModel.Companion.DEFAULT_SORT
-import exhaustive
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters.eq

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -4,8 +4,8 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.getstream.sdk.chat.exhaustive
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper
-import exhaustive
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message

--- a/library/src/main/kotlinX/Primitives.kt
+++ b/library/src/main/kotlinX/Primitives.kt
@@ -1,3 +1,5 @@
+package com.getstream.sdk.chat
+
 internal inline fun Boolean.whenTrue(crossinline f: () -> Unit): Boolean = also { if (this) f() }
 internal inline fun Boolean.whenFalse(crossinline f: () -> Unit): Boolean = also { if (!this) f() }
 


### PR DESCRIPTION
`Primitives` file already exists on LiveData module and it was giving an error when it is used into this project.
Moving it to an internal package fixes it.
Fixes: #603 