### PR TITLE
Don't display loading indicator over channels from cache

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -26,7 +26,6 @@ public class ChannelListView @JvmOverloads constructor(
     defStyle: Int = 0
 ) : RecyclerView(context, attrs, defStyle) {
 
-    private val channelListItemAdapter: ChannelListItemAdapter
     private val layoutManager: ScrollPauseLinearLayoutManager
     private val scrollListener: EndReachedScrollListener = EndReachedScrollListener()
     private val dividerDecoration: SimpleVerticalListDivider = SimpleVerticalListDivider()
@@ -37,8 +36,7 @@ public class ChannelListView @JvmOverloads constructor(
         setHasFixedSize(true)
         layoutManager = ScrollPauseLinearLayoutManager(context)
         setLayoutManager(layoutManager)
-        channelListItemAdapter = ChannelListItemAdapter(parseStyleAttributes(context, attrs))
-        adapter = channelListItemAdapter
+        adapter = ChannelListItemAdapter(parseStyleAttributes(context, attrs))
         setSwipeListener(ChannelItemSwipeListener(this, layoutManager))
         setMoreOptionsClickListener { channel ->
             context.getFragmentManager()?.let { fragmentManager ->
@@ -128,7 +126,7 @@ public class ChannelListView @JvmOverloads constructor(
     }
 
     public fun hasChannels(): Boolean {
-        return channelListItemAdapter.itemCount > 0
+        return requireAdapter().itemCount > 0
     }
 
     public override fun onVisibilityChanged(view: View, visibility: Int) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -26,16 +26,19 @@ public class ChannelListView @JvmOverloads constructor(
     defStyle: Int = 0
 ) : RecyclerView(context, attrs, defStyle) {
 
-    private var endReachedListener: EndReachedListener? = null
+    private val channelListItemAdapter: ChannelListItemAdapter
     private val layoutManager: ScrollPauseLinearLayoutManager
     private val scrollListener: EndReachedScrollListener = EndReachedScrollListener()
     private val dividerDecoration: SimpleVerticalListDivider = SimpleVerticalListDivider()
+
+    private var endReachedListener: EndReachedListener? = null
 
     init {
         setHasFixedSize(true)
         layoutManager = ScrollPauseLinearLayoutManager(context)
         setLayoutManager(layoutManager)
-        adapter = ChannelListItemAdapter(parseStyleAttributes(context, attrs))
+        channelListItemAdapter = ChannelListItemAdapter(parseStyleAttributes(context, attrs))
+        adapter = channelListItemAdapter
         setSwipeListener(ChannelItemSwipeListener(this, layoutManager))
         setMoreOptionsClickListener { channel ->
             context.getFragmentManager()?.let { fragmentManager ->
@@ -122,6 +125,10 @@ public class ChannelListView @JvmOverloads constructor(
 
     public fun setChannels(channels: List<Channel>) {
         requireAdapter().submitList(channels)
+    }
+
+    public fun hasChannels(): Boolean {
+        return channelListItemAdapter.itemCount > 0
     }
 
     public override fun onVisibilityChanged(view: View, visibility: Int) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
@@ -177,6 +177,10 @@ public class ChannelsView @JvmOverloads constructor(
         channelListView.reachedEndOfChannels(endReached)
     }
 
+    public fun hasChannels(): Boolean {
+        return channelListView.hasChannels()
+    }
+
     private companion object {
         private val defaultChildLayoutParams: LayoutParams by lazy {
             LayoutParams(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelsViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelsViewModelBinding.kt
@@ -19,7 +19,9 @@ public fun ChannelsViewModel.bindView(
             }
             is ChannelsViewModel.State.Loading -> {
                 view.hideEmptyStateView()
-                view.showLoadingView()
+                if (!view.hasChannels()) {
+                    view.showLoadingView()
+                }
             }
             is ChannelsViewModel.State.Result -> {
                 view.setChannels(channelState.channels)


### PR DESCRIPTION
### Description

This PR prevent channel list loading indicator from displaying over channel list received from cache. This is just a temp solution. We need to completely get rid of sealed classes in our view models and controllers:

```
data class State(
    val contentState: ContentState,
    val channels: List<Channel>,
    val loadingMore: Boolean,
    val hasMore: Boolean
)

enum class ContentState {
    CONTENT, LOADING, ERROR
}
```

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

### Before
https://user-images.githubusercontent.com/9600921/102942457-6d209f80-44c6-11eb-9646-aad1e06f9334.mov

### After
https://user-images.githubusercontent.com/9600921/102942452-6a25af00-44c6-11eb-8ffc-8bef3644bec9.mov





