### PR TITLE
CAS-272 Review viewmodels

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModel.kt
@@ -22,7 +22,7 @@ class ChannelHeaderViewModel @JvmOverloads constructor(
 
     init {
         val channelController: ChannelController =
-            chatDomain.useCases.watchChannel.invoke(cid, 0).execute().data()
+            chatDomain.useCases.watchChannel(cid, 0).execute().data()
         members = channelController.members
         channelState = map(channelController.channelData) { channelController.toChannel() }
         anyOtherUsersOnline = map(members) { members ->

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/CreateChannelViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/CreateChannelViewModel.kt
@@ -49,7 +49,7 @@ class CreateChannelViewModel @JvmOverloads constructor(
             this.createdBy = author
         }
         viewModelScope.launch(ioDispatcher) {
-            val result = domain.useCases.createChannel.invoke(channel).execute()
+            val result = domain.useCases.createChannel(channel).execute()
             when {
                 result.isSuccess -> {
                     stateMerger.postValue(State.ChannelCreated)

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.Transformations.map
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Command
@@ -12,8 +11,6 @@ import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
 import java.io.File
 
 private const val MESSAGE_LIMIT = 30
@@ -50,9 +47,7 @@ class MessageInputViewModel @JvmOverloads constructor(
         activeThread.value?.let { message.parentId = it.id }
         stopTyping()
 
-        GlobalScope.launch {
-            chatDomain.useCases.sendMessage(message.apply(messageTransformer)).enqueue()
-        }
+        chatDomain.useCases.sendMessage(message.apply(messageTransformer)).enqueue()
     }
 
     fun sendMessageWithAttachments(
@@ -62,11 +57,9 @@ class MessageInputViewModel @JvmOverloads constructor(
     ) {
         // Send message should not be cancelled when viewModel.onCleared is called
         val attachments = attachmentFiles.map { Attachment(upload = it) }.toMutableList()
-        val message = Message(cid = cid, text = message, attachments = attachments).apply(messageTransformer)
-        GlobalScope.launch {
-            chatDomain.useCases.sendMessage(message)
-                .enqueue()
-        }
+        val message =
+            Message(cid = cid, text = message, attachments = attachments).apply(messageTransformer)
+        chatDomain.useCases.sendMessage(message).enqueue()
     }
 
     /**
@@ -76,10 +69,7 @@ class MessageInputViewModel @JvmOverloads constructor(
      */
     fun editMessage(message: Message) {
         stopTyping()
-
-        viewModelScope.launch {
-            chatDomain.useCases.editMessage(message).enqueue()
-        }
+        chatDomain.useCases.editMessage(message).enqueue()
     }
 
     /**
@@ -89,10 +79,7 @@ class MessageInputViewModel @JvmOverloads constructor(
     @Synchronized
     fun keystroke() {
         if (isThread) return
-
-        viewModelScope.launch {
-            chatDomain.useCases.keystroke(cid).enqueue()
-        }
+        chatDomain.useCases.keystroke(cid).enqueue()
     }
 
     /**
@@ -100,8 +87,6 @@ class MessageInputViewModel @JvmOverloads constructor(
      */
     fun stopTyping() {
         if (isThread) return
-        viewModelScope.launch {
-            chatDomain.useCases.stopTyping(cid).enqueue()
-        }
+        chatDomain.useCases.stopTyping(cid).enqueue()
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -84,6 +84,6 @@ class ChannelsViewModelImpl(
     }
 
     private fun requestMoreChannels() {
-        chatDomain.useCases.queryChannelsLoadMore(filter, sort).enqueue { Unit }
+        chatDomain.useCases.queryChannelsLoadMore(filter, sort).enqueue()
     }
 }

--- a/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -36,7 +36,7 @@ class MessageListViewModel @JvmOverloads constructor(
     init {
         loading.value = State.Loading
 
-        val result = domain.useCases.watchChannel.invoke(cid, MESSAGES_LIMIT).execute()
+        val result = domain.useCases.watchChannel(cid, MESSAGES_LIMIT).execute()
         val channelController = result.data()
         channel = channelController.toChannel()
         currentUser = domain.currentUser
@@ -104,7 +104,7 @@ class MessageListViewModel @JvmOverloads constructor(
                 onEndRegionReached()
             }
             is Event.LastMessageRead -> {
-                domain.useCases.markRead.invoke(cid).enqueue()
+                domain.useCases.markRead(cid).enqueue()
             }
             is Event.ThreadModeEntered -> {
                 onThreadModeEntered(event.parentMessage)
@@ -166,10 +166,10 @@ class MessageListViewModel @JvmOverloads constructor(
     private fun onThreadModeEntered(parentMessage: Message) {
         currentMode = Mode.Thread(parentMessage)
         val parentId: String = parentMessage.id
-        val threadController = domain.useCases.getThread.invoke(cid, parentId).execute().data()
+        val threadController = domain.useCases.getThread(cid, parentId).execute().data()
         threadMessages = threadController.messages
         setThreadMessages(threadMessages)
-        domain.useCases.threadLoadMore.invoke(cid, parentId, MESSAGES_LIMIT).execute()
+        domain.useCases.threadLoadMore(cid, parentId, MESSAGES_LIMIT).enqueue()
     }
 
     private fun onNormalModeEntered() {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-272

### Description

- Verified that viewmodel's constructors are not doing any heavy lifting
- Removed redundant `GlobalScope.launch` and `viewModelScope.launch` invocation from the viewmodels
- Replaced `execute()` with `enqueue()` in `MessageListViewModel.onThreadModeEntered()` not to block the main thread

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
