### PR TITLE
[CAS-270] Fixes for custom scroll button

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -559,6 +559,10 @@ public class MessageListView extends ConstraintLayout {
                 && passedTime < 3000;
     }
 
+    public void scrollToBottom() {
+        layoutManager.scrollToPosition(adapter.getItemCount() - 1);
+    }
+
     /**
      * Sets the message click listener to be used by MessageListView.
      *

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -67,6 +67,7 @@ public class MessageListView extends ConstraintLayout {
 
     private RecyclerView messagesRV;
     private ConstraintLayout unseenBottomBtn;
+    boolean unseenButtonEnabled;
     private TextView newMessagesTextTV;
     private int lastViewedPosition = 0;
     private String newMessagesTextSingle;
@@ -236,7 +237,8 @@ public class MessageListView extends ConstraintLayout {
                         unseenBottomBtn,
                         newMessagesTextTV,
                         newMessagesTextSingle,
-                        newMessagesTextPlural
+                        newMessagesTextPlural,
+                        unseenButtonEnabled
                 );
     }
 
@@ -277,7 +279,15 @@ public class MessageListView extends ConstraintLayout {
                 R.styleable.MessageListView_streamButtonBackground,
                 R.drawable.stream_shape_round);
 
-        unseenBottomBtn.setBackgroundResource(backgroundRes);
+        unseenButtonEnabled = tArray.getBoolean(
+                R.styleable.MessageListView_streamDefaultButtonEnabled, true);
+
+        if (unseenButtonEnabled) {
+            unseenBottomBtn.setBackgroundResource(backgroundRes);
+        } else {
+            unseenBottomBtn.setVisibility(View.GONE);
+        }
+
         newMessagesTextSingle =
                 tArray.getString(R.styleable.MessageListView_streamNewMessagesTextSingle);
         newMessagesTextPlural =
@@ -748,7 +758,6 @@ public class MessageListView extends ConstraintLayout {
         void userScrolledToTheBottom();
 
         void onUnreadMessageCountChanged(int count);
-
     }
 
     static class DefaultScrollButtonBehaviour implements ScrollButtonBehaviour {
@@ -757,6 +766,21 @@ public class MessageListView extends ConstraintLayout {
         private TextView newMessagesTextTV;
         private String newMessagesTextSingle;
         private String newMessagesTextPlural;
+        private boolean isButtonEnabled;
+
+        private DefaultScrollButtonBehaviour(
+                ViewGroup unseenBottomBtn,
+                TextView newMessagesTextTV,
+                String newMessagesTextSingle,
+                String newMessagesTextPlural,
+                boolean isButtonEnabled
+        ) {
+            this.unseenBottomBtn = unseenBottomBtn;
+            this.newMessagesTextTV = newMessagesTextTV;
+            this.newMessagesTextSingle = newMessagesTextSingle;
+            this.newMessagesTextPlural = newMessagesTextPlural;
+            this.isButtonEnabled = isButtonEnabled;
+        }
 
         public DefaultScrollButtonBehaviour(
                 ViewGroup unseenBottomBtn,
@@ -768,11 +792,12 @@ public class MessageListView extends ConstraintLayout {
             this.newMessagesTextTV = newMessagesTextTV;
             this.newMessagesTextSingle = newMessagesTextSingle;
             this.newMessagesTextPlural = newMessagesTextPlural;
+            isButtonEnabled = true;
         }
 
         @Override
         public void userScrolledUp() {
-            if (!unseenBottomBtn.isShown()) {
+            if (!unseenBottomBtn.isShown() && isButtonEnabled) {
                 unseenBottomBtn.setVisibility(View.VISIBLE);
             }
         }

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -171,6 +171,7 @@
     <!--MessageListView-->
     <declare-styleable name="MessageListView">
         <!--Scroll button-->
+        <attr name="streamDefaultButtonEnabled" format="boolean" />
         <attr name="streamButtonBackground" format="reference" />
         <attr name="streamButtonIcon" format="reference" />
         <attr name="streamNewMessagesTextSingle" format="string" />

--- a/sample/src/main/res/layout/fragment_channel.xml
+++ b/sample/src/main/res/layout/fragment_channel.xml
@@ -27,6 +27,7 @@
         app:streamNewMessagesTextSingle="@string/new_messages_single"
         app:streamNewMessagesTextPlural="@string/new_messages_plural"
         app:streamNewMessagesBehaviour="count_new_messages"
+        app:streamButtonEnabled="false"
         app:streamButtonIcon="@drawable/stream_bottom_arrow"
         />
 

--- a/sample/src/main/res/layout/fragment_channel.xml
+++ b/sample/src/main/res/layout/fragment_channel.xml
@@ -27,7 +27,7 @@
         app:streamNewMessagesTextSingle="@string/new_messages_single"
         app:streamNewMessagesTextPlural="@string/new_messages_plural"
         app:streamNewMessagesBehaviour="count_new_messages"
-        app:streamButtonEnabled="false"
+        app:streamDefaultButtonEnabled="false"
         app:streamButtonIcon="@drawable/stream_bottom_arrow"
         />
 


### PR DESCRIPTION
[CAS-270](https://stream-io.atlassian.net/browse/CAS-270)
### Description

This PR includes code to disable the default button for scroll in the MessageListView. That's very important for the user to be able to add its own view for the button and don't show the default one. Perhaps a user wants to include its own implementation like this:

```
<com.getstream.sdk.chat.view.MessageListView
        android:id="@+id/messageListView"
        android:layout_width="0dp"
        android:layout_height="0dp"
        app:streamMessageDateShow="true"
        android:clipToPadding="false"
        android:paddingBottom="@dimen/padding_medium"
        app:streamNewMessagesBehaviour="count_new_messages"
        app:streamDefaultButtonEnabled="false"
        >

        <Button
            android:id="@+id/scrollBtn"
            android:layout_width="wrap_content"
            android:layout_height="wrap_content"
            android:layout_marginBottom="10dp"
            android:animateLayoutChanges="true"
            android:text="Scroll - 1 New message"
            app:layout_constraintBottom_toBottomOf="parent"
            app:layout_constraintEnd_toEndOf="parent"
            app:layout_constraintStart_toStartOf="parent"
            />

    </com.getstream.sdk.chat.view.MessageListView>
```

That would like this:

![Screenshot 2020-10-13 at 23 47 44](https://user-images.githubusercontent.com/10619102/95922756-43efde80-0db4-11eb-9cda-1c02710890d9.png)

Ok... maybe that button is a bit ugly, but you get the idea.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
