### PR TITLE
Drop automerge action version to 0.8.4

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.12.0"
+        uses: "pascalgn/automerge-action@v0.8.4"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
           MERGE_LABELS: "automerge"                        # automerge PRs with the 'automerge' label when ready

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -76,11 +76,13 @@ internal abstract class ChatDatabase : RoomDatabase() {
                         ChatDatabase::class.java,
                         "stream_chat_database_$userId"
                     ).fallbackToDestructiveMigration()
-                        .addCallback(object : Callback() {
-                            override fun onOpen(db: SupportSQLiteDatabase) {
-                                db.execSQL("PRAGMA synchronous = 1")
+                        .addCallback(
+                            object : Callback() {
+                                override fun onOpen(db: SupportSQLiteDatabase) {
+                                    db.execSQL("PRAGMA synchronous = 1")
+                                }
                             }
-                        })
+                        )
                         .build()
                     INSTANCES[userId] = db
                 }


### PR DESCRIPTION
Last ditch effort to fix the automerge GitHub action that rebases our PRs to their target branches, as it still isn't running PR checks again after the rebase happens