### PR TITLE
[CAS-231] Remove position parameter from ViewHolder binding method

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/BaseMessageListItemViewHolder.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/BaseMessageListItemViewHolder.kt
@@ -11,18 +11,10 @@ abstract class BaseMessageListItemViewHolder<T : MessageListItem>(
     /**
      * Workaround to allow a downcast of the MessageListItem to T
      */
-    fun bindListItem(
-        messageListItem: MessageListItem,
-        position: Int
-    ) {
-        @Suppress("UNCHECKED_CAST")
-        bind(messageListItem as T, position)
-    }
+    @Suppress("UNCHECKED_CAST")
+    fun bindListItem(messageListItem: MessageListItem) = bind(messageListItem as T)
 
-    protected abstract fun bind(
-        messageListItem: T,
-        position: Int
-    )
+    protected abstract fun bind(messageListItem: T)
 
     protected val context: Context
         get() = itemView.context

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/DateSeparatorViewHolder.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/DateSeparatorViewHolder.kt
@@ -20,10 +20,7 @@ class DateSeparatorViewHolder(
         StreamItemDateSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<DateSeparatorItem>(binding.root) {
 
-    override fun bind(
-        messageListItem: DateSeparatorItem,
-        position: Int
-    ) {
+    override fun bind(messageListItem: DateSeparatorItem) {
         configDate(messageListItem)
         applyStyle()
     }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
@@ -40,9 +40,6 @@ class MessageListItemAdapter @JvmOverloads constructor(
     }
 
     override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int) {
-        holder.bindListItem(
-            messageListItem = messageListItemList[position],
-            position = position
-        )
+        holder.bindListItem(messageListItemList[position])
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemViewHolder.kt
@@ -63,15 +63,13 @@ class MessageListItemViewHolder(
         StreamItemMessageBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<MessageItem>(binding.root) {
 
-    protected var bindingPosition = 0
     protected lateinit var message: Message
     protected lateinit var messageListItem: MessageItem
     protected lateinit var positions: List<MessageViewHolderFactory.Position>
     protected lateinit var set: ConstraintSet
 
-    override fun bind(messageListItem: MessageItem, position: Int) {
+    override fun bind(messageListItem: MessageItem) {
         this.messageListItem = messageListItem
-        this.bindingPosition = position
         this.message = messageListItem.message
         this.positions = messageListItem.positions
         this.set = ConstraintSet()
@@ -426,7 +424,7 @@ class MessageListItemViewHolder(
 
         if (!style.isThreadEnabled ||
             !channel.config.isRepliesEnabled ||
-            (bindingPosition == 0 && message.id.isEmpty()) ||
+            (bindingAdapterPosition == 0 && message.id.isEmpty()) ||
             isDeletedMessage() ||
             isFailedMessage() ||
             replyCount == 0 || isThread()

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/ThreadSeparatorViewHolder.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/ThreadSeparatorViewHolder.kt
@@ -10,10 +10,7 @@ class ThreadSeparatorViewHolder(
         StreamItemThreadSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<ThreadSeparatorItem>(binding.root) {
 
-    override fun bind(
-        messageListItem: ThreadSeparatorItem,
-        position: Int
-    ) {
+    override fun bind(messageListItem: ThreadSeparatorItem) {
         /* Empty */
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/TypingIndicatorViewHolder.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/TypingIndicatorViewHolder.kt
@@ -18,10 +18,7 @@ class TypingIndicatorViewHolder(
         StreamItemTypeIndicatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<TypingItem>(binding.root) {
 
-    override fun bind(
-        messageListItem: TypingItem,
-        position: Int
-    ) {
+    override fun bind(messageListItem: TypingItem) {
         binding.llTypingIndicator.visibility = View.VISIBLE
         binding.ivTypingIndicator.visibility = View.VISIBLE
         binding.llTypingIndicator.removeAllViews()


### PR DESCRIPTION
Removes the last unnecessary parameter from the ViewHolder binding methods, leaving just the `MessageItem` itself.