### PR TITLE
[CAS-490] Thread separator ViewHolder

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -63,7 +63,8 @@ public sealed class MessageListItem {
     ) : MessageListItem()
 
     public data class ThreadSeparatorItem(
-        val date: Date = Date(),
+        val date: Date,
+        val messageCount: Int,
     ) : MessageListItem()
 
     public object LoadingMoreIndicatorItem : MessageListItem()

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -158,7 +158,12 @@ internal class MessageListItemLiveData(
 
             // thread separator
             if (i == 1 && isThread) {
-                items.add(MessageListItem.ThreadSeparatorItem(message.getCreatedAtOrThrow()))
+                items.add(
+                    MessageListItem.ThreadSeparatorItem(
+                        date = message.getCreatedAtOrThrow(),
+                        messageCount = messages.size - 1,
+                    )
+                )
             }
 
             // determine the position (top, middle, bottom)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
@@ -32,7 +32,7 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                 } else oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
             }
             is MessageListItem.DateSeparatorItem -> oldItem.date == (newItem as? MessageListItem.DateSeparatorItem)?.date
-            is MessageListItem.ThreadSeparatorItem -> oldItem.date == (newItem as? MessageListItem.ThreadSeparatorItem)?.date
+            is MessageListItem.ThreadSeparatorItem -> oldItem == (newItem as? MessageListItem.ThreadSeparatorItem)
             is MessageListItem.LoadingMoreIndicatorItem -> true
             is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(User::id)
             is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as? MessageListItem.ReadStateItem)?.reads?.map { it.getUserId() }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainText
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.ThreadSeparatorViewHolder
 
 public open class MessageListItemViewHolderFactory {
 
@@ -70,7 +71,7 @@ public open class MessageListItemViewHolderFactory {
     }
 
     public open fun createThreadSeparatorViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {
-        return createEmptyMessageItemViewHolder(parentView)
+        return ThreadSeparatorViewHolder(parentView)
     }
 
     private fun createGiphyMessageItemViewHolder(parentView: ViewGroup): BaseMessageItemViewHolder<*> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/DateDividerViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/DateDividerViewHolder.kt
@@ -1,9 +1,9 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
 import android.text.format.DateUtils
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemDateDividerBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
@@ -11,9 +11,7 @@ import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 public class DateDividerViewHolder(
     parent: ViewGroup,
     internal val binding: StreamUiItemDateDividerBinding = StreamUiItemDateDividerBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
@@ -1,9 +1,9 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.enums.GiphyAction
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageGiphyBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.ListenerContainer
@@ -13,9 +13,7 @@ public class GiphyViewHolder(
     parent: ViewGroup,
     private val listenerContainer: ListenerContainer? = null,
     internal val binding: StreamUiItemMessageGiphyBinding = StreamUiItemMessageGiphyBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessageDeletedViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessageDeletedViewHolder.kt
@@ -1,9 +1,9 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageDeletedBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
@@ -11,9 +11,7 @@ import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 public class MessageDeletedViewHolder(
     parent: ViewGroup,
     internal val binding: StreamUiItemMessageDeletedBinding = StreamUiItemMessageDeletedBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -1,8 +1,8 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.ListenerContainer
@@ -13,9 +13,7 @@ public class MessagePlainTextViewHolder(
     private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessagePlainTextBinding =
         StreamUiItemMessagePlainTextBinding.inflate(
-            LayoutInflater.from(
-                parent.context
-            ),
+            parent.inflater,
             parent,
             false
         )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -1,8 +1,8 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFileAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.ListenerContainer
@@ -12,9 +12,7 @@ public class OnlyFileAttachmentsViewHolder(
     parent: ViewGroup,
     private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessageFileAttachmentsBinding = StreamUiItemMessageFileAttachmentsBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -1,8 +1,8 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageMediaAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
@@ -14,9 +14,7 @@ public class OnlyMediaAttachmentsViewHolder(
     parent: ViewGroup,
     private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessageMediaAttachmentsBinding = StreamUiItemMessageMediaAttachmentsBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -1,8 +1,8 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithFileAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.ListenerContainer
@@ -12,9 +12,7 @@ public class PlainTextWithFileAttachmentsViewHolder(
     parent: ViewGroup,
     private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessagePlainTextWithFileAttachmentsBinding = StreamUiItemMessagePlainTextWithFileAttachmentsBinding.inflate(
-        LayoutInflater.from(
-            parent.context
-        ),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -1,8 +1,8 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithMediaAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.ListenerContainer
@@ -13,7 +13,7 @@ public class PlainTextWithMediaAttachmentsViewHolder(
     parent: ViewGroup,
     private val listenerContainer: ListenerContainer?,
     internal val binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding = StreamUiItemMessagePlainTextWithMediaAttachmentsBinding.inflate(
-        LayoutInflater.from(parent.context),
+        parent.inflater,
         parent,
         false
     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
@@ -1,0 +1,29 @@
+package io.getstream.chat.android.ui.messages.adapter.viewholder
+
+import android.view.ViewGroup
+import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.inflater
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.databinding.StreamUiItemThreadDividerBinding
+import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
+import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
+import io.getstream.chat.android.ui.utils.extensions.context
+
+public class ThreadSeparatorViewHolder(
+    parent: ViewGroup,
+    internal val binding: StreamUiItemThreadDividerBinding =
+        StreamUiItemThreadDividerBinding.inflate(
+            parent.inflater,
+            parent,
+            false
+        )
+) : BaseMessageItemViewHolder<MessageListItem.ThreadSeparatorItem>(binding.root) {
+
+    override fun bindData(data: MessageListItem.ThreadSeparatorItem, diff: MessageListItemPayloadDiff?) {
+        binding.threadSeparatorLabel.text = context.resources.getQuantityString(
+            R.plurals.stream_ui_thread_separator_replies_label,
+            data.messageCount,
+            data.messageCount,
+        )
+    }
+}

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_thread_divider.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_thread_divider.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/threadSeparatorLabel"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="8dp"
+    android:paddingVertical="2dp"
+    android:textAlignment="center"
+    android:textColor="@color/stream_ui_text_color_light"
+    android:textSize="@dimen/stream_ui_avatar_text_size_tiny"
+    tools:text="1 Reply"
+    />

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -110,6 +110,12 @@
     <string name="stream_ui_messages_empty_state_label">No messages</string>
     <string name="stream_ui_channels_empty_state_label">No channels available</string>
 
+    <!-- Thread separator -->
+    <plurals name="stream_ui_thread_separator_replies_label">
+        <item quantity="one">%d Reply</item>
+        <item quantity="other">%d Replies</item>
+    </plurals>
+
     <!-- Message Footer -->
     <string name="stream_ui_ephemeral_msg_footer">Only visible to you</string>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-490

### Description

Adds the separator item for Threads showing the number of replies

| Light | Dark |
| --- | --- |
| ![Screenshot_1608039968](https://user-images.githubusercontent.com/12054216/103014455-11dec380-453f-11eb-8438-ab9346d94dab.png) | ![Screenshot_1608040391](https://user-images.githubusercontent.com/12054216/103014469-14411d80-453f-11eb-889c-51e556d69b5e.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
