### PR TITLE
[Bugfix] Set ListenerContainer in AttachmentViewHolderFactory

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFactory.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/AttachmentViewHolderFactory.kt
@@ -17,6 +17,8 @@ open class AttachmentViewHolderFactory {
     }
 
     lateinit var listenerContainer: ListenerContainer
+        @JvmName("setListenerContainerInternal")
+        internal set
 
     open fun getAttachmentViewType(
         attachmentItem: AttachmentListItem

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -256,7 +256,7 @@ public class MessageListView extends RecyclerView {
         }
 
         // Inject Attachment factory
-        attachmentViewHolderFactory.setListenerContainer(listenerContainer);
+        attachmentViewHolderFactory.setListenerContainerInternal(listenerContainer);
 
         // Inject Message factory
         messageViewHolderFactory.setListenerContainerInternal(listenerContainer);

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -255,7 +255,10 @@ public class MessageListView extends RecyclerView {
             bubbleHelper = DefaultBubbleHelper.initDefaultBubbleHelper(style, getContext());
         }
 
-        // Inject factory
+        // Inject Attachment factory
+        attachmentViewHolderFactory.setListenerContainer(listenerContainer);
+
+        // Inject Message factory
         messageViewHolderFactory.setListenerContainerInternal(listenerContainer);
         messageViewHolderFactory.setAttachmentViewHolderFactoryInternal(attachmentViewHolderFactory);
         messageViewHolderFactory.setBubbleHelperInternal(bubbleHelper);


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/pull/640 merged yesterday has introduced a crash when trying to render any attachment, as a `lateinit var` was not injected. This PR fixes the issue. 

(+ a style inconsistency compared to the message factory)