### PR TITLE
Add permissions to the new UI module

### DIFF
--- a/stream-chat-android-ui-components/src/main/AndroidManifest.xml
+++ b/stream-chat-android-ui-components/src/main/AndroidManifest.xml
@@ -3,6 +3,11 @@
     package="io.getstream.chat.android.ui"
     >
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+
     <application>
         <provider
             android:name="androidx.startup.InitializationProvider"


### PR DESCRIPTION

### Description

Previously we were relying on the permissions from the `stream-chat-android` module, but since we no longer depend on it, this module was now lacking these permissions.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
