### PR TITLE
Message diff

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ReactionEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ReactionEntity.kt
@@ -50,6 +50,7 @@ internal data class ReactionEntity(@PrimaryKey var messageId: String, var userId
     constructor(r: Reaction) : this(r.messageId, r.fetchUserId(), r.type) {
         score = r.score
         createdAt = r.createdAt
+        updatedAt = r.updatedAt
         // defend against GSON unsafe decoding/encoding
         extraData = r.extraData ?: mutableMapOf()
         syncStatus = r.syncStatus ?: SyncStatus.COMPLETED
@@ -63,6 +64,7 @@ internal data class ReactionEntity(@PrimaryKey var messageId: String, var userId
         r.user = userMap[userId] ?: error("userMap is missing the user for this reaction")
         r.extraData = extraData ?: mutableMapOf()
         r.createdAt = createdAt
+        r.updatedAt = updatedAt
         r.syncStatus = syncStatus ?: SyncStatus.COMPLETED
 
         return r

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
@@ -40,4 +40,13 @@ internal class MessageListItemAdapter(
     override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int) {
         holder.bindListItem(getItem(position))
     }
+
+    override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int, payloads: MutableList<Any>) {
+        val diff = if (payloads.isEmpty()) {
+            null
+        } else {
+            payloads[0] as MessageListItemPayloadDiff
+        }
+        holder.bindListItem(getItem(position), diff)
+    }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemAdapter.kt
@@ -38,15 +38,43 @@ internal class MessageListItemAdapter(
     }
 
     override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int) {
-        holder.bindListItem(getItem(position))
+        holder.bindListItem(getItem(position), FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF)
     }
 
     override fun onBindViewHolder(holder: BaseMessageListItemViewHolder<*>, position: Int, payloads: MutableList<Any>) {
-        val diff = if (payloads.isEmpty()) {
-            null
-        } else {
-            payloads[0] as MessageListItemPayloadDiff
-        }
+        val diff = (
+            payloads
+                .filterIsInstance<MessageListItemPayloadDiff>()
+                .takeIf { it.isNotEmpty() }
+                ?: listOf(FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF)
+            )
+            .fold(EMPTY_MESSAGE_LIST_ITEM_PAYLOAD_DIFF) { acc, messageListItemPayloadDiff ->
+                acc + messageListItemPayloadDiff
+            }
+
         holder.bindListItem(getItem(position), diff)
+    }
+
+    companion object {
+        private val FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF = MessageListItemPayloadDiff(
+            text = true,
+            reactions = true,
+            attachments = true,
+            replies = true,
+            syncStatus = true,
+            deleted = true,
+            positions = true,
+            readBy = true
+        )
+        private val EMPTY_MESSAGE_LIST_ITEM_PAYLOAD_DIFF = MessageListItemPayloadDiff(
+            text = false,
+            reactions = false,
+            attachments = false,
+            replies = false,
+            syncStatus = false,
+            deleted = false,
+            positions = false,
+            readBy = false
+        )
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
@@ -1,6 +1,7 @@
 package com.getstream.sdk.chat.adapter
 
 import androidx.recyclerview.widget.DiffUtil
+import io.getstream.chat.android.client.models.User
 
 internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListItem>() {
     override fun areItemsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
@@ -8,6 +9,46 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
     }
 
     override fun areContentsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
-        return oldItem == newItem
+        var equal = true
+        when (oldItem) {
+            is MessageListItem.MessageItem -> {
+                newItem as MessageListItem.MessageItem
+                equal = if (oldItem.message.text != newItem.message.text) {
+                    false
+                } else if (oldItem.message.reactionCounts != newItem.message.reactionCounts) {
+                    false
+                } else if (oldItem.message.attachments != newItem.message.attachments) {
+                    false
+                } else if (oldItem.message.replyCount != newItem.message.replyCount) {
+                    false
+                } else if (oldItem.message.syncStatus != newItem.message.syncStatus) {
+                    false
+                } else if (oldItem.positions != newItem.positions) {
+                    false
+                } else oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
+            }
+            is MessageListItem.DateSeparatorItem, is MessageListItem.ThreadSeparatorItem, is MessageListItem.LoadingMoreIndicatorItem -> equal = true
+            is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as MessageListItem.TypingItem).users.map(User::id)
+            is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as MessageListItem.ReadStateItem).reads.map { it.getUserId() }
+        }
+
+        return equal
+    }
+
+    override fun getChangePayload(oldItem: MessageListItem, newItem: MessageListItem): Any? {
+        return if (oldItem is MessageListItem.MessageItem) {
+            newItem as MessageListItem.MessageItem
+            MessageListItemPayloadDiff(
+                text = oldItem.message.text != newItem.message.text,
+                reactions = oldItem.message.reactionCounts != newItem.message.reactionCounts,
+                attachments = oldItem.message.attachments != newItem.message.attachments,
+                replies = oldItem.message.replyCount != newItem.message.replyCount,
+                syncStatus = oldItem.message.syncStatus != newItem.message.syncStatus,
+                positions = oldItem.positions != newItem.positions,
+                readBy = oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
+            )
+        } else {
+            null
+        }
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
@@ -8,12 +8,11 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
         return oldItem.getStableId() == newItem.getStableId()
     }
 
-    override fun areContentsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
-        var equal = true
+    override fun areContentsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean =
         when (oldItem) {
             is MessageListItem.MessageItem -> {
                 newItem as MessageListItem.MessageItem
-                equal = if (oldItem.message.text != newItem.message.text) {
+                if (oldItem.message.text != newItem.message.text) {
                     false
                 } else if (oldItem.message.reactionScores != newItem.message.reactionScores) {
                     false
@@ -31,13 +30,12 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                     false
                 } else oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
             }
-            is MessageListItem.DateSeparatorItem, is MessageListItem.ThreadSeparatorItem, is MessageListItem.LoadingMoreIndicatorItem -> equal = true
-            is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as MessageListItem.TypingItem).users.map(User::id)
-            is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as MessageListItem.ReadStateItem).reads.map { it.getUserId() }
+            is MessageListItem.DateSeparatorItem -> oldItem.date == (newItem as? MessageListItem.DateSeparatorItem)?.date
+            is MessageListItem.ThreadSeparatorItem -> oldItem.date == (newItem as? MessageListItem.ThreadSeparatorItem)?.date
+            is MessageListItem.LoadingMoreIndicatorItem -> true
+            is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(User::id)
+            is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as? MessageListItem.ReadStateItem)?.reads?.map { it.getUserId() }
         }
-
-        return equal
-    }
 
     override fun getChangePayload(oldItem: MessageListItem, newItem: MessageListItem): Any? {
         return if (oldItem is MessageListItem.MessageItem) {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
@@ -15,6 +15,8 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                 newItem as MessageListItem.MessageItem
                 equal = if (oldItem.message.text != newItem.message.text) {
                     false
+                } else if (oldItem.message.reactionScores != newItem.message.reactionScores) {
+                    false
                 } else if (oldItem.message.reactionCounts != newItem.message.reactionCounts) {
                     false
                 } else if (oldItem.message.attachments != newItem.message.attachments) {
@@ -22,6 +24,8 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                 } else if (oldItem.message.replyCount != newItem.message.replyCount) {
                     false
                 } else if (oldItem.message.syncStatus != newItem.message.syncStatus) {
+                    false
+                } else if (oldItem.message.deletedAt != newItem.message.deletedAt) {
                     false
                 } else if (oldItem.positions != newItem.positions) {
                     false
@@ -40,10 +44,11 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
             newItem as MessageListItem.MessageItem
             MessageListItemPayloadDiff(
                 text = oldItem.message.text != newItem.message.text,
-                reactions = oldItem.message.reactionCounts != newItem.message.reactionCounts,
+                reactions = (oldItem.message.reactionCounts != newItem.message.reactionCounts) || (oldItem.message.reactionScores != newItem.message.reactionScores),
                 attachments = oldItem.message.attachments != newItem.message.attachments,
                 replies = oldItem.message.replyCount != newItem.message.replyCount,
                 syncStatus = oldItem.message.syncStatus != newItem.message.syncStatus,
+                deleted = oldItem.message.deletedAt != newItem.message.deletedAt,
                 positions = oldItem.positions != newItem.positions,
                 readBy = oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
             )

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
@@ -6,6 +6,7 @@ public data class MessageListItemPayloadDiff(
     val attachments: Boolean = false,
     val replies: Boolean = false,
     val syncStatus: Boolean = false,
+    val deleted: Boolean = false,
     val positions: Boolean = false,
     val readBy: Boolean = false,
 )

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
@@ -1,12 +1,24 @@
 package com.getstream.sdk.chat.adapter
 
 public data class MessageListItemPayloadDiff(
-    val text: Boolean = false,
-    val reactions: Boolean = false,
-    val attachments: Boolean = false,
-    val replies: Boolean = false,
-    val syncStatus: Boolean = false,
-    val deleted: Boolean = false,
-    val positions: Boolean = false,
-    val readBy: Boolean = false,
-)
+    val text: Boolean,
+    val reactions: Boolean,
+    val attachments: Boolean,
+    val replies: Boolean,
+    val syncStatus: Boolean,
+    val deleted: Boolean,
+    val positions: Boolean,
+    val readBy: Boolean,
+) {
+    public operator fun plus(other: MessageListItemPayloadDiff): MessageListItemPayloadDiff =
+        copy(
+            text = text || other.text,
+            reactions = reactions || other.reactions,
+            attachments = attachments || other.attachments,
+            replies = replies || other.replies,
+            syncStatus = syncStatus || other.syncStatus,
+            deleted = deleted || other.deleted,
+            positions = positions || other.positions,
+            readBy = readBy || other.readBy,
+        )
+}

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemPayloadDiff.kt
@@ -1,0 +1,11 @@
+package com.getstream.sdk.chat.adapter
+
+public data class MessageListItemPayloadDiff(
+    val text: Boolean = false,
+    val reactions: Boolean = false,
+    val attachments: Boolean = false,
+    val replies: Boolean = false,
+    val syncStatus: Boolean = false,
+    val positions: Boolean = false,
+    val readBy: Boolean = false,
+)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/BaseMessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/BaseMessageListItemViewHolder.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 
 public abstract class BaseMessageListItemViewHolder<T : MessageListItem>(
     itemView: View
@@ -13,9 +14,9 @@ public abstract class BaseMessageListItemViewHolder<T : MessageListItem>(
      * Workaround to allow a downcast of the MessageListItem to T
      */
     @Suppress("UNCHECKED_CAST")
-    internal fun bindListItem(messageListItem: MessageListItem) = bind(messageListItem as T)
+    internal fun bindListItem(messageListItem: MessageListItem, diff: MessageListItemPayloadDiff? = null) = bind(messageListItem as T, diff)
 
-    protected abstract fun bind(messageListItem: T)
+    protected abstract fun bind(messageListItem: T, diff: MessageListItemPayloadDiff?)
 
     protected val context: Context
         get() = itemView.context

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/BaseMessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/BaseMessageListItemViewHolder.kt
@@ -14,9 +14,9 @@ public abstract class BaseMessageListItemViewHolder<T : MessageListItem>(
      * Workaround to allow a downcast of the MessageListItem to T
      */
     @Suppress("UNCHECKED_CAST")
-    internal fun bindListItem(messageListItem: MessageListItem, diff: MessageListItemPayloadDiff? = null) = bind(messageListItem as T, diff)
+    internal fun bindListItem(messageListItem: MessageListItem, diff: MessageListItemPayloadDiff) = bind(messageListItem as T, diff)
 
-    protected abstract fun bind(messageListItem: T, diff: MessageListItemPayloadDiff?)
+    protected abstract fun bind(messageListItem: T, diff: MessageListItemPayloadDiff)
 
     protected val context: Context
         get() = itemView.context

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/DateSeparatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/DateSeparatorViewHolder.kt
@@ -22,7 +22,7 @@ internal class DateSeparatorViewHolder(
         StreamItemDateSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<DateSeparatorItem>(binding.root) {
 
-    override fun bind(messageListItem: DateSeparatorItem, diff: MessageListItemPayloadDiff?) {
+    override fun bind(messageListItem: DateSeparatorItem, diff: MessageListItemPayloadDiff) {
         configDate(messageListItem)
         applyStyle()
     }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/DateSeparatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/DateSeparatorViewHolder.kt
@@ -7,6 +7,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.updateLayoutParams
 import com.getstream.sdk.chat.adapter.MessageListItem.DateSeparatorItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import com.getstream.sdk.chat.adapter.inflater
 import com.getstream.sdk.chat.databinding.StreamItemDateSeparatorBinding
 import com.getstream.sdk.chat.enums.Dates
@@ -21,7 +22,7 @@ internal class DateSeparatorViewHolder(
         StreamItemDateSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<DateSeparatorItem>(binding.root) {
 
-    override fun bind(messageListItem: DateSeparatorItem) {
+    override fun bind(messageListItem: DateSeparatorItem, diff: MessageListItemPayloadDiff?) {
         configDate(messageListItem)
         applyStyle()
     }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/LoadingMoreViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/LoadingMoreViewHolder.kt
@@ -15,5 +15,5 @@ internal class LoadingMoreViewHolder(
     )
 ) : BaseMessageListItemViewHolder<MessageListItem.LoadingMoreIndicatorItem>(binding.root) {
 
-    override fun bind(messageListItem: MessageListItem.LoadingMoreIndicatorItem, diff: MessageListItemPayloadDiff?) = Unit
+    override fun bind(messageListItem: MessageListItem.LoadingMoreIndicatorItem, diff: MessageListItemPayloadDiff) = Unit
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/LoadingMoreViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/LoadingMoreViewHolder.kt
@@ -2,6 +2,7 @@ package com.getstream.sdk.chat.adapter.viewholder.message
 
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import com.getstream.sdk.chat.adapter.inflater
 import com.getstream.sdk.chat.databinding.StreamItemLoadingMoreBinding
 
@@ -14,5 +15,5 @@ internal class LoadingMoreViewHolder(
     )
 ) : BaseMessageListItemViewHolder<MessageListItem.LoadingMoreIndicatorItem>(binding.root) {
 
-    override fun bind(messageListItem: MessageListItem.LoadingMoreIndicatorItem) = Unit
+    override fun bind(messageListItem: MessageListItem.LoadingMoreIndicatorItem, diff: MessageListItemPayloadDiff?) = Unit
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
@@ -3,6 +3,7 @@ package com.getstream.sdk.chat.adapter.viewholder.message
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.AttachmentViewHolderFactory
 import com.getstream.sdk.chat.adapter.MessageListItem.MessageItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import com.getstream.sdk.chat.adapter.inflater
 import com.getstream.sdk.chat.adapter.viewholder.message.configurators.AttachmentConfigurator
 import com.getstream.sdk.chat.adapter.viewholder.message.configurators.Configurator
@@ -40,80 +41,104 @@ internal class MessageListItemViewHolder(
         StreamItemMessageBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<MessageItem>(binding.root) {
 
-    override fun bind(messageListItem: MessageItem) {
+    val marginConfigurator = MarginConfigurator(
+        binding,
+        style
+    )
+    val messageTextConfigurator = MessageTextConfigurator(
+        binding,
+        context,
+        style,
+        bubbleHelper,
+        messageClickListener,
+        messageLongClickListener,
+        messageRetryListener
+    )
+    val attachmentConfigurator = AttachmentConfigurator(
+        binding,
+        style,
+        viewHolderFactory
+    )
+    val indicatorConfigurator = IndicatorConfigurator(
+        binding,
+        style.readStateStyle,
+        readStateClickListener
+    )
+    val reactionConfigurator = ReactionConfigurator(
+        binding,
+        context,
+        style,
+        channel,
+        reactionViewClickListener,
+        configParamsReadIndicator = { messageItem ->
+            indicatorConfigurator.configParamsReadIndicator(messageItem)
+        }
+    )
+    val replyConfigurator = ReplyConfigurator(
+        binding,
+        context,
+        style,
+        channel,
+        messageClickListener,
+        bindingAdapterPosition = { bindingAdapterPosition }
+    )
+    val spaceConfigurator = SpaceConfigurator(
+        binding
+    )
+    val userAvatarConfigurator = UserAvatarConfigurator(
+        binding,
+        context,
+        style,
+        userClickListener
+    )
+    val usernameAndDateConfigurator = UsernameAndDateConfigurator(
+        binding,
+        style
+    )
+
+    override fun bind(messageListItem: MessageItem, diff: MessageListItemPayloadDiff?) {
+        val configurators: List<Configurator>
+        configurators = if (diff == null) {
+            listOf(
+                marginConfigurator,
+                messageTextConfigurator,
+                attachmentConfigurator,
+                reactionConfigurator,
+                replyConfigurator,
+                indicatorConfigurator,
+                spaceConfigurator,
+                userAvatarConfigurator,
+                usernameAndDateConfigurator
+            )
+        } else {
+            val configs = mutableListOf<Configurator>(marginConfigurator)
+            if (diff.text || diff.positions) {
+                configs.add(messageTextConfigurator)
+            }
+            if (diff.attachments) {
+                configs.add(attachmentConfigurator)
+            }
+            if (diff.reactions) {
+                configs.add(reactionConfigurator)
+            }
+            if (diff.replies) {
+                configs.add(replyConfigurator)
+            }
+            if (diff.syncStatus) {
+                configs.add(indicatorConfigurator)
+            }
+            configs.add(spaceConfigurator)
+
+            if (diff.positions) {
+                configs.add(userAvatarConfigurator)
+                configs.add(usernameAndDateConfigurator)
+            }
+
+            configs.toList()
+        }
+
         configurators.forEach { configurator ->
             configurator.configure(messageListItem)
         }
-    }
-
-    private val configurators: List<Configurator>
-
-    init {
-        val marginConfigurator = MarginConfigurator(
-            binding,
-            style
-        )
-        val messageTextConfigurator = MessageTextConfigurator(
-            binding,
-            context,
-            style,
-            bubbleHelper,
-            messageClickListener,
-            messageLongClickListener,
-            messageRetryListener
-        )
-        val attachmentConfigurator = AttachmentConfigurator(
-            binding,
-            style,
-            viewHolderFactory
-        )
-        val indicatorConfigurator = IndicatorConfigurator(
-            binding,
-            style.readStateStyle,
-            readStateClickListener
-        )
-        val reactionConfigurator = ReactionConfigurator(
-            binding,
-            context,
-            style,
-            channel,
-            reactionViewClickListener,
-            configParamsReadIndicator = { messageItem ->
-                indicatorConfigurator.configParamsReadIndicator(messageItem)
-            }
-        )
-        val replyConfigurator = ReplyConfigurator(
-            binding,
-            context,
-            style,
-            channel,
-            messageClickListener,
-            bindingAdapterPosition = { bindingAdapterPosition }
-        )
-        val spaceConfigurator = SpaceConfigurator(
-            binding
-        )
-        val userAvatarConfigurator = UserAvatarConfigurator(
-            binding,
-            context,
-            style,
-            userClickListener
-        )
-        val usernameAndDateConfigurator = UsernameAndDateConfigurator(
-            binding,
-            style
-        )
-
-        configurators = listOf(
-            marginConfigurator,
-            messageTextConfigurator,
-            attachmentConfigurator,
-            reactionConfigurator,
-            replyConfigurator,
-            indicatorConfigurator,
-            spaceConfigurator,
-            userAvatarConfigurator,
-            usernameAndDateConfigurator
-        )
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
@@ -112,7 +112,7 @@ internal class MessageListItemViewHolder(
             )
         } else {
             val configs = mutableListOf<Configurator>(marginConfigurator)
-            if (diff.text || diff.positions) {
+            if (diff.text || diff.positions || diff.deleted) {
                 configs.add(messageTextConfigurator)
             }
             if (diff.attachments) {
@@ -124,7 +124,7 @@ internal class MessageListItemViewHolder(
             if (diff.replies) {
                 configs.add(replyConfigurator)
             }
-            if (diff.syncStatus) {
+            if (diff.syncStatus || diff.readBy) {
                 configs.add(indicatorConfigurator)
             }
             configs.add(spaceConfigurator)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
@@ -112,7 +112,7 @@ internal class MessageListItemViewHolder(
             )
         } else {
             val configs = mutableListOf<Configurator>(marginConfigurator)
-            if (diff.text || diff.positions || diff.deleted) {
+            if (diff.text || diff.positions || diff.deleted || diff.reactions) {
                 configs.add(messageTextConfigurator)
             }
             if (diff.attachments) {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/ThreadSeparatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/ThreadSeparatorViewHolder.kt
@@ -12,7 +12,7 @@ internal class ThreadSeparatorViewHolder(
         StreamItemThreadSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<ThreadSeparatorItem>(binding.root) {
 
-    override fun bind(messageListItem: ThreadSeparatorItem, diff: MessageListItemPayloadDiff?) {
+    override fun bind(messageListItem: ThreadSeparatorItem, diff: MessageListItemPayloadDiff) {
         /* Empty */
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/ThreadSeparatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/ThreadSeparatorViewHolder.kt
@@ -2,6 +2,7 @@ package com.getstream.sdk.chat.adapter.viewholder.message
 
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem.ThreadSeparatorItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import com.getstream.sdk.chat.adapter.inflater
 import com.getstream.sdk.chat.databinding.StreamItemThreadSeparatorBinding
 
@@ -11,7 +12,7 @@ internal class ThreadSeparatorViewHolder(
         StreamItemThreadSeparatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<ThreadSeparatorItem>(binding.root) {
 
-    override fun bind(messageListItem: ThreadSeparatorItem) {
+    override fun bind(messageListItem: ThreadSeparatorItem, diff: MessageListItemPayloadDiff?) {
         /* Empty */
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/TypingIndicatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/TypingIndicatorViewHolder.kt
@@ -7,6 +7,7 @@ import androidx.core.view.updateMargins
 import com.getstream.sdk.chat.ImageLoader.load
 import com.getstream.sdk.chat.R
 import com.getstream.sdk.chat.adapter.MessageListItem.TypingItem
+import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import com.getstream.sdk.chat.adapter.inflater
 import com.getstream.sdk.chat.databinding.StreamItemTypeIndicatorBinding
 import com.getstream.sdk.chat.view.AvatarView
@@ -19,7 +20,7 @@ internal class TypingIndicatorViewHolder(
         StreamItemTypeIndicatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<TypingItem>(binding.root) {
 
-    override fun bind(messageListItem: TypingItem) {
+    override fun bind(messageListItem: TypingItem, diff: MessageListItemPayloadDiff?) {
         binding.llTypingIndicator.visibility = View.VISIBLE
         binding.ivTypingIndicator.visibility = View.VISIBLE
         binding.llTypingIndicator.removeAllViews()

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/TypingIndicatorViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/TypingIndicatorViewHolder.kt
@@ -20,7 +20,7 @@ internal class TypingIndicatorViewHolder(
         StreamItemTypeIndicatorBinding.inflate(parent.inflater, parent, false)
 ) : BaseMessageListItemViewHolder<TypingItem>(binding.root) {
 
-    override fun bind(messageListItem: TypingItem, diff: MessageListItemPayloadDiff?) {
+    override fun bind(messageListItem: TypingItem, diff: MessageListItemPayloadDiff) {
         binding.llTypingIndicator.visibility = View.VISIBLE
         binding.ivTypingIndicator.visibility = View.VISIBLE
         binding.llTypingIndicator.removeAllViews()

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallbackTest.kt
@@ -2,9 +2,9 @@ package com.getstream.sdk.chat.adapter
 
 import com.getstream.sdk.chat.createChannelUserRead
 import com.getstream.sdk.chat.createMessageItem
+import io.getstream.chat.android.client.models.User
 import org.amshove.kluent.shouldBe
 import org.junit.jupiter.api.Test
-import java.util.Date
 
 internal class MessageListItemDiffCallbackTest {
 
@@ -17,9 +17,7 @@ internal class MessageListItemDiffCallbackTest {
         isMine = msgWithUserRead.isMine,
         messageReadBy = mutableListOf(
             channelUserRead.copy(
-                lastRead = Date.from(
-                    channelUserRead.lastRead!!.toInstant().plusSeconds(10)
-                )
+                user = User("other")
             )
         )
     )


### PR DESCRIPTION
We were previously triggering many rerenders of the message list item. Here's a list of the most common causes for rerendering the message:

```
- Message.user can have
-- different unread counts, we shouldn't rerender when that happens
-- different last online values, again shouldn't trigger a rerender
- The user objects on message.latestReactions and message.ownReactions have the same issue with last online and unread counts values on the user object
- messageReadBy returns a list of channel user read objects, the problem is that they contain unread message counts which can trigger a diff
- reaction.updated at wasn't stored in the reaction entity, so the offline & online version were always different
```

**Solutions:**
- MessageListItemDiffCallback implements areContentsTheSame focused on the UI that we use
- MessageListItemDiffCallback implements getChangePayload
- fix reaction to reaction entity conversion to use reaction.updated at