### PR TITLE
Fix documentation comment styles

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -58,7 +58,7 @@ import io.getstream.chat.android.client.utils.observable.Disposable
 import java.io.File
 import java.util.Date
 
-/***
+/**
  * The ChatClient is the main entry point for all low-level operations on chat
  */
 public class ChatClient internal constructor(
@@ -111,7 +111,7 @@ public class ChatClient internal constructor(
 
     //region Set user
 
-    /***
+    /**
      * Initializes [ChatClient] for a specific user using the given user [token].
      *
      * @see ChatClient.setUser with [TokenProvider] for advanced use cases
@@ -120,7 +120,7 @@ public class ChatClient internal constructor(
         setUser(user, ImmediateTokenProvider(token), listener)
     }
 
-    /***
+    /**
      * Initializes [ChatClient] for a specific user. The [tokenProvider] implementation is used
      * for the initial token, and it's also invoked whenever the user's token has expired, to
      * fetch a new token.
@@ -279,7 +279,7 @@ public class ChatClient internal constructor(
         return eventsObservable.subscribe(listener = listener)
     }
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the client.
      *
      * @see [io.getstream.chat.android.client.models.EventType] for type constants
@@ -294,7 +294,7 @@ public class ChatClient internal constructor(
         return eventsObservable.subscribe(filter, listener)
     }
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the client, in the lifecycle of [lifecycleOwner].
      *
      * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -325,7 +325,7 @@ public class ChatClient internal constructor(
         return disposable
     }
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the client.
      */
     public fun subscribeFor(
@@ -338,7 +338,7 @@ public class ChatClient internal constructor(
         return eventsObservable.subscribe(filter, listener)
     }
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the client, in the lifecycle of [lifecycleOwner].
      *
      * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -369,7 +369,7 @@ public class ChatClient internal constructor(
         return disposable
     }
 
-    /***
+    /**
      * Subscribes for the next event with the given [eventType].
      */
     public fun subscribeForSingle(
@@ -382,7 +382,7 @@ public class ChatClient internal constructor(
         return eventsObservable.subscribeSingle(filter, listener)
     }
 
-    /***
+    /**
      * Subscribes for the next event with the given [eventType].
      */
     public fun <T : ChatEvent> subscribeForSingle(
@@ -683,7 +683,7 @@ public class ChatClient internal constructor(
         }
     }
 
-    /***
+    /**
      * Returns a [ChannelClient] for given type and id
      *
      * @param channelType the channel type. ie messaging
@@ -693,7 +693,7 @@ public class ChatClient internal constructor(
         return ChannelClient(channelType, channelId, this)
     }
 
-    /***
+    /**
      * Returns a [ChannelClient] for given cid
      *
      * @param cid the full channel id. ie messaging:123

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ClientExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ClientExtensions.kt
@@ -5,7 +5,7 @@ import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.utils.observable.Disposable
 import kotlin.reflect.KClass
 
-/***
+/**
  * Subscribes to client events of type [T].
  */
 public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
@@ -17,7 +17,7 @@ public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
     )
 }
 
-/***
+/**
  * Subscribes to client events of type [T], in the lifecycle of [lifecycleOwner].
  *
  * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -33,7 +33,7 @@ public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
     )
 }
 
-/***
+/**
  * Subscribes to the specific [eventTypes] of the client.
  */
 public fun ChatClient.subscribeFor(
@@ -44,7 +44,7 @@ public fun ChatClient.subscribeFor(
     return subscribeFor(*javaClassTypes, listener = listener)
 }
 
-/***
+/**
  * Subscribes to the specific [eventTypes] of the client, in the lifecycle of [lifecycleOwner].
  *
  * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -58,7 +58,7 @@ public fun ChatClient.subscribeFor(
     return subscribeFor(lifecycleOwner, *javaClassTypes, listener = listener)
 }
 
-/***
+/**
  * Subscribes for the next client event of type [T].
  */
 public inline fun <reified T : ChatEvent> ChatClient.subscribeForSingle(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClientExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClientExtensions.kt
@@ -5,7 +5,7 @@ import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.utils.observable.Disposable
 import kotlin.reflect.KClass
 
-/***
+/**
  * Subscribes to events of type [T] in the channel.
  */
 public inline fun <reified T : ChatEvent> ChannelClient.subscribeFor(
@@ -17,7 +17,7 @@ public inline fun <reified T : ChatEvent> ChannelClient.subscribeFor(
     )
 }
 
-/***
+/**
  * Subscribes to events of type [T] in the channel, in the lifecycle of [lifecycleOwner].
  *
  * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -33,7 +33,7 @@ public inline fun <reified T : ChatEvent> ChannelClient.subscribeFor(
     )
 }
 
-/***
+/**
  * Subscribes to the specific [eventTypes] of the channel.
  */
 public fun ChannelClient.subscribeFor(
@@ -44,7 +44,7 @@ public fun ChannelClient.subscribeFor(
     return subscribeFor(*javaClassTypes, listener = listener)
 }
 
-/***
+/**
  * Subscribes to the specific [eventTypes] of the channel, in the lifecycle of [lifecycleOwner].
  *
  * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -58,7 +58,7 @@ public fun ChannelClient.subscribeFor(
     return subscribeFor(lifecycleOwner, *javaClassTypes, listener = listener)
 }
 
-/***
+/**
  * Subscribes for the next channel event of type [T].
  */
 public inline fun <reified T : ChatEvent> ChannelClient.subscribeForSingle(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -68,7 +68,7 @@ public interface ChannelController {
         listener: (event: ChatEvent) -> Unit
     ): Disposable
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the channel, in the lifecycle of [lifecycleOwner].
      *
      * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -86,7 +86,7 @@ public interface ChannelController {
         listener: (event: ChatEvent) -> Unit
     ): Disposable
 
-    /***
+    /**
      * Subscribes to the specific [eventTypes] of the channel, in the lifecycle of [lifecycleOwner].
      *
      * Only receives events when the lifecycle is in a STARTED state, otherwise events are dropped.
@@ -97,14 +97,14 @@ public interface ChannelController {
         listener: (event: ChatEvent) -> Unit
     ): Disposable
 
-    /***
+    /**
      * Subscribes for the next channel event with the given [eventType].
      *
      * @see [io.getstream.chat.android.client.models.EventType] for type constants
      */
     public fun subscribeForSingle(eventType: String, listener: (event: ChatEvent) -> Unit): Disposable
 
-    /***
+    /**
      * Subscribes for the next channel event with the given [eventType].
      */
     public fun <T : ChatEvent> subscribeForSingle(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -3,7 +3,7 @@ package io.getstream.chat.android.client.uploader
 import io.getstream.chat.android.client.utils.ProgressCallback
 import java.io.File
 
-/***
+/**
  * The FileUploader is responsible for sending and deleting files from given channel
  */
 public interface FileUploader {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputViewModelBinding.kt
@@ -5,7 +5,7 @@ package io.getstream.chat.android.ui.textinput
 import androidx.lifecycle.LifecycleOwner
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 
-/***
+/**
  * Binds [MessageInputView] with [MessageInputViewModel], updating the view's state
  * based on data provided by the ViewModel, and forwarding View events to the ViewModel.
  */

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/exomedia/ui/widget/VideoControls.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/exomedia/ui/widget/VideoControls.java
@@ -30,6 +30,12 @@ import android.widget.ProgressBar;
 import android.widget.RelativeLayout;
 import android.widget.TextView;
 
+import androidx.annotation.ColorRes;
+import androidx.annotation.IntRange;
+import androidx.annotation.LayoutRes;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
 import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.utils.exomedia.listener.VideoControlsButtonListener;
 import com.getstream.sdk.chat.utils.exomedia.listener.VideoControlsSeekListener;
@@ -40,8 +46,6 @@ import com.getstream.sdk.chat.utils.exomedia.util.TimeFormatUtil;
 
 import java.util.LinkedList;
 import java.util.List;
-
-import androidx.annotation.*;
 
 /**
  * This is a simple abstraction for the {@link VideoView} to have a single "View" to add
@@ -162,7 +166,7 @@ public abstract class VideoControls extends RelativeLayout implements VideoContr
      */
     protected abstract void updateTextContainerVisibility();
 
-    /***
+    /**
      * Updates the current timestamp
      *
      * @param position The position in milliseconds

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/exomedia/util/DeviceUtil.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/utils/exomedia/util/DeviceUtil.java
@@ -21,10 +21,10 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Build;
 
+import androidx.annotation.NonNull;
+
 import java.util.LinkedList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
 
 /**
  * A Utility class to help determine characteristics about the device
@@ -89,7 +89,7 @@ public class DeviceUtil {
     public static class NonCompatibleDevice {
         private final String model;
         private final String manufacturer;
-        /***
+        /**
          * True if we should treat all devices from the manufacturer as non compliant
          */
         private boolean ignoreModel;

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/ChannelHeaderView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/ChannelHeaderView.kt
@@ -21,7 +21,7 @@ public class ChannelHeaderView @JvmOverloads constructor(
     private val binding: StreamViewChannelHeaderBinding
     private val style: ChannelHeaderViewStyle
 
-    /***
+    /**
      * Callback invoked when the header's back button is clicked.
      */
     public var onBackClick: () -> Unit = { }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModelBinding.kt
@@ -12,7 +12,7 @@ import com.getstream.sdk.chat.utils.extensions.isInLastMinute
 import com.getstream.sdk.chat.view.ChannelHeaderView
 import io.getstream.chat.android.client.models.Member
 
-/***
+/**
  * Binds [ChannelHeaderView] with [ChannelHeaderViewModel], updating the view's state
  * based on data provided by the ViewModel.
  */

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
@@ -7,7 +7,7 @@ import com.getstream.sdk.chat.view.messageinput.MessageInputView
 import io.getstream.chat.android.client.models.Message
 import java.io.File
 
-/***
+/**
  * Binds [MessageInputView] with [MessageInputViewModel], updating the view's state
  * based on data provided by the ViewModel, and forwarding View events to the ViewModel.
  * This includes handling typing detection and sending messages.

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -15,7 +15,7 @@ import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.livedata.ChatDomain
 
-/***
+/**
  * ViewModel class for [com.getstream.sdk.chat.view.channels.ChannelsView].
  * Responsible for keeping the channels list up to date.
  * Can be bound to the view using [ChannelsViewModel.bindView] function.

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModelBinding.kt
@@ -5,7 +5,7 @@ package com.getstream.sdk.chat.viewmodel.channels
 import androidx.lifecycle.LifecycleOwner
 import com.getstream.sdk.chat.view.channels.ChannelsView
 
-/***
+/**
  * Binds [ChannelsView] with [ChannelsViewModel], updating the view's state
  * based on data provided by the ViewModel, and forwarding View events to
  * the ViewModel, to load more channels as the View is scrolled.

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -16,7 +16,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDomain
 import kotlin.properties.Delegates
 
-/***
+/**
  * View model class for [com.getstream.sdk.chat.view.MessageListView].
  * Responsible for updating the list of messages.
  * Can be bound to the view using [MessageListViewModel.bindView] function.
@@ -41,13 +41,13 @@ public class MessageListViewModel @JvmOverloads constructor(
     private val _channel = MediatorLiveData<Channel>()
     public val channel: LiveData<Channel> = _channel
 
-    /***
+    /**
      * Whether the user is viewing a thread
      * @see Mode
      */
     public val mode: MutableLiveData<Mode> = MutableLiveData(currentMode)
 
-    /***
+    /**
      * Current message list state
      * @see State
      */
@@ -126,7 +126,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         }
     }
 
-    /***
+    /**
      * Handles an [event] coming from the View layer
      * @see Event
      */

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelBinding.kt
@@ -12,7 +12,7 @@ import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.Last
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.RetryMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.ThreadModeEntered
 
-/***
+/**
  * Binds [MessageListView] with [MessageListViewModel].
  * Sets the View's handlers and displays new messages based on the ViewModel's state.
  */


### PR DESCRIPTION
### Description

Fixes doc comments, having an extra `*` causes them to render incorrectly, as it's interpreted as an empty list item
![image](https://user-images.githubusercontent.com/12054216/100626669-661ecb00-3326-11eb-9ddd-c85546eee737.png)



### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added

![](https://i.kym-cdn.com/entries/icons/original/000/028/186/spidey.jpg)
