### PR TITLE
[CAS-428] Behaviour for Message Options

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -187,6 +187,15 @@ public class MessageListViewModel @JvmOverloads constructor(
             is Event.MuteUser -> {
                 client.muteUser(event.user.id).enqueue()
             }
+            is Event.BlockUser -> {
+                client.shadowBanUser(
+                    targetId = event.user.id,
+                    channelType = event.channel.type ,
+                    channelId = event.channel.id,
+                    reason = null,
+                    timeout = null
+                ).enqueue()
+            }
         }.exhaustive
     }
 
@@ -283,6 +292,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         public data class RetryMessage(val message: Message) : Event()
         public data class MessageReaction(val message: Message, val reactionType: String) : Event()
         public data class MuteUser(val user: User) : Event()
+        public data class BlockUser(val user: User, val channel: Channel) : Event()
     }
 
     public sealed class Mode {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -184,6 +184,9 @@ public class MessageListViewModel @JvmOverloads constructor(
             is Event.MessageReaction -> {
                 onMessageReaction(event.message, event.reactionType)
             }
+            is Event.MuteUser -> {
+                client.muteUser(event.user.id).enqueue()
+            }
         }.exhaustive
     }
 
@@ -279,6 +282,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         public data class GiphyActionSelected(val message: Message, val action: GiphyAction) : Event()
         public data class RetryMessage(val message: Message) : Event()
         public data class MessageReaction(val message: Message, val reactionType: String) : Event()
+        public data class MuteUser(val user: User) : Event()
     }
 
     public sealed class Mode {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -190,7 +190,7 @@ public class MessageListViewModel @JvmOverloads constructor(
             is Event.BlockUser -> {
                 client.shadowBanUser(
                     targetId = event.user.id,
-                    channelType = event.channel.type ,
+                    channelType = event.channel.type,
                     channelId = event.channel.id,
                     reason = null,
                     timeout = null

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -822,14 +822,12 @@ public class MessageListView : ConstraintLayout {
     }
 
     public fun setOnBlockUserHandler(onUserBlockHandler: (User, Channel) -> Unit) {
-        val blockUserForThisChannel : (User) -> Unit = { user ->
+        val blockUserForThisChannel: (User) -> Unit = { user ->
             onUserBlockHandler(user, channel)
         }
 
         this.onBlockUserHandler = blockUserForThisChannel
-
     }
-
 
     public fun interface MessageClickListener {
         public fun onMessageClick(message: Message)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -128,6 +128,9 @@ public class MessageListView : ConstraintLayout {
     private var onMessageReactionHandler: (Message, String) -> Unit = { _, _ ->
         throw IllegalStateException("onMessageReactionHandler must be set.")
     }
+    private var onUserMutedHandler: (User) -> Unit = {
+        throw IllegalStateException("onUserMutedHandler must be set.")
+    }
 
     private lateinit var messageOptionsConfiguration: MessageOptionsView.Configuration
 
@@ -157,6 +160,7 @@ public class MessageListView : ConstraintLayout {
                     threadReplyHandler = onStartThreadHandler,
                     editClickHandler = onMessageEditHandler,
                     flagClickHandler = onMessageFlagHandler,
+                    muteClickHandler = onUserMutedHandler,
                     deleteClickHandler = onMessageDeleteHandler
                 )
 
@@ -807,6 +811,10 @@ public class MessageListView : ConstraintLayout {
 
     public fun setOnMessageReactionHandler(onMessageReactionHandler: (Message, String) -> Unit) {
         this.onMessageReactionHandler = onMessageReactionHandler
+    }
+
+    public fun setOnUserMutedHandler(onUserMutedHandler: (User) -> Unit) {
+        this.onUserMutedHandler = onUserMutedHandler
     }
 
     public fun interface MessageClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -169,11 +169,11 @@ public class MessageListView : ConstraintLayout {
                 )
 
                 MessageOptionsOverlayDialogFragment
-                    .newInstance(message.toMessageItemForOverlay(), messageOptionsConfiguration, handlers)
+                    .newInstance(message.toMessageItemForOverlay(), messageOptionsConfiguration)
                     .apply {
-                        setReactionClickListener { message, reactionType ->
-                            onMessageReactionHandler(message, reactionType)
-                        }
+                        setReactionClickListener(onMessageReactionHandler)
+
+                        setMessageOptionsHandlers(handlers)
                     }
                     .show(framentManager, MessageOptionsOverlayDialogFragment.TAG)
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -401,19 +401,19 @@ public class MessageListView : ConstraintLayout {
 
         val deleteDialogTitle =
             tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
-            ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_title)
+                ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_title)
 
         val deleteDialogMessage =
             tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
-            ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_message)
+                ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_message)
 
         val deleteDialogPositiveButton =
             tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
-            ?: resources.getString(R.string.stream_ui_message_option_delete_positive_button)
+                ?: resources.getString(R.string.stream_ui_message_option_delete_positive_button)
 
         val deleteDialogNegativeButton =
             tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
-            ?: resources.getString(R.string.stream_ui_message_option_delete_negative_button)
+                ?: resources.getString(R.string.stream_ui_message_option_delete_negative_button)
 
         messageOptionsConfiguration = MessageOptionsView.Configuration(
             iconsTint = iconsTint,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -377,6 +377,8 @@ public class MessageListView : ConstraintLayout {
             R.drawable.stream_ui_ic_delete
         )
 
+        val copyTextEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
+
         messageOptionsConfiguration = MessageOptionsView.Configuration(
             iconsTint = iconsTint,
             replyText = replyText,
@@ -390,7 +392,8 @@ public class MessageListView : ConstraintLayout {
             blockText = blockText,
             blockIcon = blockIcon,
             deleteText = deleteText,
-            deleteIcon = deleteIcon
+            deleteIcon = deleteIcon,
+            copyTextEnabled = copyTextEnabled
         )
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -356,6 +356,13 @@ public class MessageListView : ConstraintLayout {
             R.drawable.stream_ui_ic_copy
         )
 
+        val editText = tArray.getString(R.styleable.MessageListView_streamUiEditOptionMessage)
+            ?: context.getString(R.string.stream_ui_message_option_edit)
+        val editIcon = tArray.getResourceId(
+            R.styleable.MessageListView_streamUiEditOptionIcon,
+            R.drawable.stream_ui_ic_edit
+        )
+
         val muteText = tArray.getString(R.styleable.MessageListView_streamUiMuteOptionMessage)
             ?: context.getString(R.string.stream_ui_message_option_mute)
         val muteIcon = tArray.getResourceId(
@@ -387,6 +394,8 @@ public class MessageListView : ConstraintLayout {
             threadReplyIcon = threadReplyIcon,
             copyText = copyText,
             copyIcon = copyIcon,
+            editText = editText,
+            editIcon = editIcon,
             muteText = muteText,
             muteIcon = muteIcon,
             blockText = blockText,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -165,7 +165,7 @@ public class MessageListView : ConstraintLayout {
                     flagClickHandler = onMessageFlagHandler,
                     muteClickHandler = onMuteUserHandler,
                     blockClickHandler = onBlockUserHandler,
-                    deleteClickHandler = onMessageDeleteHandler
+                    deleteClickHandler = onMessageDeleteHandler,
                 )
 
                 MessageOptionsOverlayDialogFragment

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -128,8 +128,11 @@ public class MessageListView : ConstraintLayout {
     private var onMessageReactionHandler: (Message, String) -> Unit = { _, _ ->
         throw IllegalStateException("onMessageReactionHandler must be set.")
     }
-    private var onUserMutedHandler: (User) -> Unit = {
-        throw IllegalStateException("onUserMutedHandler must be set.")
+    private var onMuteUserHandler: (User) -> Unit = {
+        throw IllegalStateException("onMuteUserHandler must be set.")
+    }
+    private var onBlockUserHandler: (User) -> Unit = {
+        throw IllegalStateException("onBlockUserHandler must be set.")
     }
 
     private lateinit var messageOptionsConfiguration: MessageOptionsView.Configuration
@@ -160,7 +163,8 @@ public class MessageListView : ConstraintLayout {
                     threadReplyHandler = onStartThreadHandler,
                     editClickHandler = onMessageEditHandler,
                     flagClickHandler = onMessageFlagHandler,
-                    muteClickHandler = onUserMutedHandler,
+                    muteClickHandler = onMuteUserHandler,
+                    blockClickHandler = onBlockUserHandler,
                     deleteClickHandler = onMessageDeleteHandler
                 )
 
@@ -813,9 +817,19 @@ public class MessageListView : ConstraintLayout {
         this.onMessageReactionHandler = onMessageReactionHandler
     }
 
-    public fun setOnUserMutedHandler(onUserMutedHandler: (User) -> Unit) {
-        this.onUserMutedHandler = onUserMutedHandler
+    public fun setOnMuteUserHandler(onUserMuteHandler: (User) -> Unit) {
+        this.onMuteUserHandler = onUserMuteHandler
     }
+
+    public fun setOnBlockUserHandler(onUserBlockHandler: (User, Channel) -> Unit) {
+        val blockUserForThisChannel : (User) -> Unit = { user ->
+            onUserBlockHandler(user, channel)
+        }
+
+        this.onBlockUserHandler = blockUserForThisChannel
+
+    }
+
 
     public fun interface MessageClickListener {
         public fun onMessageClick(message: Message)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -153,14 +153,18 @@ public class MessageListView : ConstraintLayout {
     private val DEFAULT_MESSAGE_LONG_CLICK_LISTENER =
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { framentManager ->
+                val handlers = MessageOptionsOverlayDialogFragment.Handlers(
+                    deleteClickHandler = onMessageDeleteHandler
+                )
+
                 MessageOptionsOverlayDialogFragment
-                    .newInstance(message.toMessageItemForOverlay(), messageOptionsConfiguration)
+                    .newInstance(message.toMessageItemForOverlay(), messageOptionsConfiguration, handlers)
                     .apply {
                         setReactionClickListener { message, reactionType ->
                             onMessageReactionHandler(message, reactionType)
                         }
                     }
-                    .show(framentManager, ReactionsOverlayDialogFragment.TAG)
+                    .show(framentManager, MessageOptionsOverlayDialogFragment.TAG)
             }
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -325,7 +325,7 @@ public class MessageListView : ConstraintLayout {
         configureMessageOptions(tArray)
         tArray.recycle()
     }
-
+    
     private fun lastPosition(): Int {
         return adapter.itemCount - 1
     }
@@ -388,6 +388,25 @@ public class MessageListView : ConstraintLayout {
 
         val copyTextEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
 
+        val deleteConfirmationEnabled =
+            tArray.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)
+
+        val deleteDialogTitle =
+            tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
+            ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_title)
+
+        val deleteDialogMessage =
+            tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
+            ?: resources.getString(R.string.stream_ui_message_option_delete_confirmation_message)
+
+        val deleteDialogPositiveButton =
+            tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
+            ?: resources.getString(R.string.stream_ui_message_option_delete_positive_button)
+
+        val deleteDialogNegativeButton =
+            tArray.getString(R.styleable.MessageListView_streamUiDeleteConfirmationTitle)
+            ?: resources.getString(R.string.stream_ui_message_option_delete_negative_button)
+
         messageOptionsConfiguration = MessageOptionsView.Configuration(
             iconsTint = iconsTint,
             replyText = replyText,
@@ -404,7 +423,12 @@ public class MessageListView : ConstraintLayout {
             blockIcon = blockIcon,
             deleteText = deleteText,
             deleteIcon = deleteIcon,
-            copyTextEnabled = copyTextEnabled
+            copyTextEnabled = copyTextEnabled,
+            deleteConfirmationEnabled = deleteConfirmationEnabled,
+            deleteConfirmationTitle = deleteDialogTitle,
+            deleteConfirmationMessage = deleteDialogMessage,
+            deleteConfirmationPositiveButton = deleteDialogPositiveButton,
+            deleteConfirmationNegativeButton = deleteDialogNegativeButton
         )
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -154,6 +154,7 @@ public class MessageListView : ConstraintLayout {
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { framentManager ->
                 val handlers = MessageOptionsOverlayDialogFragment.Handlers(
+                    threadReplyHandler = onStartThreadHandler,
                     editClickHandler = onMessageEditHandler,
                     deleteClickHandler = onMessageDeleteHandler
                 )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -154,6 +154,7 @@ public class MessageListView : ConstraintLayout {
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { framentManager ->
                 val handlers = MessageOptionsOverlayDialogFragment.Handlers(
+                    editClickHandler = onMessageEditHandler,
                     deleteClickHandler = onMessageDeleteHandler
                 )
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -156,6 +156,7 @@ public class MessageListView : ConstraintLayout {
                 val handlers = MessageOptionsOverlayDialogFragment.Handlers(
                     threadReplyHandler = onStartThreadHandler,
                     editClickHandler = onMessageEditHandler,
+                    flagClickHandler = onMessageFlagHandler,
                     deleteClickHandler = onMessageDeleteHandler
                 )
 
@@ -325,7 +326,7 @@ public class MessageListView : ConstraintLayout {
         configureMessageOptions(tArray)
         tArray.recycle()
     }
-    
+
     private fun lastPosition(): Int {
         return adapter.itemCount - 1
     }
@@ -363,6 +364,13 @@ public class MessageListView : ConstraintLayout {
         val editIcon = tArray.getResourceId(
             R.styleable.MessageListView_streamUiEditOptionIcon,
             R.drawable.stream_ui_ic_edit
+        )
+
+        val flagText = tArray.getString(R.styleable.MessageListView_streamUiFlagOptionMessage)
+            ?: context.getString(R.string.stream_ui_message_option_flag)
+        val flagIcon = tArray.getResourceId(
+            R.styleable.MessageListView_streamUiFlagOptionIcon,
+            R.drawable.stream_ui_ic_flag
         )
 
         val muteText = tArray.getString(R.styleable.MessageListView_streamUiMuteOptionMessage)
@@ -417,6 +425,8 @@ public class MessageListView : ConstraintLayout {
             copyIcon = copyIcon,
             editText = editText,
             editIcon = editIcon,
+            flagText = flagText,
+            flagIcon = flagIcon,
             muteText = muteText,
             muteIcon = muteIcon,
             blockText = blockText,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
@@ -35,7 +35,8 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
     view.setOnMessageReactionHandler { message, reactionType ->
         onEvent(MessageReaction(message, reactionType))
     }
-    view.setOnUserMutedHandler { onEvent(MuteUser(it)) }
+    view.setOnMuteUserHandler { onEvent(MuteUser(it)) }
+    view.setOnBlockUserHandler { user, channel -> onEvent(MessageListViewModel.Event.BlockUser(user, channel)) }
 
     state.observe(lifecycleOwner) { state ->
         when (state) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
@@ -12,6 +12,7 @@ import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.Last
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.MessageReaction
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.RetryMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.ThreadModeEntered
+import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.MuteUser
 
 /**
  * Binds [MessageListView] with [MessageListViewModel].
@@ -34,6 +35,7 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
     view.setOnMessageReactionHandler { message, reactionType ->
         onEvent(MessageReaction(message, reactionType))
     }
+    view.setOnUserMutedHandler { onEvent(MuteUser(it)) }
 
     state.observe(lifecycleOwner) { state ->
         when (state) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
@@ -10,9 +10,9 @@ import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.Flag
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.GiphyActionSelected
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.LastMessageRead
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.MessageReaction
+import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.MuteUser
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.RetryMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.ThreadModeEntered
-import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.MuteUser
 
 /**
  * Binds [MessageListView] with [MessageListViewModel].

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -32,7 +32,6 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
         private const val ARG_MESSAGE = "message"
         private const val ARG_OPTIONS_CONFIG = "optionsConfig"
-        private const val ARG_HANDLERS = "handlers"
 
         fun newInstance(
             messageItem: MessageListItem.MessageItem,
@@ -240,6 +239,6 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         val flagClickHandler: (Message) -> Unit,
         val muteClickHandler: (User) -> Unit,
         val blockClickHandler: (User) -> Unit,
-        val deleteClickHandler: (Message) -> Unit
+        val deleteClickHandler: (Message) -> Unit,
     ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -37,13 +37,11 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         fun newInstance(
             messageItem: MessageListItem.MessageItem,
             configuration: MessageOptionsView.Configuration,
-            handlers: Handlers
         ): MessageOptionsOverlayDialogFragment {
             return MessageOptionsOverlayDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_MESSAGE to MessageItemWrapper(messageItem),
-                    ARG_OPTIONS_CONFIG to configuration,
-                    ARG_HANDLERS to handlers
+                    ARG_OPTIONS_CONFIG to configuration
                 )
             }
         }
@@ -61,6 +59,11 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
     private lateinit var messageView: View
 
     private var reactionClickListener: ReactionClickListener? = null
+    private var handlers: Handlers? = null
+
+    private val configuration by lazy {
+        requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -89,12 +92,10 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
             dismiss()
         }
 
-        val configuration = requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
-
         setupEditReactionsView()
         setupMessageView()
         configureMessageOptions(configuration, messageItem.isTheirs)
-        setupClickListeners(configuration)
+        handlers?.let(::setupMessageOptionClickListeners)
     }
 
     override fun onDestroy() {
@@ -104,6 +105,10 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
     fun setReactionClickListener(reactionClickListener: ReactionClickListener) {
         this.reactionClickListener = reactionClickListener
+    }
+
+    fun setMessageOptionsHandlers(handlers: Handlers) {
+        this.handlers = handlers
     }
 
     private fun setupEditReactionsView() {
@@ -120,9 +125,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         binding.messageOptionsView.configure(configuration, isTheirs)
     }
 
-    private fun setupClickListeners(configuration: MessageOptionsView.Configuration) {
-        val handlers = requireArguments().getSerializable(ARG_HANDLERS) as Handlers
-
+    private fun setupMessageOptionClickListeners(handlers: Handlers) {
         binding.messageOptionsView.run {
             setThreadListener {
                 handlers.threadReplyHandler(messageItem.message)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -122,12 +122,18 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         val handlers = requireArguments().getSerializable(ARG_HANDLERS) as Handlers
 
         binding.messageOptionsView.run {
+            setThreadListener {
+                handlers.threadReplyHandler(messageItem.message)
+                dismiss()
+            }
+
             setCopyListener {
                 copyText(messageItem.message)
             }
 
             setEditMessageListener {
                 handlers.editClickHandler(messageItem.message)
+                dismiss()
             }
 
             setDeleteMessageListener {
@@ -193,6 +199,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
     }
 
     internal class Handlers(
+        val threadReplyHandler: (Message) -> Unit,
         val editClickHandler: (Message) -> Unit,
         val deleteClickHandler: (Message) -> Unit
     ) : Serializable

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -93,7 +93,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
         setupEditReactionsView()
         setupMessageView()
-        configureMessageOptions(configuration)
+        configureMessageOptions(configuration, messageItem.isTheirs)
         setupClickListeners(configuration)
     }
 
@@ -116,8 +116,8 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         binding.messageOptionsView.setOnClickListener {}
     }
 
-    private fun configureMessageOptions(configuration: MessageOptionsView.Configuration) {
-        binding.messageOptionsView.configure(configuration)
+    private fun configureMessageOptions(configuration: MessageOptionsView.Configuration, isTheirs: Boolean) {
+        binding.messageOptionsView.configure(configuration, isTheirs)
     }
 
     private fun setupClickListeners(configuration: MessageOptionsView.Configuration) {
@@ -146,6 +146,11 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
             setMuteUserListener {
                 handlers.muteClickHandler(messageItem.message.user)
+                dismiss()
+            }
+
+            setBlockUserListener {
+                handlers.blockClickHandler(messageItem.message.user)
                 dismiss()
             }
 
@@ -231,6 +236,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         val editClickHandler: (Message) -> Unit,
         val flagClickHandler: (Message) -> Unit,
         val muteClickHandler: (User) -> Unit,
+        val blockClickHandler: (User) -> Unit,
         val deleteClickHandler: (Message) -> Unit
     ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -17,6 +17,7 @@ import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.ui.databinding.StreamUiDialogMessageOptionsBinding
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemViewHolderFactory
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemViewTypeMapper
@@ -133,13 +134,18 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
                 dismiss()
             }
 
+            setEditMessageListener {
+                handlers.editClickHandler(messageItem.message)
+                dismiss()
+            }
+
             setFlagMessageListener {
                 handlers.flagClickHandler(messageItem.message)
                 dismiss()
             }
 
-            setEditMessageListener {
-                handlers.editClickHandler(messageItem.message)
+            setMuteUserListener {
+                handlers.muteClickHandler(messageItem.message.user)
                 dismiss()
             }
 
@@ -163,7 +169,6 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
                 }
             }
         }
-        handlers.deleteClickHandler
     }
 
     private fun copyText(message: Message) {
@@ -225,6 +230,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         val threadReplyHandler: (Message) -> Unit,
         val editClickHandler: (Message) -> Unit,
         val flagClickHandler: (Message) -> Unit,
+        val muteClickHandler: (User) -> Unit,
         val deleteClickHandler: (Message) -> Unit
     ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -22,6 +22,28 @@ import java.io.Serializable
 
 internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
+    companion object {
+        const val TAG = "messageOptions"
+
+        private const val ARG_MESSAGE = "message"
+        private const val ARG_OPTIONS_CONFIG = "optionsConfig"
+        private const val ARG_HANDLERS = "handlers"
+
+        fun newInstance(
+            messageItem: MessageListItem.MessageItem,
+            configuration: MessageOptionsView.Configuration,
+            handlers: Handlers
+        ): MessageOptionsOverlayDialogFragment {
+            return MessageOptionsOverlayDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_MESSAGE to MessageItemWrapper(messageItem),
+                    ARG_OPTIONS_CONFIG to configuration,
+                    ARG_HANDLERS to handlers
+                )
+            }
+        }
+    }
+
     private var _binding: StreamUiDialogMessageOptionsBinding? = null
     private val binding get() = _binding!!
 
@@ -67,6 +89,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         configureMessageOptions(
             requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
         )
+        setupClickListeners()
     }
 
     override fun onDestroy() {
@@ -90,6 +113,17 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
 
     private fun configureMessageOptions(configuration: MessageOptionsView.Configuration) {
         binding.messageOptionsView.configure(configuration)
+    }
+
+    private fun setupClickListeners() {
+        val handlers = requireArguments().getSerializable(ARG_HANDLERS) as Handlers
+
+        binding.messageOptionsView.run {
+            setDeleteMessageListener {
+                handlers.deleteClickHandler(messageItem.message)
+            }
+        }
+        handlers.deleteClickHandler
     }
 
     override fun onStart() {
@@ -140,22 +174,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         fun onReactionClick(message: Message, reactionType: String)
     }
 
-    companion object {
-        const val TAG = "messageOptions"
-
-        private const val ARG_MESSAGE = "message"
-        private const val ARG_OPTIONS_CONFIG = "optionsConfig"
-
-        fun newInstance(
-            messageItem: MessageListItem.MessageItem,
-            configuration: MessageOptionsView.Configuration
-        ): MessageOptionsOverlayDialogFragment {
-            return MessageOptionsOverlayDialogFragment().apply {
-                arguments = bundleOf(
-                    ARG_MESSAGE to MessageItemWrapper(messageItem),
-                    ARG_OPTIONS_CONFIG to configuration
-                )
-            }
-        }
-    }
+    internal class Handlers(
+        val deleteClickHandler: (Message) -> Unit
+    ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -133,6 +133,11 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
                 dismiss()
             }
 
+            setFlagMessageListener {
+                handlers.flagClickHandler(messageItem.message)
+                dismiss()
+            }
+
             setEditMessageListener {
                 handlers.editClickHandler(messageItem.message)
                 dismiss()
@@ -219,6 +224,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
     internal class Handlers(
         val threadReplyHandler: (Message) -> Unit,
         val editClickHandler: (Message) -> Unit,
+        val flagClickHandler: (Message) -> Unit,
         val deleteClickHandler: (Message) -> Unit
     ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -122,12 +122,16 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
         val handlers = requireArguments().getSerializable(ARG_HANDLERS) as Handlers
 
         binding.messageOptionsView.run {
-            setDeleteMessageListener {
-                handlers.deleteClickHandler(messageItem.message)
-            }
-
             setCopyListener {
                 copyText(messageItem.message)
+            }
+
+            setEditMessageListener {
+                handlers.editClickHandler(messageItem.message)
+            }
+
+            setDeleteMessageListener {
+                handlers.deleteClickHandler(messageItem.message)
             }
         }
         handlers.deleteClickHandler
@@ -189,6 +193,7 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
     }
 
     internal class Handlers(
+        val editClickHandler: (Message) -> Unit,
         val deleteClickHandler: (Message) -> Unit
     ) : Serializable
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsOverlayDialogFragment.kt
@@ -1,6 +1,9 @@
 package io.getstream.chat.android.ui.options
 
 import android.app.Dialog
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
@@ -122,8 +125,19 @@ internal class MessageOptionsOverlayDialogFragment : DialogFragment() {
             setDeleteMessageListener {
                 handlers.deleteClickHandler(messageItem.message)
             }
+
+            setCopyListener {
+                copyText(messageItem.message)
+            }
         }
         handlers.deleteClickHandler
+    }
+
+    private fun copyText(message: Message) {
+        val clipboard = requireContext().getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        val clip = ClipData.newPlainText("label", message.text)
+        clipboard.setPrimaryClip(clip)
+        dismiss()
     }
 
     override fun onStart() {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -40,6 +40,8 @@ public class MessageOptionsView : FrameLayout {
         val threadReplyIcon: Int,
         val copyText: String,
         val copyIcon: Int,
+        val editText: String,
+        val editIcon: Int,
         val muteText: String,
         val muteIcon: Int,
         val blockText: String,
@@ -62,6 +64,7 @@ public class MessageOptionsView : FrameLayout {
             binding.copyTV.isVisible = false
         }
 
+        binding.editTV.configureListItem(configuration.editText, configuration.editIcon, iconsTint)
         binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
         binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -41,6 +41,8 @@ public class MessageOptionsView : FrameLayout {
         val copyIcon: Int,
         val editText: String,
         val editIcon: Int,
+        val flagText: String,
+        val flagIcon: Int,
         val muteText: String,
         val muteIcon: Int,
         val blockText: String,
@@ -69,6 +71,7 @@ public class MessageOptionsView : FrameLayout {
         }
 
         binding.editTV.configureListItem(configuration.editText, configuration.editIcon, iconsTint)
+        binding.flagTV.configureListItem(configuration.flagText, configuration.flagIcon, iconsTint)
         binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
         binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
 
@@ -99,6 +102,12 @@ public class MessageOptionsView : FrameLayout {
     public fun setEditMessageListener(onEdit: () -> Unit) {
         binding.editTV.setOnClickListener {
             onEdit()
+        }
+    }
+
+    public fun setFlagMessageListener(onFlag: () -> Unit) {
+        binding.flagTV.setOnClickListener {
+            onFlag()
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -6,6 +6,7 @@ import android.widget.FrameLayout
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
+import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.R
@@ -44,7 +45,8 @@ public class MessageOptionsView : FrameLayout {
         val blockText: String,
         val blockIcon: Int,
         val deleteText: String,
-        val deleteIcon: Int
+        val deleteIcon: Int,
+        val copyTextEnabled: Boolean
     ) : Serializable
 
     private fun configureMessageOptions(configuration: Configuration) {
@@ -52,7 +54,14 @@ public class MessageOptionsView : FrameLayout {
 
         binding.replyTV.configureListItem(configuration.replyText, configuration.replyIcon, iconsTint)
         binding.threadReplyTV.configureListItem(configuration.threadReplyText, configuration.threadReplyIcon, iconsTint)
-        binding.copyTV.configureListItem(configuration.copyText, configuration.copyIcon, iconsTint)
+
+        if (configuration.copyTextEnabled) {
+            binding.copyTV.isVisible = true
+            binding.copyTV.configureListItem(configuration.copyText, configuration.copyIcon, iconsTint)
+        } else {
+            binding.copyTV.isVisible = false
+        }
+
         binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
         binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
 
@@ -68,6 +77,18 @@ public class MessageOptionsView : FrameLayout {
         }
     }
 
+    public fun setDeleteMessageListener(onDelete: () -> Unit) {
+        binding.deleteTV.setOnClickListener {
+            onDelete()
+        }
+    }
+
+    public fun setCopyListener(onCopy: () -> Unit) {
+        binding.copyTV.setOnClickListener {
+            onCopy()
+        }
+    }
+
     private fun TextView.configureListItem(text: String, icon: Int, iconTint: Int) {
         this.text = text
         this.setLeftDrawable(icon, iconTint)
@@ -80,11 +101,5 @@ public class MessageOptionsView : FrameLayout {
             null,
             null
         )
-    }
-
-    public fun setDeleteMessageListener(onDelete: () -> Unit) {
-        binding.deleteTV.setOnClickListener {
-            onDelete()
-        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -79,9 +79,9 @@ public class MessageOptionsView : FrameLayout {
         }
     }
 
-    public fun setDeleteMessageListener(onDelete: () -> Unit) {
-        binding.deleteTV.setOnClickListener {
-            onDelete()
+    public fun setThreadListener(onThreadReply: () -> Unit) {
+        binding.threadReplyTV.setOnClickListener {
+            onThreadReply()
         }
     }
 
@@ -94,6 +94,12 @@ public class MessageOptionsView : FrameLayout {
     public fun setEditMessageListener(onEdit: () -> Unit) {
         binding.editTV.setOnClickListener {
             onEdit()
+        }
+    }
+
+    public fun setDeleteMessageListener(onDelete: () -> Unit) {
+        binding.deleteTV.setOnClickListener {
+            onDelete()
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -46,21 +46,15 @@ public class MessageOptionsView : FrameLayout {
             binding.flagTV.configureListItem(configuration.flagText, configuration.flagIcon, iconsTint)
             binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
             binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
+            binding.deleteTV.isVisible = false
         } else {
             binding.flagTV.isVisible = false
             binding.muteTV.isVisible = false
             binding.blockTV.isVisible = false
-        }
-
-        binding.deleteTV.run {
-            text = configuration.deleteText
-            setTextColor(ContextCompat.getColor(context, R.color.stream_ui_light_red))
-            setCompoundDrawablesWithIntrinsicBounds(
-                ResourcesCompat.getDrawable(resources, configuration.deleteIcon, null),
-                null,
-                null,
-                null
-            )
+            binding.deleteTV.run {
+                configureListItem(configuration.deleteText, configuration.deleteIcon, iconsTint)
+                setTextColor(ContextCompat.getColor(context, R.color.stream_ui_light_red))
+            }
         }
     }
 
@@ -87,7 +81,7 @@ public class MessageOptionsView : FrameLayout {
         val deleteConfirmationTitle: String,
         val deleteConfirmationMessage: String,
         val deleteConfirmationPositiveButton: String,
-        val deleteConfirmationNegativeButton: String
+        val deleteConfirmationNegativeButton: String,
     ) : Serializable
 
     public fun setThreadListener(onThreadReply: () -> Unit) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -54,7 +54,7 @@ public class MessageOptionsView : FrameLayout {
         val deleteConfirmationTitle: String,
         val deleteConfirmationMessage: String,
         val deleteConfirmationPositiveButton: String,
-        val deleteConfirmationNegativeButton: String,
+        val deleteConfirmationNegativeButton: String
     ) : Serializable
 
     private fun configureMessageOptions(configuration: Configuration) {
@@ -114,6 +114,12 @@ public class MessageOptionsView : FrameLayout {
     public fun setDeleteMessageListener(onDelete: () -> Unit) {
         binding.deleteTV.setOnClickListener {
             onDelete()
+        }
+    }
+
+    public fun setMuteUserListener(onMute: () -> Unit) {
+        binding.muteTV.setOnClickListener {
+            onMute()
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -27,8 +27,41 @@ public class MessageOptionsView : FrameLayout {
         defStyleAttr
     )
 
-    internal fun configure(configuration: Configuration) {
-        configureMessageOptions(configuration)
+    internal fun configure(configuration: Configuration, isMessageTheirs: Boolean) {
+        val iconsTint = configuration.iconsTint
+
+        binding.replyTV.configureListItem(configuration.replyText, configuration.replyIcon, iconsTint)
+        binding.threadReplyTV.configureListItem(configuration.threadReplyText, configuration.threadReplyIcon, iconsTint)
+
+        if (configuration.copyTextEnabled) {
+            binding.copyTV.isVisible = true
+            binding.copyTV.configureListItem(configuration.copyText, configuration.copyIcon, iconsTint)
+        } else {
+            binding.copyTV.isVisible = false
+        }
+
+        binding.editTV.configureListItem(configuration.editText, configuration.editIcon, iconsTint)
+
+        if (isMessageTheirs) {
+            binding.flagTV.configureListItem(configuration.flagText, configuration.flagIcon, iconsTint)
+            binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
+            binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
+        } else {
+            binding.flagTV.isVisible = false
+            binding.muteTV.isVisible = false
+            binding.blockTV.isVisible = false
+        }
+
+        binding.deleteTV.run {
+            text = configuration.deleteText
+            setTextColor(ContextCompat.getColor(context, R.color.stream_ui_light_red))
+            setCompoundDrawablesWithIntrinsicBounds(
+                ResourcesCompat.getDrawable(resources, configuration.deleteIcon, null),
+                null,
+                null,
+                null
+            )
+        }
     }
 
     internal data class Configuration(
@@ -56,36 +89,6 @@ public class MessageOptionsView : FrameLayout {
         val deleteConfirmationPositiveButton: String,
         val deleteConfirmationNegativeButton: String
     ) : Serializable
-
-    private fun configureMessageOptions(configuration: Configuration) {
-        val iconsTint = configuration.iconsTint
-
-        binding.replyTV.configureListItem(configuration.replyText, configuration.replyIcon, iconsTint)
-        binding.threadReplyTV.configureListItem(configuration.threadReplyText, configuration.threadReplyIcon, iconsTint)
-
-        if (configuration.copyTextEnabled) {
-            binding.copyTV.isVisible = true
-            binding.copyTV.configureListItem(configuration.copyText, configuration.copyIcon, iconsTint)
-        } else {
-            binding.copyTV.isVisible = false
-        }
-
-        binding.editTV.configureListItem(configuration.editText, configuration.editIcon, iconsTint)
-        binding.flagTV.configureListItem(configuration.flagText, configuration.flagIcon, iconsTint)
-        binding.muteTV.configureListItem(configuration.muteText, configuration.muteIcon, iconsTint)
-        binding.blockTV.configureListItem(configuration.blockText, configuration.blockIcon, iconsTint)
-
-        binding.deleteTV.run {
-            text = configuration.deleteText
-            setTextColor(ContextCompat.getColor(context, R.color.stream_ui_light_red))
-            setCompoundDrawablesWithIntrinsicBounds(
-                ResourcesCompat.getDrawable(resources, configuration.deleteIcon, null),
-                null,
-                null,
-                null
-            )
-        }
-    }
 
     public fun setThreadListener(onThreadReply: () -> Unit) {
         binding.threadReplyTV.setOnClickListener {
@@ -120,6 +123,12 @@ public class MessageOptionsView : FrameLayout {
     public fun setMuteUserListener(onMute: () -> Unit) {
         binding.muteTV.setOnClickListener {
             onMute()
+        }
+    }
+
+    public fun setBlockUserListener(onBlock: () -> Unit) {
+        binding.blockTV.setOnClickListener {
+            onBlock()
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -8,7 +8,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.extensions.inflater
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiMessageOptionsViewBinding
 import java.io.Serializable
@@ -89,6 +88,12 @@ public class MessageOptionsView : FrameLayout {
     public fun setCopyListener(onCopy: () -> Unit) {
         binding.copyTV.setOnClickListener {
             onCopy()
+        }
+    }
+
+    public fun setEditMessageListener(onEdit: () -> Unit) {
+        binding.editTV.setOnClickListener {
+            onEdit()
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -7,6 +7,7 @@ import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import com.getstream.sdk.chat.utils.extensions.inflater
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiMessageOptionsViewBinding
 import java.io.Serializable
@@ -79,5 +80,11 @@ public class MessageOptionsView : FrameLayout {
             null,
             null
         )
+    }
+
+    public fun setDeleteMessageListener(onDelete: () -> Unit) {
+        binding.deleteTV.setOnClickListener {
+            onDelete()
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -47,7 +47,12 @@ public class MessageOptionsView : FrameLayout {
         val blockIcon: Int,
         val deleteText: String,
         val deleteIcon: Int,
-        val copyTextEnabled: Boolean
+        val copyTextEnabled: Boolean,
+        val deleteConfirmationEnabled: Boolean,
+        val deleteConfirmationTitle: String,
+        val deleteConfirmationMessage: String,
+        val deleteConfirmationPositiveButton: String,
+        val deleteConfirmationNegativeButton: String,
     ) : Serializable
 
     private fun configureMessageOptions(configuration: Configuration) {

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_edit.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_edit.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M21,21.0001H3V16.7571L16.435,3.3221C16.8255,2.9317 17.4585,2.9317 17.849,3.3221L20.678,6.1511C21.0684,6.5416 21.0684,7.1746 20.678,7.5651L9.243,19.0001H21V21.0001ZM5,19.0001H6.414L15.728,9.6861L14.314,8.2721L5,17.5861V19.0001ZM18.556,6.8581L17.142,8.2721L15.728,6.8581L17.142,5.4441L18.556,6.8581Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_flag.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_flag.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M5,2C4.4477,2 4,2.4477 4,3V4V14V21C4,21.5523 4.4477,22 5,22C5.5523,22 6,21.5523 6,21V14H20L18,9L20,4H6V3C6,2.4477 5.5523,2 5,2ZM6,6V12H17L16,9L17,6H6Z"
+      android:fillColor="#000000"
+      android:fillType="evenOdd"/>
+</vector>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -36,8 +36,10 @@
                 android:gravity="center_vertical"
                 android:paddingStart="12dp"
                 android:paddingBottom="12dp"
+                android:visibility="gone"
                 tools:drawableStart="@drawable/stream_ui_ic_arrow_curve_left"
                 tools:text="Reply"
+                tools:visibility="visible"
                 />
 
             <TextView
@@ -75,8 +77,10 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
+                android:visibility="gone"
                 tools:drawableStart="@drawable/stream_ui_ic_edit"
                 tools:text="Edit message"
+                tools:visibility="visible"
                 />
 
             <TextView
@@ -88,8 +92,10 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
+                android:visibility="gone"
                 tools:drawableStart="@drawable/stream_ui_ic_mute"
                 tools:text="Mute User"
+                tools:visibility="visible"
                 />
 
             <TextView
@@ -101,8 +107,10 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
+                android:visibility="gone"
                 tools:drawableStart="@drawable/stream_ui_ic_user_block"
                 tools:text="Block User"
+                tools:visibility="visible"
                 />
 
             <TextView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -92,7 +92,7 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
-                android:visibility="gone"
+                android:visibility="visible"
                 tools:drawableStart="@drawable/stream_ui_ic_flag"
                 tools:text="Flag message"
                 tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -84,6 +84,21 @@
                 />
 
             <TextView
+                android:id="@+id/flagTV"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="8dp"
+                android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
+                android:visibility="gone"
+                tools:drawableStart="@drawable/stream_ui_ic_flag"
+                tools:text="Flag message"
+                tools:visibility="visible"
+                />
+
+            <TextView
                 android:id="@+id/muteTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -19,87 +19,87 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="@color/stream_ui_background_light"
+            android:divider="@color/stream_ui_divider_tint_light"
             android:minWidth="200dp"
             android:orientation="vertical"
             android:paddingTop="12dp"
             android:paddingBottom="12dp"
-            android:divider="@color/stream_ui_divider"
-            android:background="@color/stream_ui_background_light"
             android:showDividers="middle"
             >
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingBottom="12dp"
                 android:id="@+id/replyTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingBottom="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_arrow_curve_left"
                 tools:text="Reply"
                 />
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
                 android:id="@+id/threadReplyTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_thread_reply"
                 tools:text="Thread Reply"
                 />
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
                 android:id="@+id/copyTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_copy"
                 tools:text="Copy message"
                 />
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
                 android:id="@+id/muteTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_mute"
                 tools:text="Mute User"
                 />
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingTop="12dp"
-                android:paddingBottom="12dp"
                 android:id="@+id/blockTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_user_block"
                 tools:text="Block User"
                 />
 
             <TextView
-                android:paddingStart="12dp"
-                android:paddingTop="12dp"
                 android:id="@+id/deleteTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:drawablePadding="8dp"
                 android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
                 tools:drawableStart="@drawable/stream_ui_ic_delete"
                 tools:text="Delete Message"
                 />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -122,7 +122,7 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
-                android:visibility="gone"
+                android:visibility="visible"
                 tools:drawableStart="@drawable/stream_ui_ic_user_block"
                 tools:text="Block User"
                 tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -107,7 +107,7 @@
                 android:paddingStart="12dp"
                 android:paddingTop="12dp"
                 android:paddingBottom="12dp"
-                android:visibility="gone"
+                android:visibility="visible"
                 tools:drawableStart="@drawable/stream_ui_ic_mute"
                 tools:text="Mute User"
                 tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -67,6 +67,19 @@
                 />
 
             <TextView
+                android:id="@+id/editTV"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:drawablePadding="8dp"
+                android:gravity="center_vertical"
+                android:paddingStart="12dp"
+                android:paddingTop="12dp"
+                android:paddingBottom="12dp"
+                tools:drawableStart="@drawable/stream_ui_ic_edit"
+                tools:text="Edit message"
+                />
+
+            <TextView
                 android:id="@+id/muteTV"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -20,7 +20,7 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent"
             android:background="@color/stream_ui_background_light"
-            android:divider="@color/stream_ui_divider_tint_light"
+            android:divider="@color/stream_ui_divider"
             android:minWidth="200dp"
             android:orientation="vertical"
             android:paddingTop="12dp"

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -220,6 +220,7 @@
         <attr name="streamUiDeleteOptionMessage" format="string" />
         <attr name="streamUiDeleteOptionIcon" format="reference" />
         <attr name="streamUiMessageOptionIconColor" format="color" />
+        <attr name="streamUiCopyMessageActionEnabled" format="color" />
     </declare-styleable>
 
     <declare-styleable name="ChannelsView">

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -213,6 +213,8 @@
         <attr name="streamUiThreadReplyOptionIcon" format="reference" />
         <attr name="streamUiCopyOptionMessage" format="string" />
         <attr name="streamUiCopyOptionIcon" format="reference" />
+        <attr name="streamUiEditOptionMessage" format="string" />
+        <attr name="streamUiEditOptionIcon" format="reference" />
         <attr name="streamUiMuteOptionMessage" format="string" />
         <attr name="streamUiMuteOptionIcon" format="reference" />
         <attr name="streamUiBlockOptionMessage" format="string" />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -223,6 +223,9 @@
         <attr name="streamUiDeleteOptionIcon" format="reference" />
         <attr name="streamUiMessageOptionIconColor" format="color" />
         <attr name="streamUiCopyMessageActionEnabled" format="color" />
+        <attr name="streamUiDeleteConfirmationEnabled" format="boolean" />
+        <attr name="streamUiDeleteConfirmationTitle" format="string" />
+        <attr name="streamUiDeleteConfirmationMessage" format="string" />
     </declare-styleable>
 
     <declare-styleable name="ChannelsView">

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -215,6 +215,8 @@
         <attr name="streamUiCopyOptionIcon" format="reference" />
         <attr name="streamUiEditOptionMessage" format="string" />
         <attr name="streamUiEditOptionIcon" format="reference" />
+        <attr name="streamUiFlagOptionMessage" format="string" />
+        <attr name="streamUiFlagOptionIcon" format="reference" />
         <attr name="streamUiMuteOptionMessage" format="string" />
         <attr name="streamUiMuteOptionIcon" format="reference" />
         <attr name="streamUiBlockOptionMessage" format="string" />

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -84,6 +84,11 @@
     <string name="stream_ui_message_option_mute">Mute</string>
     <string name="stream_ui_message_option_block_user">Block user</string>
     <string name="stream_ui_message_option_delete_user">Delete Message</string>
+    <string name="stream_ui_message_option_delete_confirmation_title">Delete Message</string>
+    <string name="stream_ui_message_option_delete_confirmation_message">Are you sure you want to permanently delete this message?</string>
+    <string name="stream_ui_message_option_delete_positive_button">Delete</string>
+    <string name="stream_ui_message_option_delete_negative_button">Cancel</string>
+
 
     <!-- Typing -->
     <plurals name="stream_ui_typing_text">

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -82,7 +82,7 @@
     <string name="stream_ui_message_option_copy">Copy</string>
     <string name="stream_ui_message_option_mute">Mute</string>
     <string name="stream_ui_message_option_block_user">Block user</string>
-    <string name="stream_ui_message_option_delete_user">Delete user</string>
+    <string name="stream_ui_message_option_delete_user">Delete Message</string>
 
     <!-- Typing -->
     <plurals name="stream_ui_typing_text">

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -79,8 +79,9 @@
     <!-- Message options -->
     <string name="stream_ui_message_option_reply">Reply</string>
     <string name="stream_ui_message_option_thread_reply">Thread reply</string>
-    <string name="stream_ui_message_option_copy">Copy</string>
-    <string name="stream_ui_message_option_edit">Edit</string>
+    <string name="stream_ui_message_option_copy">Copy Message</string>
+    <string name="stream_ui_message_option_edit">Edit Message</string>
+    <string name="stream_ui_message_option_flag">Flag Message</string>
     <string name="stream_ui_message_option_mute">Mute</string>
     <string name="stream_ui_message_option_block_user">Block user</string>
     <string name="stream_ui_message_option_delete_user">Delete Message</string>

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -80,6 +80,7 @@
     <string name="stream_ui_message_option_reply">Reply</string>
     <string name="stream_ui_message_option_thread_reply">Thread reply</string>
     <string name="stream_ui_message_option_copy">Copy</string>
+    <string name="stream_ui_message_option_edit">Edit</string>
     <string name="stream_ui_message_option_mute">Mute</string>
     <string name="stream_ui_message_option_block_user">Block user</string>
     <string name="stream_ui_message_option_delete_user">Delete Message</string>


### PR DESCRIPTION
[CAS-428](https://stream-io.atlassian.net/browse/CAS-428)

### Description

Adding the implementation for the message option. 

Is this PR I'm just binding the implementation that already exists to the list. We still need to create the behaviour for **reply**. Which is hidden.

This version: 
![Screenshot_20201222-153823](https://user-images.githubusercontent.com/10619102/102901980-91509200-446e-11eb-879f-f9662ec16f12.png)

New version: 
![Screenshot_20201223-115640](https://user-images.githubusercontent.com/10619102/102989604-2eb2d100-4516-11eb-93a5-834acd2ad5bc.png)

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes. **No need**
- [ ] New code is covered by unit tests. **No need**
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
