### PR TITLE
Debounce search input events

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/search/ComponentBrowserSearchViewFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/search/ComponentBrowserSearchViewFragment.kt
@@ -6,7 +6,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import io.getstream.chat.android.ui.search.SearchView
 import io.getstream.chat.ui.sample.common.showToast
 import io.getstream.chat.ui.sample.databinding.FragmentComponentBrowserSearchViewBinding
 
@@ -34,12 +33,11 @@ class ComponentBrowserSearchViewFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.searchView.listener = object : SearchView.Listener {
-            override fun onInputChanged(query: String) {
-                Log.d(TAG, "Input: '$query'")
+        binding.searchView.apply {
+            setDebouncedInputChangedListener { query ->
+                Log.d(TAG, "Debounced input: '$query'")
             }
-
-            override fun onSearchStarted(query: String) {
+            setSearchStartedListener { query ->
                 Log.d(TAG, "Search: '$query'")
                 showToast("Search: '$query'")
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/Debouncer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/Debouncer.kt
@@ -1,0 +1,37 @@
+package io.getstream.chat.android.ui.utils
+
+import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * Utility class for debouncing high frequency events.
+ *
+ * [submit]ting a new piece of work to run within the debounce window
+ * will cancel the previously submitted pending work.
+ */
+internal class Debouncer(private val debounceMs: Long) {
+
+    private val scope = CoroutineScope(DispatcherProvider.Main)
+    private var job: Job? = null
+
+    fun submit(work: () -> Unit) {
+        job?.cancel()
+        job = scope.launch {
+            delay(debounceMs)
+            work()
+        }
+    }
+
+    /**
+     * Cleans up any pending work.
+     *
+     * Note that a shut down Debouncer will never execute work again.
+     */
+    fun shutdown() {
+        scope.cancel()
+    }
+}


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-369

### Description

Adds a listener that only notifies after debouncing test input for 300ms. Debouncing logic is contained in a reusable utility class.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~ This could be unit tested, but it'll be easier to add these tests once we have a separate test module
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
