### PR TITLE
Fix ScrollButtonBehavior when a thread is started/closed

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
@@ -48,6 +48,7 @@ import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import kotlin.math.max
+import kotlin.math.min
 
 /**
  * MessageListView renders a list of messages and extends the [RecyclerView]
@@ -367,15 +368,15 @@ public class MessageListView : ConstraintLayout {
                     if (!::layoutManager.isInitialized) {
                         return
                     }
-
                     val currentFirstVisible = layoutManager.findFirstVisibleItemPosition()
                     val currentLastVisible = layoutManager.findLastVisibleItemPosition()
 
                     hasScrolledUp = currentLastVisible < lastPosition()
                     firstVisiblePosition = currentFirstVisible
 
-                    val realLastVisibleMessage = max(currentLastVisible, lastSeenMessagePosition())
-                    lastSeenMessage = adapter.currentList[realLastVisibleMessage]
+                    val currentList = adapter.currentList
+                    val realLastVisibleMessage = min(max(currentLastVisible, lastSeenMessagePosition()), currentList.size)
+                    lastSeenMessage = currentList[realLastVisibleMessage]
 
                     val unseenItems = adapter.itemCount - 1 - realLastVisibleMessage
                     scrollButtonBehaviour.onUnreadMessageCountChanged(unseenItems)


### PR DESCRIPTION
### Description
Fix ScrollButtonBehavior when a thread is started/closed

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Reviewers added~
