### PR TITLE
Replace ensure extension with recursive search for Activity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # To be released:
+- Fix unresponsive attachment upload buttons
 
 # Oct 16th, 2020 - 4.3.1-beta-1
 - Significant performance improvements

--- a/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/common/Extensions.kt
@@ -1,8 +1,8 @@
 package com.getstream.sdk.chat.view.common
 
-import android.content.Context
 import android.content.ContextWrapper
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 
 fun View.visible(isVisible: Boolean) {
     visibility = if (isVisible) {
@@ -15,7 +15,14 @@ fun View.visible(isVisible: Boolean) {
 /**
  * Ensures the context being accessed in a View can be cast to Activity
  */
-internal fun Context.ensure() = when (this) {
-    is ContextWrapper -> baseContext
-    else -> this
-}
+internal val View.activity: AppCompatActivity?
+    get() {
+        var context = context
+        while (context is ContextWrapper) {
+            if (context is AppCompatActivity) {
+                return context
+            }
+            context = context.baseContext
+        }
+        return null
+    }

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -1,6 +1,5 @@
 package com.getstream.sdk.chat.view.messageinput
 
-import android.app.Activity
 import android.content.Context
 import android.os.Build
 import android.text.Editable
@@ -10,7 +9,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.View.OnFocusChangeListener
 import android.widget.RelativeLayout
-import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.StringRes
@@ -37,7 +35,7 @@ import com.getstream.sdk.chat.utils.TextViewUtils
 import com.getstream.sdk.chat.utils.Utils
 import com.getstream.sdk.chat.utils.whenFalse
 import com.getstream.sdk.chat.utils.whenTrue
-import com.getstream.sdk.chat.view.common.ensure
+import com.getstream.sdk.chat.view.common.activity
 import com.getstream.sdk.chat.view.common.visible
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Command
@@ -111,7 +109,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
-        val activityResultRegistry = (context.ensure() as? ComponentActivity)?.activityResultRegistry
+        val activityResultRegistry = activity?.activityResultRegistry
 
         activityResultLauncher = activityResultRegistry
             ?.register(LauncherRequestsKeys.CAPTURE_MEDIA, CaptureMediaContract()) { file: File? ->
@@ -239,7 +237,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
     }
 
     private fun setKeyboardEventListener() {
-        KeyboardVisibilityEvent.setEventListener(context as Activity) { isOpen: Boolean ->
+        KeyboardVisibilityEvent.setEventListener(activity) { isOpen: Boolean ->
             if (!isOpen) {
                 binding.messageTextInput.clearFocus()
             }


### PR DESCRIPTION
### Description

The `ensure` extension introduced in https://github.com/GetStream/stream-chat-android/pull/699 was meant to make sure that we always fetch an `Activity` in our Views through `context`, even if it returns a wrapper around the `Activity` first (e.g. when using Dagger Hilt). Its implementation checked if the current View `Context` is a `ContextWrapper`, and if it is, it used its base context instead.

The issue is that `AppCompatActivity` itself is a `ContextWrapper`, so in this case, we used its base, a `ContextThemeWrapper` instead, which we then proceeded to cast to `Activity` types.

We already removed another usage of `ensure`, as it was causing crashes, see here https://github.com/GetStream/stream-chat-android/pull/703#pullrequestreview-510736883

This PR replaces its remaining usage with a recursive search for an `AppCompatActivity` from the View's `context`.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [x] Reviewers added
