### PR TITLE
Store query entity in run query online flow.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ## stream-chat-android-offline
 - Add GetChannelController use cases which allows to get ChannelController for Channel
+- Fix not storing channels when run channels fetching after connection recovery.
 
 # Oct 26th, 2020 - 4.4.0
 ## stream-chat-android

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -163,7 +163,7 @@ internal class QueryChannelsControllerImpl(
             val configEntities = channelsResponse.associateBy { it.type }.values.map { ChannelConfigEntity(it.type, it.config) }
             domainImpl.repos.configs.insert(configEntities)
             logger.logI("api call returned ${channelsResponse.size} channels")
-
+            domainImpl.repos.queryChannels.insert(queryEntity)
             domainImpl.storeStateForChannels(channelsResponse)
         } else {
             recoveryNeeded = true
@@ -202,7 +202,6 @@ internal class QueryChannelsControllerImpl(
             output = result
             if (result.isSuccess) {
                 updateChannelsAndQueryResults(output.data(), pagination.isFirstPage)
-                domainImpl.repos.queryChannels.insert(queryEntity)
             }
         } else {
             recoveryNeeded = true


### PR DESCRIPTION
### Description

When manual checking I noticed that if we didn't query online at startup and ran query when connection was recovered, then we didn't store channel query. That's why after rerun of app we don't get channels from local repo.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
