### PR TITLE
ViewHolder margin fixes

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
@@ -1,9 +1,6 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
-import android.view.View
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
-import androidx.core.view.updateLayoutParams
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.ui.avatar.AvatarView
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
@@ -12,61 +9,50 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
-import io.getstream.chat.android.ui.utils.extensions.dpToPx
 
 internal class AvatarDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupAvatar(viewHolder.binding.avatarView, viewHolder.binding.mediaAttachmentsGroupView, data)
+        setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decoratePlainTextMessage(viewHolder: MessagePlainTextViewHolder, data: MessageListItem.MessageItem) {
-        setupAvatar(viewHolder.binding.avatarView, viewHolder.binding.messageText, data)
+        setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupAvatar(viewHolder.binding.avatarView, viewHolder.binding.mediaAttachmentsGroupView, data)
+        setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupAvatar(viewHolder.binding.avatarView, viewHolder.binding.fileAttachmentsView, data)
+        setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupAvatar(viewHolder.binding.avatarView, viewHolder.binding.fileAttachmentsView, data)
+        setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
-    private fun setupAvatar(avatarView: AvatarView, viewNextFromAvatar: View, data: MessageListItem.MessageItem) {
+    private fun setupAvatar(avatarView: AvatarView, data: MessageListItem.MessageItem) {
         if (data.isTheirs) {
             avatarView.setUserData(data.message.user)
         }
-        viewNextFromAvatar.updateLayoutParams<ConstraintLayout.LayoutParams> {
-            marginStart = 0
-        }
-        when {
-            data.isTheirs && data.positions.contains(MessageListItem.Position.BOTTOM) -> avatarView.isVisible = true
-            data.isTheirs -> {
-                avatarView.isVisible = false
-                viewNextFromAvatar.updateLayoutParams<ConstraintLayout.LayoutParams> { marginStart = AVATAR_SIDE_SPACE }
-            }
-            else -> avatarView.isVisible = false
-        }
-    }
 
-    companion object {
-        private val AVATAR_SIDE_SPACE = 48.dpToPx()
+        avatarView.isVisible = when {
+            data.isTheirs && data.positions.contains(MessageListItem.Position.BOTTOM) -> true
+            else -> false
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/DeliveryStatusDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/DeliveryStatusDecorator.kt
@@ -52,7 +52,10 @@ internal class DeliveryStatusDecorator : BaseDecorator() {
     }
 
     override fun decorateDeletedMessage(viewHolder: MessageDeletedViewHolder, data: MessageListItem.MessageItem) = Unit
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
+
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
+        viewHolder.binding.footnote.deliveryStatusIcon.isVisible = false
+    }
 
     private fun setupDeliveryStateIndicator(imageView: ImageView, data: MessageListItem.MessageItem) {
         fun hideIndicator() {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GravityDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GravityDecorator.kt
@@ -5,8 +5,6 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.updateLayoutParams
 import com.getstream.sdk.chat.adapter.MessageListItem
-import com.getstream.sdk.chat.utils.extensions.constrainViewEndToEndOfView
-import com.getstream.sdk.chat.utils.extensions.constrainViewStartToEndOfView
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessageDeletedViewHolder
@@ -25,7 +23,7 @@ internal class GravityDecorator : BaseDecorator() {
             horizontalBias = if (data.isTheirs) 0f else 1f
         }
         root.updateConstraints {
-            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
+            applyGravity(footnote.messageFooterContainer, data)
         }
     }
 
@@ -34,7 +32,7 @@ internal class GravityDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) = with(viewHolder.binding) {
         root.updateConstraints {
-            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
+            applyGravity(footnote.messageFooterContainer, data)
         }
     }
 
@@ -43,7 +41,7 @@ internal class GravityDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) = with(viewHolder.binding) {
         root.updateConstraints {
-            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
+            applyGravity(footnote.messageFooterContainer, data)
         }
     }
 
@@ -52,7 +50,7 @@ internal class GravityDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) = with(viewHolder.binding) {
         root.updateConstraints {
-            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
+            applyGravity(footnote.messageFooterContainer, data)
         }
     }
 
@@ -61,7 +59,7 @@ internal class GravityDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) = with(viewHolder.binding) {
         root.updateConstraints {
-            applyGravity(footnote.messageFooterContainer, avatarView, marginEnd, data)
+            applyGravity(footnote.messageFooterContainer, data)
         }
     }
 
@@ -75,18 +73,11 @@ internal class GravityDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) = Unit
 
-    private fun ConstraintSet.applyGravity(
-        targetView: View,
-        startView: View,
-        endView: View,
-        data: MessageListItem.MessageItem
-    ) {
-        clear(targetView.id, ConstraintSet.START)
-        clear(targetView.id, ConstraintSet.END)
+    private fun ConstraintSet.applyGravity(targetView: View, data: MessageListItem.MessageItem) {
         if (data.isTheirs) {
-            constrainViewStartToEndOfView(targetView, startView)
+            setHorizontalBias(targetView.id, 0f)
         } else {
-            constrainViewEndToEndOfView(targetView, endView)
+            setHorizontalBias(targetView.id, 1f)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -71,7 +71,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -79,7 +79,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginStart="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -37,7 +39,6 @@
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatarView"
         style="@style/StreamUiMessageListAvatarStyle"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -54,7 +54,9 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -24,6 +24,8 @@
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
+        android:layout_marginStart="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -20,14 +20,14 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="8dp"
     android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -20,14 +20,14 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
-        android:layout_marginStart="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    xmlns:tools="http://schemas.android.com/tools"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -18,12 +18,13 @@
         android:id="@+id/cardView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_small"
+        android:background="@color/stream_ui_background_default_selector"
+        android:clipToPadding="false"
         app:cardElevation="@dimen/stream_ui_elevation_big"
         app:layout_constraintEnd_toStartOf="@id/marginEnd"
         app:layout_constraintStart_toEndOf="@id/marginStart"
         app:layout_constraintTop_toBottomOf="@id/gapView"
-        android:background="@color/stream_ui_background_default_selector"
-        android:clipToPadding="false"
         >
 
         <androidx.constraintlayout.widget.ConstraintLayout
@@ -44,21 +45,21 @@
                 android:id="@+id/previousButton"
                 android:layout_width="32dp"
                 android:layout_height="32dp"
-                android:layout_marginTop="8dp"
                 android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
                 android:layout_marginBottom="8dp"
-                android:paddingTop="4dp"
-                android:paddingBottom="4dp"
-                android:paddingStart="3dp"
-                android:paddingEnd="5dp"
-                android:elevation="@dimen/stream_ui_elevation_big"
-                android:src="@drawable/stream_ui_arrow_left_rounded"
                 android:background="@drawable/stream_ui_circle_white"
-                app:tint="@color/stream_ui_send_button_disabled"
                 android:clickable="false"
+                android:elevation="@dimen/stream_ui_elevation_big"
+                android:paddingStart="3dp"
+                android:paddingTop="4dp"
+                android:paddingEnd="5dp"
+                android:paddingBottom="4dp"
+                android:src="@drawable/stream_ui_arrow_left_rounded"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintRight_toLeftOf="@id/giphyTextLabel"
                 app:layout_constraintTop_toBottomOf="@id/mediaAttachmentView"
+                app:tint="@color/stream_ui_send_button_disabled"
                 />
 
             <TextView
@@ -66,13 +67,13 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:gravity="center"
+                android:textColor="@color/stream_ui_black"
+                android:textSize="14sp"
+                android:textStyle="italic"
                 app:layout_constraintBottom_toBottomOf="@id/previousButton"
                 app:layout_constraintLeft_toRightOf="@id/previousButton"
                 app:layout_constraintRight_toLeftOf="@id/nextButton"
                 app:layout_constraintTop_toTopOf="@id/previousButton"
-                android:textStyle="italic"
-                android:textColor="@color/stream_ui_black"
-                android:textSize="14sp"
                 tools:text="Some giphy label"
                 />
 
@@ -81,19 +82,19 @@
                 android:layout_width="32dp"
                 android:layout_height="32dp"
                 android:layout_marginEnd="8dp"
-                android:elevation="@dimen/stream_ui_elevation_big"
-                android:src="@drawable/stream_ui_arrow_right"
-                android:paddingTop="4dp"
-                android:paddingBottom="4dp"
-                android:paddingStart="5dp"
-                android:paddingEnd="3dp"
                 android:background="@drawable/stream_ui_circle_white"
                 android:duplicateParentState="false"
+                android:elevation="@dimen/stream_ui_elevation_big"
+                android:paddingStart="5dp"
+                android:paddingTop="4dp"
+                android:paddingEnd="3dp"
+                android:paddingBottom="4dp"
+                android:src="@drawable/stream_ui_arrow_right"
+                app:layout_constraintBottom_toBottomOf="@id/previousButton"
                 app:layout_constraintHorizontal_chainStyle="spread_inside"
                 app:layout_constraintLeft_toRightOf="@id/giphyTextLabel"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="@id/previousButton"
-                app:layout_constraintBottom_toBottomOf="@id/previousButton"
                 />
 
             <View
@@ -110,44 +111,46 @@
                 android:id="@+id/cancel_button"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
-                app:layout_constraintTop_toBottomOf="@id/horizontalDivider"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintLeft_toLeftOf="parent"
-                app:layout_constraintRight_toLeftOf="@id/verticalDivider"
+                android:background="?selectableItemBackground"
+                android:gravity="center"
                 android:paddingTop="16dp"
                 android:paddingBottom="16dp"
-                android:gravity="center"
+                android:text="@string/stream_ui_cancel_label"
                 android:textColor="@color/stream_ui_attachment_dialog_button_enabled"
                 android:textSize="14sp"
                 android:textStyle="bold"
-                android:text="@string/stream_ui_cancel_label"
-                android:background="?selectableItemBackground"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toLeftOf="@id/verticalDivider"
+                app:layout_constraintTop_toBottomOf="@id/horizontalDivider"
                 />
 
             <View
                 android:id="@+id/verticalDivider"
                 android:layout_width="1dp"
                 android:layout_height="0dp"
-                app:layout_constraintTop_toTopOf="@id/cancel_button"
+                android:background="@color/stream_ui_black_10"
                 app:layout_constraintBottom_toBottomOf="@id/cancel_button"
                 app:layout_constraintLeft_toRightOf="@id/cancel_button"
                 app:layout_constraintRight_toLeftOf="@id/sendButton"
-                android:background="@color/stream_ui_black_10"/>
+                app:layout_constraintTop_toTopOf="@id/cancel_button"
+                />
 
             <TextView
                 android:id="@+id/sendButton"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
-                app:layout_constraintTop_toTopOf="@id/cancel_button"
-                app:layout_constraintBottom_toBottomOf="@id/cancel_button"
-                app:layout_constraintRight_toRightOf="parent"
-                app:layout_constraintLeft_toRightOf="@id/verticalDivider"
+                android:background="?selectableItemBackground"
                 android:gravity="center"
+                android:text="@string/stream_ui_send_label"
                 android:textColor="@color/stream_ui_blue"
                 android:textSize="14sp"
                 android:textStyle="bold"
-                android:text="@string/stream_ui_send_label"
-                android:background="?selectableItemBackground"/>
+                app:layout_constraintBottom_toBottomOf="@id/cancel_button"
+                app:layout_constraintLeft_toRightOf="@id/verticalDivider"
+                app:layout_constraintRight_toRightOf="parent"
+                app:layout_constraintTop_toTopOf="@id/cancel_button"
+                />
 
 
         </androidx.constraintlayout.widget.ConstraintLayout>
@@ -159,7 +162,8 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginTop="8dp"
+        android:layout_marginTop="@dimen/stream_ui_spacing_small"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_small"
         app:layout_constraintRight_toRightOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/cardView"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -169,7 +169,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -177,7 +177,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -152,7 +152,6 @@
                 app:layout_constraintTop_toTopOf="@id/cancel_button"
                 />
 
-
         </androidx.constraintlayout.widget.ConstraintLayout>
 
     </com.google.android.material.card.MaterialCardView>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -161,9 +161,11 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/cardView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -71,7 +71,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -79,7 +79,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginStart="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -37,7 +39,6 @@
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatarView"
         style="@style/StreamUiMessageListAvatarStyle"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="8dp"
     android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -19,15 +19,15 @@
     <io.getstream.chat.android.ui.messages.adapter.view.MediaAttachmentsGroupView
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
-        android:layout_marginStart="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -65,7 +65,9 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/mediaAttachmentsGroupView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -20,14 +20,14 @@
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -19,6 +19,8 @@
     <io.getstream.chat.android.ui.messages.adapter.view.MediaAttachmentsGroupView
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
+        android:layout_marginStart="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -31,7 +31,7 @@
         android:id="@+id/messageText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:hyphenationFrequency="normal"
         android:lineHeight="16sp"
@@ -46,7 +46,7 @@
         app:layout_constraintStart_toEndOf="@id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         tools:text="@tools:sample/lorem"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -80,7 +80,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -88,7 +88,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="8dp"
     android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -31,12 +31,11 @@
         android:id="@+id/messageText"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginStart="0dp"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:hyphenationFrequency="normal"
         android:lineHeight="16sp"
         android:paddingLeft="@dimen/stream_ui_spacing_medium"
-        android:layout_marginStart="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:paddingTop="@dimen/stream_ui_spacing_small"
         android:paddingRight="@dimen/stream_ui_spacing_medium"
         android:paddingBottom="@dimen/stream_ui_spacing_small"
@@ -47,6 +46,7 @@
         app:layout_constraintStart_toEndOf="@id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         tools:text="@tools:sample/lorem"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -35,6 +35,8 @@
         android:hyphenationFrequency="normal"
         android:lineHeight="16sp"
         android:paddingLeft="@dimen/stream_ui_spacing_medium"
+        android:layout_marginStart="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:paddingTop="@dimen/stream_ui_spacing_small"
         android:paddingRight="@dimen/stream_ui_spacing_medium"
         android:paddingBottom="@dimen/stream_ui_spacing_small"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginStart="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -17,7 +19,6 @@
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatarView"
         style="@style/StreamUiMessageListAvatarStyle"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -63,7 +63,9 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -31,6 +31,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
+        android:layout_marginStart="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginEnd="8dp"
+    android:layout_marginStart="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -65,7 +67,6 @@
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatarView"
         style="@style/StreamUiMessageListAvatarStyle"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -99,7 +99,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -107,7 +107,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginEnd="8dp"
     android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -30,13 +30,13 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:layout_marginStart="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/reactionsView"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -36,6 +36,7 @@
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/reactionsView"
+        app:layout_goneMarginEnd="0dp"
         app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -30,13 +30,13 @@
         android:id="@+id/fileAttachmentsView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="4dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/reactionsView"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -82,7 +82,9 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -99,7 +99,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_begin="20dp"
+        tools:layout_constraintGuide_begin="20dp"
         />
 
     <androidx.constraintlayout.widget.Guideline
@@ -107,7 +107,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        app:layout_constraintGuide_end="20dp"
+        tools:layout_constraintGuide_end="20dp"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -30,14 +30,14 @@
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="0dp"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:layout_marginStart="8dp"
+    android:layout_marginEnd="8dp"
     >
 
     <io.getstream.chat.android.ui.messages.adapter.view.GapView
@@ -65,7 +67,6 @@
     <io.getstream.chat.android.ui.avatar.AvatarView
         android:id="@+id/avatarView"
         style="@style/StreamUiMessageListAvatarStyle"
-        android:layout_marginStart="8dp"
         android:layout_marginTop="8dp"
         android:layout_marginEnd="8dp"
         android:layout_marginBottom="8dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -30,14 +30,14 @@
         android:id="@+id/mediaAttachmentsGroupView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:layout_marginStart="0dp"
-        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:padding="1dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         app:layout_goneMarginEnd="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         />
 
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -31,6 +31,8 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
+        android:layout_marginStart="0dp"
+        app:layout_goneMarginStart="@dimen/stream_ui_avatar_size_small"
         android:padding="1dp"
         app:layout_constraintEnd_toEndOf="@+id/deliveryFailedIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -82,7 +82,9 @@
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintRight_toRightOf="@+id/marginEnd"
+        android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        app:layout_constraintEnd_toEndOf="@+id/marginEnd"
+        app:layout_constraintStart_toEndOf="@+id/avatarView"
         app:layout_constraintTop_toBottomOf="@+id/messageText"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/values/dimens.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/dimens.xml
@@ -114,4 +114,7 @@
     <dimen name="stream_ui_channel_item_title">15sp</dimen>
     <dimen name="stream_ui_channel_item_message">13sp</dimen>
     <dimen name="stream_ui_channel_item_message_date">11sp</dimen>
+
+    <!-- Message ViewHolders -->
+    <dimen name="stream_ui_message_viewholder_avatar_missing_margin">40dp</dimen>
 </resources>


### PR DESCRIPTION
### Description

Various fixes around ViewHolder margins and similar things:

- Fix start/end margins on ViewHolders
- Use `tools` namespace in ViewHolder layouts for guideline positioning, as setting those values does nothing (overridden at runtime by a decorator)
- Hides the delivery status on Giphy ViewHolders
- Fix incorrect spacing of ViewHolder content when avatars are hidden

| Before | After |
| --- | --- |
| ![Screenshot_1608039968](https://user-images.githubusercontent.com/12054216/102981934-00c78f80-450a-11eb-917b-22bc79f22220.png) | ![Screenshot_1608040391](https://user-images.githubusercontent.com/12054216/102993361-56596780-451d-11eb-9774-6fe2e90a37fc.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
