### PR TITLE
Add NORMAL synchronous mode for SQLite

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -41,7 +41,7 @@ import io.getstream.chat.android.livedata.entity.UserEntity
         ChannelConfigEntity::class,
         SyncStateEntity::class
     ],
-    version = 28,
+    version = 27,
     exportSchema = false
 )
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -5,6 +5,7 @@ import androidx.room.Database
 import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
+import androidx.sqlite.db.SupportSQLiteDatabase
 import io.getstream.chat.android.livedata.converter.ConfigConverter
 import io.getstream.chat.android.livedata.converter.DateConverter
 import io.getstream.chat.android.livedata.converter.ExtraDataConverter
@@ -40,7 +41,7 @@ import io.getstream.chat.android.livedata.entity.UserEntity
         ChannelConfigEntity::class,
         SyncStateEntity::class
     ],
-    version = 27,
+    version = 28,
     exportSchema = false
 )
 
@@ -74,7 +75,13 @@ internal abstract class ChatDatabase : RoomDatabase() {
                         context.applicationContext,
                         ChatDatabase::class.java,
                         "stream_chat_database_$userId"
-                    ).fallbackToDestructiveMigration().build()
+                    ).fallbackToDestructiveMigration()
+                        .addCallback(object : Callback() {
+                            override fun onOpen(db: SupportSQLiteDatabase) {
+                                db.execSQL("PRAGMA synchronous = 1")
+                            }
+                        })
+                        .build()
                     INSTANCES[userId] = db
                 }
             }


### PR DESCRIPTION
### Description
Speed up of messages fetching from DB. 
I noticed that sometimes message queries from DB for channel takes some long time. At my slow device _(1 CPU, 750 MB RAM_) for one channel it takes **246.570539 ms** in average. And also I see we have already added indices for table for its' selection params.
 I looked at SQLite manual and found very important setup parameter `PRAGMA synchronous` (docs available [here](https://www.sqlite.org/pragma.html#pragma_synchronous)). It defines how DB ensures its' sync via multithreaded transactional environment (it needs for critical situations as OS crashes). Since Lollipop SQLite uses `WAL mode` for journaling (faster then the previous `PERSIST mode`). And with `WAL` we don't need `FULL synchronous mode` it's too strict. We can apply `NORMAL synchronous mode` that makes our use-case of SQLite is faster but still reliable even when app crash occurs. 
I measured changed sync mode at testing emulator. 
Result: and querying of messages for channel had decreased from **246.570539 ms** in average to **121.3027312 ms** in average. Result of experiments are available [here](https://docs.google.com/spreadsheets/d/13ZCXOnNK8B4t_SdjLLWetyDCaK2piCW4gwXU7dxRYSc/edit?usp=sharing)
So in this PR I apply `NORMAL synchronous mode`

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
