### PR TITLE
[CAS-448] Set "Acept Invite Message" optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - New artifact name: `io.getstream:stream-chat-android-client:STREAM_VERSION`
 - Show date of the last message into channels list when data comes from offline storage
 - Show text of the last message into channels list when data comes from offline storage
+- Accept Invite Message is now optional, if null value is sent, no message will be sent to the rest of members about this action
 
 ## stream-chat-android-offline
 - New artifact name: `io.getstream:stream-chat-android-offline:STREAM_VERSION`

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -552,7 +552,7 @@ public class ChatClient internal constructor(
     public fun acceptInvite(
         channelType: String,
         channelId: String,
-        message: String
+        message: String?
     ): Call<Channel> {
         return api.acceptInvite(channelType, channelId, message)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -479,7 +479,7 @@ internal class ChatApi(
     fun acceptInvite(
         channelType: String,
         channelId: String,
-        message: String
+        message: String?
     ): Call<Channel> {
         return retrofitApi.acceptInvite(
             channelType,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -342,7 +342,7 @@ public class ChannelClient internal constructor(
         return client.removeMembers(channelType, channelId, userIds.toList())
     }
 
-    override fun acceptInvite(message: String): Call<Channel> {
+    override fun acceptInvite(message: String?): Call<Channel> {
         return client.acceptInvite(channelType, channelId, message)
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -117,7 +117,7 @@ public interface ChannelController {
     public fun disableSlowMode(): Call<Channel>
     public fun addMembers(vararg userIds: String): Call<Channel>
     public fun removeMembers(vararg userIds: String): Call<Channel>
-    public fun acceptInvite(message: String): Call<Channel>
+    public fun acceptInvite(message: String?): Call<Channel>
     public fun rejectInvite(): Call<Channel>
     public fun mute(): Call<Unit>
     public fun unmute(): Call<Unit>


### PR DESCRIPTION
### Description
Accept Invite Message is now optional, if null value is sent, no message will be sent to the rest of members about this action

Fixes #909 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
