### PR TITLE
Fix wrong casting

### DIFF
--- a/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
+++ b/library/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
@@ -532,10 +532,9 @@ public class MessageListView : ConstraintLayout {
                     layoutSize
                 )
             )
-            val messageItem = entities.lastOrNull() as MessageItem?
-            val isMine = messageItem?.isMine ?: false
+            val isMine = (entities.lastOrNull() as? MessageItem)?.isMine ?: false
             // Scroll to bottom when the user wrote the message.
-            if (entities.isNotEmpty() && isMine ||
+            if (isMine ||
                 !hasScrolledUp ||
                 newMessagesBehaviour == NewMessagesBehaviour.SCROLL_TO_BOTTOM
             ) {


### PR DESCRIPTION
### Description
`MessageListItem` wasn't being casted properly. In the case that it was different than `MessageItem` it would crash

### Checklist

- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
