### PR TITLE
Deprecate two parameter Result ctor

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -107,7 +107,11 @@ internal class ChatApi(
                 connectionId = connectionId,
                 file = file
             )
-            Result(result, null)
+            if (result != null) {
+                Result(result)
+            } else {
+                Result(ChatError("Upload failed"))
+            }
         }
     }
 
@@ -120,7 +124,11 @@ internal class ChatApi(
                 connectionId = connectionId,
                 file = file
             )
-            Result(result, null)
+            if (result != null) {
+                Result(result)
+            } else {
+                Result(ChatError("Upload failed"))
+            }
         }
     }
 
@@ -133,7 +141,7 @@ internal class ChatApi(
                 connectionId = connectionId,
                 url = url
             )
-            Result(Unit, null)
+            Result(Unit)
         }
     }
 
@@ -146,7 +154,7 @@ internal class ChatApi(
                 connectionId = connectionId,
                 url = url
             )
-            Result(Unit, null)
+            Result(Unit)
         }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ErrorCall.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ErrorCall.kt
@@ -13,12 +13,12 @@ internal class ErrorCall<T : Any>(private val e: ChatError) : Call<T> {
     }
 
     override fun execute(): Result<T> {
-        return Result(null, e)
+        return Result(e)
     }
 
     override fun enqueue(callback: Call.Callback<T>) {
         GlobalScope.launch(DispatcherProvider.Main) {
-            callback.onResult(Result(null, e))
+            callback.onResult(Result(e))
         }
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/call/RetrofitCall.kt
@@ -86,19 +86,14 @@ internal class RetrofitCall<T : Any>(
     }
 
     private fun getResult(retrofitResponse: Response<T>): Result<T> {
-        var data: T? = null
-        var error: ChatError? = null
-
-        if (retrofitResponse.isSuccessful) {
+        return if (retrofitResponse.isSuccessful) {
             try {
-                data = retrofitResponse.body()
+                Result(retrofitResponse.body()!!)
             } catch (t: Throwable) {
-                error = failedError(t)
+                Result(failedError(t))
             }
         } else {
-            error = parser.toError(retrofitResponse.raw())
+            Result(parser.toError(retrofitResponse.raw()))
         }
-
-        return Result(data, error)
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/ChatParserImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/ChatParserImpl.kt
@@ -59,15 +59,9 @@ internal class ChatParserImpl : ChatParser {
 
     override fun <T : Any> fromJsonOrError(raw: String, clazz: Class<T>): Result<T> {
         return try {
-            Result(
-                fromJson(raw, clazz),
-                null
-            )
+            Result(fromJson(raw, clazz))
         } catch (t: Throwable) {
-            Result(
-                null,
-                ChatError("fromJsonOrError error parsing of $clazz into $raw", t)
-            )
+            Result(ChatError("fromJsonOrError error parsing of $clazz into $raw", t))
         }
     }
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
@@ -19,10 +19,10 @@ internal class MapCall<T : Any, K : Any>(
 
         return if (resultA.isSuccess) {
             val data = mapper(resultA.data())
-            Result(data, null)
+            Result(data)
         } else {
             val error = resultA.error()
-            Result(null, error)
+            Result(error)
         }
     }
 
@@ -34,10 +34,10 @@ internal class MapCall<T : Any, K : Any>(
 
             if (it.isSuccess) {
                 val data = mapper(it.data())
-                callback.onResult(Result(data, null))
+                callback.onResult(Result(data))
             } else {
                 val error = it.error()
-                callback.onResult(Result(null, error))
+                callback.onResult(Result(error))
             }
         }
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/ZipCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/ZipCall.kt
@@ -39,7 +39,7 @@ internal class ZipCall<A : Any, B : Any>(
                 return@runBlocking getErrorB(resultB)
             }
 
-            Result(Pair(resultA.data(), resultB.data()), null)
+            Result(Pair(resultA.data(), resultB.data()))
         }
     }
 
@@ -65,21 +65,15 @@ internal class ZipCall<A : Any, B : Any>(
                 return@launch
             }
 
-            performCallback(Result(Pair(resultA.data(), resultB.data()), null))
+            performCallback(Result(Pair(resultA.data(), resultB.data())))
         }
     }
 
     private fun <A : Any, B : Any> getErrorA(resultA: Result<A>): Result<Pair<A, B>> {
-        return Result(
-            null,
-            ChatError("Error executing callA", resultA.error().cause)
-        )
+        return Result(ChatError("Error executing callA", resultA.error().cause))
     }
 
     private fun <A : Any, B : Any> getErrorB(resultB: Result<B>): Result<Pair<A, B>> {
-        return Result(
-            null,
-            ChatError("Error executing callB", resultB.error().cause)
-        )
+        return Result(ChatError("Error executing callB", resultB.error().cause))
     }
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/utils/Result.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/utils/Result.kt
@@ -2,12 +2,18 @@ package io.getstream.chat.android.client.utils
 
 import io.getstream.chat.android.client.errors.ChatError
 
-public data class Result<T : Any>(
+public data class Result<T : Any> @Deprecated(
+    level = DeprecationLevel.WARNING,
+    message = "Use the constructors taking either the result or the error instead."
+) constructor(
     private val data: T?,
     private val error: ChatError?
 ) {
 
+    @Suppress("DEPRECATION")
     public constructor(data: T) : this(data, null)
+
+    @Suppress("DEPRECATION")
     public constructor(error: ChatError) : this(null, error)
 
     val isSuccess: Boolean

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -417,7 +417,7 @@ internal class ChatDomainImpl internal constructor(
                 if (result.isSuccess) {
                     c.syncStatus = SyncStatus.COMPLETED
                     repos.insertChannel(c)
-                    Result(result.data(), null)
+                    Result(result.data())
                 } else {
                     if (result.error().isPermanent()) {
                         c.syncStatus = SyncStatus.FAILED_PERMANENTLY
@@ -425,13 +425,13 @@ internal class ChatDomainImpl internal constructor(
                         c.syncStatus = SyncStatus.SYNC_NEEDED
                     }
                     repos.insertChannel(c)
-                    Result(null, result.error())
+                    Result(result.error())
                 }
             } else {
-                Result(c, null)
+                Result(c)
             }
         } catch (e: IllegalStateException) {
-            Result(null, ChatError(cause = e))
+            Result(ChatError(cause = e))
         }
 
     fun addError(error: ChatError) {
@@ -594,7 +594,7 @@ internal class ChatDomainImpl internal constructor(
                 }
             }
         } else {
-            Result(emptyList(), null)
+            Result(emptyList())
         }
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -226,7 +226,6 @@ internal class QueryChannelsControllerImpl(
         if (loader.value) {
             logger.logI("Another query channels request is in progress. Ignoring this request.")
             return Result(
-                null,
                 ChatError("Another query channels request is in progress. Ignoring this request.")
             )
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ThreadControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ThreadControllerImpl.kt
@@ -10,9 +10,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.ChatDomainImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 import wasCreatedAfterOrAt
 
@@ -58,7 +56,7 @@ internal class ThreadControllerImpl(
         if (_loadingOlderMessages.value) {
             val errorMsg = "already loading messages for this thread, ignoring the load more requests."
             logger.logI(errorMsg)
-            return Result(null, ChatError(errorMsg))
+            return Result(ChatError(errorMsg))
         }
         _loadingOlderMessages.value = true
         val firstMessage: Message? = sortedVisibleMessages.first().firstOrNull()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
@@ -24,7 +24,7 @@ internal class GetChannelControllerImpl(private val domainImpl: ChatDomainImpl) 
 
         val channelControllerImpl = domainImpl.channel(cid)
         return CoroutineCall(domainImpl.scope) {
-            Result(channelControllerImpl, null)
+            Result(channelControllerImpl)
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetThreadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetThreadImpl.kt
@@ -28,7 +28,7 @@ internal class GetThreadImpl(private val domainImpl: ChatDomainImpl) : GetThread
         val threadController: ThreadController = threadControllerImpl
 
         return CoroutineCall(domainImpl.scope) {
-            Result(threadController, null)
+            Result(threadController)
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetTotalUnreadCountImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetTotalUnreadCountImpl.kt
@@ -21,7 +21,7 @@ public interface GetTotalUnreadCount {
 internal class GetTotalUnreadCountImpl(private val domainImpl: ChatDomainImpl) : GetTotalUnreadCount {
     override operator fun invoke(): Call<LiveData<Int>> {
         return CoroutineCall(domainImpl.scope) {
-            Result(domainImpl.totalUnreadCount, null)
+            Result(domainImpl.totalUnreadCount)
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetUnreadChannelCountImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetUnreadChannelCountImpl.kt
@@ -21,7 +21,7 @@ public interface GetUnreadChannelCount {
 internal class GetUnreadChannelCountImpl(private val domainImpl: ChatDomainImpl) : GetUnreadChannelCount {
     override operator fun invoke(): Call<LiveData<Int>> {
         return CoroutineCall(domainImpl.scope) {
-            Result(domainImpl.channelUnreadCount, null)
+            Result(domainImpl.channelUnreadCount)
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImpl.kt
@@ -23,6 +23,6 @@ internal data class MarkAllReadImpl(private val domain: ChatDomainImpl) : MarkAl
 
         // then update via remote API
         domain.client.markAllRead().execute()
-        Result(true, null)
+        Result(true)
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkReadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkReadImpl.kt
@@ -30,7 +30,7 @@ internal class MarkReadImpl(private val domainImpl: ChatDomainImpl) : MarkRead {
                         .execute()
                 }
 
-                Result(markedRead, null)
+                Result(markedRead)
             }
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
@@ -37,7 +37,7 @@ internal class QueryChannelsImpl(private val domainImpl: ChatDomainImpl) : Query
                     queryChannelsControllerImpl.query(limit, messageLimit)
                 }
             }
-            Result(queryChannelsControllerImpl, null)
+            Result(queryChannelsControllerImpl)
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/WatchChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/WatchChannelImpl.kt
@@ -33,7 +33,7 @@ internal class WatchChannelImpl(private val domainImpl: ChatDomainImpl) : WatchC
         }
 
         return CoroutineCall(domainImpl.scope) {
-            Result(channelController, null)
+            Result(channelController)
         }
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest.kt
@@ -117,13 +117,10 @@ internal open class BaseDomainTest {
         val connectedEvent = DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date()).apply {
         }
 
-        val result = Result(listOf(data.channel1), null)
+        val result = Result(listOf(data.channel1))
         channelClientMock = mock {
             on { sendMessage(any()) } doReturn TestCall(
-                Result(
-                    data.message1,
-                    null
-                )
+                Result(data.message1)
             )
         }
         val events = listOf<ChatEvent>()
@@ -149,12 +146,9 @@ internal open class BaseDomainTest {
                     any<String>(),
                     any<Map<String, Any>>()
                 )
-            } doReturn TestCall(Result(data.channel1, null))
+            } doReturn TestCall(Result(data.channel1))
             on { sendReaction(any()) } doReturn TestCall(
-                Result(
-                    data.reaction1,
-                    null
-                )
+                Result(data.reaction1)
             )
         }
         return client
@@ -164,19 +158,13 @@ internal open class BaseDomainTest {
 
         val connectedEvent = ConnectedEvent(EventType.HEALTH_CHECK, Date(), data.user1, data.connection1)
 
-        val result = Result(listOf(data.channel1), null)
+        val result = Result(listOf(data.channel1))
         channelClientMock = mock {
             on { query(any()) } doReturn TestCall(
-                Result(
-                    data.channel1,
-                    null
-                )
+                Result(data.channel1)
             )
             on { watch(any<WatchChannelRequest>()) } doReturn TestCall(
-                Result(
-                    data.channel1,
-                    null
-                )
+                Result(data.channel1)
             )
         }
         val events = listOf<ChatEvent>()
@@ -195,10 +183,7 @@ internal open class BaseDomainTest {
             on { channel(any(), any()) } doReturn channelClientMock
             on { channel(any()) } doReturn channelClientMock
             on { sendReaction(any()) } doReturn TestCall(
-                Result(
-                    data.reaction1,
-                    null
-                )
+                Result(data.reaction1)
             )
         }
         When calling client.setUser(any(), any<String>(), any()) doAnswer {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/BaseDomainTest2.kt
@@ -119,19 +119,13 @@ internal open class BaseDomainTest2 {
             DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date())
         }
 
-        val result = Result(listOf(data.channel1), null)
+        val result = Result(listOf(data.channel1))
         channelClientMock = mock {
             on { query(any()) } doReturn TestCall(
-                Result(
-                    data.channel1,
-                    null
-                )
+                Result(data.channel1)
             )
             on { watch(any<WatchChannelRequest>()) } doReturn TestCall(
-                Result(
-                    data.channel1,
-                    null
-                )
+                Result(data.channel1)
             )
         }
         val events = listOf<ChatEvent>()
@@ -150,10 +144,7 @@ internal open class BaseDomainTest2 {
             on { channel(any(), any()) } doReturn channelClientMock
             on { channel(any()) } doReturn channelClientMock
             on { sendReaction(any()) } doReturn TestCall(
-                Result(
-                    data.reaction1,
-                    null
-                )
+                Result(data.reaction1)
             )
         }
         When calling client.setUser(any(), any<String>(), any()) doAnswer {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
@@ -54,10 +54,8 @@ internal class SendMessageWithFilesTest : BaseDomainTest2() {
     }
 
     private fun mockFileUploadsFailure(files: List<File>) {
-
         for (file in files) {
-            val path: String? = null
-            val result = Result(path, file.toChatError())
+            val result = Result<String>(file.toChatError())
             When calling clientMock.sendFile(
                 eq(channelControllerImpl.channelType),
                 eq(channelControllerImpl.channelId),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
@@ -258,7 +258,7 @@ internal class TestDataHelper {
     // no created by
     val notificationAddedToChannel3Event = NotificationAddedToChannelEvent(EventType.NOTIFICATION_ADDED_TO_CHANNEL, Date(), channel3.cid, channel3.type, channel3.id, channel3)
     val user1UpdatedEvent = UserUpdatedEvent(EventType.USER_UPDATED, Date(), user1updated)
-    val syncHistoryResult: Result<List<ChatEvent>> = Result(listOf(notificationAddedToChannelEvent, newMessageEvent, newMessageEvent2), null)
+    val syncHistoryResult: Result<List<ChatEvent>> = Result(listOf(notificationAddedToChannelEvent, newMessageEvent, newMessageEvent2))
 
     val channelTruncatedEvent = ChannelTruncatedEvent(EventType.CHANNEL_TRUNCATED, Date(), channel1.cid, channel1.type, channel1.id, user1, channel1)
     val notificationChannelTruncated = NotificationChannelTruncatedEvent(EventType.NOTIFICATION_CHANNEL_TRUNCATED, Date(), channel1.cid, channel1.type, channel1.id, user1, channel1)


### PR DESCRIPTION
### Description

This constructor allowed its users to create a Result that had both a result and an error in it, or neither of them. Both of these cases are misusing the Result type.

There is still a single usage of the old constructor, because we rely on both the result and the error being returned there 😞 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
