### PR TITLE
Clear search input on back button press before closing Activity

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
@@ -92,6 +92,10 @@ class ChannelListFragment : Fragment() {
     private fun setupOnClickListeners() {
         activity?.apply {
             onBackPressedDispatcher.addCallback(viewLifecycleOwner) {
+                if (binding.searchInputView.clear()) {
+                    return@addCallback
+                }
+
                 finish()
             }
         }


### PR DESCRIPTION

### Description

Currently, pressing "back" while in a search closes the entire app. This change clears the input field (and therefore closes search) on a back button press instead, effectively navigating back to the channel list.

<img width="400" src="https://user-images.githubusercontent.com/12054216/101347376-48071c80-388a-11eb-9b82-6f8555f13937.gif"/>

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
