### PR TITLE
CAS-395 Editing the last message doesn’t update the channel preview

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.java
@@ -5,9 +5,7 @@ import java.util.List;
 import androidx.annotation.Nullable;
 import androidx.recyclerview.widget.DiffUtil;
 import io.getstream.chat.android.client.models.Channel;
-import io.getstream.chat.android.client.models.Message;
 
-import static com.getstream.sdk.chat.utils.LlcMigrationUtils.computeLastMessage;
 import static com.getstream.sdk.chat.utils.LlcMigrationUtils.currentUserRead;
 import static com.getstream.sdk.chat.utils.LlcMigrationUtils.equalsLastMessageDate;
 import static com.getstream.sdk.chat.utils.LlcMigrationUtils.equalsName;
@@ -67,19 +65,12 @@ public class ChannelListDiffCallback extends DiffUtil.Callback {
     @Nullable
     @Override
     public Object getChangePayload(int oldItemPosition, int newItemPosition) {
-
         ChannelItemPayloadDiff diff = new ChannelItemPayloadDiff();
 
         Channel oldChannel = oldList.get(oldItemPosition);
         Channel newChannel = newList.get(newItemPosition);
 
-        Message oldLastMessage = computeLastMessage(oldChannel);
-        Message newLastMessage = computeLastMessage(newChannel);
-
-        if (oldLastMessage != null && newLastMessage != null) {
-            diff.lastMessage = !oldLastMessage.getId().equals(newLastMessage.getId());
-        }
-
+        diff.lastMessage = !lastMessagesAreTheSame(oldChannel, newChannel);
         diff.name = !equalsName(newChannel, oldChannel);
         diff.avatarView = !equalsUserLists(getOtherUsers(oldChannel.getMembers()), getOtherUsers(newChannel.getMembers()));
         diff.readState = currentUserRead(oldChannel, newChannel);


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-395

### Description

Correctly display last messages in channel list when:
- user observes channel list
- somebody modifies the last message in the channel

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
