### PR TITLE
Improve message dates comparing

### DIFF
--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -50,7 +50,7 @@ private const val TIMBER_VERSION = "4.7.1"
 private const val RECYCLERVIEW_VERSION = "1.2.0-alpha05"
 private const val RETROFIT_VERSION = "2.9.0"
 private const val ROOM_VERSION = "2.2.5"
-private const val STREAM_LIVEDATA_VERSION = "0.8.4"
+private const val STREAM_LIVEDATA_VERSION = "0.8.5"
 
 object Dependencies {
     const val activityKtx = "androidx.activity:activity-ktx:$ACTIVITY_KTX_VERSION"

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.java
@@ -110,8 +110,15 @@ public class MessageListItemLiveData extends LiveData<MessageListItemWrapper> {
                         // last read message is added by this user, so break
                         break;
                     }
+                    final Message message = messageListItem.getMessage();
+                    Date messageCreatedAt;
+                    if (message.getCreatedAt() != null) {
+                        messageCreatedAt = message.getCreatedAt();
+                    } else {
+                        messageCreatedAt = message.getCreatedLocallyAt();
+                    }
                     if (userRead.getLastRead() != null &&
-                            !userRead.getLastRead().before(messageListItem.getMessage().getCreatedAt())) {
+                            !userRead.getLastRead().before(messageCreatedAt)) {
                         // set the read state on this entity
                         messageListItem.getMessageReadBy().add(userRead);
                         // we only show it for the last message, so break

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.java
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.java
@@ -141,7 +141,26 @@ public class MessageListItemLiveData extends LiveData<MessageListItemWrapper> {
 
     private boolean isSameDay(Message a, Message b) {
         SimpleDateFormat fmt = new SimpleDateFormat("yyyyMMdd");
-        return fmt.format(a.getCreatedAt()).equals(fmt.format(b.getCreatedAt()));
+        Date aCreatedAt = null;
+        Date bCreatedAt = null;
+
+        if (a.getCreatedAt() != null) {
+            aCreatedAt = a.getCreatedAt();
+        } else if (a.getCreatedLocallyAt() != null) {
+            aCreatedAt = a.getCreatedLocallyAt();
+        }
+
+        if (b.getCreatedAt() != null) {
+            bCreatedAt = b.getCreatedAt();
+        } else if (b.getCreatedLocallyAt() != null) {
+            bCreatedAt = b.getCreatedLocallyAt();
+        }
+
+        if (aCreatedAt == null || bCreatedAt == null) {
+            return false;
+        } else {
+            return fmt.format(aCreatedAt).equals(fmt.format(bCreatedAt));
+        }
     }
 
     private boolean isThread() {


### PR DESCRIPTION

### Description

Add null checks before comparing messages by `createdAt: Date` or `createdLocallyAt: Date`.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] Reviewers added
