### PR TITLE
Disable logging in release build

### DIFF
--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.sample.BuildConfig
 import io.getstream.chat.sample.R
 
 class ChatInitializer(private val context: Context) {
@@ -21,9 +22,17 @@ class ChatInitializer(private val context: Context) {
                 smallIcon = R.drawable.ic_chat_bubble
             )
         val notificationHandler = SampleNotificationHandler(context, notificationConfig)
+        val logLevel = if (BuildConfig.DEBUG) ChatLogLevel.ALL else ChatLogLevel.NOTHING
+        val client = ChatClient.Builder(apiKey, context)
+            .loggerHandler(FirebaseLogger)
+            .notifications(notificationHandler)
+            .logLevel(logLevel)
+            .build()
 
-        val client = ChatClient.Builder(apiKey, context).loggerHandler(FirebaseLogger).notifications(notificationHandler).logLevel(ChatLogLevel.ALL).build()
-        val domain = ChatDomain.Builder(client, user, context).offlineEnabled().build()
+        val domain = ChatDomain.Builder(client, user, context)
+            .offlineEnabled()
+            .build()
+
         val ui = ChatUI.Builder(context).build()
     }
 

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/FirebaseLogger.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/FirebaseLogger.kt
@@ -5,7 +5,7 @@ import io.getstream.chat.android.client.logger.ChatLoggerHandler
 import timber.log.Timber
 
 object FirebaseLogger : ChatLoggerHandler {
-
+    private const val INTERNAL_LOG_PREFIX = "Chat"
     private val logger: FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
 
     var userId: String? = null
@@ -15,6 +15,10 @@ object FirebaseLogger : ChatLoggerHandler {
         }
 
     private fun log(tag: Any? = null, message: String? = null, error: Throwable? = null) {
+        if (tag is String && tag.startsWith(INTERNAL_LOG_PREFIX)) {
+            return
+        }
+
         if (tag == null && message == null && error == null) {
             Timber.d("No data provided; skipping Crashlytics logging")
             return

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.ui.sample.BuildConfig
 import io.getstream.chat.ui.sample.R
 
 class ChatInitializer(private val context: Context) {
@@ -21,9 +22,17 @@ class ChatInitializer(private val context: Context) {
                 smallIcon = R.drawable.ic_chat_bubble
             )
         val notificationHandler = SampleNotificationHandler(context, notificationConfig)
+        val logLevel = if (BuildConfig.DEBUG) ChatLogLevel.ALL else ChatLogLevel.NOTHING
+        val client = ChatClient.Builder(apiKey, context)
+            .loggerHandler(FirebaseLogger)
+            .notifications(notificationHandler)
+            .logLevel(logLevel)
+            .build()
 
-        val client = ChatClient.Builder(apiKey, context).loggerHandler(FirebaseLogger).notifications(notificationHandler).logLevel(ChatLogLevel.ALL).build()
-        val domain = ChatDomain.Builder(client, user, context).offlineEnabled().build()
+        val domain = ChatDomain.Builder(client, user, context)
+            .offlineEnabled()
+            .build()
+
         val ui = ChatUI.Builder(context).build()
     }
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/FirebaseLogger.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/FirebaseLogger.kt
@@ -5,6 +5,7 @@ import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.logger.ChatLoggerHandler
 
 object FirebaseLogger : ChatLoggerHandler {
+    private const val INTERNAL_LOG_PREFIX = "Chat"
     private val logger = ChatLogger.get("FirebaseLogger")
     private val crashlytics: FirebaseCrashlytics = FirebaseCrashlytics.getInstance()
 
@@ -15,6 +16,10 @@ object FirebaseLogger : ChatLoggerHandler {
         }
 
     private fun log(tag: Any? = null, message: String? = null, error: Throwable? = null) {
+        if (tag is String && tag.startsWith(INTERNAL_LOG_PREFIX)) {
+            return
+        }
+
         if (tag == null && message == null && error == null) {
             logger.logD("No data provided; skipping Crashlytics logging")
             return


### PR DESCRIPTION
### Description

- Set log level to `ChatLogLevel.NOTHING` for release builds
- Filtered out internal log events with tags starting with "Chat" from `FirebaseLogger` (Mostly https requests, websocket events, etc.)

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [] Comparison screenshots added for visual changes
- [X] Reviewers added
