### PR TITLE
[CAS-312] Add possibility to replace default FileUploader:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Create custom login screen in sample app
 - Bump Coil to 1.0.0
 - Add message sending/sent indicators in `MessageListView`
+- Add possibility to replace default FileUploader
 
 # Oct 19th, 2020 - 4.3.1-beta-2
 - Allow setting custom `NotificationHandler` in `Chat.Builder`

--- a/stream-chat-android-client-CHANGELOG.md
+++ b/stream-chat-android-client-CHANGELOG.md
@@ -1,5 +1,6 @@
 # To be released:
 - Fix ConcurrentModificationException in `ChatEventsObservable`
+- Add possibility to replace default FileUploader
 
 # 1.16.8 - Fri 16th of Oct 2020
 - Add `lastUpdated` property to `Channel`

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.client.notifications.handler.ChatNotificationHa
 import io.getstream.chat.android.client.socket.InitConnectionListener
 import io.getstream.chat.android.client.socket.SocketListener
 import io.getstream.chat.android.client.token.TokenProvider
+import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.observable.ChatObservable
@@ -316,6 +317,7 @@ public interface ChatClient {
         private var warmUp: Boolean = true
         private var loggerHandler: ChatLoggerHandler? = null
         private var notificationsHandler: ChatNotificationHandler = ChatNotificationHandler(appContext)
+        private var fileUploader: FileUploader? = null
 
         public fun logLevel(level: ChatLogLevel): Builder {
             logLevel = level
@@ -334,6 +336,11 @@ public interface ChatClient {
 
         public fun notifications(notificationsHandler: ChatNotificationHandler): Builder {
             this.notificationsHandler = notificationsHandler
+            return this
+        }
+
+        public fun fileUploader(fileUploader: FileUploader): Builder {
+            this.fileUploader = fileUploader
             return this
         }
 
@@ -396,7 +403,8 @@ public interface ChatClient {
                 cdnTimeout,
                 warmUp,
                 ChatLogger.Config(logLevel, loggerHandler),
-                notificationsHandler
+                notificationsHandler,
+                fileUploader
             )
 
             val module = ChatModule(appContext, config)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatClientConfig.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatClientConfig.kt
@@ -4,6 +4,7 @@ import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.notifications.handler.ChatNotificationHandler
 import io.getstream.chat.android.client.token.TokenManager
 import io.getstream.chat.android.client.token.TokenManagerImpl
+import io.getstream.chat.android.client.uploader.FileUploader
 
 internal class ChatClientConfig(
     val apiKey: String,
@@ -15,6 +16,7 @@ internal class ChatClientConfig(
     val warmUp: Boolean,
     val loggerConfig: ChatLogger.Config,
     val notificationsHandler: ChatNotificationHandler,
+    val fileUploader: FileUploader? = null,
     val tokenManager: TokenManager = TokenManagerImpl()
 ) {
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
@@ -34,6 +34,12 @@ internal open class BaseChatModule(
     }
     private val defaultApi by lazy { buildApi(config) }
     private val defaultSocket by lazy { buildSocket(config, parser()) }
+    private val defaultFileUploader by lazy {
+        StreamFileUploader(
+            config.apiKey,
+            buildRetrofitCdnApi()
+        )
+    }
 
     //region Modules
 
@@ -130,7 +136,7 @@ internal open class BaseChatModule(
             chatConfig.apiKey,
             buildRetrofitApi(),
             UuidGeneratorImpl(),
-            StreamFileUploader(chatConfig.apiKey, buildRetrofitCdnApi())
+            chatConfig.fileUploader ?: defaultFileUploader
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientImplTest.kt
@@ -49,7 +49,7 @@ internal class ChatClientImplTest {
             false,
             ChatLogger.Config(ChatLogLevel.NOTHING, null),
             ChatNotificationHandler(mock()),
-            FakeTokenManager("")
+            tokenManager = FakeTokenManager("")
         )
 
         socket = FakeChatSocket()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
@@ -59,7 +59,7 @@ internal class MockClientBuilder {
             1000,
             false,
             ChatLogger.Config(ChatLogLevel.NOTHING, null),
-            ChatNotificationHandler(context)
+            ChatNotificationHandler(context),
         )
 
         socket = FakeChatSocket()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
@@ -48,7 +48,7 @@ internal class ClientConnectionTests {
         false,
         ChatLogger.Config(ChatLogLevel.NOTHING, null),
         ChatNotificationHandler(context),
-        FakeTokenManager(token)
+        tokenManager = FakeTokenManager(token)
     )
 
     private val connectedEvent = ConnectedEvent(

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/Chat.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/Chat.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.client.logger.ChatLoggerHandler
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.notifications.handler.ChatNotificationHandler
 import io.getstream.chat.android.client.socket.InitConnectionListener
+import io.getstream.chat.android.client.uploader.FileUploader
 
 public interface Chat {
     public val navigator: ChatNavigator
@@ -46,6 +47,7 @@ public interface Chat {
         public var notificationHandler: ChatNotificationHandler = ChatNotificationHandler(context)
         public var chatLogLevel: ChatLogLevel = ChatLogLevel.ALL
         public var chatLoggerHandler: ChatLoggerHandler? = null
+        public var fileUploader: FileUploader? = null
 
         public fun build(): Chat = ChatImpl(
             ChatFontsImpl(style, context),
@@ -58,7 +60,8 @@ public interface Chat {
             offlineEnabled,
             notificationHandler,
             chatLogLevel,
-            chatLoggerHandler
+            chatLoggerHandler,
+            fileUploader
         ).apply {
             instance = this
         }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -23,6 +23,7 @@ import io.getstream.chat.android.client.logger.ChatLoggerHandler;
 import io.getstream.chat.android.client.models.User;
 import io.getstream.chat.android.client.notifications.handler.ChatNotificationHandler;
 import io.getstream.chat.android.client.socket.InitConnectionListener;
+import io.getstream.chat.android.client.uploader.FileUploader;
 import io.getstream.chat.android.livedata.ChatDomain;
 import kotlin.UninitializedPropertyAccessException;
 import kotlin.Unit;
@@ -57,7 +58,8 @@ class ChatImpl implements Chat {
              boolean offlineEnabled,
              ChatNotificationHandler chatNotificationHandler,
              ChatLogLevel chatLogLevel,
-             ChatLoggerHandler chatLoggerHandler) {
+             @Nullable ChatLoggerHandler chatLoggerHandler,
+             @Nullable FileUploader fileUploader) {
         this.chatStrings = chatStrings;
         this.chatFonts = chatFonts;
         this.urlSigner = urlSigner;
@@ -71,11 +73,19 @@ class ChatImpl implements Chat {
             navigator.setHandler(navigationHandler);
         }
 
-        new ChatClient.Builder(this.apiKey, context)
+        ChatClient.Builder chatBuilder = new ChatClient.Builder(this.apiKey, context)
                 .notifications(chatNotificationHandler)
-                .logLevel(chatLogLevel)
-                .loggerHandler(chatLoggerHandler)
-                .build();
+                .logLevel(chatLogLevel);
+
+        if (chatLoggerHandler != null) {
+            chatBuilder.loggerHandler(chatLoggerHandler);
+        }
+
+        if (fileUploader != null) {
+            chatBuilder.fileUploader(fileUploader);
+        }
+
+        chatBuilder.build();
 
         ChatLogger.Companion.getInstance().logI("Chat", "Initialized: " + getVersion());
     }


### PR DESCRIPTION
- Add fileUploader method to ChatClient.Builder
- Add fileUploader property to Chat.Builder
- Fix setting Nullable Logger

There is no need to provide builder methods to `ChatDomain.Builder` because it takes `ChatClient` as a parameter


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
