### PR TITLE
[cas-484] Thread replies footnote for different message types

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,17 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8">
-      <module name="stream-chat-android.buildSrc" target="11" />
-      <module name="stream-chat-android.stream-chat-android" target="11" />
-      <module name="stream-chat-android.stream-chat-android-client" target="11" />
-      <module name="stream-chat-android.stream-chat-android-docs" target="11" />
-      <module name="stream-chat-android.stream-chat-android-offline" target="11" />
-      <module name="stream-chat-android.stream-chat-android-sample" target="11" />
-      <module name="stream-chat-android.stream-chat-android-test" target="11" />
-      <module name="stream-chat-android.stream-chat-android-ui-common" target="11" />
-      <module name="stream-chat-android.stream-chat-android-ui-components" target="11" />
-      <module name="stream-chat-android.stream-chat-android-ui-components-sample" target="11" />
-    </bytecodeTargetLevel>
+    <bytecodeTargetLevel target="1.8" />
   </component>
 </project>

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="1.8">
+      <module name="stream-chat-android.buildSrc" target="11" />
+      <module name="stream-chat-android.stream-chat-android" target="11" />
+      <module name="stream-chat-android.stream-chat-android-client" target="11" />
+      <module name="stream-chat-android.stream-chat-android-docs" target="11" />
+      <module name="stream-chat-android.stream-chat-android-offline" target="11" />
+      <module name="stream-chat-android.stream-chat-android-sample" target="11" />
+      <module name="stream-chat-android.stream-chat-android-test" target="11" />
+      <module name="stream-chat-android.stream-chat-android-ui-common" target="11" />
+      <module name="stream-chat-android.stream-chat-android-ui-components" target="11" />
+      <module name="stream-chat-android.stream-chat-android-ui-components-sample" target="11" />
+    </bytecodeTargetLevel>
   </component>
 </project>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -149,9 +149,10 @@ internal class BackgroundDecorator : BaseDecorator() {
         private val MESSAGE_OTHER_USER_BACKGROUND = R.color.stream_ui_white
         private val MESSAGE_CURRENT_USER_BACKGROUND = R.color.stream_ui_grey_90
         private val MESSAGE_LINK_BACKGROUND = R.color.stream_ui_blue_alice
-        private val DEFAULT_CORNER_RADIUS = 16.dpToPxPrecise()
         private val DEFAULT_STROKE_WIDTH = 1.dpToPxPrecise()
         private val SMALL_CARD_VIEW_CORNER_RADIUS = 2.dpToPxPrecise()
         private val IMAGE_VIEW_CORNER_RADIUS = 8.dpToPxPrecise()
+
+        internal val DEFAULT_CORNER_RADIUS = 16.dpToPxPrecise()
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -1,13 +1,13 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
 import android.content.res.Resources
+import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.R
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFootnoteBinding
 import io.getstream.chat.android.ui.databinding.StreamUiMessageThreadsFootnoteBinding
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
@@ -24,7 +24,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     ) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.fileAttachmentsView.id,
             data
@@ -37,7 +37,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     ) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.fileAttachmentsView.id,
             data
@@ -50,7 +50,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     ) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.mediaAttachmentsGroupView.id,
             data
@@ -63,7 +63,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     ) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.mediaAttachmentsGroupView.id,
             data
@@ -73,7 +73,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(viewHolder: MessagePlainTextViewHolder, data: MessageListItem.MessageItem) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.messageContainer.id,
             data
@@ -83,7 +83,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
         setupThreadRepliesView(
             viewHolder.binding.threadRepliesFootnote,
-            viewHolder.binding.footnote,
+            viewHolder.binding.footnote.root,
             viewHolder.binding.root,
             viewHolder.binding.cardView.id,
             data
@@ -92,9 +92,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
 
     private fun setupThreadRepliesView(
         threadRepliesFootNote: StreamUiMessageThreadsFootnoteBinding,
-        footNoteBinding: StreamUiItemMessageFootnoteBinding,
+        messageFootnote: View,
         rootView: ConstraintLayout,
-        anchorViewId: Int,
+        footnoteAnchorViewId: Int,
         data: MessageListItem.MessageItem
     ) {
         val replyCount = data.message.replyCount
@@ -109,18 +109,18 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
 
         rootView.updateConstraints {
             val threadRepliesFootnoteId = threadRepliesFootNote.root.id
-            val footnoteId = footNoteBinding.root.id
+            val footnoteId = messageFootnote.id
 
             clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, anchorViewId, ConstraintSet.LEFT)
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, footnoteAnchorViewId, ConstraintSet.LEFT)
                 connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
             } else {
                 connect(
                     threadRepliesFootnoteId,
                     ConstraintSet.RIGHT,
-                    anchorViewId,
+                    footnoteAnchorViewId,
                     ConstraintSet.RIGHT
                 )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
@@ -131,7 +131,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
         }
 
         threadRepliesFootNote.root.translationY = -DEFAULT_CORNER_RADIUS
-        footNoteBinding.root.translationY = -DEFAULT_CORNER_RADIUS
+        messageFootnote.translationY = -DEFAULT_CORNER_RADIUS
 
         threadRepliesFootNote.threadRepliesButton.text =
             getRepliesQuantityString(rootView.resources, replyCount)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -1,17 +1,14 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
 import android.content.res.Resources
+import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.R
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFileAttachmentsBinding
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessageGiphyBinding
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessageMediaAttachmentsBinding
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithFileAttachmentsBinding
-import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithMediaAttachmentsBinding
+import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFootnoteBinding
+import io.getstream.chat.android.ui.databinding.StreamUiMessageThreadsFootnoteBinding
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachmentsViewHolder
@@ -25,66 +22,105 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.fileAttachmentsView.id,
+            data
+        )
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.fileAttachmentsView.id,
+            data
+        )
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.mediaAttachmentsGroupView.id,
+            data
+        )
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.mediaAttachmentsGroupView.id,
+            data
+        )
     }
 
     override fun decoratePlainTextMessage(viewHolder: MessagePlainTextViewHolder, data: MessageListItem.MessageItem) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.messageContainer.id,
+            data
+        )
     }
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
-        setupThreadRepliesView(viewHolder.binding, data)
+        setupThreadRepliesView(
+            viewHolder.binding.threadRepliesFootnote,
+            viewHolder.binding.footnote,
+            viewHolder.binding.root,
+            viewHolder.binding.cardView.id,
+            data
+        )
     }
 
     private fun setupThreadRepliesView(
-        binding: StreamUiItemMessagePlainTextWithFileAttachmentsBinding,
+        threadRepliesFootNote: StreamUiMessageThreadsFootnoteBinding,
+        footNoteBinding: StreamUiItemMessageFootnoteBinding,
+        rootView: ConstraintLayout,
+        anchorViewId: Int,
         data: MessageListItem.MessageItem
     ) {
         val replyCount = data.message.replyCount
         if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
+            threadRepliesFootNote.root.isVisible = false
             return
         }
 
-        binding.root.isVisible = true
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
+        threadRepliesFootNote.root.isVisible = true
+        threadRepliesFootNote.threadsOrnamentLeft.isVisible = data.isTheirs
+        threadRepliesFootNote.threadsOrnamentRight.isVisible = !data.isTheirs
 
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
+        rootView.updateConstraints {
+            val threadRepliesFootnoteId = threadRepliesFootNote.root.id
+            val footnoteId = footNoteBinding.root.id
 
             clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.fileAttachmentsView.id, ConstraintSet.LEFT)
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, anchorViewId, ConstraintSet.LEFT)
                 connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
             } else {
                 connect(
                     threadRepliesFootnoteId,
                     ConstraintSet.RIGHT,
-                    binding.fileAttachmentsView.id,
+                    anchorViewId,
                     ConstraintSet.RIGHT
                 )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
@@ -94,219 +130,11 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
 
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        threadRepliesFootNote.root.translationY = -DEFAULT_CORNER_RADIUS
+        footNoteBinding.root.translationY = -DEFAULT_CORNER_RADIUS
 
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
-    }
-
-    private fun setupThreadRepliesView(
-        binding: StreamUiItemMessageFileAttachmentsBinding,
-        data: MessageListItem.MessageItem
-    ) {
-        val replyCount = data.message.replyCount
-        if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
-            return
-        }
-
-        binding.root.isVisible = true
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
-
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
-
-            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
-
-            if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.fileAttachmentsView.id, ConstraintSet.LEFT)
-                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            } else {
-                connect(
-                    threadRepliesFootnoteId,
-                    ConstraintSet.RIGHT,
-                    binding.fileAttachmentsView.id,
-                    ConstraintSet.RIGHT
-                )
-                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
-            }
-
-            clearVerticalConstraints(footnoteId)
-            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
-        }
-
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
-
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
-    }
-
-    private fun setupThreadRepliesView(
-        binding: StreamUiItemMessageMediaAttachmentsBinding,
-        data: MessageListItem.MessageItem
-    ) {
-        val replyCount = data.message.replyCount
-        if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
-            return
-        }
-
-        binding.root.isVisible = true
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
-
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
-
-            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
-
-            if (data.isTheirs) {
-                connect(
-                    threadRepliesFootnoteId,
-                    ConstraintSet.LEFT,
-                    binding.mediaAttachmentsGroupView.id,
-                    ConstraintSet.LEFT
-                )
-                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            } else {
-                connect(
-                    threadRepliesFootnoteId,
-                    ConstraintSet.RIGHT,
-                    binding.mediaAttachmentsGroupView.id,
-                    ConstraintSet.RIGHT
-                )
-                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
-            }
-
-            clearVerticalConstraints(footnoteId)
-            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
-        }
-
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
-
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
-    }
-
-    private fun setupThreadRepliesView(binding: StreamUiItemMessageGiphyBinding, data: MessageListItem.MessageItem) {
-        val replyCount = data.message.replyCount
-        if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
-            return
-        }
-
-        binding.root.isVisible = true
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
-
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
-
-            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
-
-            if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.cardView.id, ConstraintSet.LEFT)
-                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            } else {
-                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.cardView.id, ConstraintSet.RIGHT)
-                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
-            }
-
-            clearVerticalConstraints(footnoteId)
-            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
-        }
-
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
-
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
-    }
-
-    private fun setupThreadRepliesView(
-        binding: StreamUiItemMessagePlainTextBinding,
-        data: MessageListItem.MessageItem
-    ) {
-        val replyCount = data.message.replyCount
-        if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
-            return
-        }
-
-        binding.threadRepliesFootnote.root.isVisible = true
-
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
-
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
-
-            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
-
-            if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.messageContainer.id, ConstraintSet.LEFT)
-                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            } else {
-                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.messageContainer.id, ConstraintSet.RIGHT)
-                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
-            }
-
-            clearVerticalConstraints(footnoteId)
-            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
-        }
-        
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
-
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
-    }
-
-    private fun setupThreadRepliesView(
-        binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding,
-        data: MessageListItem.MessageItem
-    ) {
-        val replyCount = data.message.replyCount
-        if (replyCount == 0) {
-            binding.threadRepliesFootnote.root.isVisible = false
-            return
-        }
-
-        binding.root.isVisible = true
-        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
-        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
-
-        binding.root.updateConstraints {
-            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
-            val footnoteId = binding.footnote.root.id
-
-            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
-
-            if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.messageContainer.id, ConstraintSet.LEFT)
-                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            } else {
-                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.messageContainer.id, ConstraintSet.RIGHT)
-                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
-            }
-
-            clearVerticalConstraints(footnoteId)
-            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
-        }
-
-        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
-        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
-
-        binding.threadRepliesFootnote.threadRepliesButton.text =
-            getRepliesQuantityString(binding.root.resources, replyCount)
+        threadRepliesFootNote.threadRepliesButton.text =
+            getRepliesQuantityString(rootView.resources, replyCount)
     }
 
     private fun ConstraintSet.clearHorizontalConstraints(vararg viewIds: Int) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -1,10 +1,12 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
+import android.content.res.Resources
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFileAttachmentsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageGiphyBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageMediaAttachmentsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
@@ -20,12 +22,16 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) = Unit
+    ) {
+
+    }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) = Unit
+    ) {
+        setupThreadRepliesView(viewHolder.binding, data)
+    }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
@@ -50,6 +56,49 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     }
 
     private fun setupThreadRepliesView(
+        binding: StreamUiItemMessageFileAttachmentsBinding,
+        data: MessageListItem.MessageItem
+    ) {
+        val replyCount = data.message.replyCount
+        if (replyCount == 0) {
+            binding.threadRepliesFootnote.root.isVisible = false
+            return
+        }
+
+        if (data.isTheirs) {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
+        } else {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
+        }
+
+        binding.root.updateConstraints {
+            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
+            val footnoteId = binding.footnote.root.id
+
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
+
+            if (data.isTheirs) {
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.fileAttachmentsView.id, ConstraintSet.LEFT)
+                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            } else {
+                connect(
+                    threadRepliesFootnoteId,
+                    ConstraintSet.RIGHT,
+                    binding.fileAttachmentsView.id,
+                    ConstraintSet.RIGHT
+                )
+                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
+            }
+        }
+
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadRepliesButton.text =
+            getRepliesQuantityString(binding.root.resources, replyCount)
+    }
+
+    private fun setupThreadRepliesView(
         binding: StreamUiItemMessageMediaAttachmentsBinding,
         data: MessageListItem.MessageItem
     ) {
@@ -71,31 +120,30 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
             val footnoteId = binding.footnote.root.id
 
-            clear(threadRepliesFootnoteId, ConstraintSet.START)
-            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
-            clear(threadRepliesFootnoteId, ConstraintSet.END)
-            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            clear(footnoteId, ConstraintSet.END)
-            clear(footnoteId, ConstraintSet.LEFT)
-            clear(footnoteId, ConstraintSet.START)
-            clear(footnoteId, ConstraintSet.RIGHT)
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
-                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.mediaAttachmentsGroupView.id, ConstraintSet.LEFT)
+                connect(
+                    threadRepliesFootnoteId,
+                    ConstraintSet.LEFT,
+                    binding.mediaAttachmentsGroupView.id,
+                    ConstraintSet.LEFT
+                )
                 connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
             } else {
-                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.mediaAttachmentsGroupView.id, ConstraintSet.RIGHT)
+                connect(
+                    threadRepliesFootnoteId,
+                    ConstraintSet.RIGHT,
+                    binding.mediaAttachmentsGroupView.id,
+                    ConstraintSet.RIGHT
+                )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
         }
 
         binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
-            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
-                R.plurals.stream_ui_thread_messages_indicator,
-                replyCount,
-                replyCount
-            )
+            getRepliesQuantityString(binding.root.resources, replyCount)
     }
 
     private fun setupThreadRepliesView(binding: StreamUiItemMessageGiphyBinding, data: MessageListItem.MessageItem) {
@@ -117,14 +165,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
             val footnoteId = binding.footnote.root.id
 
-            clear(threadRepliesFootnoteId, ConstraintSet.START)
-            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
-            clear(threadRepliesFootnoteId, ConstraintSet.END)
-            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            clear(footnoteId, ConstraintSet.END)
-            clear(footnoteId, ConstraintSet.LEFT)
-            clear(footnoteId, ConstraintSet.START)
-            clear(footnoteId, ConstraintSet.RIGHT)
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
                 connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.cardView.id, ConstraintSet.LEFT)
@@ -137,11 +178,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
 
         binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
-            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
-                R.plurals.stream_ui_thread_messages_indicator,
-                replyCount,
-                replyCount
-            )
+            getRepliesQuantityString(binding.root.resources, replyCount)
     }
 
     private fun setupThreadRepliesView(
@@ -163,14 +200,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
             val footnoteId = binding.footnote.root.id
 
-            clear(threadRepliesFootnoteId, ConstraintSet.START)
-            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
-            clear(threadRepliesFootnoteId, ConstraintSet.END)
-            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            clear(footnoteId, ConstraintSet.END)
-            clear(footnoteId, ConstraintSet.LEFT)
-            clear(footnoteId, ConstraintSet.START)
-            clear(footnoteId, ConstraintSet.RIGHT)
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
                 connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.messageContainer.id, ConstraintSet.LEFT)
@@ -182,13 +212,8 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
         }
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
-            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
-                R.plurals.stream_ui_thread_messages_indicator,
-                replyCount,
-                replyCount
-            )
+            getRepliesQuantityString(binding.root.resources, replyCount)
     }
-
 
     private fun setupThreadRepliesView(
         binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding,
@@ -212,14 +237,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
             val footnoteId = binding.footnote.root.id
 
-            clear(threadRepliesFootnoteId, ConstraintSet.START)
-            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
-            clear(threadRepliesFootnoteId, ConstraintSet.END)
-            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
-            clear(footnoteId, ConstraintSet.END)
-            clear(footnoteId, ConstraintSet.LEFT)
-            clear(footnoteId, ConstraintSet.START)
-            clear(footnoteId, ConstraintSet.RIGHT)
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
 
             if (data.isTheirs) {
                 connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.messageContainer.id, ConstraintSet.LEFT)
@@ -232,10 +250,24 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
 
         binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
-            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
-                R.plurals.stream_ui_thread_messages_indicator,
-                replyCount,
-                replyCount
-            )
+            getRepliesQuantityString(binding.root.resources, replyCount)
     }
+
+    private fun ConstraintSet.clearHorizontalConstraints(vararg viewIds: Int) {
+        viewIds.forEach {
+            clear(it, ConstraintSet.START)
+            clear(it, ConstraintSet.LEFT)
+            clear(it, ConstraintSet.END)
+            clear(it, ConstraintSet.RIGHT)
+        }
+    }
+
+    private fun getRepliesQuantityString(
+        res: Resources,
+        replyCount: Int
+    ) = res.getQuantityString(
+        R.plurals.stream_ui_thread_messages_indicator,
+        replyCount,
+        replyCount
+    )
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -18,6 +18,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.BackgroundDecorator.Companion.DEFAULT_CORNER_RADIUS
 
 internal class ThreadRepliesDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
@@ -88,7 +89,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -126,7 +133,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -169,7 +182,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 )
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -199,7 +218,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.cardView.id, ConstraintSet.RIGHT)
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -233,7 +258,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.messageContainer.id, ConstraintSet.RIGHT)
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+        
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -266,7 +297,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
                 connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.messageContainer.id, ConstraintSet.RIGHT)
                 connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
             }
+
+            clearVerticalConstraints(footnoteId)
+            connect(footnoteId, ConstraintSet.BOTTOM, threadRepliesFootnoteId, ConstraintSet.BOTTOM)
         }
+
+        binding.threadRepliesFootnote.root.translationY = - DEFAULT_CORNER_RADIUS
+        binding.footnote.root.translationY = - DEFAULT_CORNER_RADIUS
 
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
@@ -278,6 +315,13 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             clear(it, ConstraintSet.LEFT)
             clear(it, ConstraintSet.END)
             clear(it, ConstraintSet.RIGHT)
+        }
+    }
+
+    private fun ConstraintSet.clearVerticalConstraints(vararg viewIds: Int) {
+        viewIds.forEach {
+            clear(it, ConstraintSet.BOTTOM)
+            clear(it, ConstraintSet.TOP)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFileAttachmen
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageGiphyBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageMediaAttachmentsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
+import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithFileAttachmentsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithMediaAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
@@ -23,7 +24,7 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem
     ) {
-
+        setupThreadRepliesView(viewHolder.binding, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
@@ -53,6 +54,49 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
         setupThreadRepliesView(viewHolder.binding, data)
+    }
+
+    private fun setupThreadRepliesView(
+        binding: StreamUiItemMessagePlainTextWithFileAttachmentsBinding,
+        data: MessageListItem.MessageItem
+    ) {
+        val replyCount = data.message.replyCount
+        if (replyCount == 0) {
+            binding.threadRepliesFootnote.root.isVisible = false
+            return
+        }
+
+        if (data.isTheirs) {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
+        } else {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
+        }
+
+        binding.root.updateConstraints {
+            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
+            val footnoteId = binding.footnote.root.id
+
+            clearHorizontalConstraints(threadRepliesFootnoteId, footnoteId)
+
+            if (data.isTheirs) {
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.fileAttachmentsView.id, ConstraintSet.LEFT)
+                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            } else {
+                connect(
+                    threadRepliesFootnoteId,
+                    ConstraintSet.RIGHT,
+                    binding.fileAttachmentsView.id,
+                    ConstraintSet.RIGHT
+                )
+                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
+            }
+        }
+
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadRepliesButton.text =
+            getRepliesQuantityString(binding.root.resources, replyCount)
     }
 
     private fun setupThreadRepliesView(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -5,7 +5,9 @@ import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.databinding.StreamUiItemMessageGiphyBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextBinding
+import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWithMediaAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachmentsViewHolder
@@ -27,7 +29,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem
-    ) = Unit
+    ) {
+        setupThreadRepliesView(viewHolder.binding, data)
+    }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
@@ -38,7 +42,55 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
         setupThreadRepliesView(viewHolder.binding, data)
     }
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
+        setupThreadRepliesView(viewHolder.binding, data)
+    }
+
+    private fun setupThreadRepliesView(binding: StreamUiItemMessageGiphyBinding, data: MessageListItem.MessageItem) {
+        val replyCount = data.message.replyCount
+        if (replyCount == 0) {
+            binding.threadRepliesFootnote.root.isVisible = false
+            return
+        }
+
+        if (data.isTheirs) {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
+        } else {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
+        }
+
+        binding.root.updateConstraints {
+            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
+            val footnoteId = binding.footnote.root.id
+
+            clear(threadRepliesFootnoteId, ConstraintSet.START)
+            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
+            clear(threadRepliesFootnoteId, ConstraintSet.END)
+            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            clear(footnoteId, ConstraintSet.END)
+            clear(footnoteId, ConstraintSet.LEFT)
+            clear(footnoteId, ConstraintSet.START)
+            clear(footnoteId, ConstraintSet.RIGHT)
+
+            if (data.isTheirs) {
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.cardView.id, ConstraintSet.LEFT)
+                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            } else {
+                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.cardView.id, ConstraintSet.RIGHT)
+                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
+            }
+        }
+
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadRepliesButton.text =
+            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
+                R.plurals.stream_ui_thread_messages_indicator,
+                replyCount,
+                replyCount
+            )
+    }
 
     private fun setupThreadRepliesView(
         binding: StreamUiItemMessagePlainTextBinding,
@@ -77,6 +129,56 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
+        binding.threadRepliesFootnote.threadRepliesButton.text =
+            binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
+                R.plurals.stream_ui_thread_messages_indicator,
+                replyCount,
+                replyCount
+            )
+    }
+
+
+    private fun setupThreadRepliesView(
+        binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding,
+        data: MessageListItem.MessageItem
+    ) {
+        val replyCount = data.message.replyCount
+        if (replyCount == 0) {
+            binding.threadRepliesFootnote.root.isVisible = false
+            return
+        }
+
+        if (data.isTheirs) {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
+        } else {
+            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
+            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
+        }
+
+        binding.root.updateConstraints {
+            val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
+            val footnoteId = binding.footnote.root.id
+
+            clear(threadRepliesFootnoteId, ConstraintSet.START)
+            clear(threadRepliesFootnoteId, ConstraintSet.LEFT)
+            clear(threadRepliesFootnoteId, ConstraintSet.END)
+            clear(threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            clear(footnoteId, ConstraintSet.END)
+            clear(footnoteId, ConstraintSet.LEFT)
+            clear(footnoteId, ConstraintSet.START)
+            clear(footnoteId, ConstraintSet.RIGHT)
+
+            if (data.isTheirs) {
+                connect(threadRepliesFootnoteId, ConstraintSet.LEFT, binding.messageContainer.id, ConstraintSet.LEFT)
+                connect(footnoteId, ConstraintSet.LEFT, threadRepliesFootnoteId, ConstraintSet.RIGHT)
+            } else {
+                connect(threadRepliesFootnoteId, ConstraintSet.RIGHT, binding.messageContainer.id, ConstraintSet.RIGHT)
+                connect(footnoteId, ConstraintSet.RIGHT, threadRepliesFootnoteId, ConstraintSet.LEFT)
+            }
+        }
+
+        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             binding.threadRepliesFootnote.threadRepliesButton.resources.getQuantityString(
                 R.plurals.stream_ui_thread_messages_indicator,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ThreadRepliesDecorator.kt
@@ -66,13 +66,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -94,7 +90,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
     }
@@ -109,13 +104,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -137,7 +128,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
     }
@@ -152,13 +142,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -185,7 +171,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
     }
@@ -197,13 +182,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -220,7 +201,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
     }
@@ -269,13 +249,9 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             return
         }
 
-        if (data.isTheirs) {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = true
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = false
-        } else {
-            binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = false
-            binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = true
-        }
+        binding.root.isVisible = true
+        binding.threadRepliesFootnote.threadsOrnamentLeft.isVisible = data.isTheirs
+        binding.threadRepliesFootnote.threadsOrnamentRight.isVisible = !data.isTheirs
 
         binding.root.updateConstraints {
             val threadRepliesFootnoteId = binding.threadRepliesFootnote.root.id
@@ -292,7 +268,6 @@ internal class ThreadRepliesDecorator : BaseDecorator() {
             }
         }
 
-        binding.root.isVisible = true
         binding.threadRepliesFootnote.threadRepliesButton.text =
             getRepliesQuantityString(binding.root.resources, replyCount)
     }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -98,6 +98,15 @@
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
         />
 
+    <include
+        android:id="@+id/threadRepliesFootnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        layout="@layout/stream_ui_message_threads_footnote"
+        app:layout_constraintLeft_toLeftOf="@id/fileAttachmentsView"
+        app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
+        />
+
     <ImageView
         android:id="@+id/deliveryFailedIcon"
         android:layout_width="24dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_footnote.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_footnote.xml
@@ -15,6 +15,7 @@
         android:layout_marginRight="@dimen/stream_ui_spacing_small"
         android:gravity="start"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+        android:textSize="@dimen/stream_ui_text_small"
         android:visibility="gone"
         tools:ignore="RtlHardcoded"
         tools:text="Visible only for you"
@@ -35,6 +36,7 @@
         android:layout_height="wrap_content"
         android:gravity="start"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
+        android:textSize="@dimen/stream_ui_text_small"
         android:visibility="gone"
         tools:text="16:25"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -162,7 +162,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/stream_ui_spacing_small"
-        android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
         app:layout_constraintTop_toBottomOf="@+id/cardView"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -165,7 +165,15 @@
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
         app:layout_constraintEnd_toEndOf="@+id/marginEnd"
-        app:layout_constraintStart_toEndOf="@+id/avatarView"
+        app:layout_constraintTop_toBottomOf="@+id/cardView"
+        />
+
+    <include
+        android:id="@+id/threadRepliesFootnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        layout="@layout/stream_ui_message_threads_footnote"
+        app:layout_constraintLeft_toLeftOf="@id/cardView"
         app:layout_constraintTop_toBottomOf="@+id/cardView"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -108,6 +108,15 @@
         app:layout_constraintTop_toBottomOf="@+id/mediaAttachmentsGroupView"
         />
 
+    <include
+        android:id="@+id/threadRepliesFootnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        layout="@layout/stream_ui_message_threads_footnote"
+        app:layout_constraintLeft_toLeftOf="@id/mediaAttachmentsGroupView"
+        app:layout_constraintTop_toBottomOf="@+id/mediaAttachmentsGroupView"
+        />
+
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/marginStart"
         android:layout_width="wrap_content"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -135,6 +135,15 @@
         app:layout_constraintTop_toBottomOf="@+id/messageContainer"
         />
 
+    <include
+        android:id="@+id/threadRepliesFootnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        layout="@layout/stream_ui_message_threads_footnote"
+        app:layout_constraintLeft_toLeftOf="@id/fileAttachmentsView"
+        app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
+        />
+
     <ImageView
         android:id="@+id/deliveryFailedIcon"
         android:layout_width="24dp"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -125,6 +125,15 @@
         />
 
     <include
+        android:id="@+id/threadRepliesFootnote"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        layout="@layout/stream_ui_message_threads_footnote"
+        app:layout_constraintLeft_toLeftOf="@id/messageContainer"
+        app:layout_constraintTop_toBottomOf="@+id/messageContainer"
+        />
+
+    <include
         android:id="@+id/footnote"
         layout="@layout/stream_ui_item_message_footnote"
         android:layout_width="wrap_content"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_threads_footnote.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_threads_footnote.xml
@@ -1,19 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.appcompat.widget.LinearLayoutCompat
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.appcompat.widget.LinearLayoutCompat xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
     android:gravity="bottom"
+    android:orientation="horizontal"
     tools:showIn="@layout/stream_ui_item_message_plain_text"
-    android:translationY="-20dp"
     >
 
     <androidx.appcompat.widget.AppCompatImageView
         android:id="@+id/threadsOrnamentLeft"
         android:layout_width="13dp"
-        android:layout_height="38dp"
+        android:layout_height="33dp"
         android:src="@drawable/stream_ui_thread_replies_ornament_left"
         />
 
@@ -24,7 +22,8 @@
         android:layout_marginLeft="@dimen/stream_ui_spacing_tiny"
         android:layout_marginRight="@dimen/stream_ui_spacing_tiny"
         android:textColor="@color/stream_ui_blue"
-        android:textFontWeight="600"
+        android:textSize="@dimen/stream_ui_text_small"
+        android:textStyle="bold"
         tools:text="100 Thread Replies"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/values/dimens.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/dimens.xml
@@ -119,6 +119,7 @@
 
     <!-- Message ViewHolders -->
     <dimen name="stream_ui_message_viewholder_avatar_missing_margin">40dp</dimen>
+    <dimen name="stream_ui_message_corner_radius_negative">-16dp</dimen>
 
     <!-- Attachment Gallery -->
     <dimen name="stream_ui_gallery_default_bar_height">56dp</dimen>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-484

### Description

Adding thread replies count label for all of the available message types. 

<img width="456" alt="Screenshot 2020-12-31 at 12 39 36" src="https://user-images.githubusercontent.com/4527432/103409389-deb3ba00-4b66-11eb-9900-5ffb2dfc0cbe.png">
<img width="454" alt="Screenshot 2020-12-31 at 12 39 25" src="https://user-images.githubusercontent.com/4527432/103409393-dfe4e700-4b66-11eb-8d86-c6fb1f3782c6.png">
<img width="455" alt="Screenshot 2020-12-31 at 12 38 54" src="https://user-images.githubusercontent.com/4527432/103409395-e07d7d80-4b66-11eb-9083-3a128d788e6f.png">
<img width="458" alt="Screenshot 2020-12-31 at 12 38 29" src="https://user-images.githubusercontent.com/4527432/103409396-e1161400-4b66-11eb-8c18-0d899fbf02fe.png">


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
~- [ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
