### PR TITLE
Update the API of the Call class

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Common changes for all artifacts
 - Updated to Kotlin 1.4.21
+- For Java clients only: deprecated the `Call.enqueue(Function1)` method, please use `Call.enqueue(Callback)` instead
 
 ## stream-chat-android
 - Add new attrs to `MessageListView`: `streamDeleteMessageActionEnabled`, `streamEditMessageActionEnabled`

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ErrorCall.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ErrorCall.kt
@@ -16,9 +16,9 @@ internal class ErrorCall<T : Any>(private val e: ChatError) : Call<T> {
         return Result(null, e)
     }
 
-    override fun enqueue(callback: (Result<T>) -> Unit) {
+    override fun enqueue(callback: Call.Callback<T>) {
         GlobalScope.launch(DispatcherProvider.Main) {
-            callback(Result(null, e))
+            callback.onResult(Result(null, e))
         }
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
@@ -28,10 +28,10 @@ internal class RetrofitCall<T : Any>(
         return execute(call)
     }
 
-    override fun enqueue(callback: (Result<T>) -> Unit) {
+    override fun enqueue(callback: Call.Callback<T>) {
         enqueue(call) {
             if (!canceled.get()) {
-                callback(it)
+                callback.onResult(it)
             }
         }
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
@@ -27,7 +27,31 @@ public interface Call<T : Any> {
      * Executes the call asynchronously, on a background thread. Safe to call from the main
      * thread. The [callback] will always be invoked on the main thread.
      */
-    public fun enqueue(callback: (Result<T>) -> Unit = {})
+    @Suppress("DeprecatedCallableAddReplaceWith", "NEWER_VERSION_IN_SINCE_KOTLIN")
+    @Deprecated(
+        level = DeprecationLevel.ERROR,
+        message = "Use the enqueue method with a Callback<T> parameter instead",
+    )
+    // Prevent usages from Kotlin, force call resolution to select the new enqueue function
+    @SinceKotlin("99999.9")
+    public fun enqueue(callback: (Result<T>) -> Unit = {}) {
+        // Not recursive, calls the overload with a Callback parameter
+        enqueue(callback)
+    }
+
+    /**
+     * Executes the call asynchronously, on a background thread. Safe to call from the main
+     * thread. The [callback] will always be invoked on the main thread.
+     */
+    public fun enqueue(callback: Callback<T>)
+
+    /**
+     * Executes the call asynchronously, on a background thread. Safe to call from the main
+     * thread.
+     *
+     * To get notified of the result and handle errors, use enqueue(callback) instead.
+     */
+    public fun enqueue(): Unit = enqueue {}
 
     /**
      * Cancels the execution of the call, if cancellation is supported for the operation.
@@ -35,6 +59,10 @@ public interface Call<T : Any> {
      * Note that calls can not be cancelled when running them with [execute].
      */
     public fun cancel()
+
+    public fun interface Callback<T : Any> {
+        public fun onResult(result: Result<T>)
+    }
 }
 
 /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/CoroutineCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/CoroutineCall.kt
@@ -25,11 +25,11 @@ public class CoroutineCall<T : Any>(
         return runBlocking { runnable() }
     }
 
-    override fun enqueue(callback: (Result<T>) -> Unit) {
+    override fun enqueue(callback: Call.Callback<T>) {
         job = scope.launch {
             val result = runnable()
             withContext(DispatcherProvider.Main) {
-                callback(result)
+                callback.onResult(result)
             }
         }
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
@@ -26,7 +26,7 @@ internal class MapCall<T : Any, K : Any>(
         }
     }
 
-    override fun enqueue(callback: (Result<K>) -> Unit) {
+    override fun enqueue(callback: Call.Callback<K>) {
         call.enqueue callback@{
             if (canceled.get()) {
                 return@callback
@@ -34,10 +34,10 @@ internal class MapCall<T : Any, K : Any>(
 
             if (it.isSuccess) {
                 val data = mapper(it.data())
-                callback(Result(data, null))
+                callback.onResult(Result(data, null))
             } else {
                 val error = it.error()
-                callback(Result(null, error))
+                callback.onResult(Result(null, error))
             }
         }
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/ZipCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/ZipCall.kt
@@ -43,9 +43,9 @@ internal class ZipCall<A : Any, B : Any>(
         }
     }
 
-    override fun enqueue(callback: (Result<Pair<A, B>>) -> Unit) {
+    override fun enqueue(callback: Call.Callback<Pair<A, B>>) {
         suspend fun performCallback(result: Result<Pair<A, B>>) {
-            withContext(DispatcherProvider.Main) { callback(result) }
+            withContext(DispatcherProvider.Main) { callback.onResult(result) }
         }
 
         job = GlobalScope.launch {

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Channels.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Channels.java
@@ -60,7 +60,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -76,7 +75,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -90,7 +88,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -116,7 +113,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -156,7 +152,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Get the second 10 channels
@@ -168,7 +163,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -194,7 +188,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error(), result.error().getCause()));
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -212,7 +205,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error(), result.error().getCause()));
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -232,7 +224,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -253,7 +244,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Remove member with id "thierry" and "josh"
@@ -263,7 +253,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -285,7 +274,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -311,7 +299,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -325,7 +312,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -339,7 +325,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -360,7 +345,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -381,7 +365,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -398,7 +381,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -413,7 +395,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Shows a previously hidden channel
@@ -423,7 +404,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Hide the channel and clear the message history
@@ -433,7 +413,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -453,7 +432,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Get list of muted channels when user is connected
@@ -494,7 +472,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Retrieve muted channels
@@ -505,7 +482,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -520,7 +496,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -545,7 +520,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Here are some commons filters you can use:
@@ -579,7 +553,6 @@ public class Channels {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ClientAndUsers.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ClientAndUsers.java
@@ -20,7 +20,6 @@ import io.getstream.chat.android.client.token.TokenProvider;
 import io.getstream.chat.android.client.utils.ChatUtils;
 import io.getstream.chat.android.client.utils.FilterObject;
 import io.getstream.chat.docs.TokenService;
-import kotlin.Unit;
 
 import static io.getstream.chat.docs.StaticInstances.TAG;
 
@@ -230,7 +229,6 @@ public class ClientAndUsers {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
         }
@@ -247,7 +245,6 @@ public class ClientAndUsers {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -267,7 +264,6 @@ public class ClientAndUsers {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -287,7 +283,6 @@ public class ClientAndUsers {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Events.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Events.java
@@ -119,10 +119,10 @@ public class Events {
     class TypingEvents {
         public void sendTypingEvent() {
             // Sends a typing.start event if it's been more than 3000 ms since the last event
-            channelController.keystroke().enqueue(result -> Unit.INSTANCE);
+            channelController.keystroke().enqueue();
 
             // Sends an event typing.stop to all channel participants
-            channelController.stopTyping().enqueue(result -> Unit.INSTANCE);
+            channelController.stopTyping().enqueue();
         }
     }
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
@@ -19,7 +19,6 @@ import io.getstream.chat.android.client.models.Reaction;
 import io.getstream.chat.android.client.models.User;
 import io.getstream.chat.android.client.utils.FilterObject;
 import io.getstream.chat.android.client.utils.ProgressCallback;
-import kotlin.Unit;
 
 import static io.getstream.chat.docs.StaticInstances.TAG;
 
@@ -61,7 +60,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -75,7 +73,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -93,7 +90,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -107,7 +103,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -174,7 +169,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -188,7 +182,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -203,7 +196,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Get the second 10 reactions
@@ -213,7 +205,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Get 10 reactions after particular reaction
@@ -224,7 +215,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -244,7 +234,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -266,7 +255,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
 
@@ -282,7 +270,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
             // Retrieve the 20 more messages before the message with id "42"
@@ -292,7 +279,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -312,7 +298,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
         }
     }
@@ -343,7 +328,6 @@ public class Messages {
                 } else {
                     Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
                 }
-                return Unit.INSTANCE;
             });
 
         }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/TypingIndicators.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/TypingIndicators.java
@@ -13,10 +13,10 @@ public class TypingIndicators {
      */
     public void sendingStartAndStopTypingEvents() {
         // Sends a typing.start event at most once every two seconds
-        channelController.keystroke().enqueue(result -> Unit.INSTANCE);
+        channelController.keystroke().enqueue();
 
         // Sends the typing.stop event
-        channelController.stopTyping().enqueue(result -> Unit.INSTANCE);
+        channelController.stopTyping().enqueue();
     }
 
     /**

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/UserPresence.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/UserPresence.java
@@ -67,7 +67,6 @@ public class UserPresence {
             } else {
                 Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
             }
-            return Unit.INSTANCE;
         });
 
         // 2. Query some channels with presence events
@@ -91,7 +90,6 @@ public class UserPresence {
             } else {
                 Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
             }
-            return Unit.INSTANCE;
         });
 
         // 3. Query some users for presence event
@@ -106,7 +104,6 @@ public class UserPresence {
             } else {
                 Log.e(TAG, String.format("There was an error %s", result.error()), result.error().getCause());
             }
-            return Unit.INSTANCE;
         });
 
         // Finally, Subscribe to events

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCall.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCall.kt
@@ -10,8 +10,8 @@ public class TestCall<T : Any>(public val result: Result<T>) : Call<T> {
         cancelled = true
     }
 
-    override fun enqueue(callback: (Result<T>) -> Unit) {
-        callback(result)
+    override fun enqueue(callback: Call.Callback<T>) {
+        callback.onResult(result)
     }
 
     override fun execute(): Result<T> {

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/channels/ChannelListViewModelTest.kt
@@ -124,7 +124,7 @@ private class Fixture {
     fun givenMoreChannels(moreChannels: List<Channel>): Fixture {
         val mockCall: Call<List<Channel>> = mock()
         When calling queryChannelsLoadMore.invoke(any(), any(), any(), any()) doReturn mockCall
-        When calling mockCall.enqueue(any()) doAnswer {
+        When calling mockCall.enqueue() doAnswer {
             channelsLiveData.postValue((channelsLiveData.value ?: emptyList()) + moreChannels)
         }
         return this


### PR DESCRIPTION

### Description

Using the `Call` class from Java is inconvenient, as evidenced by our documentation snippets. Using a Kotlin function type as the parameter of `enqueue` (the preferred way of running a `Call` from Java) means that we're forcing our clients to return `kotlin.Unit` explicitly in their implementations, and/or to implement an ugly `Function1<Result<T>, Unit>()` type.

This PR replaces the function type with a `fun interface`, which lets Java clients use a more natural API. The old `enqueue` signature is kept around to keep source compatibility for Java clients, but it's hidden from Kotlin clients. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
