### PR TITLE
[CAS-404] Add streamShowSendAlsoToChannelCheckbox attr to MessageInputStyle 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Added new MessageInputView structure
 - Remove `BaseStyle` class and extract its properties into `AvatarStyle` and `ReadStateStyle`.
     - Use composition with `AvatarStyle` and `ReadStateStyle` instead of inheriting from `BaseStyle`.
     - Convert to kotlin: `ReadStateView`, `MessageListViewStyle`
+- Add `streamShowSendAlsoToChannelCheckbox` attr to `MessageInputView` controlling visibility of "send also to channel" checkbox
 
 ## stream-chat-android-client
 - Deprecate `User::unreadCount` property, replace with `User::totalUnreadCount`

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
@@ -62,7 +62,7 @@ internal class MessageInputController(
     private fun configureThreadInputMode() {
         binding.vPreviewMessage.isVisible = false
         binding.ivOpenAttach.isVisible = style.isShowAttachmentButton
-        binding.cbSendAlsoToChannel.isVisible = true
+        binding.cbSendAlsoToChannel.isVisible = style.sendAlsoToChannelCheckboxEnabled
         binding.cbSendAlsoToChannel.isChecked = false
     }
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputStyle.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputStyle.kt
@@ -29,6 +29,8 @@ internal class MessageInputStyle(private val context: Context, attrs: AttributeS
     val attachmentButtonHeight: Int
     val attachmentCloseButtonBackground: Drawable?
     val inputSendAlsoToChannelTextColor: Int
+    val sendAlsoToChannelCheckboxEnabled: Boolean
+
     private var inputHint = ""
     private val attachmentButtonIcon: Int
     private val attachmentButtonDefaultIconColor: Int
@@ -264,6 +266,10 @@ internal class MessageInputStyle(private val context: Context, attrs: AttributeS
                 "MessageInputStyle",
                 Context.MODE_PRIVATE
             )
+
+            sendAlsoToChannelCheckboxEnabled =
+                getBoolean(R.styleable.MessageInputView_streamShowSendAlsoToChannelCheckbox, true)
+
             recycle()
         }
     }

--- a/stream-chat-android/src/main/res/values/attrs.xml
+++ b/stream-chat-android/src/main/res/values/attrs.xml
@@ -114,8 +114,11 @@
         <!-- Text of the empty state label -->
         <attr name="streamChannelsEmptyStateLabelText" format="string" />
     </declare-styleable>
+
     <!--MessageInputView-->
     <declare-styleable name="MessageInputView">
+        <!-- Thread mode "send also to channel" CheckBox -->
+        <attr name="streamShowSendAlsoToChannelCheckbox" format="boolean" />
         <!--AvatarGroupView(automention)-->
         <attr name="streamAvatarWidth" />
         <attr name="streamAvatarHeight" />


### PR DESCRIPTION
### Description

This PR adds `streamShowSendAlsoToChannelCheckbox` attr to `MessageInputStyle` controlling visibility of "send also to channel" checkbox 
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
