### PR TITLE
Fix unread counters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 ## stream-chat-android
 
 ## stream-chat-android-client
+- Depecrate `User::unreadCount` property, replace with `User::totalUnreadCount`
 
 ## stream-chat-android-offline
+- Update `totalUnreadCount` when user is connected
+- Update `channelUnreadCount` when user is connected
 
 # Nov 4th, 2020 - 4.4.1
 ## Common changes for all artifacts

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/User.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/User.kt
@@ -52,6 +52,10 @@ public data class User(
 
     @IgnoreSerialisation
     @SerializedName("unread_count")
+    @Deprecated(
+        message = "This property is deprecated, it value could be wrong and will be removed in a future version",
+        replaceWith = ReplaceWith("this.totalUnreadCount")
+    )
     var unreadCount: Int = 0,
 
     @IgnoreSerialisation

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -235,8 +235,6 @@ internal class ChatDomainImpl internal constructor(
             // fetch the configs for channels
             repos.configs.load()
 
-            val me = repos.users.selectMe()
-            me?.let { updateCurrentUser(it) }
             // load the current user from the db
             val initialSyncState = SyncStateEntity(currentUser.id)
             syncState = repos.syncState.select(currentUser.id) ?: initialSyncState

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -290,6 +290,8 @@ internal class ChatDomainImpl internal constructor(
         currentUser = me
         repos.users.insertMe(me)
         _mutedUsers.postValue(me.mutes)
+        setTotalUnreadCount(me.totalUnreadCount)
+        setChannelUnreadCount(me.unreadChannels)
 
         setBanned(me.banned)
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventBatchUpdate.kt
@@ -63,9 +63,7 @@ internal class EventBatchUpdate private constructor(
 
     suspend fun execute() {
         // actually insert the data
-        val currentUser = domainImpl.currentUser
-        domainImpl.updateCurrentUser(currentUser)
-        userMap -= currentUser.id
+        userMap -= domainImpl.currentUser.id
         domainImpl.repos.users.insert(userMap.values.toList())
         // we only cache messages for which we're receiving events
         domainImpl.repos.messages.insert(messageMap.values.toList(), true)


### PR DESCRIPTION
Fixes #802 

### Description
`totalUnreadCount` and `channelUnreadCount` weren't being updated when the user is connected and the proper value was not assigned until a new message arrived.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
