### PR TITLE
[CAS-382] [CAS-388] Fix livedata updated in background thread

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -77,7 +77,7 @@ public interface ChatDomain {
     public var retryPolicy: RetryPolicy
 
     /** a helper object which lists all the initialized use cases for the chat domain */
-    public var useCases: UseCaseHelper
+    public val useCases: UseCaseHelper
 
     public suspend fun disconnect()
     public fun isOnline(): Boolean

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -258,7 +258,7 @@ internal class ChatDomainImpl internal constructor(
         }
 
         if (client.isSocketConnected()) {
-            setOnline()
+            postOnline()
         }
         startListening()
         initClean()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -194,14 +194,13 @@ internal class ChatDomainImpl internal constructor(
     override var retryPolicy: RetryPolicy =
         DefaultRetryPolicy()
 
-    internal fun clearState() {
-        _initialized.value = false
-        _online.value = false
-        _totalUnreadCount.value = 0
-        _channelUnreadCount.value = 0
-        _banned.value = false
+    private fun clearState() {
+        _initialized.postValue(false)
+        _online.postValue(false)
+        _totalUnreadCount.postValue(0)
+        _channelUnreadCount.postValue(0)
+        _banned.postValue(false)
         _mutedUsers.value = emptyList()
-
         activeChannelMapImpl.clear()
         activeQueryMapImpl.clear()
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -159,10 +159,7 @@ internal class ChatDomainImpl internal constructor(
     override val errorEvents: LiveData<Event<ChatError>> = _errorEvent
 
     /** the event subscription, cancel using repo.stopListening */
-    private var eventSubscription: Disposable = object : Disposable {
-        override val isDisposed: Boolean = true
-        override fun dispose() { }
-    }
+    private var eventSubscription: Disposable = EMPTY_DISPOSABLE
 
     /** stores the mapping from cid to channelRepository */
     private val activeChannelMapImpl: ConcurrentHashMap<String, ChannelControllerImpl> = ConcurrentHashMap()
@@ -743,5 +740,12 @@ internal class ChatDomainImpl internal constructor(
 
     fun postInitialized() {
         _initialized.postValue(true)
+    }
+
+    companion object {
+        val EMPTY_DISPOSABLE = object : Disposable {
+            override val isDisposed: Boolean = true
+            override fun dispose() {}
+        }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -185,7 +185,7 @@ internal class ChatDomainImpl internal constructor(
     internal val scope = CoroutineScope(Dispatchers.IO + job)
 
     internal lateinit var repos: RepositoryHelper
-    internal var syncState: SyncStateEntity? = null
+    private var syncState: SyncStateEntity? = null
     internal lateinit var initJob: Deferred<SyncStateEntity?>
 
     private var isOnline = false
@@ -211,7 +211,7 @@ internal class ChatDomainImpl internal constructor(
         Room.inMemoryDatabaseBuilder(context, ChatDatabase::class.java).build()
     }
 
-    fun isTestRunner(): Boolean {
+    private fun isTestRunner(): Boolean {
         return Build.FINGERPRINT.toLowerCase().contains("robolectric")
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -114,7 +114,7 @@ internal class ChatDomainImpl internal constructor(
     private val syncModule by lazy { SyncProvider(appContext) }
 
     /** a helper object which lists all the initialized use cases for the chat domain */
-    override var useCases: UseCaseHelper = UseCaseHelper(this)
+    override val useCases: UseCaseHelper = UseCaseHelper(this)
 
     var defaultConfig: Config = Config(isConnectEvents = true, isMutes = true)
 
@@ -168,7 +168,7 @@ internal class ChatDomainImpl internal constructor(
 
     // TODO 1.1: We should accelerate online/offline detection
 
-    internal var eventHandler: EventHandlerImpl
+    internal val eventHandler: EventHandlerImpl = EventHandlerImpl(this)
 
     private var logger = ChatLogger.get("Domain")
     private val cleanTask = object : Runnable {
@@ -263,8 +263,6 @@ internal class ChatDomainImpl internal constructor(
     init {
         logger.logI("Initializing ChatDomain with version " + getVersion())
 
-        useCases = UseCaseHelper(this)
-
         // if the user is already defined, just call setUser ourselves
         val current = userOverwrite ?: client.getCurrentUser()
         if (current != null) {
@@ -286,7 +284,6 @@ internal class ChatDomainImpl internal constructor(
         }
 
         // start listening for events
-        eventHandler = EventHandlerImpl(this)
         startListening()
         initClean()
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
@@ -42,7 +42,6 @@ internal open class BaseConnectedIntegrationTest : BaseDomainTest() {
             .recoveryDisabled()
             .buildImpl()
         chatDomain = chatDomainImpl
-        chatDomainImpl.eventHandler = EventHandlerImpl(chatDomainImpl, true)
         chatDomainImpl.retryPolicy = object :
             RetryPolicy {
             override fun shouldRetry(client: ChatClient, attempt: Int, error: ChatError): Boolean {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDisconnectedIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDisconnectedIntegrationTest.kt
@@ -47,7 +47,6 @@ internal open class BaseDisconnectedIntegrationTest : BaseDomainTest() {
         chatDomainImpl = ChatDomain.Builder(context, client, data.user1).database(
             db
         ).offlineEnabled().userPresenceEnabled().recoveryDisabled().buildImpl()
-        chatDomainImpl.eventHandler = EventHandlerImpl(chatDomainImpl, true)
         chatDomainImpl.retryPolicy = object :
             RetryPolicy {
             override fun shouldRetry(client: ChatClient, attempt: Int, error: ChatError): Boolean {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
@@ -226,7 +226,6 @@ internal open class BaseDomainTest {
         chatDomainImpl = ChatDomain.Builder(context, client, data.user1).database(db).offlineEnabled()
             .userPresenceEnabled().buildImpl()
 
-        chatDomainImpl.eventHandler = EventHandlerImpl(chatDomainImpl, true)
         chatDomainImpl.retryPolicy = object :
             RetryPolicy {
             override fun shouldRetry(client: ChatClient, attempt: Int, error: ChatError): Boolean {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.socket.InitConnectionListener
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.livedata.controller.QueryChannelsControllerImpl
 import io.getstream.chat.android.livedata.controller.QueryChannelsSpec
 import io.getstream.chat.android.livedata.utils.EventObserver
@@ -127,7 +128,10 @@ internal open class BaseDomainTest {
             on { subscribe(any()) } doAnswer { invocation ->
                 val listener = invocation.arguments[0] as (ChatEvent) -> Unit
                 listener.invoke(connectedEvent)
-                null
+                object : Disposable {
+                    override val isDisposed: Boolean = true
+                    override fun dispose() { }
+                }
             }
             on { getSyncHistory(any(), any()) } doReturn TestCall(eventResults)
             on { queryChannels(any()) } doReturn TestCall(result)
@@ -177,7 +181,10 @@ internal open class BaseDomainTest {
             on { subscribe(any()) } doAnswer { invocation ->
                 val listener = invocation.arguments[0] as (ChatEvent) -> Unit
                 listener.invoke(connectedEvent)
-                null
+                object : Disposable {
+                    override val isDisposed: Boolean = true
+                    override fun dispose() { }
+                }
             }
             on { getSyncHistory(any(), any()) } doReturn TestCall(eventResults)
             on { queryChannels(any()) } doReturn TestCall(result)


### PR DESCRIPTION
### Description

Some of our LiveData was been used from a background thread when calling `setValue()`, and it is not allowed.
There were other race-conditions with our eventListeners and the properties that should be initialized but weren't. All Listener Initialization has been moved after the user is set

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
