### PR TITLE
Update Offline Support version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Fix a crash related to behaviour changes in 1.3.0-alpha08 of the AndroidX Fragment library
 - Replace Glide with Coil in AttachmentViewHolderMedia (Fix GIFs loading issues)
 - `MessageListView.BubbleHelper`'s methods now have nullability annotations, and use primitive `boolean` values as parameters
+- Update Offline Support to the [last version](. See changes: )https://github.com/GetStream/stream-chat-android-livedata/releases/tag/0.8.6)
 
 # Oct 14th, 2020 - 4.3.0-beta-6
 - Update to Kotlin 1.4.10

--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -50,7 +50,7 @@ private const val TIMBER_VERSION = "4.7.1"
 private const val RECYCLERVIEW_VERSION = "1.2.0-alpha05"
 private const val RETROFIT_VERSION = "2.9.0"
 private const val ROOM_VERSION = "2.2.5"
-private const val STREAM_LIVEDATA_VERSION = "0.8.5"
+private const val STREAM_LIVEDATA_VERSION = "0.8.6"
 
 object Dependencies {
     const val activityKtx = "androidx.activity:activity-ktx:$ACTIVITY_KTX_VERSION"


### PR DESCRIPTION
### Description

Update Offline Support to the [last version](https://github.com/GetStream/stream-chat-android-livedata/releases/tag/0.8.6)

### Checklist

- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
~- [ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
