### PR TITLE
[CAS-324] Remove leftover reference to a databinding type

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/CommandMentionListItemAdapter.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/CommandMentionListItemAdapter.java
@@ -6,7 +6,6 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.BaseAdapter;
 
-import androidx.databinding.ViewDataBinding;
 import androidx.viewbinding.ViewBinding;
 
 import com.getstream.sdk.chat.R;
@@ -63,7 +62,7 @@ public class CommandMentionListItemAdapter<STYLE extends BaseStyle> extends Base
             }
             convertView.setTag(binding);
         } else {
-            binding = (ViewDataBinding) convertView.getTag();
+            binding = (ViewBinding) convertView.getTag();
         }
 
         if (isCommand) {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-324

### Description

This was an incorrect cast to a supertype of databinding bindings instead of viewbinding bindings, which produced a crash

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
