### PR TITLE
[Fix] NPE at Channel.lastMessageByCurrentUserWasRead()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## stream-chat-android-ui-components
 - Adding AttachmentGallery to handle attachments
+- Fix NPE at Channel.lastMessageByCurrentUserWasRead()
 
 # Nov 24th, 2020 - 4.4.5
 ## Common changes for all artifacts

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -100,7 +100,12 @@ internal fun Channel.getGroupSubtitle(context: Context): String {
 internal fun Channel.lastMessageByCurrentUserWasRead(): Boolean {
     return getCurrentUserLastMessage()?.let { currentUserLastMessage ->
         read.any { channelRead ->
-            channelRead.lastRead?.before(currentUserLastMessage.createdAt)?.not() ?: false
+            val lastMessageCreatedAt = currentUserLastMessage.createdAt
+            if (lastMessageCreatedAt != null) {
+                channelRead.lastRead?.before(lastMessageCreatedAt)?.not() ?: false
+            } else {
+                false
+            }
         }
     } ?: false
 }


### PR DESCRIPTION
< Jira issue link, if applicable >

### Description

This PR fixes NPE at `Channel.lastMessageByCurrentUserWasRead()`
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
~- [ ] New code is covered by unit tests~
~- [ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
