### PR TITLE
Check for null values of navigationHandler

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -17,20 +17,14 @@ import org.jetbrains.annotations.Nullable;
 
 import io.getstream.chat.android.client.ChatClient;
 import io.getstream.chat.android.client.errors.ChatError;
-import io.getstream.chat.android.client.events.ChatEvent;
-import io.getstream.chat.android.client.events.ConnectedEvent;
 import io.getstream.chat.android.client.logger.ChatLogger;
 import io.getstream.chat.android.client.models.User;
-import io.getstream.chat.android.client.notifications.ChatNotifications;
-import io.getstream.chat.android.client.notifications.ChatNotificationsImpl;
 import io.getstream.chat.android.client.notifications.handler.ChatNotificationHandler;
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig;
 import io.getstream.chat.android.client.socket.InitConnectionListener;
-import io.getstream.chat.android.client.socket.SocketListener;
 import io.getstream.chat.android.livedata.ChatDomain;
 import kotlin.UninitializedPropertyAccessException;
 import kotlin.Unit;
-import kotlin.jvm.functions.Function1;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
 import kotlinx.coroutines.Dispatchers;
@@ -74,8 +68,8 @@ class ChatImpl implements Chat {
             navigator.setHandler(navigationHandler);
         }
         new ChatClient.Builder(this.apiKey, context)
-                        .notifications(new ChatNotificationHandler(context, notificationConfig))
-                        .build();
+                .notifications(new ChatNotificationHandler(context, notificationConfig))
+                .build();
         ChatLogger.Companion.getInstance().logI("Chat", "Initialized: " + getVersion());
     }
 
@@ -175,7 +169,7 @@ class ChatImpl implements Chat {
                     Dispatchers.getIO(),
                     CoroutineStart.DEFAULT,
                     (scope, continuation) -> chatDomain.disconnect(continuation));
-        } catch(UninitializedPropertyAccessException e) {
+        } catch (UninitializedPropertyAccessException e) {
             ChatLogger.Companion.get("ChatImpl").logD("ChatDomain was not initialized yet. No need to disconnect.");
         }
     }

--- a/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -13,6 +13,7 @@ import com.getstream.sdk.chat.style.ChatFonts;
 import com.getstream.sdk.chat.utils.strings.ChatStrings;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import io.getstream.chat.android.client.ChatClient;
 import io.getstream.chat.android.client.errors.ChatError;
@@ -53,7 +54,7 @@ class ChatImpl implements Chat {
 
     ChatImpl(ChatFonts chatFonts,
              ChatStrings chatStrings,
-             ChatNavigationHandler navigationHandler,
+             @Nullable ChatNavigationHandler navigationHandler,
              UrlSigner urlSigner,
              ChatMarkdown markdown,
              String apiKey,
@@ -69,7 +70,9 @@ class ChatImpl implements Chat {
         this.offlineEnabled = offlineEnabled;
         this.notificationConfig = notificationConfig;
 
-        navigator.setHandler(navigationHandler);
+        if (navigationHandler != null) {
+            navigator.setHandler(navigationHandler);
+        }
         new ChatClient.Builder(this.apiKey, context)
                         .notifications(new ChatNotificationHandler(context, notificationConfig))
                         .build();


### PR DESCRIPTION
Forgot to check for nullability of the handler in Java code, added a check now. If `null` handler is passed in from the builder, the default one is used internally instead.