### PR TITLE
Fix binding of data in ReadUsersDialog

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/CommandMentionListItemAdapter.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/CommandMentionListItemAdapter.java
@@ -59,5 +59,6 @@ public class CommandMentionListItemAdapter extends BaseAdapter {
     public void configMentions(StreamItemMentionBinding binding, int position) {
         User user = items.get(position);
         binding.avatar.setUser(user, style.getAvatarStyle());
+        binding.tvUsername.setText(user.getExtraValue("name", ""));
     }
 }

--- a/stream-chat-android/src/main/res/layout/stream_item_mention.xml
+++ b/stream-chat-android/src/main/res/layout/stream_item_mention.xml
@@ -26,15 +26,4 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <TextView
-        android:id="@+id/tv_you"
-        style="@style/text"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_margin="5dp"
-        android:text="@{null}"
-        app:layout_constraintBottom_toBottomOf="@+id/tv_username"
-        app:layout_constraintStart_toEndOf="@+id/tv_username"
-        app:layout_constraintTop_toTopOf="@+id/tv_username"
-        />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION

### Description

Fixes the binding logic in `CommandMentionListItemAdapter`, removes an unused TextView.

| Before | After |
| --- | --- |
| ![Screenshot_1608039968](https://user-images.githubusercontent.com/12054216/102223824-7cf81c80-3ee5-11eb-93d2-35f7e9060128.png) | ![Screenshot_1608040391](https://user-images.githubusercontent.com/12054216/102223864-87b2b180-3ee5-11eb-8362-db39203ded3b.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
