### PR TITLE
Revise GitHub actions workflows

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,47 @@
+name: Build and test
+
+on:
+  push:
+    branches:
+      - develop
+      - master
+
+jobs:
+  debug_build:
+    name: Debug build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build
+        run: ./gradlew assembleDebug
+
+  release_build:
+    name: Release build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build
+        run: ./gradlew assembleRelease
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Unit tests
+        run: ./gradlew test --stacktrace

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -1,6 +1,6 @@
-name: Stream Chat Android CI
+name: Pull request CI checks
 
-on: [push]
+on: [pull_request]
 
 jobs:
   stream_chat_android_client:


### PR DESCRIPTION
### Description

- Supposedly fixes our problems with the automerge plugin, where it doesn't re-trigger PR workflows after it auto-rebases a branch (by changing the `push` trigger to `pull_request`)
- Adds a new workflow that builds both debug and release variants and executes tests, only on the `develop` and `master` branch, so we always see an up-to-date build status for those branches

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
