### PR TITLE
Feature/update chat client observation

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -5,7 +5,7 @@ import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.OnLifecycleEvent
 import androidx.lifecycle.ProcessLifecycleOwner
 import io.getstream.chat.core.internal.coroutines.DispatcherProvider
-import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : LifecycleObserver {
@@ -15,7 +15,7 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
     fun observe() {
         if (isObserving.not()) {
             isObserving = true
-            CoroutineScope(DispatcherProvider.Main).launch {
+            GlobalScope.launch(DispatcherProvider.Main) {
                 ProcessLifecycleOwner.get()
                     .lifecycle
                     .addObserver(this@StreamLifecycleObserver)
@@ -24,7 +24,7 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
     }
 
     fun dispose() {
-        CoroutineScope(DispatcherProvider.Main).launch {
+        GlobalScope.launch(DispatcherProvider.Main) {
             ProcessLifecycleOwner.get()
                 .lifecycle
                 .removeObserver(this@StreamLifecycleObserver)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -10,12 +10,16 @@ import kotlinx.coroutines.launch
 
 internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : LifecycleObserver {
     private var recurringResumeEvent = false
+    @Volatile private var isObserving = false
 
     fun observe() {
-        CoroutineScope(DispatcherProvider.Main).launch {
-            ProcessLifecycleOwner.get()
-                .lifecycle
-                .addObserver(this@StreamLifecycleObserver)
+        if (isObserving.not()) {
+            isObserving = true
+            CoroutineScope(DispatcherProvider.Main).launch {
+                ProcessLifecycleOwner.get()
+                    .lifecycle
+                    .addObserver(this@StreamLifecycleObserver)
+            }
         }
     }
 
@@ -25,6 +29,7 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
                 .lifecycle
                 .removeObserver(this@StreamLifecycleObserver)
         }
+        isObserving = false
         recurringResumeEvent = false
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -20,9 +20,11 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
     }
 
     fun dispose() {
-        ProcessLifecycleOwner.get()
-            .lifecycle
-            .removeObserver(this)
+        CoroutineScope(DispatcherProvider.Main).launch {
+            ProcessLifecycleOwner.get()
+                .lifecycle
+                .removeObserver(this@StreamLifecycleObserver)
+        }
         recurringResumeEvent = false
     }
 


### PR DESCRIPTION
### Description
We can't delegate observation to the initCallback, because the setUser could fails but have a reconnection process that complete this process. On that case our observer won't be registered. This behavior has been updated to be registered when the connection is done. 
Other corner-case happend here, because our observer could be registered multiple times, that is because our `StreamLifecycleObserver` has been updated as well to only allow observe once

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
