### PR TITLE
Fix/cas 440 channels not sorted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - It's no longer required to wait for `setUser` to finish before querying channels
 
 ## stream-chat-android-offline
+- Fix bug when channels with newer messages don't go to the first position in the list
 
 # Nov 13th, 2020 - 4.4.2
 ## stream-chat-android-ui-component

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -73,6 +73,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
+import kotlin.math.max
 
 private const val KEY_MESSAGE_ACTION = "image_action"
 private const val MESSAGE_ACTION_SHUFFLE = "shuffle"
@@ -841,7 +842,19 @@ internal class ChannelControllerImpl(
 
     private fun upsertMessages(messages: List<Message>) {
         val newMessages = parseMessages(messages)
+        updateLastMessageAtByNewMessages(newMessages.values)
         _messages.value = newMessages
+    }
+
+    private fun updateLastMessageAtByNewMessages(newMessages: Collection<Message>) {
+        if (newMessages.isEmpty()) {
+            return
+        }
+        val newLastMessageAt = newMessages.mapNotNull { it.createdAt ?: it.createdLocallyAt }.maxOf(Date::getTime)
+        lastMessageAt.value = when (val currentLastMessageAt = lastMessageAt.value) {
+            null -> Date(newLastMessageAt)
+            else -> max(currentLastMessageAt.time, newLastMessageAt).let(::Date)
+        }
     }
 
     private fun upsertOldMessages(messages: List<Message>) {
@@ -1275,7 +1288,11 @@ internal class ChannelControllerImpl(
         return channel
     }
 
-    internal fun loadOlderThreadMessages(threadId: String, limit: Int, firstMessage: Message? = null): Result<List<Message>> {
+    internal fun loadOlderThreadMessages(
+        threadId: String,
+        limit: Int,
+        firstMessage: Message? = null
+    ): Result<List<Message>> {
         val result = if (firstMessage != null) {
             client.getRepliesMore(threadId, firstMessage.id, limit).execute()
         } else {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -853,7 +853,8 @@ internal class ChannelControllerImpl(
         if (newMessages.isEmpty()) {
             return
         }
-        val newLastMessageAt = newMessages.mapNotNull { it.createdAt ?: it.createdLocallyAt }.maxOf(Date::getTime)
+        val newLastMessageAt =
+            newMessages.mapNotNull { it.createdAt ?: it.createdLocallyAt }.maxOfOrNull(Date::getTime) ?: return
         lastMessageAt.value = when (val currentLastMessageAt = lastMessageAt.value) {
             null -> Date(newLastMessageAt)
             else -> max(currentLastMessageAt.time, newLastMessageAt).let(::Date)


### PR DESCRIPTION
[CAS-440](https://stream-io.atlassian.net/browse/CAS-440?atlOrigin=eyJpIjoiZTdhZDc0NTI0ZjA1NDU5NTg4ZTU5N2ExZmUzMDIwOTAiLCJwIjoiaiJ9)
### Description

Customer has complained that channels with new messages don't pop up in the list. It happened because a field which is used in sort algorithm by default wasn't updated properly. It fixes the problem.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
