### PR TITLE
Add a build step to our PR checks

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,19 @@ jobs:
       - name: ktlint
         run: ./gradlew ktlintCheck
 
+  debug_build:
+    name: Debug build
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build
+        run: ./gradlew assembleDebug
+
   test:
     name: Unit tests
     runs-on: ubuntu-18.04


### PR DESCRIPTION
### Description

Without this, modules without any tests in them could pass PR checks even if they had broken code in them. This adds an explicit build job that builds all modules (only the debug variant still).

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
