### PR TITLE
Add automerge GitHub Actions workflow

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,34 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.12.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge"                        # automerge PRs with the 'automerge' label when ready
+          MERGE_REMOVE_LABELS: "automerge,no-autorebase"   # remove these labels after the PR is merged
+          MERGE_METHOD: "merge"                            # regular merge, with a merge commit
+          MERGE_FORKS: "false"                             # don't manage forks
+          MERGE_COMMIT_MESSAGE: "automatic"                # default GitHub commit message
+          UPDATE_METHOD: "rebase"                          # update open PRs by rebasing them to target branch
+          UPDATE_LABELS: "!no-autorebase"                  # prevent auto-rebase with the 'no-autorebase' label, auto-rebase all others

--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -1,6 +1,6 @@
 name: Stream Chat Android CI
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
   stream_chat_android_client:


### PR DESCRIPTION
### Description

Adds a new GitHub actions workflow using [pascalgn/automerge-action](https://github.com/pascalgn/automerge-action), and changes the existing build/lint/test workflow so that it only runs on `push` events. 

This will do two things in the repo:
- Keep all PR branches up-to-date by rebasing them on the target branch when it changes (can be prevented by adding a `no-autorebase` label, if necessary for some reason).
- Automatically merge PRs that have passed the pipeline checks and got the required review, if they're labeled with `automerge`.

See the config in the modified file for more details.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
