### PR TITLE
Message input context wrapper

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
@@ -1,5 +1,7 @@
 package com.getstream.sdk.chat.view.common
 
+import android.content.Context
+import android.content.ContextWrapper
 import android.view.View
 
 fun View.visible(isVisible: Boolean) {
@@ -8,4 +10,12 @@ fun View.visible(isVisible: Boolean) {
     } else {
         View.GONE
     }
+}
+
+/**
+ * Ensures the context being accessed in a View can be cast to Activity
+ */
+fun Context.ensure() = when (this) {
+    is ContextWrapper -> baseContext
+    else -> this
 }

--- a/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
@@ -15,7 +15,7 @@ fun View.visible(isVisible: Boolean) {
 /**
  * Ensures the context being accessed in a View can be cast to Activity
  */
-fun Context.ensure() = when (this) {
+internal fun Context.ensure() = when (this) {
     is ContextWrapper -> baseContext
     else -> this
 }

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -2,6 +2,7 @@ package com.getstream.sdk.chat.view.messageinput
 
 import android.app.Activity
 import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import android.text.Editable
 import android.text.TextUtils
@@ -238,11 +239,14 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     }
 
     private fun setKeyboardEventListener() {
-        KeyboardVisibilityEvent.setEventListener(
-            context as Activity
-        ) { isOpen: Boolean ->
-            if (!isOpen) {
-                binding.messageTextInput.clearFocus()
+        when (context) {
+            is ContextWrapper -> (context as ContextWrapper).baseContext
+            else -> context
+        }.let {
+            KeyboardVisibilityEvent.setEventListener(it as Activity) { isOpen: Boolean ->
+                if (!isOpen) {
+                    binding.messageTextInput.clearFocus()
+                }
             }
         }
     }

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -2,7 +2,6 @@ package com.getstream.sdk.chat.view.messageinput
 
 import android.app.Activity
 import android.content.Context
-import android.content.ContextWrapper
 import android.os.Build
 import android.text.Editable
 import android.text.TextUtils
@@ -38,6 +37,7 @@ import com.getstream.sdk.chat.utils.TextViewUtils
 import com.getstream.sdk.chat.utils.Utils
 import com.getstream.sdk.chat.utils.whenFalse
 import com.getstream.sdk.chat.utils.whenTrue
+import com.getstream.sdk.chat.view.common.ensure
 import com.getstream.sdk.chat.view.common.visible
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Command
@@ -111,7 +111,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        val activityResultRegistry = (context as? ComponentActivity)?.activityResultRegistry
+        val activityResultRegistry = (context.ensure() as? ComponentActivity)?.activityResultRegistry
 
         activityResultLauncher = activityResultRegistry
             ?.register(LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
@@ -239,14 +239,9 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     }
 
     private fun setKeyboardEventListener() {
-        when (context) {
-            is ContextWrapper -> (context as ContextWrapper).baseContext
-            else -> context
-        }.let {
-            KeyboardVisibilityEvent.setEventListener(it as Activity) { isOpen: Boolean ->
-                if (!isOpen) {
-                    binding.messageTextInput.clearFocus()
-                }
+        KeyboardVisibilityEvent.setEventListener(context.ensure() as Activity) { isOpen: Boolean ->
+            if (!isOpen) {
+                binding.messageTextInput.clearFocus()
             }
         }
     }


### PR DESCRIPTION
### Description

Found more crashes happening when using Hilt & MessageInputView. Hilt makes the view's context a FragmentContextWrapper, so casting to an activity causes a crash.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
~- [ ] Changelog updated with client-facing changes~
~- [ ] New code is covered by unit tests~
~- [ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
