### PR TITLE
Fix crash caused by relying on UninitializedPropertyAccessException

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -441,5 +441,8 @@ public interface ChatClient {
         @JvmStatic
         public fun instance(): ChatClient = instance
             ?: throw IllegalStateException("ChatClient.Builder::build() must be called before obtaining ChatClient instance")
+
+        public val isInitialized: Boolean
+            get() = instance != null
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -202,5 +202,8 @@ public interface ChatDomain {
         @JvmStatic
         public fun instance(): ChatDomain = instance
             ?: throw IllegalStateException("ChatDomain.Builder::build() must be called before obtaining ChatDomain instance")
+
+        public val isInitialized: Boolean
+            get() = instance != null
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatImpl.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatImpl.java
@@ -25,7 +25,6 @@ import io.getstream.chat.android.client.notifications.handler.ChatNotificationHa
 import io.getstream.chat.android.client.socket.InitConnectionListener;
 import io.getstream.chat.android.client.uploader.FileUploader;
 import io.getstream.chat.android.livedata.ChatDomain;
-import kotlin.UninitializedPropertyAccessException;
 import kotlin.Unit;
 import kotlinx.coroutines.BuildersKt;
 import kotlinx.coroutines.CoroutineStart;
@@ -189,15 +188,16 @@ class ChatImpl implements Chat {
     }
 
     private void disconnectChatDomainIfAlreadyInitialized() {
-        try {
-            final ChatDomain chatDomain = ChatDomain.instance();
-            BuildersKt.launch(GlobalScope.INSTANCE,
-                    Dispatchers.getIO(),
-                    CoroutineStart.DEFAULT,
-                    (scope, continuation) -> chatDomain.disconnect(continuation));
-        } catch (UninitializedPropertyAccessException e) {
+        if (!ChatDomain.Companion.isInitialized()) {
             ChatLogger.Companion.getInstance().logD("ChatImpl", "ChatDomain was not initialized yet. No need to disconnect.");
+            return;
         }
+
+        final ChatDomain chatDomain = ChatDomain.instance();
+        BuildersKt.launch(GlobalScope.INSTANCE,
+                Dispatchers.getIO(),
+                CoroutineStart.DEFAULT,
+                (scope, continuation) -> chatDomain.disconnect(continuation));
     }
 
     protected void init() {


### PR DESCRIPTION
### Description

https://github.com/GetStream/stream-chat-android/pull/764 changed `lateinit` `instance` properties to nullable. Turns out we were relying on `lateinit` sometimes throwing an `UninitializedPropertyAccessException`.

This PR adds a new method for checking whether the `ChatClient` or `ChatDomain` is already set. (This API could be marked internal or opt-in later, for now, it's probably fine for it to be `public`.)

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
