### PR TITLE
FileProvider updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
+- Use custom `StreamFileProvider` instead of androidx `FileProvider` to avoid conflicts
 
 ## stream-chat-android-client
 

--- a/stream-chat-android/src/main/AndroidManifest.xml
+++ b/stream-chat-android/src/main/AndroidManifest.xml
@@ -35,7 +35,7 @@
         </receiver>
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".StreamFileProvider"
             android:authorities="${applicationId}.streamfileprovider"
             android:exported="false"
             android:grantUriPermissions="true"

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/CaptureMediaContract.kt
@@ -46,6 +46,12 @@ public class CaptureMediaContract : ActivityResultContract<Unit, File>() {
     private fun createFileName(prefix: String, extension: String) =
         "${prefix}_${dateFormat.format(Date().time)}.$extension"
 
+    private fun getFileProviderAuthority(context: Context): String {
+        val compName = ComponentName(context, StreamFileProvider::class.java.name)
+        val providerInfo = context.packageManager.getProviderInfo(compName, 0)
+        return providerInfo.authority
+    }
+
     private fun createIntentList(
         context: Context,
         action: String,
@@ -53,7 +59,7 @@ public class CaptureMediaContract : ActivityResultContract<Unit, File>() {
     ): List<Intent> {
         val destinationUri = FileProvider.getUriForFile(
             context,
-            "${context.packageName}.streamfileprovider",
+            getFileProviderAuthority(context),
             destinationFile
         )
         val actionIntent = Intent(action)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/StreamFileProvider.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/StreamFileProvider.kt
@@ -1,0 +1,5 @@
+package com.getstream.sdk.chat
+
+import androidx.core.content.FileProvider
+
+public class StreamFileProvider : FileProvider()


### PR DESCRIPTION

### Description

Updates some usages of FileProvider after reviewing it due to https://github.com/GetStream/stream-chat-android/issues/925

- Use separate `StreamFileProvider` class instead of the androidx `FileProvider` ([as described here](https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html))
- Update the way we create the authority string, fetch it from `PackageManager` instead of assembling it ourselves

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
