### PR TITLE
CAS-303/hide channel fix2

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -1180,6 +1180,7 @@ internal class ChannelControllerImpl(
         channel.config = getConfig()
         channel.unreadCount = computeUnreadCount(domainImpl.currentUser, _read.value, messages)
         channel.lastMessageAt = messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
+        channel.hidden = _hidden.value
 
         return channel
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -251,10 +251,13 @@ internal class QueryChannelsControllerImpl(
     private fun refreshChannels(cIds: List<String>) {
         val cIdsInQuery = queryEntity.channelCids.intersect(cIds)
         val newChannels = cIdsInQuery.map { domainImpl.channel(it).toChannel() }
-        val existingChannelMap = _channels.value ?: mapOf()
-        val merged = (existingChannelMap.values + newChannels).associateBy { it.cid }
+        val existingChannelMap = _channels.value?.toMutableMap() ?: mutableMapOf()
 
-        _channels.postValue(merged)
+        newChannels.forEach { channel ->
+            existingChannelMap[channel.cid] = channel
+        }
+
+        _channels.postValue(existingChannelMap)
     }
 
     /**

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplTest.kt
@@ -192,6 +192,15 @@ internal class ChannelControllerImplTest : BaseDomainTest() {
         }
     }
 
+    @Test
+    fun `Should include hidden property in the toChannel method`() {
+        runBlocking(Dispatchers.IO) {
+            When calling chatClient.hideChannel(any(), any(), any()) doReturn TestResultCall(Result(Unit))
+
+            channelController.toChannel().hidden shouldBeEqualTo false
+        }
+    }
+
     private fun givenMockedFileUploads(result: Result<String>) {
         When calling chatClient.sendImage(any(), any(), any()) doReturn TestResultCall(result)
         When calling chatClient.sendFile(any(), any(), any()) doReturn TestResultCall(result)

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/channels/ChannelsFragment.kt
@@ -3,9 +3,11 @@ package io.getstream.chat.sample.feature.channels
 import android.os.Bundle
 import android.view.View
 import androidx.activity.OnBackPressedCallback
+import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
 import androidx.navigation.fragment.findNavController
+import com.getstream.sdk.chat.view.channels.ChannelListView
 import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModel
 import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModelImpl
 import com.getstream.sdk.chat.viewmodel.channels.bindView
@@ -44,6 +46,19 @@ class ChannelsFragment : Fragment(R.layout.fragment_channels) {
         addNewChannelButton.setOnClickListener {
             findNavController().navigateSafely(R.id.action_to_create_channel)
         }
+
+        channelsListView.setOnLongClickListener(
+            ChannelListView.ChannelClickListener { channel ->
+                AlertDialog.Builder(requireContext())
+                    .setMessage(R.string.hide_channel_dialog)
+                    .setNegativeButton(R.string.deny) { dialog, _ ->
+                        dialog.dismiss()
+                    }
+                    .setPositiveButton(R.string.confirm) { _, _ ->
+                        viewModel.hideChannel(channel)
+                    }.show()
+            }
+        )
 
         activity?.apply {
             onBackPressedDispatcher.addCallback(

--- a/stream-chat-android-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-sample/src/main/res/values/strings.xml
@@ -22,4 +22,8 @@
     <string name="login_field_user_name_hint">User name (optional)</string>
     <string name="login_sdk_version_template">Stream SDK v %s</string>
     <string name="login_validation_error">This field is required</string>
+
+    <string name="hide_channel_dialog">Would you like to hide this channel?</string>
+    <string name="deny">No</string>
+    <string name="confirm">Yes</string>
 </resources>

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -57,11 +57,11 @@ public class ChannelsViewModelImpl(
         val queryChannelsController = chatDomain.useCases.queryChannels(filter, sort).execute().data()
         queryChannelsController.run {
             loadingData.postValue(ChannelsViewModel.State.Loading)
-            channelsData = map(channels) {
-                if (it.isEmpty()) {
+            channelsData = map(channels) { channelList ->
+                if (channelList.isEmpty()) {
                     ChannelsViewModel.State.NoChannelsAvailable
                 } else {
-                    ChannelsViewModel.State.Result(it)
+                    ChannelsViewModel.State.Result(channelList.filter { it.hidden == false })
                 }
             }
             loadingMoreData = map(loadingMore) { ChannelsViewModel.State.LoadingNextPage(it) }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -83,6 +83,11 @@ public class ChannelsViewModelImpl(
         }.exhaustive
     }
 
+    public fun hideChannel(channel: Channel) {
+        loadingData.postValue(ChannelsViewModel.State.Loading)
+        chatDomain.useCases.hideChannel(channel.cid, true).enqueue()
+    }
+
     private fun requestMoreChannels() {
         chatDomain.useCases.queryChannelsLoadMore(filter, sort).enqueue()
     }

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModelTest.kt
@@ -72,8 +72,8 @@ internal class ChannelListViewModelTest {
     }
 
     companion object {
-        val mockChannels = listOf(Channel(cid = "1"), Channel(cid = "2"))
-        val moreChannels = listOf(Channel(cid = "3"), Channel(cid = "3"))
+        val mockChannels = listOf(Channel(cid = "1", hidden = false), Channel(cid = "2", hidden = false))
+        val moreChannels = listOf(Channel(cid = "3", hidden = false), Channel(cid = "3", hidden = false))
     }
 }
 


### PR DESCRIPTION
[CAS-303](https://stream-io.atlassian.net/browse/CAS-303)

### Description

Removing hide channel from list when user requests it. Like this:

![guohy1](https://user-images.githubusercontent.com/10619102/97030007-7b058300-155e-11eb-9139-fe80275c13ee.gif)

If a new message is send to this channel and the channel is listening to it, the channel will reaper. **But there's still a problem that I need some changes in the backend to solve**:

The back end does not return the hidden channels, so the app doesn't listen for hidden channels because they are not returned in the query. So, if a user hides the channel and leaves the app, the channel won't be revealed when new messages come because this channel will not be returned by the new query. To solve this the backend should return **all the channels to the user, including the hidden ones.** Anyways I think this PR can be merged while we wait for the backend to change this behaviour. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
