### PR TITLE
Do not rely on current time in LegacyDateFormatter

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/LegacyDateFormatter.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/LegacyDateFormatter.kt
@@ -24,7 +24,7 @@ public abstract class LegacyDateFormatter : DateFormatter {
         formatTime(localTime?.let(::toTime))
 
     private fun toTime(localTime: LocalTime): Date {
-        return Date().apply {
+        return Date(0L).apply {
             hours = localTime.hour
             minutes = localTime.minute
             seconds = localTime.second

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/LegacyDateFormatterTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/LegacyDateFormatterTest.kt
@@ -47,7 +47,7 @@ internal class LegacyDateFormatterTest {
         val legacyFormatter = TestDateFormatter()
         legacyFormatter.formatTime(localTime)
 
-        val expected = Date().apply {
+        val expected = Date(0L).apply {
             hours = 15
             minutes = 50
             seconds = 37


### PR DESCRIPTION
### Description

Removes calls to the `Date()` constructor, which returns a `Date` representing the current time. Use a blank `Date` instead, which then has its hour/minute/second values set.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
