### PR TITLE
Disable reselection of the same item in bottom navigation

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
@@ -59,6 +59,8 @@ class HomeFragment : Fragment() {
         val navHostFragment =
             childFragmentManager.findFragmentById(R.id.hostFragmentContainer) as NavHostFragment
         binding.bottomNavigationView.setupWithNavController(navHostFragment.navController)
+        // disable reloading fragment when clicking again on the same tab
+        binding.bottomNavigationView.setOnNavigationItemReselectedListener {}
     }
 
     private fun setupNavigationDrawer() {


### PR DESCRIPTION
### Description

To be consistent with the majority of modern apps, do not reload current page when the current bottom navigation item is reselected.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
