### PR TITLE
[CAS-494] Add member count to ChannelData

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -7,5 +7,6 @@
 
 ## stream-chat-android-offline
 - Add LeaveChannel use case
+- Add ChannelData::memberCount
 
 ## stream-chat-android-ui-common

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
@@ -30,6 +30,8 @@ public data class ChannelData(
     var updatedAt: Date? = null,
     /** when the channel was deleted */
     var deletedAt: Date? = null,
+    /** channel member count */
+    var memberCount: Int = 0,
     /** all the custom data provided for this channel */
     var extraData: MutableMap<String, Any> = mutableMapOf()
 ) {
@@ -41,6 +43,7 @@ public data class ChannelData(
         createdAt = c.createdAt
         updatedAt = c.updatedAt
         deletedAt = c.deletedAt
+        memberCount = c.memberCount
         extraData = c.extraData
 
         createdBy = c.createdBy


### PR DESCRIPTION
`ChannelData` is being propagated through `MutableStateFlow` which doesn't update its value when the new one is equal to the previous:

>      The current value of this state flow.
>     Setting a value that is [equal][Any.equals] to the previous one does nothing.

That's why our `MessagesHeaderView` (which shows member count and relies on `ChannelHeaderViewModel::channelState`) wasn't updated properly after adding or removing a channel member. 
Adding `memberCount` to `ChannelData` solves that issue but we should review our `ChannelHeaderViewModel::channelState` implementation because it exposes `Channel` based on `ChannelData` updates so it might not contain proper data (for example when channel watchers change).
I think that there are two possible solutions for that problem:
1. Add unique id to `ChannelData` object so the new value will be propagated every time `Channel` changes and we will expose proper data in `ChannelHeaderViewModel::channelState`
2. Change `ChannelHeaderViewModel::channelState` type to `ChannelData` (breaking change)
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
