### PR TITLE
Introduce AttachmentListItem wrapper class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Fix .gif preview rendering on message list 
 
 - Remove border related attributes from MessageInputView. Add close button background attribute to MessageInputView.
+- Wrap Attachment into AttachmentListItem for use in adapter
 
 # Sep 4th, 2020 - 4.2.11-beta-11
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentListItem.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentListItem.kt
@@ -1,0 +1,7 @@
+package com.getstream.sdk.chat.adapter
+
+import io.getstream.chat.android.client.models.Attachment
+
+data class AttachmentListItem(
+    val attachment: Attachment
+)

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentListItemAdapter.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentListItemAdapter.java
@@ -11,8 +11,8 @@ import com.getstream.sdk.chat.view.MessageListViewStyle;
 
 import java.util.List;
 
-import io.getstream.chat.android.client.models.Attachment;
 import io.getstream.chat.android.client.models.Message;
+import kotlin.collections.CollectionsKt;
 
 
 public class AttachmentListItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
@@ -22,7 +22,7 @@ public class AttachmentListItemAdapter extends RecyclerView.Adapter<RecyclerView
     private MessageViewHolderFactory factory;
     private Context context;
     private MessageListItem.MessageItem messageListItem;
-    private List<Attachment> attachments;
+    private List<AttachmentListItem> attachments;
     private MessageListViewStyle style;
     private MessageListView.AttachmentClickListener attachmentClickListener;
     private MessageListView.MessageLongClickListener longClickListener;
@@ -30,19 +30,21 @@ public class AttachmentListItemAdapter extends RecyclerView.Adapter<RecyclerView
     private MessageListView.BubbleHelper bubbleHelper;
 
 
-    public AttachmentListItemAdapter(Context context, @NonNull MessageListItem.MessageItem messageListItem, @NonNull MessageViewHolderFactory factory) {
+    public AttachmentListItemAdapter(Context context,
+                                     @NonNull MessageListItem.MessageItem messageListItem,
+                                     @NonNull MessageViewHolderFactory factory) {
         this.context = context;
         this.messageListItem = messageListItem;
         this.message = messageListItem.getMessage();
         this.factory = factory;
-        this.attachments = message.getAttachments();
+        this.attachments = CollectionsKt.map(message.getAttachments(), AttachmentListItem::new);
     }
 
     @Override
     public int getItemViewType(int position) {
         try {
-            Attachment attachment = attachments.get(position);
-            return factory.getAttachmentViewType(attachment);
+            AttachmentListItem attachmentItem = attachments.get(position);
+            return factory.getAttachmentViewType(attachmentItem);
         } catch (IndexOutOfBoundsException e) {
             return 0;
         }
@@ -62,12 +64,12 @@ public class AttachmentListItemAdapter extends RecyclerView.Adapter<RecyclerView
 
     @Override
     public void onBindViewHolder(@NonNull RecyclerView.ViewHolder holder, int position) {
-        Attachment attachment = attachments.get(position);
+        AttachmentListItem attachmentItem = attachments.get(position);
         ((BaseAttachmentViewHolder) holder).bind(
                 context,
                 messageListItem,
                 message,
-                attachment,
+                attachmentItem,
                 style,
                 bubbleHelper,
                 attachmentClickListener,

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolder.java
@@ -60,7 +60,7 @@ public class AttachmentViewHolder extends BaseAttachmentViewHolder {
     public void bind(@NonNull Context context,
                      @NonNull MessageListItem.MessageItem messageListItem,
                      @NonNull Message message,
-                     @NonNull Attachment attachment,
+                     @NonNull AttachmentListItem attachmentItem,
                      @NonNull MessageListViewStyle style,
                      @NonNull MessageListView.BubbleHelper bubbleHelper,
                      @Nullable MessageListView.AttachmentClickListener clickListener,
@@ -69,7 +69,7 @@ public class AttachmentViewHolder extends BaseAttachmentViewHolder {
         this.context = context;
         this.messageListItem = messageListItem;
         this.message = message;
-        this.attachment = attachment;
+        this.attachment = attachmentItem.getAttachment();
         this.style = style;
         this.bubbleHelper = bubbleHelper;
         this.clickListener = clickListener;

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFile.java
@@ -49,7 +49,7 @@ public class AttachmentViewHolderFile extends BaseAttachmentViewHolder {
     public void bind(@NonNull Context context,
                      @NonNull MessageListItem.MessageItem messageListItem,
                      @NonNull Message message,
-                     @NonNull Attachment attachment,
+                     @NonNull AttachmentListItem attachmentItem,
                      @NonNull MessageListViewStyle style,
                      @NonNull MessageListView.BubbleHelper bubbleHelper,
                      @Nullable MessageListView.AttachmentClickListener clickListener,
@@ -58,7 +58,7 @@ public class AttachmentViewHolderFile extends BaseAttachmentViewHolder {
         this.context = context;
         this.messageListItem = messageListItem;
         this.message = message;
-        this.attachment = attachment;
+        this.attachment = attachmentItem.getAttachment();
         this.style = style;
         this.bubbleHelper = bubbleHelper;
         this.clickListener = clickListener;

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderMedia.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderMedia.java
@@ -69,7 +69,7 @@ public class AttachmentViewHolderMedia extends BaseAttachmentViewHolder {
     public void bind(@NonNull Context context,
                      @NonNull MessageListItem.MessageItem messageListItem,
                      @NonNull Message message,
-                     @NonNull Attachment attachment,
+                     @NonNull AttachmentListItem attachmentItem,
                      @NonNull MessageListViewStyle style,
                      @NonNull MessageListView.BubbleHelper bubbleHelper,
                      @Nullable MessageListView.AttachmentClickListener clickListener,
@@ -77,7 +77,7 @@ public class AttachmentViewHolderMedia extends BaseAttachmentViewHolder {
         this.context = context;
         this.messageListItem = messageListItem;
         this.message = message;
-        this.attachment = attachment;
+        this.attachment = attachmentItem.getAttachment();
         this.style = style;
         this.bubbleHelper = bubbleHelper;
         this.clickListener = clickListener;

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/BaseAttachmentViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/BaseAttachmentViewHolder.java
@@ -11,7 +11,6 @@ import androidx.recyclerview.widget.RecyclerView;
 import com.getstream.sdk.chat.view.MessageListView;
 import com.getstream.sdk.chat.view.MessageListViewStyle;
 
-import io.getstream.chat.android.client.models.Attachment;
 import io.getstream.chat.android.client.models.Message;
 
 public abstract class BaseAttachmentViewHolder extends RecyclerView.ViewHolder{
@@ -23,7 +22,7 @@ public abstract class BaseAttachmentViewHolder extends RecyclerView.ViewHolder{
     public abstract void bind(@NonNull Context context,
                               @NonNull MessageListItem.MessageItem messageListItem,
                               @NonNull Message message,
-                              @NonNull Attachment attachment,
+                              @NonNull AttachmentListItem attachmentListItem,
                               @NonNull MessageListViewStyle style,
                               @NonNull MessageListView.BubbleHelper bubbleHelper,
                               @Nullable MessageListView.AttachmentClickListener clickListener,

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
@@ -7,7 +7,6 @@ import com.getstream.sdk.chat.adapter.MessageListItem.MessageItem
 import com.getstream.sdk.chat.adapter.MessageListItem.ThreadSeparatorItem
 import com.getstream.sdk.chat.adapter.MessageListItem.TypingItem
 import com.getstream.sdk.chat.model.ModelType
-import io.getstream.chat.android.client.models.Attachment
 
 /**
  * Allows you to easily customize message rendering or message attachment rendering
@@ -37,9 +36,9 @@ open class MessageViewHolderFactory {
     }
 
     open fun getAttachmentViewType(
-        attachment: Attachment
+        attachmentItem: AttachmentListItem
     ): Int {
-        return when (attachment.type) {
+        return when (attachmentItem.attachment.type) {
             null ->
                 GENERIC_ATTACHMENT
             ModelType.attach_video ->


### PR DESCRIPTION
Wraps the `Attachment` network model into the `AttachmentListItem` class, so that it's not used directly in `AttachmentListItemAdapter`. This allows us to add extra properties to the list item later, if needed.

See previous discussion in https://github.com/GetStream/stream-chat-android/pull/614#discussion_r484452890