### PR TITLE
Create JUnit5 extension for coroutine tests

### DIFF
--- a/library/src/test/java/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
+++ b/library/src/test/java/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
@@ -1,38 +1,22 @@
 package com.getstream.sdk.chat.utils
 
 import com.getstream.sdk.chat.randomString
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.test.setMain
 import org.amshove.kluent.`should be equal to`
-import org.junit.After
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 @ExperimentalCoroutinesApi
 class StartStopBufferTest {
 
-    private val testCoroutineDispatcher = TestCoroutineDispatcher()
-    private val testCoroutineScope = TestCoroutineScope(testCoroutineDispatcher)
-
-    @BeforeEach
-    fun setup() {
-        Dispatchers.setMain(testCoroutineDispatcher)
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-        testCoroutineScope.cleanupTestCoroutines()
-    }
+    @JvmField
+    @RegisterExtension
+    val testCoroutines = TestCoroutineExtension()
 
     @Test
     fun `data should only be propagated when enqueueData and subscribe are done`() {
-        StartStopBuffer<String>(testCoroutineDispatcher).run {
+        StartStopBuffer<String>(testCoroutines.dispatcher).run {
             val data = randomString()
             var resultText = ""
 
@@ -47,19 +31,20 @@ class StartStopBufferTest {
     }
 
     @Test
-    fun `data should not be propagated if hold is called before subscribe`() = testCoroutineScope.runBlockingTest {
-        StartStopBuffer<String>(testCoroutineDispatcher).run {
-            val initialValue = randomString()
-            val data = randomString()
-            var resultText = initialValue
+    fun `data should not be propagated if hold is called before subscribe`() =
+        testCoroutines.scope.runBlockingTest {
+            StartStopBuffer<String>(testCoroutines.dispatcher).run {
+                val initialValue = randomString()
+                val data = randomString()
+                var resultText = initialValue
 
-            enqueueData(data)
-            hold()
-            subscribe { result ->
-                resultText = result
+                enqueueData(data)
+                hold()
+                subscribe { result ->
+                    resultText = result
+                }
+
+                resultText `should be equal to` initialValue
             }
-
-            resultText `should be equal to` initialValue
         }
-    }
 }

--- a/library/src/test/java/com/getstream/sdk/chat/utils/TestCoroutineExtension.kt
+++ b/library/src/test/java/com/getstream/sdk/chat/utils/TestCoroutineExtension.kt
@@ -1,0 +1,31 @@
+@file:Suppress("EXPERIMENTAL_API_USAGE")
+
+package com.getstream.sdk.chat.utils
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.extension.AfterAllCallback
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+class TestCoroutineExtension : BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+
+    val dispatcher = TestCoroutineDispatcher()
+    val scope = TestCoroutineScope(dispatcher)
+
+    override fun beforeAll(context: ExtensionContext) {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    override fun afterEach(context: ExtensionContext) {
+        scope.cleanupTestCoroutines()
+    }
+
+    override fun afterAll(context: ExtensionContext) {
+        Dispatchers.resetMain()
+    }
+}


### PR DESCRIPTION
### Description

Introduces a new `TestCoroutineExtension` class that can be used to easily use test coroutine constructs (dispatchers and scopes) in unit tests.

Also moves some of the mocking logic to different methods than where we used them before: setting and reseting the Main dispatcher now only happens once for each test class, and coroutines are cleaned up after every individual test.

Usage example (note that `@JvmField` is required to make the field storing the extension public for JUnit):

```kotlin
class MyTestThatNeedsCoroutines {
    @JvmField
    @RegisterExtension
    val testCoroutines = TestCoroutineExtension()
 
    @Test
    fun `I should be able to run coroutines`() {
        testCoroutines.scope.runBlockingTest { 
            withContext(testCoroutines.dispatcher) {
                
            }
        }
    }
}

```

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
