### PR TITLE
[CAS-381] Remove initialization from App::onCreate

### DIFF
--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/App.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/App.kt
@@ -5,21 +5,16 @@ import io.getstream.chat.sample.BuildConfig
 import io.getstream.chat.sample.data.dataModule
 import io.getstream.chat.sample.feature.custom_login.customLoginModule
 import io.getstream.chat.sample.feature.user_login.userLoginModule
-import org.koin.android.ext.android.inject
 import org.koin.android.ext.koin.androidContext
 import org.koin.android.ext.koin.androidLogger
 import org.koin.core.context.startKoin
 
 class App : Application() {
-    private val appConfig: AppConfig by inject()
-    private val chatInitializer: ChatInitializer by inject()
 
     override fun onCreate() {
         super.onCreate()
         DebugMetricsHelper().init()
         initKoin()
-        chatInitializer.init(appConfig.apiKey)
-
         ExtraDependenciesImpl().config(this)
     }
 


### PR DESCRIPTION
### Description
We were initializing our SDK twice. The one from `App` class is not needed, because at this time we doesn't know which APIKey is going to be used

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
