### PR TITLE
[CAS-434] Hotfix/update users endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Added new MessageInputView structure
 ## stream-chat-android-client
 - Deprecate `User::unreadCount` property, replace with `User::totalUnreadCount`
 - Added MarkAllReadEvent
+- Fix UpdateUsers call
 
 ## stream-chat-android-offline
 - Update `totalUnreadCount` when user is connected

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -345,6 +345,7 @@ internal class ChatApi(
         val map = users.associateBy({ it.id }, { user -> user })
 
         return retrofitApi.updateUsers(
+            apiKey,
             connectionId,
             UpdateUsersRequest(map)
         )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -205,6 +205,7 @@ internal interface RetrofitApi {
 
     @POST("/users")
     fun updateUsers(
+        @Query("api_key") apiKey: String,
         @Query("connection_id") connectionId: String,
         @Body body: UpdateUsersRequest
     ): RetrofitCall<UpdateUsersResponse>


### PR DESCRIPTION
### Description
`ChatClient::UpdateUsers` wasn't working fine because we didn't add the `api_key` to our query and backend was rejecting this call

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
