### PR TITLE
Cache in live data of ChannelController value of Channel::lastMessageAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Added new MessageInputView structure
 - Update `totalUnreadCount` when user is connected
 - Update `channelUnreadCount` when user is connected
 - Fix bug when channels could be shown without names
+- Fix bug when local channels could be sorted not properly
 
 # Nov 4th, 2020 - 4.4.1
 ## Common changes for all artifacts

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -100,6 +100,8 @@ internal class ChannelControllerImpl(
     private val _loadingNewerMessages = MutableLiveData(false)
     private val _channelData = MutableLiveData<ChannelData>()
     private val _oldMessages = MutableLiveData<Map<String, Message>>()
+    private val lastMessageAt = MutableLiveData<Date?>()
+
     internal var hideMessagesBefore: Date? = null
     val unfilteredMessages: LiveData<List<Message>> =
         Transformations.map(_messages) { it.values.toList() }
@@ -1130,6 +1132,7 @@ internal class ChannelControllerImpl(
         setMembers(c.members)
         setWatchers(c.watchers)
         upsertMessages(c.messages)
+        lastMessageAt.setOnUi(c.lastMessageAt)
     }
 
     private suspend fun updateOldMessagesFromChannel(c: Channel) {
@@ -1258,7 +1261,8 @@ internal class ChannelControllerImpl(
         val channel = channelData.toChannel(messages, members, reads, watchers, watcherCount)
         channel.config = getConfig()
         channel.unreadCount = computeUnreadCount(domainImpl.currentUser, _read.value, messages)
-        channel.lastMessageAt = messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
+        channel.lastMessageAt =
+            lastMessageAt.value ?: messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
         channel.hidden = _hidden.value
 
         return channel


### PR DESCRIPTION
[CAS-401](https://stream-io.atlassian.net/browse/CAS-401?atlOrigin=eyJpIjoiM2IyNzc1OWU5OTNiNGU4ZjhjMWQ1NjQxMWEwNzJlNjQiLCJwIjoiaiJ9)

### Description

We have an issue when local channels weren't sorted correctly. 
It happened because only for showing channels we extracted them from DB without messages. But sorting was based on last message date. So it was null and the channels list wasn't sorted correctly. I added a cache for lastMessageAt field of the Channel class via a liveData source in ChannelController. So when `ChannelController::toChannel` is invoked the lastMessageField is set.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
