### PR TITLE
fix: CAS-358 fix channels being stuck in the unread state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## stream-chat-android-offline
 - Add GetChannelController use cases which allows to get ChannelController for Channel
 - Fix not storing channels when run channels fetching after connection recovery.
+- Fix read state getting stuck in unread state
 
 # Oct 26th, 2020 - 4.4.0
 ## stream-chat-android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Fix handling of the `streamShowReadState` attribute on `MessageListView`
 - Add `streamShowDeliveredState` XML attribute to `MessageListView`
 - Add "loading more" indicator to the `MessageListView`
-- Messages in ChannelController were splitted in messages - New messages and oldMessages for messages coming from the history.
+- Messages in ChannelController were split in messages - New messages and oldMessages for messages coming from the history.
 
 ## stream-chat-android-client
 - Fix guest user authentication

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -388,7 +388,7 @@ internal class EventHandlerImpl(
         events.sortedBy { it.createdAt }
         updateOfflineStorageFromEvents(events)
 
-        // step 3 - forward the events to the active chanenls
+        // step 3 - forward the events to the active channels
 
         events.filterIsInstance<CidEvent>()
             .groupBy { it.cid }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -252,10 +252,10 @@ internal class ChannelControllerImpl(
 
         val last = messages.last()
         val lastMessageDate = last.let { it.createdAt ?: it.createdLocallyAt }
-        val shouldNotUpdate =
-            lastMarkReadEvent != null && lastMessageDate?.after(lastMarkReadEvent) == false
+        val shouldUpdate =
+            lastMarkReadEvent == null || lastMessageDate?.after(lastMarkReadEvent) == true
 
-        if (shouldNotUpdate) {
+        if (!shouldUpdate) {
             logger.logI("Last message date [$lastMessageDate] is not after last read event [$lastMarkReadEvent]; no need to update.")
             return Result(false, null)
         }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/LlcMigrationUtils.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/LlcMigrationUtils.java
@@ -3,24 +3,21 @@ package com.getstream.sdk.chat.utils;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.model.AttachmentMetaData;
 import com.getstream.sdk.chat.model.ModelType;
 
-import java.text.DateFormat;
 import java.text.DecimalFormat;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.TimeZone;
 
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import io.getstream.chat.android.client.logger.ChatLogger;
 import io.getstream.chat.android.client.models.Attachment;
 import io.getstream.chat.android.client.models.Channel;
@@ -29,9 +26,6 @@ import io.getstream.chat.android.client.models.Member;
 import io.getstream.chat.android.client.models.Message;
 import io.getstream.chat.android.client.models.User;
 import io.getstream.chat.android.livedata.ChatDomain;
-
-import static com.getstream.sdk.chat.enums.Dates.TODAY;
-import static com.getstream.sdk.chat.enums.Dates.YESTERDAY;
 
 public class LlcMigrationUtils {
 
@@ -78,8 +72,9 @@ public class LlcMigrationUtils {
         } else if (lastMessage == null) {
             return true;
         } else {
-            Date date = lastMessage.getCreatedAt() != null ? lastMessage.getCreatedAt() : lastMessage.getCreatedLocallyAt();
-            return myReadDate.getTime() > (date != null ? date.getTime() : 0);
+            Date lastMessageDate = lastMessage.getCreatedAt() != null ? lastMessage.getCreatedAt() : lastMessage.getCreatedLocallyAt();
+            boolean shouldBeMarkedRead = myReadDate.getTime() >= (lastMessageDate != null ? lastMessageDate.getTime() : 0);
+            return shouldBeMarkedRead;
         }
     }
 
@@ -107,9 +102,9 @@ public class LlcMigrationUtils {
 
     public static Date getLastActive(List<Member> members) {
         Date lastActive = new Date();
-        for (Member member: members) {
+        for (Member member : members) {
             if (member.getUser().getId() != ChatDomain.instance().getCurrentUser().getId()) {
-                if (member.getUser().getLastActive()!= null) {
+                if (member.getUser().getLastActive() != null) {
                     lastActive = member.getUser().getLastActive();
                 }
 
@@ -225,7 +220,7 @@ public class LlcMigrationUtils {
         return true;
     }
 
-    public static List<User> getOtherUsers( List<Member> members) {
+    public static List<User> getOtherUsers(List<Member> members) {
 
         List<User> result = new ArrayList<>();
 
@@ -355,7 +350,7 @@ public class LlcMigrationUtils {
         return lastMessage;
     }
 
-    public static User getCurrentUser(){
+    public static User getCurrentUser() {
         return ChatDomain.instance().getCurrentUser();
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-358

### Description

Issues:
- Our logic for visually indicating as read in the channel list only renders as read if the last read date is newer than the last message date, but the API marks reads with the message's createdAt date. This makes the comparison EQUAL, especially from online query results.

- Additionally, if we got into the state where last read & last message dates are equal, we don't send markRead updates to the UI or the API because the logic indicates we only do that if the last read date is AFTER the last message date. So, we end up stuck in an unread state.

- We execute several concurrent data fetches for offline & online. The mark read usecase gets executed immediately when a message list view loads, even before the viewmodel has a chance to run a channel query for offline and online data. This means we optimistically update the UI, then send a message to the backend to mark a message as read, then execute an offline & online query. It's possible for these last read dates to differ / be old, especially since a MessageReadEvent will be received in the middle of these updates, triggering offline caching. The online job may also return outdated reads.

Changes:
- Since last lastRead == createdAt is expected in online responses, change the logic for rendering as read to >= instead of >.- Refactor updateReads to avoid pushing old read dates to the UI.
- Refactor markRead to check error states first and provide explicit logging.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added

Fixes #698