### PR TITLE
[CAS-364] last message attachments

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
@@ -12,11 +12,12 @@ internal class KeystrokeImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun keystroke() = runBlockingTest {
-        advanceUntilIdle()
         var channelState = chatDomain.useCases.watchChannel(data.channel1.cid, 10).execute().data()
         val result = chatDomain.useCases.keystroke(data.channel1.cid).execute()
+        advanceUntilIdle()
         Truth.assertThat(result.data()).isTrue()
         val result2 = chatDomain.useCases.keystroke(data.channel1.cid).execute()
+        advanceUntilIdle()
         Truth.assertThat(result2.data()).isFalse()
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
@@ -3,8 +3,7 @@ package io.getstream.chat.android.livedata.usecase
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
-import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.yield
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -12,8 +11,8 @@ import org.junit.runner.RunWith
 internal class KeystrokeImplTest : BaseConnectedIntegrationTest() {
 
     @Test
-    fun keystroke() = runBlocking {
-        yield()
+    fun keystroke() = runBlockingTest {
+        advanceUntilIdle()
         var channelState = chatDomain.useCases.watchChannel(data.channel1.cid, 10).execute().data()
         val result = chatDomain.useCases.keystroke(data.channel1.cid).execute()
         Truth.assertThat(result.data()).isTrue()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImplTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
 import io.getstream.chat.android.livedata.utils.getOrAwaitValue
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.yield
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -14,7 +13,7 @@ internal class MarkAllReadImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun markAllRead() = testCoroutines.dispatcher.runBlockingTest {
-        yield()
+        advanceUntilIdle()
         chatDomainImpl.allActiveChannels().let { activeChannels ->
 
             // set up unread states

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImplTest.kt
@@ -13,7 +13,6 @@ internal class MarkAllReadImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun markAllRead() = testCoroutines.dispatcher.runBlockingTest {
-        advanceUntilIdle()
         chatDomainImpl.allActiveChannels().let { activeChannels ->
 
             // set up unread states
@@ -23,6 +22,7 @@ internal class MarkAllReadImplTest : BaseConnectedIntegrationTest() {
                 }
 
                 channel.handleEvent(data.newMessageFromUser2)
+                advanceUntilIdle()
 
                 channel.unreadCount.getOrAwaitValue().let { unreadCount ->
                     Truth.assertThat(unreadCount).isEqualTo(1)
@@ -31,6 +31,7 @@ internal class MarkAllReadImplTest : BaseConnectedIntegrationTest() {
 
             // mark all as read
             chatDomainImpl.useCases.markAllRead().execute()
+            advanceUntilIdle()
 
             // verify result
             activeChannels.forEach { channel ->

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkReadImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkReadImplTest.kt
@@ -13,13 +13,14 @@ internal class MarkReadImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun read() = testCoroutines.dispatcher.runBlockingTest {
-        advanceUntilIdle()
         val channelControllerImpl = chatDomainImpl.channel(data.channel1.cid)
         channelControllerImpl.handleEvent(data.newMessageFromUser2)
+        advanceUntilIdle()
         var unreadCount = channelControllerImpl.unreadCount.getOrAwaitValue()
         Truth.assertThat(unreadCount).isEqualTo(1)
 
         val result = chatDomain.useCases.markRead(data.channel1.cid).execute()
+        advanceUntilIdle()
         assertSuccess(result)
         val lastRead = channelControllerImpl.read.getOrAwaitValue()?.lastRead
         Truth.assertThat(lastRead).isEqualTo(data.messageFromUser2.createdAt)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkReadImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/MarkReadImplTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
 import io.getstream.chat.android.livedata.utils.getOrAwaitValue
 import kotlinx.coroutines.test.runBlockingTest
-import kotlinx.coroutines.yield
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -14,7 +13,7 @@ internal class MarkReadImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun read() = testCoroutines.dispatcher.runBlockingTest {
-        yield()
+        advanceUntilIdle()
         val channelControllerImpl = chatDomainImpl.channel(data.channel1.cid)
         channelControllerImpl.handleEvent(data.newMessageFromUser2)
         var unreadCount = channelControllerImpl.unreadCount.getOrAwaitValue()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
@@ -16,7 +16,13 @@ public class ChannelListItemAdapter : BaseChannelListItemAdapter() {
         ChannelViewHolderFactory()
 
     public companion object {
-        public val DEFAULT_DIFF: ChannelDiff = ChannelDiff()
+        public val EVERYTHING_CHANGED: ChannelDiff = ChannelDiff()
+        public val NOTHING_CHANGED: ChannelDiff = ChannelDiff(
+            nameChanged = false,
+            avatarViewChanged = false,
+            lastMessageChanged = false,
+            readStateChanged = false
+        )
     }
 
     /**
@@ -40,7 +46,7 @@ public class ChannelListItemAdapter : BaseChannelListItemAdapter() {
     override fun onBindViewHolder(holder: BaseChannelListItemViewHolder, position: Int, payloads: MutableList<Any>) {
         holder.bind(
             getItem(position),
-            payloads.firstOrDefault(DEFAULT_DIFF).cast(),
+            payloads.firstOrDefault(EVERYTHING_CHANGED).cast(),
             channelClickListener,
             channelLongClickListener,
             deleteClickListener,
@@ -52,7 +58,7 @@ public class ChannelListItemAdapter : BaseChannelListItemAdapter() {
     override fun onBindViewHolder(holder: BaseChannelListItemViewHolder, position: Int) {
         holder.bind(
             getItem(position),
-            null,
+            NOTHING_CHANGED,
             channelClickListener,
             channelLongClickListener,
             deleteClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
@@ -52,7 +52,7 @@ public class ChannelListItemAdapter : BaseChannelListItemAdapter() {
     override fun onBindViewHolder(holder: BaseChannelListItemViewHolder, position: Int) {
         holder.bind(
             getItem(position),
-            DEFAULT_DIFF,
+            null,
             channelClickListener,
             channelLongClickListener,
             deleteClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItemAdapter.kt
@@ -52,7 +52,7 @@ public class ChannelListItemAdapter : BaseChannelListItemAdapter() {
     override fun onBindViewHolder(holder: BaseChannelListItemViewHolder, position: Int) {
         holder.bind(
             getItem(position),
-            null,
+            DEFAULT_DIFF,
             channelClickListener,
             channelLongClickListener,
             deleteClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.diff.ChannelDiff
 public abstract class BaseChannelListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     public abstract fun bind(
         channel: Channel,
-        diff: ChannelDiff?,
+        diff: ChannelDiff,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.diff.ChannelDiff
 public abstract class BaseChannelListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     public abstract fun bind(
         channel: Channel,
-        diff: ChannelDiff,
+        diff: ChannelDiff?,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.diff.ChannelDiff
 public abstract class BaseChannelListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
     public abstract fun bind(
         channel: Channel,
-        diff: ChannelDiff? = null,
+        diff: ChannelDiff,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -7,6 +7,7 @@ import androidx.core.view.isVisible
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.ChannelListView
 import io.getstream.chat.android.ui.channel.list.ChannelListViewStyle
@@ -14,17 +15,15 @@ import io.getstream.chat.android.ui.channel.list.adapter.diff.ChannelDiff
 import io.getstream.chat.android.ui.databinding.StreamUiChannelListItemForegroundViewBinding
 import io.getstream.chat.android.ui.databinding.StreamUiChannelListItemViewBinding
 import io.getstream.chat.android.ui.utils.DateFormatter
-import io.getstream.chat.android.ui.utils.extensions.EMPTY
 import io.getstream.chat.android.ui.utils.extensions.context
-import io.getstream.chat.android.ui.utils.extensions.getCurrentUser
-import io.getstream.chat.android.ui.utils.extensions.getCurrentUserLastMessage
+import io.getstream.chat.android.ui.utils.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.ui.utils.extensions.getDimension
 import io.getstream.chat.android.ui.utils.extensions.getDisplayName
 import io.getstream.chat.android.ui.utils.extensions.getLastMessage
-import io.getstream.chat.android.ui.utils.extensions.getLastMessageTime
-import io.getstream.chat.android.ui.utils.extensions.getPreviewText
-import io.getstream.chat.android.ui.utils.extensions.getUsers
-import io.getstream.chat.android.ui.utils.extensions.lastMessageByCurrentUserWasRead
+import io.getstream.chat.android.ui.utils.extensions.getLastMessagePreviewText
+import io.getstream.chat.android.ui.utils.extensions.isDirectMessaging
+import io.getstream.chat.android.ui.utils.extensions.isMessageRead
+import io.getstream.chat.android.ui.utils.extensions.isNotNull
 import io.getstream.chat.android.ui.utils.extensions.setTextSizePx
 import io.getstream.chat.android.ui.utils.formatMessageDate
 import kotlin.math.absoluteValue
@@ -38,8 +37,8 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
     private val menuItemWidth = context.getDimension(R.dimen.stream_ui_channel_list_item_option_icon_width).toFloat()
     private val optionsMenuWidth = menuItemWidth * OPTIONS_COUNT
-
     private val dateFormatter = DateFormatter.from(context)
+    private val currentUser = ChatDomain.instance().currentUser
 
     public companion object {
         private const val OPTIONS_COUNT = 2
@@ -52,7 +51,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
     public override fun bind(
         channel: Channel,
-        diff: ChannelDiff?,
+        diff: ChannelDiff,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,
@@ -66,7 +65,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
     }
 
     private fun configureForeground(
-        diff: ChannelDiff?,
+        diff: ChannelDiff,
         channel: Channel,
         userClickListener: ChannelListView.UserClickListener,
         channelClickListener: ChannelListView.ChannelClickListener,
@@ -81,7 +80,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
             configureSwipeBehavior(channel.cid)
 
-            diff?.run {
+            diff.run {
                 if (nameChanged) {
                     configureChannelNameLabel(channel)
                 }
@@ -90,14 +89,16 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
                     configureAvatarView(channel, userClickListener, channelClickListener)
                 }
 
+                val lastMessage = channel.getLastMessage()
+
                 if (lastMessageChanged) {
-                    configureLastMessageLabel(channel)
-                    configureLastMessageTimestamp(channel)
+                    configureLastMessageLabel(channel, lastMessage)
+                    configureLastMessageTimestamp(lastMessage)
                     configureUnreadCountBadge(channel)
                 }
 
                 if (readStateChanged) {
-                    configureCurrentUserLastMessageStatus(channel)
+                    configureCurrentUserLastMessageStatus(channel, lastMessage)
                 }
             }
 
@@ -133,17 +134,18 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
     ) {
         avatarView.setChannelData(channel)
         avatarView.setOnClickListener {
-            when (channel.getUsers().size) {
-                1 -> userClickListener.onUserClick(channel.getCurrentUser())
+            when {
+                channel.isDirectMessaging() -> userClickListener.onUserClick(currentUser)
                 else -> channelClickListener.onClick(channel)
             }
         }
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureUnreadCountBadge(channel: Channel) {
-        unreadCountBadge.isVisible = channel.unreadCount ?: 0 > 0
+        val haveUnreadMessages = channel.unreadCount ?: 0 > 0
+        unreadCountBadge.isVisible = haveUnreadMessages
 
-        if (!unreadCountBadge.isVisible) {
+        if (!haveUnreadMessages) {
             return
         }
 
@@ -152,34 +154,33 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
         }
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageTimestamp(channel: Channel) {
-        lastMessageTimeLabel.isVisible = channel.messages.isNotEmpty()
+    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageTimestamp(lastMessage: Message?) {
+        lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
 
-        if (!lastMessageTimeLabel.isVisible) {
-            return
-        }
+        lastMessage ?: return
 
-        lastMessageTimeLabel.text = dateFormatter.formatMessageDate(channel.getLastMessageTime())
+        lastMessageTimeLabel.text = dateFormatter.formatMessageDate(lastMessage.getCreatedAtOrThrow())
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabel(channel: Channel) {
-        lastMessageLabel.isVisible = channel.messages.isNotEmpty()
+    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabel(
+        channel: Channel,
+        lastMessage: Message?
+    ) {
+        lastMessageLabel.isVisible = lastMessage.isNotNull()
 
-        if (!lastMessageLabel.isVisible) {
-            return
-        }
+        lastMessage ?: return
 
-        lastMessageLabel.text = channel.getLastMessage()?.getPreviewText(context) ?: String.EMPTY
+        lastMessageLabel.text = channel.getLastMessagePreviewText(context, channel.isDirectMessaging())
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureCurrentUserLastMessageStatus(channel: Channel) {
-        messageStatusImageView.isVisible = channel.messages.isNotEmpty()
+    private fun StreamUiChannelListItemForegroundViewBinding.configureCurrentUserLastMessageStatus(
+        channel: Channel,
+        lastMessage: Message?
+    ) {
 
-        if (!messageStatusImageView.isVisible) {
-            return
-        }
+        messageStatusImageView.isVisible = lastMessage != null
 
-        val lastMessage = channel.getLastMessage()
+        lastMessage ?: return
 
         /**
          * read - if the last message doesn't belong to current user, or if channel reads indicates it
@@ -187,33 +188,34 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
          * pending - if the sync status says it's pending
          */
 
-        val currentUserSentLastMessage = lastMessage == channel.getCurrentUserLastMessage()
+        val currentUserSentLastMessage = lastMessage.user.id == ChatDomain.instance().currentUser.id
+        val lastMessageByCurrentUserWasRead = channel.isMessageRead(lastMessage)
 
         when {
-            !currentUserSentLastMessage || channel.lastMessageByCurrentUserWasRead() ->
+            !currentUserSentLastMessage || lastMessageByCurrentUserWasRead -> {
                 messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_check_all)
+            }
 
-            currentUserSentLastMessage && !channel.lastMessageByCurrentUserWasRead() ->
+            currentUserSentLastMessage && !lastMessageByCurrentUserWasRead -> {
                 messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_check_gray)
+            }
 
             else -> determineLastMessageSyncStatus(lastMessage)
         }
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.determineLastMessageSyncStatus(message: Message?) {
-        message?.syncStatus?.let { sync ->
-            when (sync) {
-                SyncStatus.IN_PROGRESS, SyncStatus.SYNC_NEEDED -> {
-                    messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_clock)
-                }
+    private fun StreamUiChannelListItemForegroundViewBinding.determineLastMessageSyncStatus(message: Message) {
+        when (message.syncStatus) {
+            SyncStatus.IN_PROGRESS, SyncStatus.SYNC_NEEDED -> {
+                messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_clock)
+            }
 
-                SyncStatus.COMPLETED -> {
-                    messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_check_gray)
-                }
+            SyncStatus.COMPLETED -> {
+                messageStatusImageView.setImageResource(R.drawable.stream_ui_ic_check_gray)
+            }
 
-                SyncStatus.FAILED_PERMANENTLY -> {
-                    // no direction on this yet
-                }
+            SyncStatus.FAILED_PERMANENTLY -> {
+                // no direction on this yet
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -51,7 +51,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
     public override fun bind(
         channel: Channel,
-        diff: ChannelDiff?,
+        diff: ChannelDiff,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,
@@ -65,7 +65,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
     }
 
     private fun configureForeground(
-        diff: ChannelDiff?,
+        diff: ChannelDiff,
         channel: Channel,
         userClickListener: ChannelListView.UserClickListener,
         channelClickListener: ChannelListView.ChannelClickListener,
@@ -75,7 +75,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
         binding.itemForegroundView.apply {
             configureSwipeBehavior(channel.cid)
 
-            diff?.run {
+            diff.run {
                 if (nameChanged) {
                     configureChannelNameLabel(channel)
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -90,7 +90,6 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
                 }
 
                 val lastMessage = channel.getLastMessage()
-
                 if (lastMessageChanged) {
                     configureLastMessageLabel(channel, lastMessage)
                     configureLastMessageTimestamp(lastMessage)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -73,11 +73,6 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
         style: ChannelListViewStyle?
     ) {
         binding.itemForegroundView.apply {
-            root.x = when (swipeStateByChannelCid[channel.cid]) {
-                MenuState.Open -> -optionsMenuWidth
-                MenuState.Closed, null -> 0f
-            }
-
             configureSwipeBehavior(channel.cid)
 
             diff?.run {
@@ -235,6 +230,11 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
     @SuppressLint("ClickableViewAccessibility")
     private fun StreamUiChannelListItemForegroundViewBinding.configureSwipeBehavior(cid: String) {
+        // set the X to the preserved open / closed state
+        root.x = when (swipeStateByChannelCid[cid]) {
+            MenuState.Open -> -optionsMenuWidth
+            MenuState.Closed, null -> 0f
+        }
 
         var startX = 0f
         var startY = 0f

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolder.kt
@@ -51,7 +51,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
     public override fun bind(
         channel: Channel,
-        diff: ChannelDiff,
+        diff: ChannelDiff?,
         channelClickListener: ChannelListView.ChannelClickListener,
         channelLongClickListener: ChannelListView.ChannelClickListener,
         channelDeleteListener: ChannelListView.ChannelClickListener,
@@ -65,7 +65,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
     }
 
     private fun configureForeground(
-        diff: ChannelDiff,
+        diff: ChannelDiff?,
         channel: Channel,
         userClickListener: ChannelListView.UserClickListener,
         channelClickListener: ChannelListView.ChannelClickListener,
@@ -80,7 +80,7 @@ public class ChannelListItemViewHolder(itemView: View) : BaseChannelListItemView
 
             configureSwipeBehavior(channel.cid)
 
-            diff.run {
+            diff?.run {
                 if (nameChanged) {
                     configureChannelNameLabel(channel)
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Any.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Any.kt
@@ -9,3 +9,7 @@ internal val <AnyT> AnyT.exhaustive: AnyT
 
 // Just a way to abstract the elvis operator into a method for chaining
 internal fun <AnyT> AnyT?.getOrDefault(default: AnyT): AnyT = this ?: default
+
+internal fun <AnyT> AnyT?.isNotNull() = this != null
+
+internal fun <AnyT> AnyT.singletonList() = listOf(this)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -82,14 +82,14 @@ internal fun Channel.getGroupSubtitle(context: Context): String {
     }
 }
 
-internal fun Channel.isMessageRead(message: Message): Boolean =
-    read
-        .filter { it.user.id != message.user.id }
+internal fun Channel.isMessageRead(message: Message): Boolean {
+    val currentUser = ChatDomain.instance().currentUser
+    return read.filterNot { it.user.id == currentUser.id }
         .mapNotNull { it.lastRead }
         .any { it.time >= message.getCreatedAtOrThrow().time }
+}
 
 internal fun Channel.isDirectMessaging(): Boolean = getUsers().size == 1
-
 
 // None of the strings used to assemble the preview message are translatable - concatenation here should be fine
 internal fun Channel.getLastMessagePreviewText(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -72,7 +72,11 @@ internal fun Channel.getGroupSubtitle(context: Context): String {
     )
 
     return if (onlineUsers > 0) {
-        context.getString(R.string.stream_ui_message_list_header_group_member_count_with_online, groupMembers, onlineUsers)
+        context.getString(
+            R.string.stream_ui_message_list_header_group_member_count_with_online,
+            groupMembers,
+            onlineUsers
+        )
     } else {
         groupMembers
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -1,8 +1,10 @@
 package io.getstream.chat.android.ui.utils.extensions
 
 import android.content.Context
+import android.text.SpannableString
+import android.text.SpannableStringBuilder
+import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.name
@@ -10,7 +12,6 @@ import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.adapter.diff.ChannelDiff
 import io.getstream.chat.android.ui.utils.ModelType
-import java.util.Date
 
 internal fun Channel.getUsers(excludeCurrentUser: Boolean = true): List<User> =
     members
@@ -26,15 +27,12 @@ internal fun Channel.getDisplayName(): String = name.takeIf { it.isNotEmpty() }
     ?: getUsers().joinToString { it.name }
 
 internal fun Channel.getLastMessage(): Message? =
-    messages
-        .asSequence()
+    messages.asSequence()
         .filter { it.createdAt != null || it.createdLocallyAt != null }
         .filter { it.deletedAt == null }
         .filter { !it.silent }
         .filter { it.type == ModelType.message_regular }
         .maxByOrNull { it.createdAt ?: it.createdLocallyAt!! }
-
-internal fun Channel.getCurrentUserLastMessage(): Message? = getLastMessageByUserId(getCurrentUser().id)
 
 internal fun Channel.getLastMessageByUserId(userId: String): Message? =
     messages.lastOrNull {
@@ -45,28 +43,11 @@ internal fun Channel.getLastMessageByUserId(userId: String): Message? =
             !it.isEphemeral()
     }
 
-internal fun Channel.getUnreadUsers(): List<ChannelUserRead> =
-    read.filter { it.lastRead?.before(lastMessageAt) == true }
-
-internal fun Channel.getLastMessageReadCount(): Int =
-    read.filter { userRead ->
-        lastMessageAt?.let { lastMessage ->
-            userRead.lastRead?.before(lastMessage)
-        } == false
-    }.count()
-
-internal fun Channel.getLastMessageTime(): Date? = getLastMessage()?.let { it.createdAt ?: it.createdLocallyAt }
-
-internal fun Channel.getCurrentUser(): User = ChatDomain.instance().currentUser
-
-internal fun Channel.getCurrentUserRead(): ChannelUserRead? =
-    read.firstOrNull { it.user.id == getCurrentUser().id }
-
 internal fun Channel.diff(other: Channel): ChannelDiff =
     ChannelDiff(
         nameChanged = name != other.name,
         avatarViewChanged = getUsers() != other.getUsers(),
-        readStateChanged = unreadCount != other.unreadCount,
+        readStateChanged = read != other.read,
         lastMessageChanged = getLastMessage() != other.getLastMessage()
     )
 
@@ -97,15 +78,44 @@ internal fun Channel.getGroupSubtitle(context: Context): String {
     }
 }
 
-internal fun Channel.lastMessageByCurrentUserWasRead(): Boolean {
-    return getCurrentUserLastMessage()?.let { currentUserLastMessage ->
-        read.any { channelRead ->
-            val lastMessageCreatedAt = currentUserLastMessage.createdAt
-            if (lastMessageCreatedAt != null) {
-                channelRead.lastRead?.before(lastMessageCreatedAt)?.not() ?: false
-            } else {
-                false
+internal fun Channel.isMessageRead(message: Message): Boolean =
+    read
+        .filter { it.user.id != message.user.id }
+        .mapNotNull { it.lastRead }
+        .any { it.time >= message.getCreatedAtOrThrow().time }
+
+internal fun Channel.isDirectMessaging(): Boolean = getUsers().size == 1
+
+// None of the strings used to assemble the preview message are translatable - concatenation here should be fine
+internal fun Channel.getLastMessagePreviewText(
+    context: Context,
+    isDirectMessaging: Boolean = false
+): SpannableStringBuilder? {
+    return getLastMessage()?.let { message ->
+        val sender = message.getSenderDisplayName(context, isDirectMessaging)
+
+        // bold mentions of the current user
+        val currentUserMention = ChatDomain.instance().currentUser.asMention(context)
+        val previewText: SpannableString = message.text.trim().bold(currentUserMention.singletonList())
+
+        val attachments: SpannableString? = message.attachments
+            .takeIf { it.isNotEmpty() }
+            ?.map { attachment ->
+                attachment.title?.let { title ->
+                    "${getAttachmentPrefix(context, attachment)} $title"
+                } ?: attachment.name
             }
-        }
-    } ?: false
+            ?.joinToString()
+            ?.italicize()
+
+        listOf(sender, previewText, attachments)
+            .filterNot { it.isNullOrEmpty() }
+            .joinTo(SpannableStringBuilder(), ": ")
+    }
 }
+
+private fun getAttachmentPrefix(context: Context, attachment: Attachment): String? =
+    when (attachment.type) {
+        ModelType.attach_giphy -> context.getString(R.string.stream_last_message_attachment_giphy)
+        else -> null
+    }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -90,6 +90,7 @@ internal fun Channel.isMessageRead(message: Message): Boolean =
 
 internal fun Channel.isDirectMessaging(): Boolean = getUsers().size == 1
 
+
 // None of the strings used to assemble the preview message are translatable - concatenation here should be fine
 internal fun Channel.getLastMessagePreviewText(
     context: Context,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
@@ -1,40 +1,18 @@
 package io.getstream.chat.android.ui.utils.extensions
 
 import android.content.Context
-import android.text.Spanned
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.utils.ModelType
 import java.util.Date
 
-internal fun Message.getSenderDisplayName(context: Context): String =
+internal fun Message.getSenderDisplayName(context: Context, isDirectMessaging: Boolean = false): String? =
     when {
         user.isCurrentUser() -> getSelfDisplayName(context)
-        else -> getUserAsMention(context, user)
+        isDirectMessaging -> null
+        else -> user.asMention(context)
     }
-
-internal fun Message.getPreviewText(context: Context): Spanned =
-    context
-        .getString(
-            R.string.stream_ui_channel_item_last_message_template,
-            getSenderDisplayName(context),
-            text
-        )
-        .bold(getPreviewTextMentions(context))
-
-private fun Message.getPreviewTextMentions(context: Context): List<String> =
-    mentionedUsers
-        .map { getUserAsMention(context, it) }
-        .plus(getSenderDisplayName(context))
-        .filter { it != getSelfDisplayName(context) }
-
-private fun getUserAsMention(
-    context: Context,
-    it: User
-) = context.getString(R.string.stream_ui_mention_user_name_template, it.name)
 
 private fun getSelfDisplayName(context: Context) =
     context.getString(R.string.stream_ui_channel_display_name_self)
@@ -51,4 +29,8 @@ internal fun Message.hasNoAttachments(): Boolean = attachments.isEmpty()
 
 internal fun Message.isEphemeral(): Boolean = type == ModelType.message_ephemeral
 
-internal fun Message.getCreatedDate(): Date? = createdAt ?: createdLocallyAt
+internal fun Message.getCreatedAt(): Date? = createdAt ?: createdLocallyAt
+
+internal fun Message.getCreatedAtOrThrow(): Date = checkNotNull(getCreatedAt()) {
+    "a message needs to have a non null value for either createdAt or createdLocallyAt"
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
@@ -29,8 +29,8 @@ internal fun Message.hasNoAttachments(): Boolean = attachments.isEmpty()
 
 internal fun Message.isEphemeral(): Boolean = type == ModelType.message_ephemeral
 
-internal fun Message.getCreatedAt(): Date? = createdAt ?: createdLocallyAt
+internal fun Message.getCreatedAtOrNull(): Date? = createdAt ?: createdLocallyAt
 
-internal fun Message.getCreatedAtOrThrow(): Date = checkNotNull(getCreatedAt()) {
+internal fun Message.getCreatedAtOrThrow(): Date = checkNotNull(getCreatedAtOrNull()) {
     "a message needs to have a non null value for either createdAt or createdLocallyAt"
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/String.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/String.kt
@@ -1,24 +1,34 @@
 package io.getstream.chat.android.ui.utils.extensions
 
 import android.graphics.Typeface.BOLD
+import android.graphics.Typeface.ITALIC
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.Spanned
 import android.text.style.StyleSpan
 
 internal val String.Companion.EMPTY: String
     get() = ""
 
-internal fun String.bold(boldRanges: List<IntRange>): SpannableString =
+/**
+ * Returns a list of ranges corresponding to the indices of each occurrence of each item.
+ * If no list is provided, the range of the entire string receiver is returned.
+ *
+ * @param items the occurrences of items for which ranges should be derived
+ * @return the ranges of every occurrence of every item
+ */
+internal fun String.getOccurrenceRanges(items: List<String>? = null): List<IntRange> =
+    items?.flatMap { item ->
+        Regex(item).findAll(this).map { it.range }
+    } ?: listOf(0 until length)
+
+internal fun String.applyTypeface(typeface: Int, ranges: List<IntRange>): SpannableString =
     SpannableString(this).apply {
-        boldRanges.forEach {
-            setSpan(StyleSpan(BOLD), it.first, it.last + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        ranges.forEach {
+            setSpan(StyleSpan(typeface), it.first, it.last + 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
     }
 
-internal fun String.getMentionRanges(mentionTags: List<String>): List<IntRange> =
-    mentionTags.flatMap { tag ->
-        Regex(tag).findAll(this).map { it.range }
-    }
+internal fun String.bold(items: List<String>? = null): SpannableString = applyTypeface(BOLD, getOccurrenceRanges(items))
 
-internal fun String.bold(mentionTags: List<String>): Spanned = bold(getMentionRanges(mentionTags))
+internal fun String.italicize(items: List<String>? = null): SpannableString =
+    applyTypeface(ITALIC, getOccurrenceRanges(items))

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
@@ -3,10 +3,14 @@ package io.getstream.chat.android.ui.utils.extensions
 import android.content.Context
 import android.text.format.DateUtils
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.R
 
-internal fun List<User>.withoutCurrentUser() = this.filter { !it.isCurrentUser() }
+internal fun List<User>.withoutCurrentUser(): List<User> {
+    val currentUser = ChatDomain.instance().currentUser
+    return filter { it.id != currentUser.id }
+}
 
 internal fun User.isCurrentUser(): Boolean {
     return if (ChatDomain.isInitialized) {
@@ -27,3 +31,6 @@ public fun User.getLastSeenText(context: Context): String {
         )
     }
 }
+
+internal fun User.asMention(context: Context): String =
+    context.getString(R.string.stream_ui_mention_user_name_template, name)

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -22,7 +22,6 @@
     <string name="stream_ui_channels_header_view_offline_title">Waiting for network</string>
 
     <!--Channel List Item View-->
-    <string name="stream_ui_channel_item_last_message_template">%1$s: %2$s</string>
     <string name="stream_ui_channel_display_name_self">You</string>
 
     <!--SearchView-->


### PR DESCRIPTION
### Description

- Noticed there was no direction on handling attachments for channel list items & their previews, so asked design to provide some direction and implemented what they decided on.

- Only bold mentions of the current user

- Fixed user's last message status not updating when read

- Also updates the tests that were using `yield()` to use `advanceUntilIdle()`

<img width="542" alt="Screen Shot 2020-12-02 at 4 41 31 PM" src="https://user-images.githubusercontent.com/2574098/100944935-7cab5a80-34bd-11eb-97da-9ddcdb7d2ccf.png">
<img width="543" alt="Screen Shot 2020-12-02 at 4 41 50 PM" src="https://user-images.githubusercontent.com/2574098/100944936-7ddc8780-34bd-11eb-90a4-55684367c8df.png">

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
