### PR TITLE
WIP: draft implementations for ListenerContainer

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ListenerContainer.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ListenerContainer.kt
@@ -1,0 +1,73 @@
+package com.getstream.sdk.chat.adapter
+
+import com.getstream.sdk.chat.view.MessageListView.MessageClickListener
+import kotlin.properties.ReadWriteProperty
+import kotlin.reflect.KProperty
+
+class ListenerContainer(
+    // Empty initial listeners by default
+    messageClickListener: MessageClickListener = MessageClickListener(EMPTY_TWO_PARAM)
+) {
+
+    private companion object {
+        val EMPTY_TWO_PARAM = { _: Any, _: Any -> Unit }
+    }
+
+    // The actual listener instance
+    private var _messageClickListener: MessageClickListener = messageClickListener
+
+    // Manually implemented setter for the actual listener,
+    // as we never want it to be read externally
+    fun setMessageClickListener(messageClickListener: MessageClickListener) {
+        _messageClickListener = messageClickListener
+    }
+
+    // Wrapper that can be referenced externally, even stored, as it will
+    // always point to the actual listener, even if that changes
+    val messageClickListener: MessageClickListener =
+        MessageClickListener { message, position ->
+            _messageClickListener.onMessageClick(message, position)
+        }
+}
+
+/* ************************** */
+/* ************************** */
+/* ************************** */
+
+class ListenerContainerV2(
+    messageClickListener: MessageClickListener = MessageClickListener(EMPTY_TWO_PARAM)
+) {
+    private companion object {
+        val EMPTY_TWO_PARAM = { _: Any, _: Any -> Unit }
+    }
+
+    // Delegate to wrap up all of the above in a single property per listener
+    var messageClickListener: MessageClickListener by ListenerDelegate(
+        initialValue = messageClickListener,
+        wrap = { realListener ->
+            MessageClickListener { message, position ->
+                realListener().onMessageClick(message, position)
+            }
+        }
+    )
+}
+
+internal class ListenerDelegate<L : Any>(
+    initialValue: L,
+    // A function that has to produce the wrapper listener. The listener to wrap
+    // can be referenced by calling the realListener() method. This always returns
+    // the actual listener, even if it changes.
+    wrap: (realListener: () -> L) -> L
+) : ReadWriteProperty<Any?, L> {
+
+    private var realListener: L = initialValue
+    private val wrapper: L = wrap { realListener }
+
+    override fun getValue(thisRef: Any?, property: KProperty<*>): L {
+        return wrapper
+    }
+
+    override fun setValue(thisRef: Any?, property: KProperty<*>, value: L) {
+        realListener = value
+    }
+}

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
@@ -8,7 +8,6 @@ import com.getstream.sdk.chat.view.MessageListView
 import com.getstream.sdk.chat.view.MessageListView.AttachmentClickListener
 import com.getstream.sdk.chat.view.MessageListView.BubbleHelper
 import com.getstream.sdk.chat.view.MessageListView.GiphySendListener
-import com.getstream.sdk.chat.view.MessageListView.MessageClickListener
 import com.getstream.sdk.chat.view.MessageListView.MessageLongClickListener
 import com.getstream.sdk.chat.view.MessageListView.ReactionViewClickListener
 import com.getstream.sdk.chat.view.MessageListView.ReadStateClickListener
@@ -17,18 +16,13 @@ import io.getstream.chat.android.client.models.Channel
 
 class MessageListItemAdapter @JvmOverloads constructor(
     private var context: Context,
+    var viewHolderFactory: MessageViewHolderFactory,
     var channel: Channel? = null,
-    private var messageListItemList: List<MessageListItem> = emptyList(),
-    var viewHolderFactory: MessageViewHolderFactory = MessageViewHolderFactory()
+    private var messageListItemList: List<MessageListItem> = emptyList()
 ) : RecyclerView.Adapter<BaseMessageListItemViewHolder<*>>() {
 
     var bubbleHelper: BubbleHelper? = null
 
-    var messageClickListener: MessageClickListener? = null
-        set(value) {
-            if (style?.isReactionEnabled == true)
-                field = value
-        }
     var messageLongClickListener: MessageLongClickListener? = null
     var attachmentClickListener: AttachmentClickListener? = null
     var reactionViewClickListener: ReactionViewClickListener? = null

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
@@ -84,21 +84,25 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
     protected Message message;
     protected MessageListItem.MessageItem messageListItem;
 
+    protected MessageListView.MessageClickListener messageClickListener;
     protected MessageListView.MessageLongClickListener messageLongClickListener;
     protected MessageListView.AttachmentClickListener attachmentClickListener;
     protected MessageListView.ReactionViewClickListener reactionViewClickListener;
     protected MessageListView.UserClickListener userClickListener;
     protected MessageListView.ReadStateClickListener readStateClickListener;
     protected MessageListView.GiphySendListener giphySendListener;
-    protected final ListenerContainer listenerContainer;
 
     protected List<MessageViewHolderFactory.Position> positions;
 
     protected ConstraintSet set;
 
-    public MessageListItemViewHolder(int resId, ViewGroup viewGroup, ListenerContainer listenerContainer) {
+    public MessageListItemViewHolder(
+            int resId,
+            ViewGroup viewGroup,
+            MessageListView.MessageClickListener messageClickListener
+    ) {
         super(resId, viewGroup);
-        this.listenerContainer = listenerContainer;
+        this.messageClickListener = messageClickListener;
 
         rv_reaction = itemView.findViewById(R.id.reactionsRecyclerView);
         iv_tail = itemView.findViewById(R.id.iv_tail);
@@ -420,7 +424,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
 
             if (isFailedMessage() && !ChatClient.instance().isSocketConnected())
                 return;
-            listenerContainer.getMessageClickListener().onMessageClick(message, position);
+            messageClickListener.onMessageClick(message, position);
         });
 
         tv_text.setOnLongClickListener(view -> {
@@ -510,10 +514,10 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
         tv_reply.setText(tv_reply.getContext().getResources().getQuantityString(R.plurals.stream_reply_count, replyCount, replyCount));
 
         iv_reply.setOnClickListener(view -> {
-            listenerContainer.getMessageClickListener().onMessageClick(message, position);
+            messageClickListener.onMessageClick(message, position);
         });
         tv_reply.setOnClickListener(view -> {
-            listenerContainer.getMessageClickListener().onMessageClick(message, position);
+            messageClickListener.onMessageClick(message, position);
         });
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.java
@@ -84,20 +84,21 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
     protected Message message;
     protected MessageListItem.MessageItem messageListItem;
 
-    protected MessageListView.MessageClickListener messageClickListener;
     protected MessageListView.MessageLongClickListener messageLongClickListener;
     protected MessageListView.AttachmentClickListener attachmentClickListener;
     protected MessageListView.ReactionViewClickListener reactionViewClickListener;
     protected MessageListView.UserClickListener userClickListener;
     protected MessageListView.ReadStateClickListener readStateClickListener;
     protected MessageListView.GiphySendListener giphySendListener;
+    protected final ListenerContainer listenerContainer;
 
     protected List<MessageViewHolderFactory.Position> positions;
 
     protected ConstraintSet set;
 
-    public MessageListItemViewHolder(int resId, ViewGroup viewGroup) {
+    public MessageListItemViewHolder(int resId, ViewGroup viewGroup, ListenerContainer listenerContainer) {
         super(resId, viewGroup);
+        this.listenerContainer = listenerContainer;
 
         rv_reaction = itemView.findViewById(R.id.reactionsRecyclerView);
         iv_tail = itemView.findViewById(R.id.iv_tail);
@@ -177,10 +178,6 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
         configParamsMessageDate();
         configParamsReply();
         configParamsReadIndicator();
-    }
-
-    public void setMessageClickListener(MessageListView.MessageClickListener messageClickListener) {
-        this.messageClickListener = messageClickListener;
     }
 
     public void setMessageLongClickListener(MessageListView.MessageLongClickListener messageLongClickListener) {
@@ -423,8 +420,7 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
 
             if (isFailedMessage() && !ChatClient.instance().isSocketConnected())
                 return;
-            if (messageClickListener != null)
-                messageClickListener.onMessageClick(message, position);
+            listenerContainer.getMessageClickListener().onMessageClick(message, position);
         });
 
         tv_text.setOnLongClickListener(view -> {
@@ -514,12 +510,10 @@ public class MessageListItemViewHolder extends BaseMessageListItemViewHolder<Mes
         tv_reply.setText(tv_reply.getContext().getResources().getQuantityString(R.plurals.stream_reply_count, replyCount, replyCount));
 
         iv_reply.setOnClickListener(view -> {
-            if (messageClickListener != null)
-                messageClickListener.onMessageClick(message, position);
+            listenerContainer.getMessageClickListener().onMessageClick(message, position);
         });
         tv_reply.setOnClickListener(view -> {
-            if (messageClickListener != null)
-                messageClickListener.onMessageClick(message, position);
+            listenerContainer.getMessageClickListener().onMessageClick(message, position);
         });
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
@@ -12,7 +12,9 @@ import io.getstream.chat.android.client.models.Attachment
 /**
  * Allows you to easily customize message rendering or message attachment rendering
  */
-open class MessageViewHolderFactory {
+open class MessageViewHolderFactory(
+    protected val listenerContainer: ListenerContainer
+) {
     companion object {
         const val MESSAGEITEM_DATE_SEPARATOR = 1
         const val MESSAGEITEM_MESSAGE = 2
@@ -62,8 +64,11 @@ open class MessageViewHolderFactory {
             MESSAGEITEM_DATE_SEPARATOR ->
                 DateSeparatorViewHolder(R.layout.stream_item_date_separator, parent)
             MESSAGEITEM_MESSAGE ->
-                MessageListItemViewHolder(R.layout.stream_item_message, parent).apply {
-                    setMessageClickListener(adapter.messageClickListener)
+                MessageListItemViewHolder(
+                    R.layout.stream_item_message,
+                    parent,
+                    listenerContainer
+                ).apply {
                     setMessageLongClickListener(adapter.messageLongClickListener)
                     setAttachmentClickListener(adapter.attachmentClickListener)
                     setReactionViewClickListener(adapter.reactionViewClickListener)

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
@@ -67,7 +67,7 @@ open class MessageViewHolderFactory(
                 MessageListItemViewHolder(
                     R.layout.stream_item_message,
                     parent,
-                    listenerContainer
+                    listenerContainer.messageClickListener
                 ).apply {
                     setMessageLongClickListener(adapter.messageLongClickListener)
                     setAttachmentClickListener(adapter.attachmentClickListener)

--- a/library/src/test/java/com/getstream/sdk/chat/adapter/ListenerDelegateTest.kt
+++ b/library/src/test/java/com/getstream/sdk/chat/adapter/ListenerDelegateTest.kt
@@ -1,0 +1,43 @@
+package com.getstream.sdk.chat.adapter
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+class ListenerDelegateTest {
+
+    interface TestListener {
+        fun call(): Int
+    }
+
+    @Test
+    fun test() {
+        val listener1 = object : TestListener {
+            override fun call() = 1
+        }
+        val listener2 = object : TestListener {
+            override fun call() = 2
+        }
+
+        var delegate: TestListener by ListenerDelegate<TestListener>(
+            initialValue = listener1,
+            wrap = { realListener ->
+                object : TestListener {
+                    override fun call() = realListener().call()
+                    override fun toString() = "wrapper"
+                }
+            }
+        )
+
+        // Save reference locally
+        val localProp = delegate
+        localProp.call() shouldBeEqualTo 1
+
+        // Swap underlying listener back and forth, wrapper always calls the correct one
+        delegate = listener2
+        localProp.call() shouldBeEqualTo 2
+        delegate = listener1
+        localProp.call() shouldBeEqualTo 1
+
+        localProp.toString() shouldBeEqualTo "wrapper"
+    }
+}


### PR DESCRIPTION
This PR refactors only the `messageClickListener` used by `MessageListItemViewHolder`, as an example of what the new listener setup could look like. Instead of the ViewHolder receiving the click listener through a setter after it's created, it now accesses it through the `ListenerContainer` class.

There are two implementations of `ListenerContainer` in the same file, one of them is a more manual implementation, but perhaps easier to understand. The second implementation abstracts away the common pattern that would have to be repeated for each listener into a property delegate.

Listeners set into the Container can not be accessed directly, they can only be called through a wrapper listener exposed from the Container. Holding a reference to this wrapper is safe, as when the actual listener underneath is swapped out,  calls will start going to the new listener.