### PR TITLE
Fix keyboard utility methods

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
@@ -122,8 +122,6 @@ public class Utils {
     }
 
     public static void hideSoftKeyboard(@NonNull Context context) {
-        InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
-
         View view = null;
         if (context instanceof Activity) {
             // Find the currently focused view, so we can grab the correct window token from it.
@@ -132,11 +130,7 @@ public class Utils {
 
         // If we don't have an Activity, or no view currently has focus, create a new one,
         // just so we can grab a window token from it
-        if (view == null) {
-            view = new View(context);
-        }
-
-        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        hideSoftKeyboard(view != null ? view : new View(context));
     }
 
     public static void showSoftKeyboard(@NonNull View view) {

--- a/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/Utils.java
@@ -26,6 +26,7 @@ import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.StringRes;
 import androidx.core.graphics.drawable.RoundedBitmapDrawable;
 import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
@@ -33,15 +34,12 @@ import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.request.target.BitmapImageViewTarget;
 import com.getstream.sdk.chat.Chat;
-import com.getstream.sdk.chat.model.AttachmentMetaData;
-import com.getstream.sdk.chat.model.ModelType;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.InputStream;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
-import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -117,20 +115,37 @@ public class Utils {
         toast.show();
     }
 
-    public static void showSoftKeyboard(Activity activity) {
-        InputMethodManager inputMethodManager = (InputMethodManager) activity.getSystemService(Context.INPUT_METHOD_SERVICE);
-        if (!inputMethodManager.isAcceptingText())
-            inputMethodManager.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
+    public static void showSoftKeyboard(@NonNull Context context) {
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (!imm.isAcceptingText())
+            imm.toggleSoftInput(InputMethodManager.SHOW_FORCED, 0);
     }
 
-    public static void hideSoftKeyboard(Activity activity) {
-        InputMethodManager imm = (InputMethodManager) activity.getSystemService(Activity.INPUT_METHOD_SERVICE);
-        //Find the currently focused view, so we can grab the correct window token from it.
-        View view = activity.getCurrentFocus();
-        //If no view currently has focus, create a new one, just so we can grab a window token from it
-        if (view == null) {
-            view = new View(activity);
+    public static void hideSoftKeyboard(@NonNull Context context) {
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
+
+        View view = null;
+        if (context instanceof Activity) {
+            // Find the currently focused view, so we can grab the correct window token from it.
+            view = ((Activity) context).getCurrentFocus();
         }
+
+        // If we don't have an Activity, or no view currently has focus, create a new one,
+        // just so we can grab a window token from it
+        if (view == null) {
+            view = new View(context);
+        }
+
+        imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+    }
+
+    public static void showSoftKeyboard(@NonNull View view) {
+        showSoftKeyboard(view.getContext());
+    }
+
+    public static void hideSoftKeyboard(@NonNull View view) {
+        Context context = view.getContext();
+        InputMethodManager imm = (InputMethodManager) context.getSystemService(Activity.INPUT_METHOD_SERVICE);
         imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
 

--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.java
@@ -1,6 +1,5 @@
 package com.getstream.sdk.chat.view;
 
-import android.app.Activity;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.graphics.drawable.Drawable;
@@ -30,7 +29,6 @@ import com.getstream.sdk.chat.adapter.MessageViewHolderFactory;
 import com.getstream.sdk.chat.enums.GiphyAction;
 import com.getstream.sdk.chat.navigation.destinations.AttachmentDestination;
 import com.getstream.sdk.chat.utils.StartStopBuffer;
-import com.getstream.sdk.chat.utils.Utils;
 import com.getstream.sdk.chat.view.dialog.MessageMoreActionDialog;
 import com.getstream.sdk.chat.view.dialog.ReadUsersDialog;
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper;
@@ -151,7 +149,6 @@ public class MessageListView extends ConstraintLayout {
                 .navigate(new AttachmentDestination(message, attachment, getContext()));
     };
     private final ReactionViewClickListener DEFAULT_REACTION_VIEW_CLICK_LISTENER = message -> {
-        Utils.hideSoftKeyboard((Activity) getContext());
         new MessageMoreActionDialog(
                 getContext(),
                 channel,

--- a/library/src/main/java/com/getstream/sdk/chat/view/dialog/MessageMoreActionDialog.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/dialog/MessageMoreActionDialog.kt
@@ -1,6 +1,5 @@
 package com.getstream.sdk.chat.view.dialog
 
-import android.app.Activity
 import android.app.Dialog
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -33,8 +32,9 @@ class MessageMoreActionDialog(
     private val onStartThreadHandler: (message: Message) -> Unit,
     private val onMessageFlagHandler: (message: Message) -> Unit
 ) : Dialog(context, R.style.DialogTheme) {
+
     init {
-        Utils.hideSoftKeyboard(context as Activity)
+        Utils.hideSoftKeyboard(context)
         window?.apply {
             setFlags(
                 WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -166,8 +166,10 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         binding.messageTextInput.onFocusChangeListener =
             OnFocusChangeListener { _: View?, hasFocus: Boolean ->
                 if (hasFocus) {
-                    Utils.showSoftKeyboard(context as Activity)
-                } else Utils.hideSoftKeyboard(context as Activity)
+                    Utils.showSoftKeyboard(this)
+                } else {
+                    Utils.hideSoftKeyboard(this)
+                }
                 if (!isKeyboardEventListenerInitialized) {
                     isKeyboardEventListenerInitialized = true
                     setKeyboardEventListener()
@@ -204,7 +206,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
             GridLayoutManager(context, 1, RecyclerView.HORIZONTAL, false)
         binding.btnClose.setOnClickListener {
             messageInputController.onClickCloseAttachmentSelectionMenu()
-            Utils.hideSoftKeyboard(context as Activity)
+            Utils.hideSoftKeyboard(this)
         }
         binding.selectMedia.setOnClickListener { messageInputController.onClickOpenMediaSelectView() }
         binding.selectCamera.setOnClickListener { messageInputController.onCameraClick() }


### PR DESCRIPTION
# Description

Changed the keyboard utility methods taking an `Activity` as a parameter to take a `Context` instead, as it's often enough to perform the action.

Added two new utilities that take `View` instances as parameters, as we usually invoke these methods from our custom Views.

This fixes some crashes where our custom Views are used in Fragments that have non-Activity `Context`s.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
