### PR TITLE
Fix empty screen when returning back to channels

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
@@ -108,6 +108,10 @@ public class ChannelsView @JvmOverloads constructor(
         this.emptyStateView.isVisible = false
     }
 
+    public fun setPaginationEnabled(enabled: Boolean) {
+        channelListView.setPaginationEnabled(enabled)
+    }
+
     private fun defaultChildLayoutParams() =
         LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT, Gravity.CENTER)
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModelBinding.kt
@@ -26,13 +26,15 @@ public fun ChannelsViewModel.bindView(
                 view.hideEmptyStateView()
                 view.showLoadingView()
             }
-            ChannelsViewModel.State.NoChannelsAvailable -> {
+            is ChannelsViewModel.State.NoChannelsAvailable -> {
                 view.showEmptyStateView()
                 view.hideLoadingView()
             }
         }
     }
-
+    paginationState.observe(lifecycle) {
+        view.setPaginationEnabled(!it.endOfChannels && !it.loadingMore)
+    }
     view.setOnEndReachedListener {
         onEvent(ChannelsViewModel.Event.ReachedEndOfList)
     }


### PR DESCRIPTION
### Description

Steps to reproduce the issue:
1. Scroll channel list to the end
2. Navigate to any channel
3. Go back to the channel list and observe that the list is empty

This happens because the last state we receive on the channel list page is `EndPageReached`. When going back to that page, the UI is recreated with `EndPageReached` state and we observe an empty screen.

The root of the problem is that we try to implement our ViewModels in MVI/Redux style with a single `State` which is enough to recreate the whole UI at any point of time. Unfortunately, some of the `State` classes are more like events (e.g. `NavigateToLoginScreen`, `EndPageReached`) and they lack important bits of information to recreate the UI (e.g. when going back to the previous screen).

We have 2 options:

- Implement `State` classes in a way they contain all the information to render the screen from scratch at any point of time. The downside is that all the UI will be rendered again every time the state is reduced. I think we can't afford running diffutils every time something irrelevant changes (e.g. progress bar is shown over the channels list when hiding a channel).
- Split the state into several partial states to improve performance.

In any case, we need a separate event bus like `SingleLiveEvent` to trigger one shot events (navigation, toasts, etc.) 


### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

#### Before the fix

<img src="https://user-images.githubusercontent.com/9600921/97549557-9569b180-19e1-11eb-92ee-19af4ee99659.gif" width="300">

#### After the fix

<img src="https://user-images.githubusercontent.com/9600921/97549584-9dc1ec80-19e1-11eb-831c-f87c554a0454.gif" width="300">



