### PR TITLE
Fix ReactionsView position in the message list

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -25,7 +25,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
-            setupReactionsView(root, reactionsView, messageText, data)
+            setupReactionsView(root, reactionsView, messageText, reactionsOffsetSpace, data)
         }
     }
 
@@ -34,7 +34,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
-            setupReactionsView(root, reactionsView, mediaAttachmentsGroupView, data)
+            setupReactionsView(root, reactionsView, mediaAttachmentsGroupView, reactionsOffsetSpace, data)
         }
     }
 
@@ -43,7 +43,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
-            setupReactionsView(root, reactionsView, mediaAttachmentsGroupView, data)
+            setupReactionsView(root, reactionsView, mediaAttachmentsGroupView, reactionsOffsetSpace, data)
         }
     }
 
@@ -52,7 +52,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
-            setupReactionsView(root, reactionsView, fileAttachmentsView, data)
+            setupReactionsView(root, reactionsView, fileAttachmentsView, reactionsOffsetSpace, data)
         }
     }
 
@@ -61,7 +61,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
-            setupReactionsView(root, reactionsView, fileAttachmentsView, data)
+            setupReactionsView(root, reactionsView, fileAttachmentsView, reactionsOffsetSpace, data)
         }
     }
 
@@ -72,41 +72,50 @@ internal class ReactionsDecorator : BaseDecorator() {
     private fun setupReactionsView(
         rootConstraintLayout: ConstraintLayout,
         reactionsView: ViewReactionsView,
-        anchor: View,
+        achorView: View,
+        reactionsOffsetSpace: View,
         data: MessageListItem.MessageItem
     ) {
-        val hasReactions = data.message.latestReactions.isNotEmpty()
-        reactionsView.isVisible = hasReactions
+        if (data.message.latestReactions.isNotEmpty()) {
+            reactionsView.isVisible = true
+            reactionsView.setMessage(data.message, data.isMine)
 
-        if (!hasReactions) {
-            anchor.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            rootConstraintLayout.updateConstraints {
+                clear(reactionsView.id, ConstraintSet.START)
+                clear(reactionsView.id, ConstraintSet.END)
+                clear(reactionsOffsetSpace.id, ConstraintSet.START)
+                clear(reactionsOffsetSpace.id, ConstraintSet.END)
+            }
+            reactionsOffsetSpace.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                val offset = if (data.message.isSingleReaction()) {
+                    SINGLE_REACTION_OFFSET
+                } else {
+                    MULTIPLE_REACTIONS_OFFSET
+                }
+                if (data.isTheirs) {
+                    endToEnd = achorView.id
+                    marginEnd = offset
+                } else {
+                    startToStart = achorView.id
+                    marginStart = offset
+                }
+            }
+            reactionsView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                if (data.isTheirs) {
+                    startToEnd = reactionsOffsetSpace.id
+                } else {
+                    endToStart = reactionsOffsetSpace.id
+                }
+            }
+            achorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+                topMargin = REACTIONS_SPACING
+            }
+        } else {
+            reactionsView.isVisible = false
+            achorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = 0
             }
-            return
         }
-
-        rootConstraintLayout.updateConstraints {
-            clear(reactionsView.id, ConstraintSet.START)
-            clear(reactionsView.id, ConstraintSet.END)
-        }
-        reactionsView.updateLayoutParams<ConstraintLayout.LayoutParams> {
-            val offset = if (data.message.isSingleReaction()) {
-                SINGLE_REACTION_OFFSET
-            } else {
-                MULTIPLE_REACTIONS_OFFSET
-            }
-            if (data.isTheirs) {
-                startToEnd = anchor.id
-                marginStart = -offset
-            } else {
-                endToStart = anchor.id
-                marginEnd = -offset
-            }
-        }
-        anchor.updateLayoutParams<ConstraintLayout.LayoutParams> {
-            topMargin = if (hasReactions) REACTIONS_SPACING else 0
-        }
-        reactionsView.setMessage(data.message, data.isMine)
     }
 
     private companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -72,7 +72,7 @@ internal class ReactionsDecorator : BaseDecorator() {
     private fun setupReactionsView(
         rootConstraintLayout: ConstraintLayout,
         reactionsView: ViewReactionsView,
-        achorView: View,
+        anchorView: View,
         reactionsOffsetSpace: View,
         data: MessageListItem.MessageItem
     ) {
@@ -93,10 +93,10 @@ internal class ReactionsDecorator : BaseDecorator() {
                     MULTIPLE_REACTIONS_OFFSET
                 }
                 if (data.isTheirs) {
-                    endToEnd = achorView.id
+                    endToEnd = anchorView.id
                     marginEnd = offset
                 } else {
-                    startToStart = achorView.id
+                    startToStart = anchorView.id
                     marginStart = offset
                 }
             }
@@ -107,12 +107,12 @@ internal class ReactionsDecorator : BaseDecorator() {
                     endToStart = reactionsOffsetSpace.id
                 }
             }
-            achorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            anchorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = REACTIONS_SPACING
             }
         } else {
             reactionsView.isVisible = false
-            achorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+            anchorView.updateLayoutParams<ConstraintLayout.LayoutParams> {
                 topMargin = 0
             }
         }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -30,11 +30,18 @@
         app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
+    <Space
+        android:id="@+id/reactionsOffsetSpace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/fileAttachmentsView"
+        app:layout_constraintTop_toTopOf="@id/fileAttachmentsView"/>
+
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
         android:id="@+id/reactionsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/fileAttachmentsView"
+        app:layout_constraintStart_toEndOf="@id/reactionsOffsetSpace"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -30,11 +30,18 @@
         app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
+    <Space
+        android:id="@+id/reactionsOffsetSpace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/mediaAttachmentsGroupView"
+        app:layout_constraintTop_toTopOf="@id/mediaAttachmentsGroupView"/>
+
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
         android:id="@+id/reactionsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/mediaAttachmentsGroupView"
+        app:layout_constraintStart_toEndOf="@id/reactionsOffsetSpace"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -50,11 +50,19 @@
         tools:text="@tools:sample/lorem"
         />
 
+    <Space
+        android:id="@+id/reactionsOffsetSpace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/messageText"
+        app:layout_constraintTop_toTopOf="@id/messageText"
+        />
+
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
         android:id="@+id/reactionsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/messageText"
+        app:layout_constraintStart_toEndOf="@id/reactionsOffsetSpace"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -40,13 +40,20 @@
         app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
+    <Space
+        android:id="@+id/reactionsOffsetSpace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/fileAttachmentsView"
+        app:layout_constraintTop_toTopOf="@id/fileAttachmentsView"
+        />
+
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
         android:id="@+id/reactionsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/fileAttachmentsView"
+        app:layout_constraintStart_toEndOf="@id/reactionsOffsetSpace"
         app:layout_constraintTop_toBottomOf="@id/gapView"
-        app:layout_goneMarginEnd="0dp"
         />
 
     <TextView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -40,11 +40,19 @@
         app:layout_goneMarginStart="@dimen/stream_ui_message_viewholder_avatar_missing_margin"
         />
 
+    <Space
+        android:id="@+id/reactionsOffsetSpace"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintStart_toStartOf="@id/mediaAttachmentsGroupView"
+        app:layout_constraintTop_toTopOf="@id/mediaAttachmentsGroupView"
+        />
+
     <io.getstream.chat.android.ui.messages.reactions.ViewReactionsView
         android:id="@+id/reactionsView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        app:layout_constraintStart_toEndOf="@id/mediaAttachmentsGroupView"
+        app:layout_constraintStart_toEndOf="@id/reactionsOffsetSpace"
         app:layout_constraintTop_toBottomOf="@id/gapView"
         />
 


### PR DESCRIPTION
### Description

This PR fixes the horizontal position of `ReactionsView` in the message list. As we had to revert the most recent `ConstraintLayout` version to the stable one, negative margins stopped working. Had to implement it with the help of extra `Space` view.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
|![photo_2020-12-23 17 22 31](https://user-images.githubusercontent.com/9600921/103006849-7439c300-4543-11eb-9bc8-04c405cf499b.jpeg) | ![photo_2020-12-23 17 22 46](https://user-images.githubusercontent.com/9600921/103006884-7bf96780-4543-11eb-8be6-759dc106c887.jpeg) |




