### PR TITLE
Fix crash caused by registering for Activity results too late

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # To be released:
+- Fix a crash related to behaviour changes in 1.3.0-alpha08 of the AndroidX Fragment library
 
 # Oct 14th, 2020 - 4.3.0-beta-6
 - Update to Kotlin 1.4.10

--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -1,6 +1,6 @@
 package com.getstream.sdk.chat
 
-private const val ACTIVITY_KTX_VERSION = "1.2.0-alpha07"
+private const val ACTIVITY_KTX_VERSION = "1.2.0-beta01"
 private const val ANDROID_BUILD_TOOL_VERSION = "4.0.1"
 private const val ANDROID_JUNIT5_GRADLE_PLUGIN_VERSION = "1.6.2.0"
 private const val ANDROID_MAVEN_GRADLE_PLUGIN_VERSION = "2.1"
@@ -20,7 +20,7 @@ private const val FIREBASE_ANALYTICS_VERSION = "17.4.4"
 private const val FIREBASE_CRASHLYTICS_VERSION = "17.1.1"
 private const val FIREBASE_MESSAGING_VERSION = "20.2.4"
 private const val FIREBASE_PLUGIN_VERSION = "2.2.0"
-private const val FRAGMENT_KTX_VERSION = "1.3.0-alpha07"
+private const val FRAGMENT_KTX_VERSION = "1.3.0-beta01"
 private const val FRESCO_VERSION = "2.3.0"
 private const val GITVERSIONER_VERSION = "0.5.0"
 private const val GLIDE_VERSION = "4.11.0"

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -112,14 +112,14 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
 
         val activityResultRegistry = (context as? ComponentActivity)?.activityResultRegistry
 
-        activityResultLauncher = activityResultRegistry?.register(
-            LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
-            file?.let { messageInputController.onFileCaptured(it) }
-        }
-        selectFilesResultLauncher = activityResultRegistry?.register(
-            LauncherRequestsKeys.SELECT_FILES, SelectFilesContract()) {
-            messageInputController.onFilesSelected(it)
-        }
+        activityResultLauncher = activityResultRegistry
+            ?.register(LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
+                file?.let { messageInputController.onFileCaptured(it) }
+            }
+        selectFilesResultLauncher = activityResultRegistry
+            ?.register(LauncherRequestsKeys.SELECT_FILES, SelectFilesContract()) {
+                messageInputController.onFilesSelected(it)
+            }
     }
 
     override fun onDetachedFromWindow() {

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -109,16 +109,17 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
-        activityResultLauncher = (context as? ComponentActivity)
-            ?.activityResultRegistry
-            ?.register(LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
-                file?.let { messageInputController.onFileCaptured(it) }
-            }
-        selectFilesResultLauncher = (context as? ComponentActivity)
-            ?.activityResultRegistry
-            ?.register(LauncherRequestsKeys.SELECT_FILES, SelectFilesContract()) {
-                messageInputController.onFilesSelected(it)
-            }
+
+        val activityResultRegistry = (context as? ComponentActivity)?.activityResultRegistry
+
+        activityResultLauncher = activityResultRegistry?.register(
+            LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
+            file?.let { messageInputController.onFileCaptured(it) }
+        }
+        selectFilesResultLauncher = activityResultRegistry?.register(
+            LauncherRequestsKeys.SELECT_FILES, SelectFilesContract()) {
+            messageInputController.onFilesSelected(it)
+        }
     }
 
     override fun onDetachedFromWindow() {

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -99,16 +99,33 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         }
     }
 
-    private val activityResultLauncher: ActivityResultLauncher<Unit>? =
-        (context as? ComponentActivity)
-            ?.registerForActivityResult(CaptureMediaContract()) { file: File? ->
+    private object LauncherRequestsKeys {
+        const val CAPTURE_MEDIA = "capture_media_request_key"
+        const val SELECT_FILES = "select_files_request_key"
+    }
+
+    private var activityResultLauncher: ActivityResultLauncher<Unit>? = null
+    private var selectFilesResultLauncher: ActivityResultLauncher<Unit>? = null
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        activityResultLauncher = (context as? ComponentActivity)
+            ?.activityResultRegistry
+            ?.register(LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
                 file?.let { messageInputController.onFileCaptured(it) }
             }
+        selectFilesResultLauncher = (context as? ComponentActivity)
+            ?.activityResultRegistry
+            ?.register(LauncherRequestsKeys.SELECT_FILES, SelectFilesContract()) {
+                messageInputController.onFilesSelected(it)
+            }
+    }
 
-    private val selectFilesResultLauncher: ActivityResultLauncher<Unit>? =
-        (context as? ComponentActivity)?.registerForActivityResult(SelectFilesContract()) {
-            messageInputController.onFilesSelected(it)
-        }
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        activityResultLauncher?.unregister()
+        selectFilesResultLauncher?.unregister()
+    }
 
     private val commandsAdapter =
         CommandsAdapter(style) { messageInputController.onCommandSelected(it) }
@@ -365,8 +382,11 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         binding.fileComposer.visible(true)
     }
 
-    internal fun showMediaPermissions(shouldBeVisible: Boolean) = binding.ivMediaPermission.visible(shouldBeVisible)
-    internal fun showCameraPermissions(shouldBeVisible: Boolean) = binding.ivCameraPermission.visible(shouldBeVisible)
+    internal fun showMediaPermissions(shouldBeVisible: Boolean) =
+        binding.ivMediaPermission.visible(shouldBeVisible)
+
+    internal fun showCameraPermissions(shouldBeVisible: Boolean) =
+        binding.ivCameraPermission.visible(shouldBeVisible)
 
     internal fun hideAttachmentsMenu() {
         binding.clTitle.visible(false)
@@ -386,7 +406,9 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     internal fun showLoadingTotalAttachments(shouldBeVisible: Boolean) =
         binding.progressBarFileLoader.visible(shouldBeVisible)
 
-    internal fun showOpenAttachmentsMenuButton(shouldBeVisible: Boolean) = binding.ivOpenAttach.visible(shouldBeVisible)
+    internal fun showOpenAttachmentsMenuButton(shouldBeVisible: Boolean) =
+        binding.ivOpenAttach.visible(shouldBeVisible)
+
     fun showMessage(@StringRes messageResId: Int) = Utils.showMessage(context, messageResId)
 
     interface TypeListener {


### PR DESCRIPTION
Bugfix for issue #694 

### Description

The `registerForActivityResult` method had a behaviour change in recent Activity / Fragment KTX versions (in ``, specifically) where callbacks can no longer be registered after the Activity got into a `STARTED` state. Instead of relying on the Activity's lifecycle, we can register and unregister our callbacks dynamically, by accessing the underlying ActivityResultRegistry directly.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] Reviewers added
