### PR TITLE
MessageHeaderView amendments

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/header/ComponentBrowserMessagesHeaderViewFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/header/ComponentBrowserMessagesHeaderViewFragment.kt
@@ -37,6 +37,12 @@ class ComponentBrowserMessagesHeaderViewFragment : Fragment() {
             setOnlineStateSubtitle("Chat status")
             setAvatar(randomChannel())
         }
+        binding.headerOnlineLongBadge.apply {
+            showBackButtonBadge("2334")
+            setTitle("Chat title")
+            setOnlineStateSubtitle("Chat status")
+            setAvatar(randomChannel())
+        }
         binding.headerOnlineNoBadgeStatus.apply {
             setTitle("Chat title")
             setOnlineStateSubtitle("Chat status")

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_messages_header_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_messages_header_view.xml
@@ -43,6 +43,13 @@
                 />
 
             <io.getstream.chat.android.ui.messages.header.MessagesHeaderView
+                android:id="@+id/headerOnlineLongBadge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                />
+
+            <io.getstream.chat.android.ui.messages.header.MessagesHeaderView
                 android:id="@+id/headerOnlineNoBadgeStatus"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_badge_bg.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_badge_bg.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval"
-    />
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="8dp" />
+</shape>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_messages_header_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_messages_header_view.xml
@@ -11,7 +11,6 @@
         android:id="@+id/back_button_container"
         android:layout_width="wrap_content"
         android:layout_height="match_parent"
-        android:background="?selectableItemBackgroundBorderless"
         android:clickable="true"
         android:focusable="true"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -20,11 +19,12 @@
         tools:ignore="RtlHardcoded"
         >
 
-        <ImageButton
+        <ImageView
             android:id="@+id/back_button"
-            android:layout_width="8dp"
-            android:layout_height="14dp"
-            android:layout_marginLeft="16dp"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginLeft="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
             android:contentDescription="@string/stream_ui_content_description_back_button"
             android:src="@drawable/stream_arrow_left"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -34,19 +34,14 @@
 
         <TextView
             android:id="@+id/back_button_badge"
-            android:layout_width="16dp"
-            android:layout_height="16dp"
-            android:background="@drawable/stream_ui_badge_bg"
-            android:backgroundTint="@color/stream_ui_light_red"
-            android:gravity="center"
-            android:textColor="@color/stream_ui_white"
-            android:textSize="10dp"
-            android:textStyle="bold"
+            style="@style/StreamUiBadgeStyle"
+            android:layout_marginStart="18dp"
+            android:layout_marginBottom="16dp"
             android:visibility="gone"
-            app:layout_constraintBottom_toTopOf="@+id/back_button"
-            app:layout_constraintLeft_toRightOf="@+id/back_button"
-            tools:ignore="SpUsage"
-            tools:text="23"
+            app:layout_constraintBottom_toBottomOf="@+id/back_button"
+            app:layout_constraintStart_toStartOf="@+id/back_button"
+            tools:text="2"
+            tools:visibility="visible"
             />
     </androidx.constraintlayout.widget.ConstraintLayout>
 
@@ -120,9 +115,9 @@
                 android:id="@+id/offline_retry_button"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
+                android:background="?selectableItemBackground"
                 android:clickable="true"
                 android:focusable="true"
-                android:background="?selectableItemBackground"
                 android:text="@string/stream_ui_message_list_header_try_again"
                 android:textColor="@color/stream_ui_blue"
                 />
@@ -164,6 +159,7 @@
 
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatar"
+        style="@style/StreamUiChannelListAvatarStyle"
         android:layout_width="@dimen/stream_ui_avatar_size_medium"
         android:layout_height="@dimen/stream_ui_avatar_size_medium"
         android:layout_marginRight="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_typing_indicator_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_typing_indicator_view.xml
@@ -14,9 +14,10 @@
     <com.airbnb.lottie.LottieAnimationView
         android:id="@+id/lv_animating_dots"
         android:layout_width="20dp"
-        android:layout_height="wrap_content"
+        android:layout_height="18dp"
         app:lottie_autoPlay="true"
         app:lottie_loop="true"
+        app:lottie_speed="4"
         app:lottie_rawRes="@raw/stream_ui_typing_dots"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -105,4 +105,20 @@
         <item name="streamAvatarTextSize">@dimen/stream_ui_avatar_text_size_large</item>
         <item name="streamUiAvatarOnlineIndicatorEnabled">false</item>
     </style>
+
+    <style name="StreamUiBadgeStyle">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">16dp</item>
+        <item name="android:background">@drawable/stream_ui_badge_bg</item>
+        <item name="android:backgroundTint">@color/stream_ui_light_red</item>
+        <item name="android:minWidth">16dp</item>
+        <item name="android:minHeight">16dp</item>
+        <item name="android:singleLine">true</item>
+        <item name="android:paddingLeft">5dp</item>
+        <item name="android:paddingRight">5dp</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textSize">10sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:textColor">@color/stream_ui_white</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Description

Small changes to the `MessageHeaderView`:
- Adjusted clickable area so that it is easier to click on back button
- Added support for long badges
- Properly configured `AvatarView` (renders without white border, supports online status)
- Increased typing animation speed
- Fixed typing indicator and text position 

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
|![photo_2020-12-08 19 06 10](https://user-images.githubusercontent.com/9600921/101508245-7834e500-3988-11eb-8b5e-129379aeec5a.jpeg)| ![photo_2020-12-08 19 06 33](https://user-images.githubusercontent.com/9600921/101508286-8420a700-3988-11eb-99c4-afb6978cc7f1.jpeg) |





