### PR TITLE
Extract formatting of channel dates into DateFormatter

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -1,9 +1,9 @@
 package io.getstream.chat.android.ui.channel.list.adapter.viewholder
 
-import android.annotation.SuppressLint
 import android.util.TypedValue
 import android.view.View
 import androidx.core.view.isVisible
+import com.getstream.sdk.chat.utils.DateFormatter
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.ChannelListView
@@ -19,17 +19,8 @@ import io.getstream.chat.android.ui.utils.extensions.getLastMessage
 import io.getstream.chat.android.ui.utils.extensions.getLastMessageTime
 import io.getstream.chat.android.ui.utils.extensions.getReadStatusDrawable
 import io.getstream.chat.android.ui.utils.extensions.getUsers
-import java.text.SimpleDateFormat
-import java.util.Locale
 
 public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemViewHolder(itemView) {
-
-    public companion object {
-        @SuppressLint("ConstantLocale")
-        private val DEFAULT_LOCALE: Locale = Locale.getDefault()
-
-        private val TIME_FORMAT = SimpleDateFormat("hh:mm", DEFAULT_LOCALE)
-    }
 
     public override fun bind(
         channel: Channel,
@@ -64,9 +55,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
                         )
                     } ?: String.EMPTY
 
-                    channel.getLastMessageTime()
-                        ?.let(TIME_FORMAT::format)
-                        ?.let { lastMessageTimeLabel.text = it }
+                    lastMessageTimeLabel.text = DateFormatter.formatAsTimeOrDate(channel.getLastMessageTime())
 
                     channel.getCurrentUserUnreadCount().let { unreadCount ->
                         unreadCountBadge.apply {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemViewHolder.java
@@ -16,6 +16,7 @@ import androidx.core.graphics.drawable.DrawableCompat;
 import com.getstream.sdk.chat.ChatUI;
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.model.ModelType;
+import com.getstream.sdk.chat.utils.DateFormatter;
 import com.getstream.sdk.chat.utils.LlcMigrationUtils;
 import com.getstream.sdk.chat.utils.StringUtility;
 import com.getstream.sdk.chat.view.AvatarView;
@@ -23,12 +24,8 @@ import com.getstream.sdk.chat.view.ReadStateView;
 import com.getstream.sdk.chat.view.channels.ChannelListView;
 import com.getstream.sdk.chat.view.channels.ChannelListViewStyle;
 
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
-import java.util.Locale;
 
 import io.getstream.chat.android.client.models.Attachment;
 import io.getstream.chat.android.client.models.Channel;
@@ -38,11 +35,6 @@ import io.getstream.chat.android.client.models.User;
 import io.getstream.chat.android.livedata.ChatDomain;
 
 public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
-
-    @SuppressLint("ConstantLocale")
-    private static final DateFormat DATE_FORMAT = new SimpleDateFormat("MMM d", Locale.getDefault());
-    @SuppressLint("ConstantLocale")
-    private static final DateFormat TIME_DATEFORMAT = new SimpleDateFormat("HH:mm", Locale.getDefault());
 
     protected TextView tv_name, tv_last_message, tv_date;
     protected ReadStateView read_state;
@@ -199,22 +191,7 @@ public class ChannelListItemViewHolder extends BaseChannelListItemViewHolder {
 
         Date messageDate = lastMessage.getCreatedAt() != null ? lastMessage.getCreatedAt() : lastMessage.getCreatedLocallyAt();
 
-        if (messageDate == null) {
-            tv_date.setText("");
-        }
-        else if (isFromToday(messageDate)) {
-            tv_date.setText(TIME_DATEFORMAT.format(messageDate));
-        } else {
-            tv_date.setText(DATE_FORMAT.format(messageDate));
-        }
-    }
-
-    private boolean isFromToday(Date date) {
-        Calendar today = Calendar.getInstance();
-        Calendar messageCalendar = Calendar.getInstance();
-        messageCalendar.setTime(date);
-        return today.get(Calendar.DAY_OF_YEAR) == messageCalendar.get(Calendar.DAY_OF_YEAR)
-                && today.get(Calendar.YEAR) == messageCalendar.get(Calendar.YEAR);
+        tv_date.setText(DateFormatter.formatAsTimeOrDate(messageDate));
     }
 
     protected void configReadState(Channel channel) {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/DateFormatter.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/DateFormatter.kt
@@ -1,0 +1,40 @@
+package com.getstream.sdk.chat.utils
+
+import android.annotation.SuppressLint
+import io.getstream.chat.core.internal.InternalStreamChatApi
+import java.text.DateFormat
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+
+@InternalStreamChatApi
+public object DateFormatter {
+
+    @SuppressLint("ConstantLocale")
+    private val DEFAULT_LOCALE = Locale.getDefault()
+    private val DATE_FORMAT: DateFormat = SimpleDateFormat("MMM d", DEFAULT_LOCALE)
+    private val TIME_FORMAT: DateFormat = SimpleDateFormat("HH:mm", DEFAULT_LOCALE)
+
+    /**
+     * Formats the given [date] as 24h time if it's on the current day, and
+     * as a month/day format date otherwise.
+     */
+    @JvmStatic
+    public fun formatAsTimeOrDate(date: Date?): String {
+        return when {
+            date == null -> ""
+            isFromToday(date) -> TIME_FORMAT.format(date)
+            else -> DATE_FORMAT.format(date)
+        }
+    }
+
+    private fun isFromToday(date: Date): Boolean {
+        val today = Calendar.getInstance()
+        val dateCalendar = Calendar.getInstance().apply {
+            time = date
+        }
+        return today[Calendar.DAY_OF_YEAR] == dateCalendar[Calendar.DAY_OF_YEAR] &&
+            today[Calendar.YEAR] == dateCalendar[Calendar.YEAR]
+    }
+}

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/utils/DateFormatterTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/utils/DateFormatterTest.kt
@@ -1,0 +1,56 @@
+@file:Suppress("DEPRECATION")
+
+package com.getstream.sdk.chat.utils
+
+import com.google.common.truth.Truth
+import org.junit.jupiter.api.Test
+import java.util.Date
+
+internal class DateFormatterTest {
+
+    @Test
+    fun formatNullDate() {
+        val date: Date? = null
+
+        val result = DateFormatter.formatAsTimeOrDate(date)
+
+        Truth.assertThat(result).isEqualTo("")
+    }
+
+    @Test
+    fun formatAmHour() {
+        val date: Date? = Date().apply {
+            hours = 3
+            minutes = 47
+        }
+
+        val result = DateFormatter.formatAsTimeOrDate(date)
+
+        Truth.assertThat(result).isEqualTo("03:47")
+    }
+
+    @Test
+    fun formatPmHour() {
+        val date: Date? = Date().apply {
+            hours = 15
+            minutes = 47
+        }
+
+        val result = DateFormatter.formatAsTimeOrDate(date)
+
+        Truth.assertThat(result).isEqualTo("15:47")
+    }
+
+    @Test
+    fun formatDate() {
+        val date: Date? = Date().apply {
+            year = 2020
+            month = 10 // November
+            date = 7
+        }
+
+        val result = DateFormatter.formatAsTimeOrDate(date)
+
+        Truth.assertThat(result).isEqualTo("Nov 7")
+    }
+}


### PR DESCRIPTION

### Description

Extracts the date formatting logic that we already had duplicated in two places for the list of channel items (and we'll use in at least two more places in the new design) into a helper class + adds tests.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
