### PR TITLE
Add a message ID parameter for ChatFragment

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelFragment.kt
@@ -91,7 +91,7 @@ class AddChannelFragment : Fragment() {
                     is AddChannelViewModel.State.ShowChannel -> initializeChannel(state.cid)
                     AddChannelViewModel.State.HideChannel -> cleanChannel()
                     is AddChannelViewModel.State.NavigateToChannel -> findNavController().navigateSafely(
-                        AddChannelFragmentDirections.actionOpenChat(state.cid)
+                        AddChannelFragmentDirections.actionOpenChat(state.cid, null)
                     )
                 }
             }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
@@ -19,7 +19,6 @@ import io.getstream.chat.android.ui.search.SearchViewModel
 import io.getstream.chat.android.ui.search.bindView
 import io.getstream.chat.ui.sample.R
 import io.getstream.chat.ui.sample.common.navigateSafely
-import io.getstream.chat.ui.sample.common.showToast
 import io.getstream.chat.ui.sample.databinding.FragmentChannelsBinding
 import io.getstream.chat.ui.sample.feature.home.HomeFragmentDirections
 
@@ -59,7 +58,7 @@ class ChannelListFragment : Fragment() {
 
             setChannelClickListener {
                 requireActivity().findNavController(R.id.hostFragmentContainer)
-                    .navigateSafely(HomeFragmentDirections.actionOpenChat(it.cid))
+                    .navigateSafely(HomeFragmentDirections.actionOpenChat(it.cid, null))
             }
 
             viewModel.bindView(this, viewLifecycleOwner)
@@ -78,9 +77,9 @@ class ChannelListFragment : Fragment() {
         }
 
         searchViewModel.bindView(binding.searchResultListView, this)
-        binding.searchResultListView.setSearchResultSelectedListener {
-            // TODO navigate to result message
-            showToast("Search result selected: ${it.id}")
+        binding.searchResultListView.setSearchResultSelectedListener { message ->
+            requireActivity().findNavController(R.id.hostFragmentContainer)
+                .navigateSafely(HomeFragmentDirections.actionOpenChat(message.cid, message.id))
         }
     }
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -19,8 +19,9 @@ import io.getstream.chat.ui.sample.databinding.FragmentChatBinding
 
 class ChatFragment : Fragment() {
 
-    private val cid: String by lazy { navArgs<ChatFragmentArgs>().value.cid }
-    private val factory: ChannelViewModelFactory by lazy { ChannelViewModelFactory(cid) }
+    private val args: ChatFragmentArgs by navArgs()
+
+    private val factory: ChannelViewModelFactory by lazy { ChannelViewModelFactory(args.cid) }
     private val headerViewModel: ChannelHeaderViewModel by viewModels { factory }
     private val messageListViewModel: MessageListViewModel by viewModels { factory }
     private val inputListViewModel: MessageInputViewModel by viewModels { factory }
@@ -32,7 +33,7 @@ class ChatFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentChatBinding.inflate(inflater, container, false)
         return binding.root
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/mentions/MentionsFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/mentions/MentionsFragment.kt
@@ -7,10 +7,13 @@ import android.view.ViewGroup
 import androidx.activity.addCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.navigation.findNavController
 import io.getstream.chat.android.ui.mentions.MentionsListViewModel
 import io.getstream.chat.android.ui.mentions.bindView
-import io.getstream.chat.ui.sample.common.showToast
+import io.getstream.chat.ui.sample.R
+import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.databinding.FragmentMentionsBinding
+import io.getstream.chat.ui.sample.feature.home.HomeFragmentDirections
 
 class MentionsFragment : Fragment() {
 
@@ -37,9 +40,9 @@ class MentionsFragment : Fragment() {
         setupOnClickListeners()
 
         viewModel.bindView(binding.mentionsListView, viewLifecycleOwner)
-        binding.mentionsListView.setMentionSelectedListener {
-            // TODO add navigation
-            showToast("Selected mention ${it.id}")
+        binding.mentionsListView.setMentionSelectedListener { message ->
+            requireActivity().findNavController(R.id.hostFragmentContainer)
+                .navigateSafely(HomeFragmentDirections.actionOpenChat(message.cid, message.id))
         }
     }
 

--- a/stream-chat-android-ui-components-sample/src/main/res/navigation/main_nav_graph.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/navigation/main_nav_graph.xml
@@ -136,6 +136,11 @@
             app:argType="string"
             app:nullable="false"
             />
+        <argument
+            android:name="messageId"
+            app:argType="string"
+            app:nullable="true"
+            />
 
         <action
             android:id="@+id/action_ChatFragment_to_homeFragment"

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/mentions/MentionsListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/mentions/MentionsListViewModel.kt
@@ -26,6 +26,7 @@ public class MentionsListViewModel : ViewModel() {
         _mentions.value = List(20) {
             Message(
                 id = "dummy-id-$it",
+                cid = "messaging:placeholder",
                 user = User().apply {
                     name = "Jane Doe"
                     image = "https://randomuser.me/api/portraits/women/0.jpg"

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchViewModel.kt
@@ -25,6 +25,7 @@ public class SearchViewModel : ViewModel() {
         _results.value = List(5) {
             Message(
                 id = "dummy-id-$it",
+                cid = "messaging:placeholder",
                 user = User().apply {
                     name = "John Doe"
                     image = "https://randomuser.me/api/portraits/men/0.jpg"


### PR DESCRIPTION

### Description

Add a new parameter for `ChatFragment` to specify which message we're navigating to. This is provided when navigating to the screen from Search or Mentions, for example.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
