### PR TITLE
Fix/default bubble helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # To be released:
+- Update to Kotlin 1.4.10
+- Fix Typing view behavior
+- Fix NPE asking for `Attachment::type`
 
 # Oct 9th, 2020 - 4.3.0-beta-5
 - Improve selecting non-media attachments

--- a/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
+++ b/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
@@ -42,6 +42,7 @@ public class DefaultBubbleHelper {
             @Override
             public Drawable getDrawableForAttachment(Message message, Boolean mine, List<MessageViewHolderFactory.Position> positions, Attachment attachment) {
                 if (attachment == null
+                        || attachment.getType() == null
                         || attachment.getType().equals(ModelType.attach_unknown))
                     return null;
 

--- a/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
+++ b/library/src/main/java/com/getstream/sdk/chat/DefaultBubbleHelper.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.text.TextUtils;
 
+import androidx.core.content.ContextCompat;
+
 import com.getstream.sdk.chat.adapter.MessageViewHolderFactory;
 import com.getstream.sdk.chat.model.ModelType;
 import com.getstream.sdk.chat.view.MessageListView;
@@ -24,7 +26,7 @@ public class DefaultBubbleHelper {
             @Override
             public Drawable getDrawableForMessage(Message message, Boolean mine, List<MessageViewHolderFactory.Position> positions) {
                 if (style.getMessageBubbleDrawable(mine) != -1)
-                    return context.getDrawable(style.getMessageBubbleDrawable(mine));
+                    return ContextCompat.getDrawable(context, style.getMessageBubbleDrawable(mine));
 
                 configParams(style, mine, false);
                 if (isDefaultBubble(style, mine, context))
@@ -47,7 +49,7 @@ public class DefaultBubbleHelper {
                     return null;
 
                 if (style.getMessageBubbleDrawable(mine) != -1)
-                    return context.getDrawable(style.getMessageBubbleDrawable(mine));
+                    return ContextCompat.getDrawable(context, style.getMessageBubbleDrawable(mine));
 
                 configParams(style, mine, true);
                 if (isDefaultBubble(style, mine, context))
@@ -69,7 +71,7 @@ public class DefaultBubbleHelper {
             @Override
             public Drawable getDrawableForAttachmentDescription(Message message, Boolean mine, List<MessageViewHolderFactory.Position> positions){
                 if (style.getMessageBubbleDrawable(mine) != -1)
-                    return context.getDrawable(style.getMessageBubbleDrawable(mine));
+                    return ContextCompat.getDrawable(context, style.getMessageBubbleDrawable(mine));
 
                 configParams(style, mine, true);
                 if (isDefaultBubble(style, mine, context))


### PR DESCRIPTION
### Description

Fix NPE asking for an attachment type that could be null.
Use` ContextCompat` to obtain drawable

### Checklist

- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
