### PR TITLE
Improve message list pagination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Provide ChannelViewModelFactory and ChannelsViewModelFactory by the library to simplify setup
 - Fixes for https://github.com/GetStream/stream-chat-android/issues/698 and https://github.com/GetStream/stream-chat-android/issues/723
 - Don't show read state for the current user
+- Add load more threshold for `MessageListView`
 
 ## stream-chat-android-client
 - Fix ConcurrentModificationException in `ChatEventsObservable`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
     - See [PR #757](https://github.com/GetStream/stream-chat-android/pull/757) for full list of version updates
 
 ## stream-chat-android
+- - Add load more threshold for `MessageListView` and `streamLoadMoreThreshold` attribute
 
 ## stream-chat-android-client
 - Fix guest user authentication
@@ -25,7 +26,6 @@
 - Provide ChannelViewModelFactory and ChannelsViewModelFactory by the library to simplify setup
 - Fixes for https://github.com/GetStream/stream-chat-android/issues/698 and https://github.com/GetStream/stream-chat-android/issues/723
 - Don't show read state for the current user
-- Add load more threshold for `MessageListView`
 
 ## stream-chat-android-client
 - Fix ConcurrentModificationException in `ChatEventsObservable`

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
@@ -18,7 +18,7 @@ internal class EndlessScrollListener(
         }
         val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
         layoutManager?.let {
-            if (scrollStateReset && it.findFirstVisibleItemPosition() < loadMoreThreshold) {
+            if (scrollStateReset && it.findFirstVisibleItemPosition() <= loadMoreThreshold) {
                 scrollStateReset = false
                 recyclerView.post {
                     if (enabled) {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
@@ -1,0 +1,41 @@
+package com.getstream.sdk.chat.view
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+internal class EndlessScrollListener(
+    private var loadMoreThreshold: Int,
+    private val loadMoreListener: OnLoadMoreListener
+) : RecyclerView.OnScrollListener() {
+
+    var enabled: Boolean = false
+
+    private var scrollStateReset = true
+
+    override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+        if (dy >= 0 || !enabled) {
+            return
+        }
+        val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
+        layoutManager?.let {
+            if (scrollStateReset && it.findFirstVisibleItemPosition() < loadMoreThreshold) {
+                scrollStateReset = false
+                recyclerView.post {
+                    if (enabled) {
+                        loadMoreListener()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+        if (newState == RecyclerView.SCROLL_STATE_IDLE ||
+            newState == RecyclerView.SCROLL_STATE_DRAGGING
+        ) {
+            scrollStateReset = true
+        }
+    }
+}
+
+internal typealias OnLoadMoreListener = () -> Unit

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
@@ -4,7 +4,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
 internal class EndlessScrollListener(
-    private val loadMoreListener: OnLoadMoreListener
+    private val loadMoreListener: () -> Unit
 ) : RecyclerView.OnScrollListener() {
 
     var paginationEnabled: Boolean = false
@@ -20,14 +20,17 @@ internal class EndlessScrollListener(
         if (dy >= 0 || !paginationEnabled) {
             return
         }
-        val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
-        layoutManager?.let {
-            if (scrollStateReset && it.findFirstVisibleItemPosition() <= loadMoreThreshold) {
-                scrollStateReset = false
-                recyclerView.post {
-                    if (paginationEnabled) {
-                        loadMoreListener()
-                    }
+
+        val layoutManager = recyclerView.layoutManager
+        if (layoutManager !is LinearLayoutManager) {
+            throw IllegalStateException("EndlessScrollListener supports only LinearLayoutManager")
+        }
+        val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+        if (scrollStateReset && firstVisiblePosition <= loadMoreThreshold) {
+            scrollStateReset = false
+            recyclerView.post {
+                if (paginationEnabled) {
+                    loadMoreListener()
                 }
             }
         }
@@ -41,5 +44,3 @@ internal class EndlessScrollListener(
         }
     }
 }
-
-internal typealias OnLoadMoreListener = () -> Unit

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/EndlessScrollListener.kt
@@ -4,16 +4,20 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 
 internal class EndlessScrollListener(
-    private var loadMoreThreshold: Int,
     private val loadMoreListener: OnLoadMoreListener
 ) : RecyclerView.OnScrollListener() {
 
-    var enabled: Boolean = false
+    var paginationEnabled: Boolean = false
+    var loadMoreThreshold: Int = 0
+        set(value) {
+            require(value >= 0) { "Load more threshold must not be negative" }
+            field = value
+        }
 
     private var scrollStateReset = true
 
     override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-        if (dy >= 0 || !enabled) {
+        if (dy >= 0 || !paginationEnabled) {
             return
         }
         val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
@@ -21,7 +25,7 @@ internal class EndlessScrollListener(
             if (scrollStateReset && it.findFirstVisibleItemPosition() <= loadMoreThreshold) {
                 scrollStateReset = false
                 recyclerView.post {
-                    if (enabled) {
+                    if (paginationEnabled) {
                         loadMoreListener()
                     }
                 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -26,10 +26,11 @@ public class MessageListViewModel @JvmOverloads constructor(
     private var threadListData: MessageListItemLiveData? = null
     private val stateMerger = MediatorLiveData<State>()
     private var currentMode: Mode by Delegates.observable(Mode.Normal as Mode) { _, _, newMode -> mode.postValue(newMode) }
-    private var reads: LiveData<List<ChannelUserRead>>
+    private val reads: LiveData<List<ChannelUserRead>>
 
     public val mode: MutableLiveData<Mode> = MutableLiveData(currentMode)
     public val state: LiveData<State> = stateMerger
+    public val loadMoreLiveData: LiveData<Boolean>
     public val channel: Channel
     public val currentUser: User
 
@@ -41,6 +42,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         channel = channelController.toChannel()
         currentUser = domain.currentUser
         reads = channelController.reads
+        loadMoreLiveData = channelController.loadingOlderMessages
 
         messageListData = MessageListItemLiveData(
             currentUser,

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelBinding.kt
@@ -30,4 +30,5 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
             view.displayNewMessage(state.messageListItem)
         }
     }
+    loadMoreLiveData.observe(lifecycleOwner, view::setLoadingMore)
 }

--- a/stream-chat-android/src/main/res/values/attrs.xml
+++ b/stream-chat-android/src/main/res/values/attrs.xml
@@ -367,6 +367,7 @@
 
         <attr name="streamUserNameShow" format="boolean"/>
         <attr name="streamMessageDateShow" format="boolean"/>
+        <attr name="streamLoadMoreThreshold" format="integer"/>
     </declare-styleable>
     <!--ChannelHeaderView-->
     <declare-styleable name="ChannelHeaderView">

--- a/stream-chat-android/src/main/res/values/values.xml
+++ b/stream-chat-android/src/main/res/values/values.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <integer name="stream_attachment_preview_max_lines">5</integer>
+    <integer name="stream_load_more_threshold">10</integer>
 </resources>


### PR DESCRIPTION
### Description

Added load more threshold. As a consequence, if the user scrolls message list up at a reasonable speed, the scrolling experience will be seamless.

Load more LiveData does not contribute to the state of `MessageListItemWrapper` for performance reasons. We don't want the diff to be calculated too often.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
