### PR TITLE
Failure Indicator Decorator

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
@@ -8,6 +8,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Avatar
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.BackgroundDecorator
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.DeliveryStatusDecorator
+import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.FailedIndicatorDecorator
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.GapDecorator
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.GravityDecorator
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.MaxPossibleWidthDecorator
@@ -24,8 +25,9 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
         AvatarDecorator(),
         GravityDecorator(),
         DeliveryStatusDecorator(),
+        FailedIndicatorDecorator(),
         MessageFooterDecorator(DateFormatter.from(itemView.context)),
-        ReactionsDecorator()
+        ReactionsDecorator(),
     )
 
     public fun bind(data: T, diff: MessageListItemPayloadDiff? = null) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
@@ -1,0 +1,59 @@
+package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
+
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import com.getstream.sdk.chat.adapter.MessageListItem
+import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.MessageDeletedViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+
+internal class FailedIndicatorDecorator : BaseDecorator() {
+
+    override fun decoratePlainTextMessage(viewHolder: MessagePlainTextViewHolder, data: MessageListItem.MessageItem) {
+        setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
+    }
+
+    override fun decoratePlainTextWithFileAttachmentsMessage(
+        viewHolder: PlainTextWithFileAttachmentsViewHolder,
+        data: MessageListItem.MessageItem
+    ) {
+        setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
+    }
+
+    override fun decorateOnlyFileAttachmentsMessage(
+        viewHolder: OnlyFileAttachmentsViewHolder,
+        data: MessageListItem.MessageItem
+    ) {
+        setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
+    }
+
+    override fun decoratePlainTextWithMediaAttachmentsMessage(
+        viewHolder: PlainTextWithMediaAttachmentsViewHolder,
+        data: MessageListItem.MessageItem
+    ) {
+        setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
+    }
+
+    override fun decorateOnlyMediaAttachmentsMessage(
+        viewHolder: OnlyMediaAttachmentsViewHolder,
+        data: MessageListItem.MessageItem
+    ) {
+        setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
+    }
+
+    override fun decorateDeletedMessage(viewHolder: MessageDeletedViewHolder, data: MessageListItem.MessageItem) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
+
+    private fun setupFailedIndicator(
+        deliveryFailedIcon: ImageView,
+        data: MessageListItem.MessageItem
+    ) {
+        val isFailed = data.isMine && data.message.syncStatus == SyncStatus.FAILED_PERMANENTLY
+        deliveryFailedIcon.isVisible = isFailed
+    }
+}

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_warning.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_warning.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M12,22C6.477,22 2,17.523 2,12C2,6.477 6.477,2 12,2C17.523,2 22,6.477 22,12C22,17.523 17.523,22 12,22ZM11,15V17H13V15H11ZM11,13V7H13V13H11Z"
+      android:fillColor="#FF3842"
+      android:fillType="evenOdd"/>
+</vector>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -18,10 +18,12 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
-        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
+        app:layout_goneMarginEnd="0dp"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
@@ -53,6 +55,17 @@
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
         />
 
+    <ImageView
+        android:id="@+id/deliveryFailedIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/stream_ui_ic_warning"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/fileAttachmentsView"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        tools:visibility="visible"
+        />
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"
         android:layout_width="wrap_content"
@@ -68,4 +81,5 @@
         android:orientation="vertical"
         app:layout_constraintGuide_end="20dp"
         />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -60,7 +60,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:src="@drawable/stream_ui_ic_warning"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/fileAttachmentsView"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
         tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -51,7 +51,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:src="@drawable/stream_ui_ic_warning"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/mediaAttachmentsGroupView"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
         tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -18,10 +18,12 @@
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
-        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
+        app:layout_goneMarginEnd="0dp"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
@@ -42,6 +44,17 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@id/marginStart"
         tools:src="@tools:sample/avatars"
+        />
+
+    <ImageView
+        android:id="@+id/deliveryFailedIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/stream_ui_ic_warning"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/mediaAttachmentsGroupView"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        tools:visibility="visible"
         />
 
     <include
@@ -68,4 +81,5 @@
         android:orientation="vertical"
         app:layout_constraintGuide_end="20dp"
         />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -30,6 +30,7 @@
         android:id="@+id/messageText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:hyphenationFrequency="normal"
         android:lineHeight="16sp"
         android:paddingLeft="@dimen/stream_ui_spacing_medium"
@@ -39,9 +40,10 @@
         android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
         android:textColor="@color/stream_ui_black"
         app:layout_constrainedWidth="true"
-        app:layout_constraintEnd_toEndOf="@id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
+        app:layout_goneMarginEnd="0dp"
         tools:text="@tools:sample/lorem"
         />
 
@@ -62,6 +64,17 @@
         app:layout_constraintTop_toBottomOf="@+id/messageText"
         />
 
+    <ImageView
+        android:id="@+id/deliveryFailedIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/stream_ui_ic_warning"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/messageText"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        tools:visibility="visible"
+        />
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"
         android:layout_width="wrap_content"
@@ -77,4 +90,5 @@
         android:orientation="vertical"
         app:layout_constraintGuide_end="20dp"
         />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -88,7 +88,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:src="@drawable/stream_ui_ic_warning"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/messageText"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
         tools:visibility="visible"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -28,8 +28,9 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
-        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/reactionsView"
         />
@@ -40,6 +41,7 @@
         android:layout_height="wrap_content"
         app:layout_constraintStart_toEndOf="@id/fileAttachmentsView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
+        app:layout_goneMarginEnd="0dp"
         />
 
     <TextView
@@ -79,6 +81,17 @@
         android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
+        />
+
+    <ImageView
+        android:id="@+id/deliveryFailedIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/stream_ui_ic_warning"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/messageText"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        tools:visibility="visible"
         />
 
     <androidx.constraintlayout.widget.Guideline

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -28,10 +28,12 @@
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
-        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
+        app:layout_goneMarginEnd="0dp"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
@@ -79,6 +81,17 @@
         android:layout_height="wrap_content"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
+        />
+
+    <ImageView
+        android:id="@+id/deliveryFailedIcon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:src="@drawable/stream_ui_ic_warning"
+        android:visibility="visible"
+        app:layout_constraintBottom_toBottomOf="@+id/messageText"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        tools:visibility="visible"
         />
 
     <androidx.constraintlayout.widget.Guideline

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -88,7 +88,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:src="@drawable/stream_ui_ic_warning"
-        android:visibility="visible"
+        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/messageText"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
         tools:visibility="visible"


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-488

### Description

_[Interior Crocodile Alligator](https://www.youtube.com/watch?v=kZwhNFOn4ik)_

Adds the Failure indicator to ViewHolders for messages that failed to send with a permanent error.

<img width="400" src="https://user-images.githubusercontent.com/12054216/102978855-79781d00-4505-11eb-805a-70fed9988b3e.png" />

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
