### PR TITLE
Add AnonymousApi and AuthenticatedApi annotations

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/AnonymousApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/AnonymousApi.kt
@@ -1,0 +1,11 @@
+package io.getstream.chat.android.client.api
+
+/**
+ * Marks an API as requiring no authentication.
+ *
+ * For differences between authenticated and anonymous behaviour, see
+ * [HeadersInterceptor] and [TokenAuthInterceptor].
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+internal annotation class AnonymousApi

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/AuthenticatedApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/AuthenticatedApi.kt
@@ -1,0 +1,13 @@
+package io.getstream.chat.android.client.api
+
+/**
+ * Marks an API as requiring authentication.
+ *
+ * May be overridden by [ChatClientConfig.isAnonymous] at runtime.
+ *
+ * For differences between authenticated and anonymous behaviour, see
+ * [HeadersInterceptor] and [TokenAuthInterceptor].
+ */
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+internal annotation class AuthenticatedApi

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitAnonymousApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitAnonymousApi.kt
@@ -7,6 +7,7 @@ import retrofit2.http.Body
 import retrofit2.http.POST
 import retrofit2.http.Query
 
+@AnonymousApi
 internal interface RetrofitAnonymousApi {
 
     @POST("/guest")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -51,6 +51,7 @@ import retrofit2.http.POST
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+@AuthenticatedApi
 internal interface RetrofitApi {
 
     // region channels

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
@@ -11,6 +11,7 @@ import retrofit2.http.Part
 import retrofit2.http.Path
 import retrofit2.http.Query
 
+@AuthenticatedApi
 internal interface RetrofitCdnApi {
     @Multipart
     @POST("/channels/{type}/{id}/image")


### PR DESCRIPTION
### Description

Introduces the `AnonymousApi` and `AuthenticatedApi` annotations for deciding whether a Retrofit API requires authentication.