### PR TITLE
[CAS-292] Fix GIFs loading issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # To be released:
 
+- Replace Glide with Coil in AttachmentViewHolderMedia (Fix GIFs loading issues)
+
 # Oct 14th, 2020 - 4.3.0-beta-6
 - Update to Kotlin 1.4.10
 - Fix Typing view behavior

--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -63,6 +63,7 @@ object Dependencies {
     const val androidxMedia = "androidx.media:media:$ANDROIDX_MEDIA_VERSION"
     const val appCompat = "androidx.appcompat:appcompat:$APP_COMPAT_VERSION"
     const val coil = "io.coil-kt:coil:$COIL_VERSION"
+    const val coilGif = "io.coil-kt:coil-gif:$COIL_VERSION"
     const val coroutinesTest = "org.jetbrains.kotlinx:kotlinx-coroutines-test:$COROUTINES_VERSION"
     const val constraintLayout = "androidx.constraintlayout:constraintlayout:$CONSTRAINT_LAYOUT_VERSION"
     const val dexter = "com.karumi:dexter:$DEXTER_VERSION"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -114,6 +114,7 @@ dependencies {
 
     implementation Dependencies.androidxMedia
     implementation Dependencies.coil
+    implementation Dependencies.coilGif
 
     // ExoPlayer
     api Dependencies.exoplayerCore

--- a/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
@@ -4,11 +4,15 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.os.Build
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
 import coil.Coil
+import coil.api.load
 import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.GetRequest
 import coil.request.GetRequestBuilder
+import coil.request.RequestDisposable
 import coil.size.Precision
 import coil.transform.BlurTransformation
 import coil.transform.CircleCropTransformation
@@ -37,8 +41,27 @@ internal object ImageLoader {
             }
     }
 
-    fun getImageLoaderWithGifSupport(
+    fun ImageView.loadWithGifSupport(
+        uri: String?,
+        @DrawableRes placeholderResId: Int?,
+        onStart: () -> Unit = {},
+        onCancel: () -> Unit = {},
+        onError: (throwable: Throwable) -> Unit = {},
+        onSuccess: () -> Unit = {},
+    ): RequestDisposable =
+        load(uri, getImageLoaderWithGifSupport(context)) {
+            placeholderResId?.let { placeholder(it) }
+            listener(
+                onStart = { onStart() },
+                onCancel = { onCancel() },
+                onError = { _, throwable -> onError(throwable) },
+                onSuccess = { _, _ -> onSuccess() },
+            )
+        }
+
+    private fun getImageLoaderWithGifSupport(
         context: Context,
+        // TODO: We should probably allowHardware for performance improvements but we do software rendering in PorterShapeImageView
         allowHardware: Boolean = false,
         precision: Precision = Precision.EXACT
     ): coil.ImageLoader {

--- a/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
@@ -12,7 +12,6 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import coil.request.GetRequest
 import coil.request.GetRequestBuilder
-import coil.request.RequestDisposable
 import coil.size.Precision
 import coil.transform.BlurTransformation
 import coil.transform.CircleCropTransformation
@@ -46,7 +45,7 @@ internal object ImageLoader {
         @DrawableRes placeholderResId: Int?,
         onStart: () -> Unit = {},
         onComplete: () -> Unit = {},
-    ): RequestDisposable =
+    ) {
         load(uri, getImageLoaderWithGifSupport(context)) {
             placeholderResId?.let { placeholder(it) }
             listener(
@@ -56,25 +55,24 @@ internal object ImageLoader {
                 onSuccess = { _, _ -> onComplete() },
             )
         }
+    }
 
     private fun getImageLoaderWithGifSupport(
         context: Context,
         // TODO: We should probably allowHardware for performance improvements but we do software rendering in PorterShapeImageView
         allowHardware: Boolean = false,
         precision: Precision = Precision.EXACT
-    ): coil.ImageLoader {
-        return coil.ImageLoader.Builder(context)
-            .allowHardware(allowHardware)
-            .precision(precision)
-            .componentRegistry {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder())
-                } else {
-                    add(GifDecoder())
-                }
+    ): coil.ImageLoader = coil.ImageLoader.Builder(context)
+        .allowHardware(allowHardware)
+        .precision(precision)
+        .componentRegistry {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                add(ImageDecoderDecoder())
+            } else {
+                add(GifDecoder())
             }
-            .build()
-    }
+        }
+        .build()
 
     private fun GetRequestBuilder.applyTransformation(
         transformation: ImageTransformation,

--- a/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
@@ -45,17 +45,15 @@ internal object ImageLoader {
         uri: String?,
         @DrawableRes placeholderResId: Int?,
         onStart: () -> Unit = {},
-        onCancel: () -> Unit = {},
-        onError: (throwable: Throwable) -> Unit = {},
-        onSuccess: () -> Unit = {},
+        onComplete: () -> Unit = {},
     ): RequestDisposable =
         load(uri, getImageLoaderWithGifSupport(context)) {
             placeholderResId?.let { placeholder(it) }
             listener(
                 onStart = { onStart() },
-                onCancel = { onCancel() },
-                onError = { _, throwable -> onError(throwable) },
-                onSuccess = { _, _ -> onSuccess() },
+                onCancel = { onComplete() },
+                onError = { _, _ -> onComplete() },
+                onSuccess = { _, _ -> onComplete() },
             )
         }
 

--- a/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/ImageLoader.kt
@@ -3,9 +3,13 @@ package com.getstream.sdk.chat
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
+import android.os.Build
 import coil.Coil
+import coil.decode.GifDecoder
+import coil.decode.ImageDecoderDecoder
 import coil.request.GetRequest
 import coil.request.GetRequestBuilder
+import coil.size.Precision
 import coil.transform.BlurTransformation
 import coil.transform.CircleCropTransformation
 import coil.transform.GrayscaleTransformation
@@ -31,6 +35,24 @@ internal object ImageLoader {
                         .drawable as? BitmapDrawable
                     )?.bitmap
             }
+    }
+
+    fun getImageLoaderWithGifSupport(
+        context: Context,
+        allowHardware: Boolean = false,
+        precision: Precision = Precision.EXACT
+    ): coil.ImageLoader {
+        return coil.ImageLoader.Builder(context)
+            .allowHardware(allowHardware)
+            .precision(precision)
+            .componentRegistry {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    add(ImageDecoderDecoder())
+                } else {
+                    add(GifDecoder())
+                }
+            }
+            .build()
     }
 
     private fun GetRequestBuilder.applyTransformation(

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
@@ -70,9 +70,7 @@ class AttachmentViewHolderMedia(
             imageUrl,
             placeholderResId = R.drawable.stream_placeholder,
             onStart = { binding.progressBar.isVisible = true },
-            onCancel = { binding.progressBar.isVisible = false },
-            onError = { binding.progressBar.isVisible = false },
-            onSuccess = { binding.progressBar.isVisible = false },
+            onComplete = { binding.progressBar.isVisible = false },
         )
 
         if (messageItem.message.type != ModelType.message_ephemeral) {

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
@@ -5,7 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import com.bumptech.glide.Glide
+import coil.api.load
+import com.getstream.sdk.chat.ImageLoader
 import com.getstream.sdk.chat.R
 import com.getstream.sdk.chat.adapter.AttachmentListItem
 import com.getstream.sdk.chat.adapter.MessageListItem.MessageItem
@@ -66,11 +67,15 @@ class AttachmentViewHolderMedia(
         val thumbUrl = attachment.thumbUrl
         val imageUrl = if (thumbUrl.isNullOrEmpty()) attachment.imageUrl else thumbUrl
 
-        Glide.with(context)
-            .asDrawable()
-            .load(imageUrl)
-            .placeholder(R.drawable.stream_placeholder)
-            .into(binding.ivMediaThumb)
+        binding.ivMediaThumb.load(imageUrl, ImageLoader.getImageLoaderWithGifSupport(context)) {
+            placeholder(R.drawable.stream_placeholder)
+            listener(
+                onStart = { binding.progressBar.isVisible = true },
+                onSuccess = { _, _ -> binding.progressBar.isVisible = false },
+                onError = { _, _ -> binding.progressBar.isVisible = false },
+                onCancel = { binding.progressBar.isVisible = false },
+            )
+        }
 
         if (messageItem.message.type != ModelType.message_ephemeral) {
             binding.tvMediaTitle.text = attachment.title

--- a/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/adapter/viewholder/attachment/AttachmentViewHolderMedia.kt
@@ -5,8 +5,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
-import coil.api.load
-import com.getstream.sdk.chat.ImageLoader
+import com.getstream.sdk.chat.ImageLoader.loadWithGifSupport
 import com.getstream.sdk.chat.R
 import com.getstream.sdk.chat.adapter.AttachmentListItem
 import com.getstream.sdk.chat.adapter.MessageListItem.MessageItem
@@ -67,15 +66,14 @@ class AttachmentViewHolderMedia(
         val thumbUrl = attachment.thumbUrl
         val imageUrl = if (thumbUrl.isNullOrEmpty()) attachment.imageUrl else thumbUrl
 
-        binding.ivMediaThumb.load(imageUrl, ImageLoader.getImageLoaderWithGifSupport(context)) {
-            placeholder(R.drawable.stream_placeholder)
-            listener(
-                onStart = { binding.progressBar.isVisible = true },
-                onSuccess = { _, _ -> binding.progressBar.isVisible = false },
-                onError = { _, _ -> binding.progressBar.isVisible = false },
-                onCancel = { binding.progressBar.isVisible = false },
-            )
-        }
+        binding.ivMediaThumb.loadWithGifSupport(
+            imageUrl,
+            placeholderResId = R.drawable.stream_placeholder,
+            onStart = { binding.progressBar.isVisible = true },
+            onCancel = { binding.progressBar.isVisible = false },
+            onError = { binding.progressBar.isVisible = false },
+            onSuccess = { binding.progressBar.isVisible = false },
+        )
 
         if (messageItem.message.type != ModelType.message_ephemeral) {
             binding.tvMediaTitle.text = attachment.title


### PR DESCRIPTION
- Replace Glide with Coil in AttachmentViewHolderMedia
- Improve showing loading indicator on media

Glide sometimes has problems with GIFs loading (probably it cannot decode them) and it doesn't provide any helpful exception. On the other hand, Coil renders everything correctly and its performance is much better comparing to Glide

Describe what this PR changes, why we're making the change, how it should be tested...

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
