### PR TITLE
Show typing indicator

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.Transformations.map
 import androidx.lifecycle.ViewModel
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDomain
 
 /**
@@ -23,11 +24,13 @@ public class ChannelHeaderViewModel @JvmOverloads constructor(
     private val _members = MediatorLiveData<List<Member>>()
     private val _channelState = MediatorLiveData<Channel>()
     private val _anyOtherUsersOnline = MediatorLiveData<Boolean>()
+    private val _typingUsers = MediatorLiveData<List<User>>()
 
     public val members: LiveData<List<Member>> = _members
     public val channelState: LiveData<Channel> = _channelState
     public val anyOtherUsersOnline: LiveData<Boolean> = _anyOtherUsersOnline
     public val online: LiveData<Boolean> = chatDomain.online
+    public val typingUsers: LiveData<List<User>> = _typingUsers
 
     init {
         chatDomain.useCases.watchChannel(cid, 0).enqueue { channelControllerResult ->
@@ -44,6 +47,9 @@ public class ChannelHeaderViewModel @JvmOverloads constructor(
                             .any { it.user.online }
                     }
                 ) { _anyOtherUsersOnline.value = it }
+                _typingUsers.addSource(channelController.typing) { typingEvent ->
+                    _typingUsers.value = typingEvent.users
+                }
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderView.kt
@@ -10,6 +10,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
+import androidx.core.view.forEach
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.style.TextStyle
 import io.getstream.chat.android.client.models.Channel
@@ -21,6 +22,12 @@ import io.getstream.chat.android.ui.utils.extensions.getDimension
 import io.getstream.chat.android.ui.utils.extensions.setTextSizePx
 
 public class MessagesHeaderView : ConstraintLayout {
+
+    private val binding: StreamUiMessagesHeaderViewBinding =
+        StreamUiMessagesHeaderViewBinding.inflate(LayoutInflater.from(context), this, true)
+
+    private var subtitleState: SubtitleState = SubtitleState(emptyList(), OnlineState.NONE)
+
     public constructor(context: Context) : super(context) {
         init(null)
     }
@@ -45,9 +52,6 @@ public class MessagesHeaderView : ConstraintLayout {
     ) : super(context, attrs, defStyleAttr, defStyleRes) {
         init(attrs)
     }
-
-    private val binding: StreamUiMessagesHeaderViewBinding =
-        StreamUiMessagesHeaderViewBinding.inflate(LayoutInflater.from(context), this, true)
 
     @SuppressLint("CustomViewStyleable")
     private fun init(attrs: AttributeSet?) {
@@ -111,31 +115,23 @@ public class MessagesHeaderView : ConstraintLayout {
     }
 
     public fun hideSubtitle() {
-        binding.onlineContainer.isVisible = false
-        binding.offlineContainer.isVisible = false
-        binding.searchingForNetworkContainer.isVisible = false
-        binding.typingContainer.isVisible = false
+        reduceSubtitleState(typingUsers = emptyList(), onlineState = OnlineState.NONE)
     }
 
     public fun showOnlineStateSubtitle() {
-        hideSubtitle()
-        binding.onlineContainer.isVisible = true
+        reduceSubtitleState(onlineState = OnlineState.ONLINE)
     }
 
     public fun showSearchingForNetworkLabel() {
-        hideSubtitle()
-        binding.searchingForNetworkContainer.isVisible = true
+        reduceSubtitleState(onlineState = OnlineState.SEARCHING_FOR_NETWORK)
     }
 
     public fun showOfflineStateLabel() {
-        hideSubtitle()
-        binding.offlineContainer.isVisible = true
+        reduceSubtitleState(onlineState = OnlineState.OFFLINE)
     }
 
     public fun showTypingStateLabel(typingUsers: List<User>) {
-        hideSubtitle()
-        binding.typingContainer.isVisible = true
-        binding.typingView.setTypingUsers(typingUsers)
+        reduceSubtitleState(typingUsers = typingUsers)
     }
 
     public fun hideTitle() {
@@ -163,6 +159,33 @@ public class MessagesHeaderView : ConstraintLayout {
                     true
                 )
             indeterminateTintList = getProgressbarTintList(attrs)
+        }
+    }
+
+    private fun reduceSubtitleState(
+        typingUsers: List<User> = subtitleState.typingUsers,
+        onlineState: OnlineState = subtitleState.onlineState
+    ) {
+        subtitleState = subtitleState.copy(
+            typingUsers = typingUsers,
+            onlineState = onlineState
+        )
+        renderSubtitleState()
+    }
+
+    private fun renderSubtitleState() {
+        with(binding) {
+            subtitleContainer.forEach { it.isVisible = false }
+            if (subtitleState.typingUsers.isNotEmpty()) {
+                typingContainer.isVisible = true
+                typingView.setTypingUsers(subtitleState.typingUsers)
+            } else {
+                when (subtitleState.onlineState) {
+                    OnlineState.ONLINE -> onlineContainer.isVisible = true
+                    OnlineState.SEARCHING_FOR_NETWORK -> searchingForNetworkContainer.isVisible = true
+                    OnlineState.OFFLINE -> offlineContainer.isVisible = true
+                }
+            }
         }
     }
 
@@ -262,7 +285,8 @@ public class MessagesHeaderView : ConstraintLayout {
 
     private fun configBackButton(attrs: TypedArray) {
         binding.backButtonContainer.apply {
-            val showBackButton = attrs.getBoolean(R.styleable.MessagesHeaderView_streamUiMessagesHeaderShowBackButton, true)
+            val showBackButton =
+                attrs.getBoolean(R.styleable.MessagesHeaderView_streamUiMessagesHeaderShowBackButton, true)
             isVisible = showBackButton
             isClickable = showBackButton
         }
@@ -316,6 +340,18 @@ public class MessagesHeaderView : ConstraintLayout {
             isVisible = showAvatar
             isClickable = showAvatar
         }
+    }
+
+    private data class SubtitleState(
+        val typingUsers: List<User>,
+        val onlineState: OnlineState
+    )
+
+    private enum class OnlineState {
+        NONE,
+        ONLINE,
+        SEARCHING_FOR_NETWORK,
+        OFFLINE
     }
 
     public fun interface OnClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderViewBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderViewBinding.kt
@@ -19,4 +19,7 @@ public fun ChannelHeaderViewModel.bindView(view: MessagesHeaderView, lifecycle: 
             view.showSearchingForNetworkLabel()
         }
     }
+    typingUsers.observe(lifecycle) { typingUsers ->
+        view.showTypingStateLabel(typingUsers)
+    }
 }


### PR DESCRIPTION
### Description

Show typing users in message list header. Had to introduce some state as we need to show previous subtitle state when a user stops typing.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

https://user-images.githubusercontent.com/9600921/102976124-26f12d80-4512-11eb-8630-744f8da3117f.mov

