### PR TITLE
Long click listener for messages

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyAttachmentsMessagesComponentBrowserFragment.kt
@@ -15,7 +15,7 @@ class OnlyAttachmentsMessagesComponentBrowserFragment : BaseMessagesComponentBro
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyDeletedMessagesList(requireContext()),
-            ::OnlyMediaAttachmentsViewHolder,
+            { viewGroup -> OnlyMediaAttachmentsViewHolder(viewGroup, null) },
             OnlyMediaAttachmentsViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
@@ -9,7 +9,7 @@ class PlainTextMessagesComponentBrowserFragment : BaseMessagesComponentBrowserFr
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyMessageList(),
-            ::MessagePlainTextViewHolder,
+            { viewGroup ->  MessagePlainTextViewHolder(viewGroup, null) },
             MessagePlainTextViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
@@ -9,7 +9,7 @@ class PlainTextMessagesComponentBrowserFragment : BaseMessagesComponentBrowserFr
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyMessageList(),
-            { viewGroup ->  MessagePlainTextViewHolder(viewGroup, null) },
+            { viewGroup -> MessagePlainTextViewHolder(viewGroup, null) },
             MessagePlainTextViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.messages.adapter
 
 import android.view.View
 import android.view.ViewGroup
+import com.getstream.sdk.chat.adapter.ListenerContainer
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.viewholder.DateDividerViewHolder
@@ -10,6 +11,9 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainText
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 
 public open class MessageListItemViewHolderFactory {
+
+    public var listenerContainer: ListenerContainer? = null
+
     public fun createViewHolder(parentView: ViewGroup, viewType: Int): BaseMessageItemViewHolder<*> {
         return when (MessageListItemViewTypeMapper.viewTypeValueToViewType(viewType)) {
             MessageListItemViewType.DATE_DIVIDER -> createDateDividerViewHolder(parentView)
@@ -33,7 +37,7 @@ public open class MessageListItemViewHolderFactory {
     }
 
     public open fun createPlainTextViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {
-        return MessagePlainTextViewHolder(parentView)
+        return MessagePlainTextViewHolder(parentView, listenerContainer)
     }
 
     public open fun createReplyMessageViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -49,7 +49,7 @@ public open class MessageListItemViewHolderFactory {
     }
 
     public open fun createMediaAttachmentsViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {
-        return OnlyMediaAttachmentsViewHolder(parentView)
+        return OnlyMediaAttachmentsViewHolder(parentView, listenerContainer)
     }
 
     public open fun createAttachmentsViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.messages.adapter.viewholder
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.getstream.sdk.chat.adapter.ListenerContainer
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
@@ -9,6 +10,7 @@ import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 
 public class MessagePlainTextViewHolder(
     parent: ViewGroup,
+    private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessagePlainTextBinding =
         StreamUiItemMessagePlainTextBinding.inflate(
             LayoutInflater.from(
@@ -22,5 +24,9 @@ public class MessagePlainTextViewHolder(
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         constraintView(data.isMine, binding.messageText, binding.root)
         binding.messageText.text = data.message.text
+        binding.messageText.setOnLongClickListener {
+            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
+            true
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.messages.adapter.viewholder
 
 import android.view.LayoutInflater
 import android.view.ViewGroup
+import com.getstream.sdk.chat.adapter.ListenerContainer
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.client.models.Attachment
@@ -10,6 +11,7 @@ import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 
 public class OnlyMediaAttachmentsViewHolder(
     parent: ViewGroup,
+    private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessageAttachmentsOnlyBinding = StreamUiItemMessageAttachmentsOnlyBinding.inflate(
         LayoutInflater.from(
             parent.context
@@ -22,6 +24,11 @@ public class OnlyMediaAttachmentsViewHolder(
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         if (data.message.attachments.all { it.type == "image" }) {
             showAttachments(data.message.attachments, data.isMine)
+        }
+
+        binding.mediaAttachmentsGroupView.setOnLongClickListener {
+            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
+            true
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -144,7 +144,7 @@ public class MessageListView : ConstraintLayout, IMessageListView {
         }
     private val DEFAULT_MESSAGE_LONG_CLICK_LISTENER =
         MessageLongClickListener {
-            //Todo: Implement listener
+            // Todo: Implement listener
         }
 
     private val DEFAULT_MESSAGE_RETRY_LISTENER =

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -25,7 +25,7 @@ import com.getstream.sdk.chat.view.IMessageListView
 import com.getstream.sdk.chat.view.MessageListView.AttachmentClickListener
 import com.getstream.sdk.chat.view.MessageListView.GiphySendListener
 import com.getstream.sdk.chat.view.MessageListView.MessageClickListener
-import com.getstream.sdk.chat.view.MessageListView.MessageLongClickListenerView
+import com.getstream.sdk.chat.view.MessageListView.MessageLongClickListener
 import com.getstream.sdk.chat.view.MessageListView.MessageRetryListener
 import com.getstream.sdk.chat.view.MessageListView.ReactionViewClickListener
 import com.getstream.sdk.chat.view.MessageListView.ReadStateClickListener
@@ -143,17 +143,8 @@ public class MessageListView : ConstraintLayout, IMessageListView {
             }
         }
     private val DEFAULT_MESSAGE_LONG_CLICK_LISTENER =
-        MessageLongClickListenerView { _, view ->
-            optionsView = view
-
-            binding.blurLayer.isVisible = true
-
-            if (view.parent != null && view.parent is ViewGroup) {
-                (view.parent as ViewGroup).removeView(view)
-            }
-
-            binding.messageOptionsContainer.addView(optionsView)
-            binding.messageOptionsScroll.isVisible = true
+        MessageLongClickListener {
+            //Todo: Implement listener
         }
 
     private val DEFAULT_MESSAGE_RETRY_LISTENER =
@@ -198,7 +189,7 @@ public class MessageListView : ConstraintLayout, IMessageListView {
 
     private val listenerContainer: ListenerContainer = ListenerContainerImpl(
         messageClickListener = DEFAULT_MESSAGE_CLICK_LISTENER,
-        messageLongClickListenerView = DEFAULT_MESSAGE_LONG_CLICK_LISTENER,
+        messageLongClickListener = DEFAULT_MESSAGE_LONG_CLICK_LISTENER,
         messageRetryListener = DEFAULT_MESSAGE_RETRY_LISTENER,
         attachmentClickListener = DEFAULT_ATTACHMENT_CLICK_LISTENER,
         reactionViewClickListener = DEFAULT_REACTION_VIEW_CLICK_LISTENER,
@@ -408,6 +399,9 @@ public class MessageListView : ConstraintLayout, IMessageListView {
         if (::messageDateFormatter.isInitialized.not()) {
             messageDateFormatter = DateFormatter.from(context)
         }
+
+        messageListItemViewHolderFactory.listenerContainer = this.listenerContainer
+
         adapter = MessageListItemAdapter(messageListItemViewHolderFactory)
         adapter.setHasStableIds(true)
 
@@ -597,16 +591,6 @@ public class MessageListView : ConstraintLayout, IMessageListView {
     public fun setMessageClickListener(messageClickListener: MessageClickListener?) {
         listenerContainer.messageClickListener =
             messageClickListener ?: DEFAULT_MESSAGE_CLICK_LISTENER
-    }
-
-    /**
-     * Sets the message long click listener to be used by MessageListView.
-     *
-     * @param messageLongClickListener The listener to use. If null, the default will be used instead.
-     */
-    public fun setMessageLongClickListener(messageLongClickListenerView: MessageLongClickListenerView?) {
-        listenerContainer.messageLongClickListenerView =
-            messageLongClickListenerView ?: DEFAULT_MESSAGE_LONG_CLICK_LISTENER
     }
 
     /**


### PR DESCRIPTION
### Description

Adding click listeners for the new `MessageListItemViewHolderFactory`. Now the plain text messages and the attachment messages are working. 

Those listeners are needed to I can properly test the PR #991 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes. **No need.**
- [ ] New code is covered by unit tests. **No need.**
- [ ] Comparison screenshots added for visual changes. . **No need.**
- [x] Reviewers added
