### PR TITLE
Adjust ChatSocketListener to new events(NewMessageEvent, NotificationMarkReadEvent, NotificationMessageNewEvent) properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # To be released:
 - Adjust ChatSocketListener to new events(NewMessageEvent, NotificationMarkReadEvent, NotificationMessageNewEvent) properties.
+- Update client to the latest version. See changes: https://github.com/GetStream/stream-chat-android-client/releases/tag/1.15.6
+- Update Stream Livedata to the last version. See changes: https://github.com/GetStream/stream-chat-android-livedata/releases/tag/0.7.7
 
 # Sep 18th, 2020 - 4.2.11-beta-12
 - Implement Giphy actions handler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # To be released:
+- Adjust ChatSocketListener to new events(NewMessageEvent, NotificationMarkReadEvent, NotificationMessageNewEvent) properties.
 
 # Sep 18th, 2020 - 4.2.11-beta-12
 - Implement Giphy actions handler

--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -50,7 +50,7 @@ private const val TIMBER_VERSION = "4.7.1"
 private const val RECYCLERVIEW_VERSION = "1.2.0-alpha05"
 private const val RETROFIT_VERSION = "2.9.0"
 private const val ROOM_VERSION = "2.2.5"
-private const val STREAM_LIVEDATA_VERSION = "0.7.6"
+private const val STREAM_LIVEDATA_VERSION = "0.7.7"
 
 object Dependencies {
     val activityKtx = "androidx.activity:activity-ktx:$ACTIVITY_KTX_VERSION"

--- a/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -206,12 +206,12 @@ class ChatImpl implements Chat {
                     currentUser.postValue(user);
                     return Unit.INSTANCE;
                 },
-                newUnreadChannels -> {
-                    unreadChannels.postValue(newUnreadChannels);
-                    return Unit.INSTANCE;
-                },
                 newUnreadMessages -> {
                     unreadMessages.postValue(newUnreadMessages);
+                    return Unit.INSTANCE;
+                },
+                newUnreadChannels -> {
+                    unreadChannels.postValue(newUnreadChannels);
                     return Unit.INSTANCE;
                 }
         ));

--- a/library/src/main/java/com/getstream/sdk/chat/ChatSocketListener.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatSocketListener.kt
@@ -80,15 +80,15 @@ internal class ChatSocketListener(
         when (event) {
             is NewMessageEvent -> {
                 event.totalUnreadCount?.let(onTotalUnreadCountListener)
-                event.unreadMessages?.let(onUnreadChannels)
+                event.unreadChannels?.let(onUnreadChannels)
             }
             is NotificationMarkReadEvent -> {
                 event.totalUnreadCount?.let(onTotalUnreadCountListener)
-                event.unreadMessages?.let(onUnreadChannels)
+                event.unreadChannels?.let(onUnreadChannels)
             }
             is NotificationMessageNewEvent -> {
                 event.totalUnreadCount?.let(onTotalUnreadCountListener)
-                event.unreadMessages?.let(onUnreadChannels)
+                event.unreadChannels?.let(onUnreadChannels)
             }
             is ConnectedEvent -> {
                 onConnected(event)


### PR DESCRIPTION
Shouldn't be merged before the release of LiveData which will contain events changes in LLC (https://github.com/GetStream/stream-chat-android-client/pull/75)