### PR TITLE
Remove mentions of the ui-components module from the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,6 @@
 ## stream-chat-android-offline
 - Centralize how channels are stored locally
 
-## stream-chat-android-ui-components
-- Adding AttachmentGallery to handle attachments
-- Fix NPE at Channel.lastMessageByCurrentUserWasRead()
-
 # Nov 24th, 2020 - 4.4.5
 ## Common changes for all artifacts
 - Stream SDks has been uploaded to MavenCentral and the GroupID has changed to `io.getstream`.
@@ -33,12 +29,8 @@
 - New artifact name: `io.getstream:stream-chat-android-offline:STREAM_VERSION`
 - Provide the last message when data is load from offline storage
 
-## stream-chat-android-ui-components
-- Add MessagesHeaderView
-- New artifact name: `io.getstream:stream-chat-android-ui-components:STREAM_VERSION`
-
 # Nov 24th, 2020 - 4.4.4
-This version is a roolback to 4.4.2, The previous release (4.4.3) was not valid due to a problem with the build flow.
+This version is a rollback to 4.4.2, The previous release (4.4.3) was not valid due to a problem with the build flow.
 We are going to release 4.4.5 with the features introduced by 4.4.3 as soon as the build is back working
 
 # Nov 20th, 2020 - 4.4.3
@@ -50,12 +42,7 @@ We are going to release 4.4.5 with the features introduced by 4.4.3 as soon as t
 - Fix bug when channels with newer messages don't go to the first position in the list
 - Fix Offline usage of `ChatDomain`
 
-## stream-chat-android-ui-component
-- Add MessagesHeaderView
-
 # Nov 13th, 2020 - 4.4.2
-## stream-chat-android-ui-component
-Added new MessageInputView structure
 
 ## stream-chat-android
 - Remove `ChatClient` and `ChatDomain` as `ChatUI`'s dependencies

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -7,5 +7,3 @@
 ## stream-chat-android-client
 
 ## stream-chat-android-offline
-
-## stream-chat-android-ui-components


### PR DESCRIPTION

### Description

Hides mentions of the new `ui-components` module, as it's WIP and customers shouldn't be using it yet anyway.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes ✅
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
