### PR TITLE
[CAS-282] Use ListAdapter in MessageListItemAdapter instead of using DiffUtil directly

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
@@ -1,35 +1,32 @@
 package com.getstream.sdk.chat.adapter
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.ListAdapter
 import com.getstream.sdk.chat.adapter.viewholder.message.BaseMessageListItemViewHolder
 import com.getstream.sdk.chat.view.MessageListViewStyle
 import io.getstream.chat.android.client.models.Channel
 
-class MessageListItemAdapter @JvmOverloads constructor(
+class MessageListItemAdapter(
     val channel: Channel,
     val viewHolderFactory: MessageViewHolderFactory,
-    val style: MessageListViewStyle,
-    private var messageListItemList: List<MessageListItem> = emptyList()
-) : RecyclerView.Adapter<BaseMessageListItemViewHolder<*>>() {
+    val style: MessageListViewStyle
+) : ListAdapter<MessageListItem, BaseMessageListItemViewHolder<*>>(MessageListItemDiffCallback) {
 
     var isThread = false
 
+    @Deprecated(
+        message = "Use submitList instead",
+        replaceWith = ReplaceWith("submitList(newEntities)"),
+        level = DeprecationLevel.ERROR
+    )
     fun replaceEntities(newEntities: List<MessageListItem>) {
-        val result = DiffUtil.calculateDiff(
-            MessageListItemDiffCallback(messageListItemList, newEntities), true
-        )
-        result.dispatchUpdatesTo(this)
-        messageListItemList = newEntities
+        submitList(newEntities)
     }
 
-    override fun getItemCount(): Int = messageListItemList.size
-
-    override fun getItemId(position: Int): Long = messageListItemList[position].getStableId()
+    override fun getItemId(position: Int): Long = getItem(position).getStableId()
 
     override fun getItemViewType(position: Int): Int {
-        val messageListItem = messageListItemList[position]
+        val messageListItem = getItem(position)
         return viewHolderFactory.getMessageViewType(messageListItem)
     }
 
@@ -41,6 +38,6 @@ class MessageListItemAdapter @JvmOverloads constructor(
     }
 
     override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int) {
-        holder.bindListItem(messageListItemList[position])
+        holder.bindListItem(getItem(position))
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
@@ -2,20 +2,12 @@ package com.getstream.sdk.chat.adapter
 
 import androidx.recyclerview.widget.DiffUtil
 
-class MessageListItemDiffCallback(
-    private val oldList: List<MessageListItem>,
-    private val newList: List<MessageListItem>
-) : DiffUtil.Callback() {
-
-    override fun getOldListSize(): Int = oldList.size
-
-    override fun getNewListSize(): Int = newList.size
-
-    override fun areItemsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldList[oldItemPosition].getStableId() == newList[newItemPosition].getStableId()
+object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListItem>() {
+    override fun areItemsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
+        return oldItem.getStableId() == newItem.getStableId()
     }
 
-    override fun areContentsTheSame(oldItemPosition: Int, newItemPosition: Int): Boolean {
-        return oldList[oldItemPosition] == newList[newItemPosition]
+    override fun areContentsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
+        return oldItem == newItem
     }
 }

--- a/library/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
+++ b/library/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
@@ -4,11 +4,8 @@ import com.getstream.sdk.chat.createChannelUserRead
 import com.getstream.sdk.chat.createMessageItem
 import org.amshove.kluent.shouldBe
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInstance
-import org.junit.jupiter.api.TestInstance.Lifecycle.PER_METHOD
 import java.util.Date
 
-@TestInstance(PER_METHOD)
 class MessageListItemDiffCallbackTest {
 
     private val channelUserRead = createChannelUserRead()

--- a/library/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
+++ b/library/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
@@ -29,37 +29,36 @@ class MessageListItemDiffCallbackTest {
 
     @Test
     fun `Should properly check if items are the same when messages have the same id`() {
-        val diff = MessageListItemDiffCallback(listOf(msg), listOf(msg))
+        val result = MessageListItemDiffCallback.areItemsTheSame(msg, msg)
 
-        diff.areItemsTheSame(0, 0) shouldBe true
+        result shouldBe true
     }
 
     @Test
     fun `Should properly check if items are the same when messages have different id`() {
-        val diff = MessageListItemDiffCallback(listOf(msg), listOf(msgWithUserRead))
+        val result = MessageListItemDiffCallback.areItemsTheSame(msg, msgWithUserRead)
 
-        diff.areItemsTheSame(0, 0) shouldBe false
+        result shouldBe false
     }
 
     @Test
     fun `Should properly check if contents are the same when messages are the same`() {
-        val diff = MessageListItemDiffCallback(listOf(msgWithUserRead), listOf(msgWithUserRead))
+        val result = MessageListItemDiffCallback.areContentsTheSame(msgWithUserRead, msgWithUserRead)
 
-        diff.areContentsTheSame(0, 0) shouldBe true
+        result shouldBe true
     }
 
     @Test
     fun `Should properly check if contents are the same when messages are different`() {
-        val diff = MessageListItemDiffCallback(listOf(msg), listOf(msgWithUserRead))
+        val result = MessageListItemDiffCallback.areContentsTheSame(msg, msgWithUserRead)
 
-        diff.areContentsTheSame(0, 0) shouldBe false
+        result shouldBe false
     }
 
     @Test
     fun `Should properly check if contents are the same when messages are the same but with different user read`() {
-        val diff =
-            MessageListItemDiffCallback(listOf(msgWithUserRead), listOf(msgWithModifiedUserRead))
+        val result = MessageListItemDiffCallback.areContentsTheSame(msgWithUserRead, msgWithModifiedUserRead)
 
-        diff.areContentsTheSame(0, 0) shouldBe false
+        result shouldBe false
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-282

The [`ListAdapter`](https://developer.android.com/reference/androidx/recyclerview/widget/ListAdapter) class manages the list of items for us, and it uses [`AsyncListDiffer`](https://developer.android.com/reference/androidx/recyclerview/widget/AsyncListDiffer) internally, so the diff is calculated on a background thread.