### PR TITLE
Fix some visibility handling in ThreadRepliesDecorator

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -50,13 +50,10 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.threadRepliesFootnote.root.isVisible = true
+
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -80,7 +77,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
                 R.plurals.stream_ui_thread_messages_indicator,

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text.xml
@@ -97,9 +97,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/messageContainer"
         app:layout_constraintTop_toBottomOf="@+id/messageContainer"
         />


### PR DESCRIPTION
### Description

Hide thread replies container by default, so that it remains hidden if the Decorator is not applied to a ViewHolder

| Before | After |
| --- | --- |
|![Screenshot_20201229_132240](https://user-images.githubusercontent.com/12054216/103283871-01649800-49da-11eb-91ac-56c0d289107e.png) | ![Screenshot_20201229_132401](https://user-images.githubusercontent.com/12054216/103283887-09bcd300-49da-11eb-9b70-b54d14e979df.png) | 

### Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Reviewers added
