### PR TITLE
Add JvmField annotation to default filter and sort type inside ChannelListViewModel

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
@@ -35,9 +35,9 @@ interface ChannelsViewModel {
     }
 
     companion object {
-        @JvmStatic
+        @JvmField
         val DEFAULT_FILTER: FilterObject = eq("type", "messaging")
-        @JvmStatic
+        @JvmField
         val DEFAULT_SORT: QuerySort = QuerySort().desc("last_message_at")
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModel.kt
@@ -35,7 +35,9 @@ interface ChannelsViewModel {
     }
 
     companion object {
+        @JvmStatic
         val DEFAULT_FILTER: FilterObject = eq("type", "messaging")
+        @JvmStatic
         val DEFAULT_SORT: QuerySort = QuerySort().desc("last_message_at")
     }
 }


### PR DESCRIPTION
Adding @JvmField annotation improves UX when using SDK in Java because user can get those values directly from `ChannelListViewModel` instead of `ChannelListViewModel.Companion`