### PR TITLE
[CAS-439] Hotfix subscribe client on main thread

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.OnLifecycleEvent
-import androidx.lifecycle.ProcessLifecycleOwner
 import com.google.firebase.messaging.RemoteMessage
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ChatClientConfig
@@ -68,11 +67,15 @@ public class ChatClient internal constructor(
     private val notifications: ChatNotifications,
     private val tokenManager: TokenManager = TokenManagerImpl(),
     private val clientStateService: ClientStateService = ClientStateService()
-) : LifecycleObserver {
+) {
 
     private var connectionListener: InitConnectionListener? = null
     private val logger = ChatLogger.get("Client")
     private val eventsObservable = ChatEventsObservable(socket)
+    private val lifecycleHandler = object : LifecycleHandler {
+        override fun resume() = reconnectSocket()
+        override fun stopped() = disconnectSocket()
+    }
 
     public val disconnectListeners: MutableList<(User?) -> Unit> = mutableListOf<(User?) -> Unit>()
     public val preSetUserListeners: MutableList<(User) -> Unit> = mutableListOf<(User) -> Unit>()
@@ -98,21 +101,7 @@ public class ChatClient internal constructor(
                 }
             }
         }
-
-        // disconnect when the app is stopped
-        ProcessLifecycleOwner.get().lifecycle.addObserver(this)
-
         logger.logI("Initialised: " + getVersion())
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_RESUME)
-    public fun onResume() {
-        reconnectSocket()
-    }
-
-    @OnLifecycleEvent(Lifecycle.Event.ON_STOP)
-    public fun onStopped() {
-        disconnectSocket()
     }
 
     //region Set user
@@ -152,7 +141,7 @@ public class ChatClient internal constructor(
         for (preSetUserListener in preSetUserListeners) {
             preSetUserListener(user)
         }
-        connectionListener = listener
+        connectionListener = wrapListener(listener)
         config.isAnonymous = false
         tokenManager.setTokenProvider(tokenProvider)
 
@@ -165,11 +154,22 @@ public class ChatClient internal constructor(
 
     public fun setAnonymousUser(listener: InitConnectionListener? = null) {
         clientStateService.onSetAnonymousUser()
-        connectionListener = listener
+        connectionListener = wrapListener(listener)
         config.isAnonymous = true
         warmUp()
         getTokenAndConnect {
             socket.connectAnonymously()
+        }
+    }
+
+    private fun wrapListener(listener: InitConnectionListener?) = object : InitConnectionListener() {
+        override fun onSuccess(data: ConnectionData) {
+            StreamLifecycleObserver(lifecycleHandler).observe()
+            listener?.onSuccess(data)
+        }
+
+        override fun onError(error: ChatError) {
+            listener?.onError(error)
         }
     }
 
@@ -915,6 +915,7 @@ public class ChatClient internal constructor(
                 module.notifications(),
                 tokenManager
             )
+
             instance = result
 
             return result

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -4,14 +4,19 @@ import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
+import io.getstream.chat.android.client.internal.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : LifecycleObserver {
     private var recurringResumeEvent = false
 
     fun observe() {
-        ProcessLifecycleOwner.get()
-            .lifecycle
-            .addObserver(this)
+        CoroutineScope(DispatcherProvider.Main).launch {
+            ProcessLifecycleOwner.get()
+                .lifecycle
+                .addObserver(this@StreamLifecycleObserver)
+        }
     }
 
     fun dispose() {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -1,11 +1,11 @@
-package com.getstream.sdk.chat
+package io.getstream.chat.android.client
 
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 
-internal class StreamLifecycleObserver(var handler: LifecycleHandler) : LifecycleObserver {
+internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : LifecycleObserver {
     private var recurringResumeEvent = false
 
     fun observe() {
@@ -34,4 +34,9 @@ internal class StreamLifecycleObserver(var handler: LifecycleHandler) : Lifecycl
     fun onStopped() {
         handler.stopped()
     }
+}
+
+internal interface LifecycleHandler {
+    fun resume()
+    fun stopped()
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/LifecycleHandler.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/LifecycleHandler.java
@@ -1,7 +1,0 @@
-package com.getstream.sdk.chat;
-
-public interface LifecycleHandler {
-    void resume();
-
-    void stopped();
-}


### PR DESCRIPTION
### Description
`LifecycleObserver` instances only are able to be registered on MainThread. We had a crash previously because our `ChatClient` (That was a LifecycleObserver) was registered from a background thread when it was started by a push notification.
Reviewing our previous implementation, I could see we were registering it into the constructor, but we don't need to do it there if a user has not been set. I have refactored that logic to only observe when the user is set properly.
On the other hand, we had a previous implementation of `StreamLifecycleObserver` that prevented to be called immediately after we register our observer and removing an unnecessary call to reconnect that was been done previously

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
