### PR TITLE
[CAS-350] Add GetChannelController use case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Fix guest user authentication
 
 ## stream-chat-android-offline
+- Add GetChannel use cases which allows to get ChannelController for Channel
 
 # Oct 26th, 2020 - 4.4.0
 ## stream-chat-android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Fix guest user authentication
 
 ## stream-chat-android-offline
-- Add GetChannel use cases which allows to get ChannelController for Channel
+- Add GetChannelController use cases which allows to get ChannelController for Channel
 
 # Oct 26th, 2020 - 4.4.0
 ## stream-chat-android

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
@@ -7,7 +7,7 @@ import io.getstream.chat.android.livedata.utils.Call2
 import io.getstream.chat.android.livedata.utils.CallImpl2
 import io.getstream.chat.android.livedata.utils.validateCid
 
-public interface GetChannel {
+public interface GetChannelController {
     /**
      * Returns a ChannelController for given cid
      *
@@ -19,7 +19,7 @@ public interface GetChannel {
     public operator fun invoke(cid: String): Call2<ChannelController>
 }
 
-internal class GetChannelImpl(private val domainImpl: ChatDomainImpl) : GetChannel {
+internal class GetChannelControllerImpl(private val domainImpl: ChatDomainImpl) : GetChannelController {
     override operator fun invoke(cid: String): Call2<ChannelController> {
         validateCid(cid)
         val channelControllerImpl = domainImpl.channel(cid)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelImpl.kt
@@ -1,0 +1,35 @@
+package io.getstream.chat.android.livedata.usecase
+
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.controller.ChannelController
+import io.getstream.chat.android.livedata.utils.Call2
+import io.getstream.chat.android.livedata.utils.CallImpl2
+import io.getstream.chat.android.livedata.utils.validateCid
+
+public interface GetChannel {
+    /**
+     * Returns a ChannelController for given cid
+     *
+     * @param cid the full channel id. ie messaging:123
+
+     * @return A call object with ChannelController as the return type
+     * @see io.getstream.chat.android.livedata.controller.ChannelController
+     */
+    public operator fun invoke(cid: String): Call2<ChannelController>
+}
+
+internal class GetChannelImpl(private val domainImpl: ChatDomainImpl) : GetChannel {
+    override operator fun invoke(cid: String): Call2<ChannelController> {
+        validateCid(cid)
+        val channelControllerImpl = domainImpl.channel(cid)
+
+        val runnable = suspend {
+            Result(channelControllerImpl as ChannelController, null)
+        }
+        return CallImpl2(
+            runnable,
+            channelControllerImpl.scope
+        )
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
@@ -12,6 +12,11 @@ public class UseCaseHelper internal constructor(chatDomainImpl: ChatDomainImpl) 
 
     // getting controllers
     /**
+     * Get channel controller for cid
+     * Returns a channel controller object
+     */
+    public val getChannel: GetChannel = GetChannelImpl(chatDomainImpl)
+    /**
      * Watch a channel/ Start listening for events on a channel
      * Returns a channel controller object
      */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
@@ -15,7 +15,7 @@ public class UseCaseHelper internal constructor(chatDomainImpl: ChatDomainImpl) 
      * Get channel controller for cid
      * Returns a channel controller object
      */
-    public val getChannel: GetChannel = GetChannelImpl(chatDomainImpl)
+    public val getChannelController: GetChannelController = GetChannelControllerImpl(chatDomainImpl)
     /**
      * Watch a channel/ Start listening for events on a channel
      * Returns a channel controller object


### PR DESCRIPTION

Adding a separate use case for getting `ChannelController`. We shouldn't use `watchChannel` use case for that because it triggers unneeded calls to API and offline storage.


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
