### PR TITLE
Fix footnote positioning

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GravityDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GravityDecorator.kt
@@ -16,52 +16,58 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFil
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
 
 internal class GravityDecorator : BaseDecorator() {
-    override fun decoratePlainTextMessage(viewHolder: MessagePlainTextViewHolder, data: MessageListItem.MessageItem) {
-        viewHolder.binding.messageText.updateLayoutParams<ConstraintLayout.LayoutParams> {
+    override fun decoratePlainTextMessage(
+        viewHolder: MessagePlainTextViewHolder,
+        data: MessageListItem.MessageItem
+    ) = with(viewHolder.binding) {
+        messageText.updateLayoutParams<ConstraintLayout.LayoutParams> {
             horizontalBias = if (data.isTheirs) 0f else 1f
         }
-        viewHolder.binding.root.updateConstraints {
-            applyGravity(viewHolder.binding.footnote.messageFooterContainer, viewHolder.binding.avatarView, viewHolder.binding.marginEnd, data)
+        root.updateConstraints {
+            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
         }
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) {
-        viewHolder.binding.root.updateConstraints {
-            applyGravity(viewHolder.binding.footnote.messageFooter, viewHolder.binding.avatarView, viewHolder.binding.marginEnd, data)
+    ) = with(viewHolder.binding) {
+        root.updateConstraints {
+            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
         }
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) {
-        viewHolder.binding.root.updateConstraints {
-            applyGravity(viewHolder.binding.footnote.messageFooter, viewHolder.binding.avatarView, viewHolder.binding.marginEnd, data)
+    ) = with(viewHolder.binding) {
+        root.updateConstraints {
+            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
         }
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) {
-        viewHolder.binding.root.updateConstraints {
-            applyGravity(viewHolder.binding.footnote.messageFooter, viewHolder.binding.avatarView, viewHolder.binding.marginEnd, data)
+    ) = with(viewHolder.binding) {
+        root.updateConstraints {
+            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
         }
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) {
-        viewHolder.binding.root.updateConstraints {
-            applyGravity(viewHolder.binding.footnote.messageFooter, viewHolder.binding.avatarView, viewHolder.binding.marginEnd, data)
+    ) = with(viewHolder.binding) {
+        root.updateConstraints {
+            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
         }
     }
 
-    override fun decorateDeletedMessage(viewHolder: MessageDeletedViewHolder, data: MessageListItem.MessageItem) = Unit
+    override fun decorateDeletedMessage(
+        viewHolder: MessageDeletedViewHolder,
+        data: MessageListItem.MessageItem
+    ) = Unit
 
     private fun ConstraintSet.applyGravity(
         targetView: View,

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -44,10 +44,14 @@
         tools:src="@tools:sample/avatars"
         />
 
-    <include android:id="@+id/footnote"
+    <include
+        android:id="@+id/footnote"
+        layout="@layout/stream_ui_item_message_footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
-        layout="@layout/stream_ui_item_message_footnote" />
+        />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -44,10 +44,14 @@
         tools:src="@tools:sample/avatars"
         />
 
-    <include android:id="@+id/footnote"
+    <include
+        android:id="@+id/footnote"
+        layout="@layout/stream_ui_item_message_footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/mediaAttachmentsGroupView"
-        layout="@layout/stream_ui_item_message_footnote" />
+        />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -53,10 +53,14 @@
         app:layout_constraintTop_toBottomOf="@id/gapView"
         />
 
-    <include android:id="@+id/footnote"
+    <include
+        android:id="@+id/footnote"
+        layout="@layout/stream_ui_item_message_footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
-        layout="@layout/stream_ui_item_message_footnote" />
+        />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -73,10 +72,14 @@
         tools:src="@tools:sample/avatars"
         />
 
-    <include android:id="@+id/footnote"
+    <include
+        android:id="@+id/footnote"
+        layout="@layout/stream_ui_item_message_footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
-        layout="@layout/stream_ui_item_message_footnote" />
+        />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -74,9 +74,12 @@
 
     <include
         android:id="@+id/footnote"
+        layout="@layout/stream_ui_item_message_footnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
-        layout="@layout/stream_ui_item_message_footnote" />
+        />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"


### PR DESCRIPTION
### Description

This PR fixes the lost `layout_width` and `layout_height` params of footnote include. When including a layout there are basically 2 options:
- Not override any layout params
- Override all layout parameters, otherwise they will be lost

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
| ![photo_2020-12-23 01 42 32](https://user-images.githubusercontent.com/9600921/102939894-2b8cf600-44c0-11eb-9176-52a4448e8d6a.jpeg) | ![photo_2020-12-23 01 42 35](https://user-images.githubusercontent.com/9600921/102939883-26c84200-44c0-11eb-9e57-a5ae11b911d3.jpeg) |



