### PR TITLE
Add extensions for setting soft input mode in Fragments

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelFragment.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.ui.sample.R
 import io.getstream.chat.ui.sample.common.initToolbar
 import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.databinding.FragmentAddChannelBinding
+import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
 
 class AddChannelFragment : Fragment() {
 
@@ -36,6 +37,11 @@ class AddChannelFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         initToolbar(binding.toolbar)
         bindAddChannelView()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        useAdjustResize()
     }
 
     override fun onDestroyView() {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/group/AddGroupChannelFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/group/AddGroupChannelFragment.kt
@@ -18,6 +18,7 @@ import io.getstream.chat.ui.sample.common.initToolbar
 import io.getstream.chat.ui.sample.databinding.FragmentAddGroupChannelBinding
 import io.getstream.chat.ui.sample.feature.channel.add.AddChannelViewModel
 import io.getstream.chat.ui.sample.feature.channel.add.bindView
+import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
 
 class AddGroupChannelFragment : Fragment() {
 
@@ -35,7 +36,7 @@ class AddGroupChannelFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentAddGroupChannelBinding.inflate(inflater, container, false)
         return binding.root
     }
@@ -54,6 +55,11 @@ class AddGroupChannelFragment : Fragment() {
                 }
             }
         )
+    }
+
+    override fun onResume() {
+        super.onResume()
+        useAdjustResize()
     }
 
     override fun onDestroyView() {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -19,6 +19,7 @@ import io.getstream.chat.android.ui.messages.header.bindView
 import io.getstream.chat.android.ui.textinput.bindView
 import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.databinding.FragmentChatBinding
+import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
 
 class ChatFragment : Fragment() {
 
@@ -54,6 +55,11 @@ class ChatFragment : Fragment() {
         initMessagesViewModel()
         initMessageInputViewModel()
         configureBackButtonHandling()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        useAdjustResize()
     }
 
     private fun configureBackButtonHandling() {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoFragment.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.ui.sample.databinding.FragmentGroupChatInfoBinding
 import io.getstream.chat.ui.sample.feature.chat.ChatViewModelFactory
 import io.getstream.chat.ui.sample.feature.chat.info.ChatInfoItem
 import io.getstream.chat.ui.sample.feature.chat.info.group.users.GroupChatInfoAddUsersDialogFragment
+import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
 
 class GroupChatInfoFragment : Fragment() {
 
@@ -60,6 +61,11 @@ class GroupChatInfoFragment : Fragment() {
             }
         }
         bindGroupInfoViewModel()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        useAdjustResize()
     }
 
     override fun onDestroyView() {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
@@ -19,6 +19,7 @@ import io.getstream.chat.ui.sample.R
 import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.common.setBadgeNumber
 import io.getstream.chat.ui.sample.databinding.FragmentHomeBinding
+import io.getstream.chat.ui.sample.util.extensions.useAdjustNothing
 
 class HomeFragment : Fragment() {
 
@@ -65,6 +66,11 @@ class HomeFragment : Fragment() {
                 binding.drawerLayout.openDrawer(GravityCompat.START)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        useAdjustNothing()
     }
 
     override fun onDestroyView() {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginFragment.kt
@@ -35,7 +35,7 @@ class UserLoginFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = FragmentUserLoginBinding.inflate(inflater, container, false)
         return binding.root
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/util/extensions/Fragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/util/extensions/Fragment.kt
@@ -1,0 +1,16 @@
+package io.getstream.chat.ui.sample.util.extensions
+
+import android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_NOTHING
+import android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_PAN
+import android.view.WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+import androidx.fragment.app.Fragment
+
+fun Fragment.useAdjustNothing() = setSoftInputMode(SOFT_INPUT_ADJUST_NOTHING)
+
+fun Fragment.useAdjustPan() = setSoftInputMode(SOFT_INPUT_ADJUST_PAN)
+
+fun Fragment.useAdjustResize() = setSoftInputMode(SOFT_INPUT_ADJUST_RESIZE)
+
+private fun Fragment.setSoftInputMode(flags: Int) {
+    (activity ?: return).window.setSoftInputMode(flags)
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/file/FileAttachmentFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/file/FileAttachmentFragment.kt
@@ -49,7 +49,7 @@ public class FileAttachmentFragment : Fragment() {
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?
-    ): View? {
+    ): View {
         _binding = StreamUiFragmentAttachmentFileBinding.inflate(inflater, container, false)
         return binding.root
     }


### PR DESCRIPTION

### Description

We need different window handling behaviour depending on which Fragment we're in. Sometimes we want to resize the window so that it all fits above the keyboard, and sometimes we want to cover its bottom half with the keyboard.

This PR removes adds extensions for `Fragment` to dynamically set this for each screen.

https://user-images.githubusercontent.com/12054216/102590365-beb8db00-4110-11eb-9626-51437c4ffbed.mov

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
