### PR TITLE
[CAS-467] Integrate shadow ban in sample app

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -6,6 +6,7 @@
 ## stream-chat-android-client
 - Improve `banUser` and `unBanUser` methods - make `reason` and `timeout` parameter nullable
 - Add support for shadow ban - add `shadowBanUser` and `removeShadowBan` methods to `ChatClient` and `ChannelClient`
+- Add `shadowBanned` property to `Member` class
 
 ## stream-chat-android-offline
 - Add filtering `shadowed` messages

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Member.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Member.kt
@@ -15,5 +15,7 @@ public data class Member(
     @SerializedName("invite_accepted_at")
     var inviteAcceptedAt: Date? = null,
     @SerializedName("invite_rejected_at")
-    var inviteRejectedAt: Date? = null
+    var inviteRejectedAt: Date? = null,
+    @SerializedName("shadow_banned")
+    var shadowBanned: Boolean = false,
 ) : UserEntity

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -41,7 +41,7 @@ import io.getstream.chat.android.livedata.entity.UserEntity
         ChannelConfigEntity::class,
         SyncStateEntity::class
     ],
-    version = 29,
+    version = 30,
     exportSchema = false
 )
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/MemberEntity.kt
@@ -26,6 +26,9 @@ internal data class MemberEntity(var userId: String) {
     /** the date the invite was rejected */
     var inviteRejectedAt: Date? = null
 
+    /** if channel member is shadow banned */
+    var shadowBanned: Boolean = false
+
     /** creates a memberEntity from the member */
     constructor(r: Member) : this(r.getUserId()) {
         role = r.role ?: r.user.role
@@ -34,6 +37,7 @@ internal data class MemberEntity(var userId: String) {
         isInvited = r.isInvited ?: false
         inviteAcceptedAt = r.inviteAcceptedAt
         inviteRejectedAt = r.inviteRejectedAt
+        shadowBanned = r.shadowBanned
     }
 
     /** converts a member entity into a member */
@@ -44,6 +48,6 @@ internal data class MemberEntity(var userId: String) {
                 .logE("userMap is missing the user with id='$userId` needed to create this member")
             return null
         }
-        return Member(user, role, createdAt, updatedAt, isInvited, inviteAcceptedAt, inviteRejectedAt)
+        return Member(user, role, createdAt, updatedAt, isInvited, inviteAcceptedAt, inviteRejectedAt, shadowBanned)
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
@@ -9,6 +9,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.models.ChannelMute
+import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDomain
@@ -28,22 +29,28 @@ class ChatInfoViewModel(
 
     init {
         _state.value = State()
-        chatDomain.useCases.getChannelController(cid).enqueue { result ->
+        viewModelScope.launch {
+            // Currently, we don't receive any event when channel member is banned/shadow banned, so
+            // we need to get member data from the server
+            val result =
+                channelClient.queryMembers(offset = 0, limit = 1, filter = Filters.ne("id", chatDomain.currentUser.id))
+                    .await()
             if (result.isSuccess) {
-                val controller = result.data()
+                val member = result.data().first()
+                // Update member and member block status
+                _state.value =
+                    _state.value!!.copy(chatMember = ChatMember(member, false), isMemberBlocked = member.shadowBanned)
                 // Update channel notifications
                 updateChannelNotificationsStatus(chatDomain.currentUser.channelMutes)
 
-                // Update members
-                _state.addSource(controller.members) { members ->
-                    _state.value =
-                        _state.value!!.copy(chatMember = ChatMember(members.first { it.getUserId() != chatDomain.currentUser.id }))
-                }
                 // Muted channel members
                 _state.addSource(chatDomain.muted) { mutes ->
-                    val member = _state.value!!.chatMember.member
-                    _state.value = _state.value?.copy(isMemberMuted = mutes.any { it.target.id == member.getUserId() })
+                    val currentState = state.value!!
+                    _state.value =
+                        currentState.copy(isMemberMuted = mutes.any { it.target.id == currentState.chatMember.member.getUserId() })
                 }
+            } else {
+                // TODO: Handle error
             }
         }
     }
@@ -92,7 +99,22 @@ class ChatInfoViewModel(
     }
 
     private fun switchUserBlock(isEnabled: Boolean) {
-        // TODO: Shadow ban is not supported yet
+        viewModelScope.launch {
+            val currentState = _state.value!!
+            val result = if (isEnabled) {
+                channelClient.shadowBanUser(
+                    targetId = currentState.chatMember.member.getUserId(),
+                    reason = null,
+                    timeout = null
+                ).await()
+            } else {
+                channelClient.removeShadowBan(currentState.chatMember.member.getUserId()).await()
+            }
+            if (result.isError) {
+                // TODO: Show error message
+                _state.value = _state.value!!.copy(isMemberBlocked = !isEnabled)
+            }
+        }
     }
 
     private fun deleteChannel() {


### PR DESCRIPTION
Currently, the only way to determine whether a channel member is shadow banned is to query members and check `shadowBan` flag. Unfortunately, we don't receive any event when a member is banned/unbanned so we need to get fresh data every time we enter `ChatInfo` screen

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
