### PR TITLE
use stateflow to fix chatDomainImpl.clearState

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -62,7 +62,7 @@ public interface ChatDomain {
      *   })
      *
      */
-    public val errorEvents: LiveData<Event<ChatError>?>
+    public val errorEvents: LiveData<Event<ChatError>>
 
     /**
      * list of users that you've muted

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -62,7 +62,7 @@ public interface ChatDomain {
      *   })
      *
      */
-    public val errorEvents: LiveData<Event<ChatError>>
+    public val errorEvents: LiveData<Event<ChatError>?>
 
     /**
      * list of users that you've muted

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -6,7 +6,6 @@ import android.os.Handler
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
-import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.asLiveData
 import androidx.room.Room
 import com.google.gson.Gson
@@ -127,12 +126,13 @@ internal class ChatDomainImpl internal constructor(
     private val _initialized = MutableStateFlow(false)
     private val _online = MutableStateFlow(false)
 
-    private val _totalUnreadCount = MutableLiveData<Int>()
-    private val _channelUnreadCount = MutableLiveData<Int>()
-    private val _errorEvent = MutableLiveData<Event<ChatError>>()
-    private val _banned = MutableLiveData(false)
-    private val _mutedUsers = MutableLiveData<List<Mute>>()
+    private val _totalUnreadCount = MutableStateFlow(0)
+    private val _channelUnreadCount = MutableStateFlow(0)
+    private val _errorEvent = MutableStateFlow<Event<ChatError>?>(null)
+    private val _banned = MutableStateFlow(false)
+    private val _mutedUsers = MutableStateFlow<List<Mute>>(emptyList())
     private val _typingChannels = MediatorLiveData<TypingEvent>()
+
     override lateinit var currentUser: User
     lateinit var database: ChatDatabase
     private val syncModule by lazy { SyncProvider(appContext) }
@@ -154,22 +154,22 @@ internal class ChatDomainImpl internal constructor(
      * The total unread message count for the current user.
      * Depending on your app you'll want to show this or the channelUnreadCount
      */
-    override val totalUnreadCount: LiveData<Int> = _totalUnreadCount
+    override val totalUnreadCount: LiveData<Int> = _totalUnreadCount.asLiveData()
 
     /**
      * the number of unread channels for the current user
      */
-    override val channelUnreadCount: LiveData<Int> = _channelUnreadCount
+    override val channelUnreadCount: LiveData<Int> = _channelUnreadCount.asLiveData()
 
     /**
      * list of users that you've muted
      */
-    override val muted: LiveData<List<Mute>> = _mutedUsers
+    override val muted: LiveData<List<Mute>> = _mutedUsers.asLiveData()
 
     /**
      * if the current user is banned or not
      */
-    override val banned: LiveData<Boolean> = _banned
+    override val banned: LiveData<Boolean> = _banned.asLiveData()
 
     /**
      * The error event livedata object is triggered when errors in the underlying components occure.
@@ -180,7 +180,7 @@ internal class ChatDomainImpl internal constructor(
      *   })
      *
      */
-    override val errorEvents: LiveData<Event<ChatError>> = _errorEvent
+    override val errorEvents: LiveData<Event<ChatError>?> = _errorEvent.asLiveData()
 
     /** the event subscription, cancel using repo.stopListening */
     private var eventSubscription: Disposable = EMPTY_DISPOSABLE
@@ -215,9 +215,9 @@ internal class ChatDomainImpl internal constructor(
     private fun clearState() {
         _initialized.value = false
         _online.value = false
-        _totalUnreadCount.postValue(0)
-        _channelUnreadCount.postValue(0)
-        _banned.postValue(false)
+        _totalUnreadCount.value = 0
+        _channelUnreadCount.value = 0
+        _banned.value = false
         _mutedUsers.value = emptyList()
         activeChannelMapImpl.clear()
         activeQueryMapImpl.clear()
@@ -317,7 +317,7 @@ internal class ChatDomainImpl internal constructor(
         }
         currentUser = me
         repos.users.insertMe(me)
-        _mutedUsers.postValue(me.mutes)
+        _mutedUsers.value = me.mutes
         setTotalUnreadCount(me.totalUnreadCount)
         setChannelUnreadCount(me.unreadChannels)
 
@@ -435,11 +435,7 @@ internal class ChatDomainImpl internal constructor(
         }
 
     fun addError(error: ChatError) {
-        _errorEvent.postValue(
-            Event(
-                error
-            )
-        )
+        _errorEvent.value = Event(error)
     }
 
     fun isActiveChannel(cid: String): Boolean {
@@ -447,24 +443,15 @@ internal class ChatDomainImpl internal constructor(
     }
 
     fun setChannelUnreadCount(newCount: Int) {
-        val currentCount = _channelUnreadCount.value ?: 0
-        if (currentCount != newCount) {
-            _channelUnreadCount.postValue(newCount)
-        }
+        _channelUnreadCount.value = newCount
     }
 
     fun setBanned(newBanned: Boolean) {
-        val banned = _banned.value ?: false
-        if (newBanned != banned) {
-            _banned.postValue(newBanned)
-        }
+        _banned.value = newBanned
     }
 
     fun setTotalUnreadCount(newCount: Int) {
-        val currentCount = _totalUnreadCount.value ?: 0
-        if (currentCount != newCount) {
-            _totalUnreadCount.postValue(newCount)
-        }
+        _totalUnreadCount.value = newCount
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -55,6 +55,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.launch
 import java.util.Date
 import java.util.InputMismatchException
@@ -180,7 +181,7 @@ internal class ChatDomainImpl internal constructor(
      *   })
      *
      */
-    override val errorEvents: LiveData<Event<ChatError>?> = _errorEvent.asLiveData()
+    override val errorEvents: LiveData<Event<ChatError>> = _errorEvent.filterNotNull().asLiveData()
 
     /** the event subscription, cancel using repo.stopListening */
     private var eventSubscription: Disposable = EMPTY_DISPOSABLE
@@ -191,8 +192,6 @@ internal class ChatDomainImpl internal constructor(
     override val typingUpdates: LiveData<TypingEvent> = _typingChannels
 
     private val activeQueryMapImpl: ConcurrentHashMap<String, QueryChannelsControllerImpl> = ConcurrentHashMap()
-
-    // TODO 1.1: We should accelerate online/offline detection
 
     internal val eventHandler: EventHandlerImpl = EventHandlerImpl(this)
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseConnectedIntegrationTest.kt
@@ -1,8 +1,10 @@
 package io.getstream.chat.android.livedata
 
 import android.content.Context
+import android.os.Handler
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth
+import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.errors.ChatError
@@ -35,11 +37,22 @@ internal open class BaseConnectedIntegrationTest : BaseDomainTest() {
         db = createRoomDb()
 
         val context = ApplicationProvider.getApplicationContext() as Context
-        chatDomainImpl = ChatDomain.Builder(context, client, data.user1).database(db)
-            .offlineEnabled()
-            .userPresenceEnabled()
-            .recoveryDisabled()
-            .buildImpl()
+        val handler: Handler = mock()
+        val offlineEnabled = true
+        val userPresence = true
+        val recoveryEnabled = false
+        val backgroundSyncEnabled = false
+        chatDomainImpl = ChatDomainImpl(
+            client,
+            data.user1,
+            db,
+            handler,
+            offlineEnabled,
+            userPresence,
+            recoveryEnabled,
+            backgroundSyncEnabled,
+            context
+        )
         chatDomain = chatDomainImpl
         chatDomainImpl.retryPolicy = object :
             RetryPolicy {


### PR DESCRIPTION
Use StateFlow to fix the error triggered by calling clearState from the IO thread:

https://console.firebase.google.com/project/stream-chat-internal/crashlytics/app/android:io.getstream.chat.sample.debug/issues/3d76c3f580802cc57d67fa27be437dcf?time=last-seven-days&sessionEventKey=5FB681280016000139B4D82C531C700B_1475287504195377751

Remove unused typingEvents implementation, design is dropping this feature request.