### PR TITLE
Improve chat builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Update to Kotlin 1.4.10
 - Fix Typing view behavior
 - Fix NPE asking for `Attachment::type`
+- Fix ChatDomain initialization issue
 
 # Oct 9th, 2020 - 4.3.0-beta-5
 - Improve selecting non-media attachments

--- a/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/library/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -136,14 +136,14 @@ class ChatImpl implements Chat {
         if (offlineEnabled) {
             domainBuilder.offlineEnabled();
         }
-        final ChatDomain chatDomain = domainBuilder
-                .userPresenceEnabled()
-                .notificationConfig(notificationConfig)
-                .build();
+        domainBuilder
+            .userPresenceEnabled()
+            .notificationConfig(notificationConfig);
+
         client.setUser(user, userToken, new InitConnectionListener() {
             @Override
             public void onSuccess(@NotNull ConnectionData data) {
-                chatDomain.setCurrentUser(user);
+                domainBuilder.build().setCurrentUser(user);
                 callbacks.onSuccess(data);
             }
 


### PR DESCRIPTION
### Description
Clean up `ChatDomain` initialization in `ChatImpl.setUser()` function. 
Initialize `ChatDomain` instance only after user was set in `ChatClient` successfully.

### Checklist

- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Reviewers added
