### PR TITLE
Callback threading

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCallAdapterFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCallAdapterFactory.kt
@@ -32,9 +32,10 @@ internal class RetrofitCallAdapterFactory private constructor(
     }
 
     companion object {
-        val mainThreadExecutor by lazy {
-            Executor { r ->
-                Handler(Looper.getMainLooper()).post(r)
+        val mainThreadExecutor: Executor = object : Executor {
+            val handler: Handler by lazy { Handler(Looper.getMainLooper()) }
+            override fun execute(command: Runnable?) {
+                command?.let(handler::post)
             }
         }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCallAdapterFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCallAdapterFactory.kt
@@ -32,11 +32,15 @@ internal class RetrofitCallAdapterFactory private constructor(
     }
 
     companion object {
-        private val mainThreadHandler by lazy { Handler(Looper.getMainLooper()) }
+        val mainThreadExecutor by lazy {
+            Executor { r ->
+                Handler(Looper.getMainLooper()).post(r)
+            }
+        }
 
         fun create(
             chatParser: ChatParser,
-            callbackExecutor: Executor = Executor { r -> mainThreadHandler.post(r) }
+            callbackExecutor: Executor = mainThreadExecutor
         ): RetrofitCallAdapterFactory = RetrofitCallAdapterFactory(chatParser, callbackExecutor)
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
@@ -8,11 +8,13 @@ import io.getstream.chat.android.client.parser.ChatParser
 import io.getstream.chat.android.client.utils.Result
 import retrofit2.Callback
 import retrofit2.Response
+import java.util.concurrent.Executor
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class RetrofitCall<T : Any>(
     val call: retrofit2.Call<T>,
-    private val parser: ChatParser
+    private val parser: ChatParser,
+    private val callbackExecutor: Executor
 ) : Call<T> {
 
     protected var canceled = AtomicBoolean(false)
@@ -42,11 +44,15 @@ internal class RetrofitCall<T : Any>(
         call.enqueue(
             object : Callback<T> {
                 override fun onResponse(call: retrofit2.Call<T>, response: Response<T>) {
-                    callback(getResult(response))
+                    callbackExecutor.execute {
+                        callback(getResult(response))
+                    }
                 }
 
                 override fun onFailure(call: retrofit2.Call<T>, t: Throwable) {
-                    callback(failedResult(t))
+                    callbackExecutor.execute {
+                        callback(failedResult(t))
+                    }
                 }
             }
         )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/RetroError.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/RetroError.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.client.utils
 
+import io.getstream.chat.android.client.api.RetrofitCallAdapterFactory
 import io.getstream.chat.android.client.call.RetrofitCall
 import io.getstream.chat.android.client.parser.ChatParserImpl
 import okhttp3.MediaType.Companion.toMediaType
@@ -13,7 +14,7 @@ import retrofit2.Response
 internal class RetroError<T : Any>(val statusCode: Int) : Call<T> {
 
     fun toRetrofitCall(): RetrofitCall<T> {
-        return RetrofitCall(this, ChatParserImpl())
+        return RetrofitCall(this, ChatParserImpl(), RetrofitCallAdapterFactory.mainThreadExecutor)
     }
 
     override fun enqueue(callback: Callback<T>) {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/RetroSuccess.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/RetroSuccess.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.client.utils
 
+import io.getstream.chat.android.client.api.RetrofitCallAdapterFactory
 import io.getstream.chat.android.client.call.RetrofitCall
 import io.getstream.chat.android.client.parser.ChatParserImpl
 import okhttp3.Request
@@ -11,7 +12,7 @@ import retrofit2.Response
 internal class RetroSuccess<T : Any>(val result: T) : Call<T> {
 
     fun toRetrofitCall(): RetrofitCall<T> {
-        return RetrofitCall(this, ChatParserImpl())
+        return RetrofitCall(this, ChatParserImpl(), RetrofitCallAdapterFactory.mainThreadExecutor)
     }
 
     override fun enqueue(callback: Callback<T>) {


### PR DESCRIPTION
### Description

Our custom call class was invoking callbacks without switching to the main thread. This meant if you used `.enqueue { ... }` and tried to touch the UI, your app would have a very bad time. This fix specifies a default main thread executor and uses it to invoke callbacks on the main thread. It also allows one to specify a callback executor when creating the call adapter factory.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
