### PR TITLE
[CAS-295] Fix sending gifs from keyboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # To be released:
 
+- Fix sending GIFs from keyboard
+
 # Oct 16th, 2020 - 4.3.1-beta-1
 - Significant performance improvements
 - Fix a crash related to behaviour changes in 1.3.0-alpha08 of the AndroidX Fragment library

--- a/library/src/main/java/com/getstream/sdk/chat/model/ModelType.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/model/ModelType.kt
@@ -44,6 +44,7 @@ object ModelType {
     const val attach_mime_mp4 = "video/mp4"
     const val attach_mime_mp3 = "audio/mp3"
     const val attach_mime_m4a = "audio/m4a"
+    const val attach_mime_gif = "image/gif"
 
     // Action Type
     const val action_send = "send"

--- a/library/src/main/java/com/getstream/sdk/chat/utils/GifEditText.java
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/GifEditText.java
@@ -9,6 +9,7 @@ import android.widget.EditText;
 
 import androidx.core.view.inputmethod.EditorInfoCompat;
 import androidx.core.view.inputmethod.InputConnectionCompat;
+import com.getstream.sdk.chat.model.ModelType;
 
 @SuppressLint("AppCompatCustomView")
 public class GifEditText extends EditText {
@@ -30,7 +31,7 @@ public class GifEditText extends EditText {
     public InputConnection onCreateInputConnection(EditorInfo editorInfo) {
         final InputConnection ic = super.onCreateInputConnection(editorInfo);
         EditorInfoCompat.setContentMimeTypes(editorInfo,
-                new String[]{"image/gif"});
+                new String[]{ModelType.attach_mime_gif});
         if (callback != null)
             return InputConnectionCompat.createWrapper(ic, editorInfo, callback);
         else return null;

--- a/library/src/main/java/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -6,6 +6,7 @@ import android.database.Cursor
 import android.net.Uri
 import android.provider.MediaStore
 import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
 import androidx.core.database.getLongOrNull
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
@@ -15,7 +16,7 @@ import java.util.Date
 import java.util.Locale
 
 internal class StorageHelper {
-    private val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US)
+    private val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmssSSS", Locale.US)
 
     internal fun getCachedFileFromUri(
         context: Context,
@@ -30,10 +31,8 @@ internal class StorageHelper {
         val cachedFile = File(
             context.cacheDir,
             "STREAM_${
-            dateFormat.format(
-                Date().time
-            )
-            }_${attachmentMetaData.title}"
+            dateFormat.format(Date().time)
+            }_${attachmentMetaData.getTitleWithExtension()}"
         )
         context.contentResolver.openInputStream(attachmentMetaData.uri!!)?.use { inputStream ->
             cachedFile.outputStream().use {
@@ -129,6 +128,16 @@ internal class StorageHelper {
         }
 
         return attachments
+    }
+}
+
+private fun AttachmentMetaData.getTitleWithExtension(): String {
+    val extension = MimeTypeMap.getFileExtensionFromUrl(title)
+    return if (extension.isNullOrEmpty() && !mimeType.isNullOrEmpty()) {
+        "$title.${MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)}"
+    } else {
+        // TODO: Attachment's title should never be null. Review AttachmentMetaData class
+        title ?: ""
     }
 }
 

--- a/library/src/main/java/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -28,12 +28,7 @@ internal class StorageHelper {
         if (attachmentMetaData.file != null) {
             return attachmentMetaData.file!!
         }
-        val cachedFile = File(
-            context.cacheDir,
-            "STREAM_${
-            dateFormat.format(Date().time)
-            }_${attachmentMetaData.getTitleWithExtension()}"
-        )
+        val cachedFile = File(context.cacheDir, getFileName(attachmentMetaData))
         context.contentResolver.openInputStream(attachmentMetaData.uri!!)?.use { inputStream ->
             cachedFile.outputStream().use {
                 inputStream.copyTo(it)
@@ -129,6 +124,9 @@ internal class StorageHelper {
 
         return attachments
     }
+
+    private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
+        "STREAM_${dateFormat.format(Date().time)}_${attachmentMetaData.getTitleWithExtension()}"
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -323,10 +323,10 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         messageInputController.setSelectedAttachments(
             setOf(
                 AttachmentMetaData(
-                    inputContentInfo.contentUri,
-                    ModelType.attach_image,
-                    ModelType.attach_mime_gif,
-                    inputContentInfo.description.label.toString(),
+                    uri = inputContentInfo.contentUri,
+                    type = ModelType.attach_image,
+                    mimeType = ModelType.attach_mime_gif,
+                    title = inputContentInfo.description.label.toString(),
                 )
             )
         )

--- a/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -39,7 +39,6 @@ import com.getstream.sdk.chat.utils.whenFalse
 import com.getstream.sdk.chat.utils.whenTrue
 import com.getstream.sdk.chat.view.common.ensure
 import com.getstream.sdk.chat.view.common.visible
-import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
@@ -200,7 +199,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
             )
         }
         binding.messageTextInput.setCallback { inputContentInfo, flags, _ ->
-            sendGiphyFromKeyboard(inputContentInfo, flags)
+            sendGifFromKeyboard(inputContentInfo, flags)
         }
     }
 
@@ -308,7 +307,7 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
         binding.sendButton.isEnabled = true
     }
 
-    private fun sendGiphyFromKeyboard(
+    private fun sendGifFromKeyboard(
         inputContentInfo: InputContentInfoCompat,
         flags: Int
     ): Boolean {
@@ -321,14 +320,16 @@ class MessageInputView(context: Context, attrs: AttributeSet?) : RelativeLayout(
                 return false
             }
         }
-        if (inputContentInfo.linkUri == null) return false
-        val url = inputContentInfo.linkUri.toString()
-        val attachment = Attachment()
-        attachment.thumbUrl = url
-        attachment.titleLink = url
-        attachment.title = inputContentInfo.description.label.toString()
-        attachment.type = ModelType.attach_giphy
-        messageInputController.setSelectedAttachments(setOf(AttachmentMetaData(attachment)))
+        messageInputController.setSelectedAttachments(
+            setOf(
+                AttachmentMetaData(
+                    inputContentInfo.contentUri,
+                    ModelType.attach_image,
+                    ModelType.attach_mime_gif,
+                    inputContentInfo.description.label.toString(),
+                )
+            )
+        )
         binding.messageTextInput.setText("")
         onSendMessage()
         return true


### PR DESCRIPTION
### Description
- Fix selecting gifs from the keyboard
- Add missing file extension when creating cached files (some files (e.g. GIFs selected from keyboard) don't have proper extension in its title so we need to add it manually otherwise, they will be sent as files instead of images)
- Add milliseconds to the cached file name to prevent files from overriding

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
