### PR TITLE
Fix navigation in sample apps.

### DIFF
--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
@@ -25,4 +25,8 @@ class ChatInitializer(private val context: Context) {
         val domain = ChatDomain.Builder(client, context).offlineEnabled().notificationConfig(notificationConfig).build()
         val ux = ChatUI.Builder(client, domain, context).build()
     }
+
+    fun isUserSet(): Boolean {
+        return ChatClient.isInitialized && ChatClient.instance().getCurrentUser() != null
+    }
 }

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
@@ -3,16 +3,19 @@ package io.getstream.chat.sample.feature.startup
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.sample.R
+import io.getstream.chat.sample.application.ChatInitializer
 import io.getstream.chat.sample.common.navigateSafely
+import org.koin.android.ext.android.inject
 
 class StartupFragment : Fragment() {
+
+    private val chatInitializer: ChatInitializer by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         findNavController().navigateSafely(
-            if (ChatClient.isInitialized && ChatClient.instance().getCurrentUser() != null) {
+            if (chatInitializer.isUserSet()) {
                 R.id.action_startupFragmentFragment_to_channelsFragment
             } else {
                 R.id.action_startupFragmentFragment_to_userLoginFragment

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
@@ -1,0 +1,22 @@
+package io.getstream.chat.sample.feature.startup
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.sample.R
+import io.getstream.chat.sample.common.navigateSafely
+
+class StartupFragment : Fragment() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        findNavController().navigateSafely(
+            if (ChatClient.isInitialized && ChatClient.instance().getCurrentUser() != null) {
+                R.id.action_startupFragmentFragment_to_channelsFragment
+            } else {
+                R.id.action_startupFragmentFragment_to_userLoginFragment
+            }
+        )
+    }
+}

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginFragment.kt
@@ -70,7 +70,7 @@ class UserLoginFragment : Fragment() {
             }
         )
 
-        activity?.intent?.apply {
+        requireActivity().intent?.apply {
             val channelId = getStringExtra(EXTRA_CHANNEL_ID)
             val channelType = getStringExtra(EXTRA_CHANNEL_TYPE)
             if (!channelId.isNullOrBlank() && !channelType.isNullOrBlank()) {
@@ -79,7 +79,7 @@ class UserLoginFragment : Fragment() {
             }
         }
 
-        activity?.apply {
+        requireActivity().apply {
             onBackPressedDispatcher.addCallback(
                 viewLifecycleOwner,
                 object : OnBackPressedCallback(true) {

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.OnBackPressedCallback
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Observer
@@ -76,6 +77,17 @@ class UserLoginFragment : Fragment() {
                 val cid = "$channelType:$channelId"
                 viewModel.targetChannelDataReceived(cid)
             }
+        }
+
+        activity?.apply {
+            onBackPressedDispatcher.addCallback(
+                viewLifecycleOwner,
+                object : OnBackPressedCallback(true) {
+                    override fun handleOnBackPressed() {
+                        activity?.finish()
+                    }
+                }
+            )
         }
     }
 

--- a/stream-chat-android-sample/src/main/res/navigation/main_navigation.xml
+++ b/stream-chat-android-sample/src/main/res/navigation/main_navigation.xml
@@ -2,7 +2,22 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_navigation"
-    app:startDestination="@id/userLoginFragment">
+    app:startDestination="@id/startupFragment">
+
+    <fragment
+        android:id="@+id/startupFragment"
+        android:name="io.getstream.chat.sample.feature.startup.StartupFragment"
+        android:label="StartupFragment">
+        <action
+            android:id="@+id/action_startupFragmentFragment_to_userLoginFragment"
+            app:destination="@id/userLoginFragment"
+            app:popUpTo="@+id/startupFragment"
+            app:popUpToInclusive="true"/>
+
+        <action
+            android:id="@+id/action_startupFragmentFragment_to_channelsFragment"
+            app:destination="@id/channelsFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/userLoginFragment"

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -25,4 +25,8 @@ class ChatInitializer(private val context: Context) {
         val domain = ChatDomain.Builder(client, context).offlineEnabled().notificationConfig(notificationConfig).build()
         val ux = ChatUI.Builder(client, domain, context).build()
     }
+
+    fun isUserSet(): Boolean {
+        return ChatClient.isInitialized && ChatClient.instance().getCurrentUser() != null
+    }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/startup/StartupFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/startup/StartupFragment.kt
@@ -1,0 +1,22 @@
+package io.getstream.chat.ui.sample.feature.startup
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import io.getstream.chat.ui.sample.R
+import io.getstream.chat.ui.sample.application.App
+import io.getstream.chat.ui.sample.common.navigateSafely
+
+class StartupFragment : Fragment() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        findNavController().navigateSafely(
+            if (App.instance.chatInitializer.isUserSet()) {
+                R.id.action_startupFragmentFragment_to_homeFragment
+            } else {
+                R.id.action_startupFragmentFragment_to_userLoginFragment
+            }
+        )
+    }
+}

--- a/stream-chat-android-ui-components-sample/src/main/res/navigation/main_nav_graph.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/navigation/main_nav_graph.xml
@@ -2,7 +2,22 @@
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_navigation"
-    app:startDestination="@id/userLoginFragment">
+    app:startDestination="@id/startupFragment">
+
+    <fragment
+        android:id="@+id/startupFragment"
+        android:name="io.getstream.chat.ui.sample.feature.startup.StartupFragment"
+        android:label="StartupFragment">
+        <action
+            android:id="@+id/action_startupFragmentFragment_to_userLoginFragment"
+            app:destination="@id/userLoginFragment"
+            app:popUpTo="@+id/startupFragment"
+            app:popUpToInclusive="true"/>
+
+        <action
+            android:id="@+id/action_startupFragmentFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 
     <fragment
         android:id="@+id/userLoginFragment"


### PR DESCRIPTION
Add startup fragment to prevent multiple ChatClient initializations.
Previous implementation allowed creating multiple ChatClient instances without deinitializing old ones.
This was happening when user was on channels fragment, clicked the back button and reopened the app which
was kept in memory.
That was causing multiple socket connections to be opened because socket connection is automatically restored
after resuming the app.
Moreover, back button wasn't working correctly after logging out (Activity wasn't destroyed).

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
