### PR TITLE
[CAS-230] Revise hardcoded string IDs in MessageListItem, simplify checksum calculation

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -14,10 +14,9 @@ sealed class MessageListItem(
 ) {
     fun getStableId(): Long {
         val checksum: Checksum = CRC32()
-        var plaintext = "$this:"
-        plaintext += when (this) {
-            is TypingItem -> "typing"
-            is ThreadSeparatorItem -> "Start of a new thread"
+        val plaintext = when (this) {
+            is TypingItem -> "id_typing"
+            is ThreadSeparatorItem -> "id_thread_separator"
             is MessageItem -> message.id
             is DateSeparatorItem -> date.toString()
         }


### PR DESCRIPTION
The task was to extract hardcoded text from this class, but these strings are not displayed on the UI. They are only being used to calculate a checksum, which then in turn is used to provide a unique stable ID for `RecyclerView` items.

The changes made here simplify this ID generation, removing the very long `this.toString()` prefix from the checksum calculation, and adding more obvious hardcoded IDs for the _typing_ and _thread separator_ items. IDs will still stay unique as before, but their generation is simpler and quicker.

---

Note: In the long term, this stable ID mechanism will be made obsolete anyway, as using `DiffUtil` and [`RecyclerView.ListAdapter`](https://developer.android.com/reference/androidx/recyclerview/widget/ListAdapter) will replace it.