### PR TITLE
[CAS-496] Thread opening logic, thread listeners

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainer.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.ui.messages.adapter
 
+import io.getstream.chat.android.ui.messages.view.MessageListView
 import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.GiphySendListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageClickListener
@@ -13,6 +14,7 @@ public interface MessageListListenerContainer {
     public val messageClickListener: MessageClickListener
     public val messageLongClickListener: MessageLongClickListener
     public val messageRetryListener: MessageRetryListener
+    public val threadClickListener: MessageListView.ThreadClickListener
     public val attachmentClickListener: AttachmentClickListener
     public val reactionViewClickListener: ReactionViewClickListener
     public val userClickListener: UserClickListener

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainerImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainerImpl.kt
@@ -8,17 +8,19 @@ import io.getstream.chat.android.ui.messages.view.MessageListView.MessageLongCli
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageRetryListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.ReactionViewClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.ReadStateClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.ThreadClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.UserClickListener
 
 internal class MessageListListenerContainerImpl(
     messageClickListener: MessageClickListener = MessageClickListener(EmptyFunctions.ONE_PARAM),
     messageLongClickListener: MessageLongClickListener = MessageLongClickListener(EmptyFunctions.ONE_PARAM),
     messageRetryListener: MessageRetryListener = MessageRetryListener(EmptyFunctions.ONE_PARAM),
+    threadClickListener: ThreadClickListener = ThreadClickListener(EmptyFunctions.ONE_PARAM),
     attachmentClickListener: AttachmentClickListener = AttachmentClickListener(EmptyFunctions.TWO_PARAM),
     reactionViewClickListener: ReactionViewClickListener = ReactionViewClickListener(EmptyFunctions.ONE_PARAM),
     userClickListener: UserClickListener = UserClickListener(EmptyFunctions.ONE_PARAM),
     readStateClickListener: ReadStateClickListener = ReadStateClickListener(EmptyFunctions.ONE_PARAM),
-    giphySendListener: GiphySendListener = GiphySendListener(EmptyFunctions.TWO_PARAM)
+    giphySendListener: GiphySendListener = GiphySendListener(EmptyFunctions.TWO_PARAM),
 ) : MessageListListenerContainer {
     private object EmptyFunctions {
         val ONE_PARAM: (Any) -> Unit = { _ -> Unit }
@@ -46,6 +48,14 @@ internal class MessageListListenerContainerImpl(
     ) { realListener ->
         MessageRetryListener { message ->
             realListener().onRetryMessage(message)
+        }
+    }
+
+    override var threadClickListener: ThreadClickListener by ListenerDelegate(
+        threadClickListener
+    ) { realListener ->
+        ThreadClickListener { message ->
+            realListener().onThreadClick(message)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -24,16 +24,15 @@ public class MessagePlainTextViewHolder(
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
 
-        binding.messageContainer.setOnClickListener {
+        binding.root.setOnClickListener {
             listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.root.setOnLongClickListener {
+            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
+            true
         }
         binding.threadRepliesFootnote.root.setOnClickListener {
             listenerContainer?.threadClickListener?.onThreadClick(data.message)
-        }
-
-        binding.messageContainer.setOnLongClickListener {
-            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
-            true
         }
         binding.reactionsView.setReactionClickListener {
             listenerContainer?.reactionViewClickListener?.onReactionViewClick(data.message)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -23,6 +23,14 @@ public class MessagePlainTextViewHolder(
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
+
+        binding.messageContainer.setOnClickListener {
+            listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.threadRepliesFootnote.root.setOnClickListener {
+            listenerContainer?.threadClickListener?.onThreadClick(data.message)
+        }
+
         binding.messageContainer.setOnLongClickListener {
             listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
             true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -21,6 +21,13 @@ public class OnlyFileAttachmentsViewHolder(
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     public override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        binding.root.setOnClickListener {
+            listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.root.setOnLongClickListener {
+            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
+            true
+        }
         binding.fileAttachmentsView.setAttachments(
             data.message.attachments
         ) { attachment -> listenerContainer?.attachmentClickListener?.onAttachmentClick(data.message, attachment) }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -31,5 +31,8 @@ public class OnlyFileAttachmentsViewHolder(
         binding.reactionsView.setReactionClickListener {
             listenerContainer?.reactionViewClickListener?.onReactionViewClick(data.message)
         }
+        binding.threadRepliesFootnote.root.setOnClickListener {
+            listenerContainer?.threadClickListener?.onThreadClick(data.message)
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -25,18 +25,18 @@ public class OnlyMediaAttachmentsViewHolder(
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         listenerContainer?.let { listeners ->
             binding.run {
-                mediaAttachmentsGroupView.listener =
-                    { attachment -> listeners.attachmentClickListener.onAttachmentClick(data.message, attachment) }
-
-                mediaAttachmentsGroupView.setOnLongClickListener {
+                root.setOnClickListener {
+                    listeners.messageClickListener.onMessageClick(data.message)
+                }
+                root.setOnLongClickListener {
                     listeners.messageLongClickListener.onMessageLongClick(data.message)
                     true
                 }
-
+                mediaAttachmentsGroupView.listener =
+                    { attachment -> listeners.attachmentClickListener.onAttachmentClick(data.message, attachment) }
                 reactionsView.setReactionClickListener {
                     listeners.reactionViewClickListener.onReactionViewClick(data.message)
                 }
-
                 threadRepliesFootnote.root.setOnClickListener {
                     listeners.threadClickListener.onThreadClick(data.message)
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -36,6 +36,10 @@ public class OnlyMediaAttachmentsViewHolder(
                 reactionsView.setReactionClickListener {
                     listeners.reactionViewClickListener.onReactionViewClick(data.message)
                 }
+
+                threadRepliesFootnote.root.setOnClickListener {
+                    listeners.threadClickListener.onThreadClick(data.message)
+                }
             }
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -23,6 +23,14 @@ public class PlainTextWithFileAttachmentsViewHolder(
 
     public override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
+
+        binding.messageContainer.setOnClickListener {
+            listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.threadRepliesFootnote.root.setOnClickListener {
+            listenerContainer?.threadClickListener?.onThreadClick(data.message)
+        }
+
         binding.fileAttachmentsView.setAttachments(
             data.message.attachments.filter { attachment -> attachment.hasLink().not() }
         ) { attachment -> listenerContainer?.attachmentClickListener?.onAttachmentClick(data.message, attachment) }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -24,20 +24,19 @@ public class PlainTextWithFileAttachmentsViewHolder(
     public override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
 
-        binding.messageContainer.setOnClickListener {
+        binding.root.setOnClickListener {
             listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.root.setOnLongClickListener {
+            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
+            true
         }
         binding.threadRepliesFootnote.root.setOnClickListener {
             listenerContainer?.threadClickListener?.onThreadClick(data.message)
         }
-
         binding.fileAttachmentsView.setAttachments(
             data.message.attachments.filter { attachment -> attachment.hasLink().not() }
         ) { attachment -> listenerContainer?.attachmentClickListener?.onAttachmentClick(data.message, attachment) }
-        binding.fileAttachmentsView.setOnLongClickListener {
-            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
-            true
-        }
         binding.reactionsView.setReactionClickListener {
             listenerContainer?.reactionViewClickListener?.onReactionViewClick(data.message)
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -21,6 +21,13 @@ public class PlainTextWithMediaAttachmentsViewHolder(
     )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        binding.messageContainer.setOnClickListener {
+            listenerContainer?.messageClickListener?.onMessageClick(data.message)
+        }
+        binding.threadRepliesFootnote.root.setOnClickListener {
+            listenerContainer?.threadClickListener?.onThreadClick(data.message)
+        }
+
         listenerContainer?.let { listeners ->
             binding.run {
                 mediaAttachmentsGroupView.listener = { attachment ->

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -21,24 +21,23 @@ public class PlainTextWithMediaAttachmentsViewHolder(
     )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
-        binding.messageContainer.setOnClickListener {
-            listenerContainer?.messageClickListener?.onMessageClick(data.message)
-        }
-        binding.threadRepliesFootnote.root.setOnClickListener {
-            listenerContainer?.threadClickListener?.onThreadClick(data.message)
-        }
-
         listenerContainer?.let { listeners ->
             binding.run {
-                mediaAttachmentsGroupView.listener = { attachment ->
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, attachment)
+                root.setOnClickListener {
+                    listeners.messageClickListener.onMessageClick(data.message)
                 }
-                backgroundView.setOnLongClickListener {
+                root.setOnLongClickListener {
                     listeners.messageLongClickListener.onMessageLongClick(data.message)
                     true
                 }
+                mediaAttachmentsGroupView.listener = { attachment ->
+                    listeners.attachmentClickListener.onAttachmentClick(data.message, attachment)
+                }
                 reactionsView.setReactionClickListener {
                     listeners.reactionViewClickListener.onReactionViewClick(data.message)
+                }
+                threadRepliesFootnote.root.setOnClickListener {
+                    listeners.threadClickListener.onThreadClick(data.message)
                 }
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -161,7 +161,12 @@ public class MessageListView : ConstraintLayout {
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { fragmentManager ->
                 MessageOptionsDialogFragment
-                    .newMessageOptionsInstance(message, messageOptionsConfiguration)
+                    .newMessageOptionsInstance(
+                        message,
+                        messageOptionsConfiguration.copy(
+                            threadEnabled = !adapter.isThread,
+                        )
+                    )
                     .apply {
                         setReactionClickHandler(onMessageReactionHandler)
                         setMessageOptionsHandlers(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -43,6 +43,7 @@ import io.getstream.chat.android.ui.messages.view.MessageListView.MessageLongCli
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageRetryListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.ReactionViewClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.ReadStateClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.ThreadClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.UserClickListener
 import io.getstream.chat.android.ui.options.MessageOptionsDialogFragment
 import io.getstream.chat.android.ui.options.MessageOptionsView
@@ -179,10 +180,16 @@ public class MessageListView : ConstraintLayout {
                     .show(fragmentManager, MessageOptionsDialogFragment.TAG)
             }
         }
-
     private val DEFAULT_MESSAGE_RETRY_LISTENER =
         MessageRetryListener { message ->
             onMessageRetryHandler.invoke(message)
+        }
+    private val DEFAULT_THREAD_CLICK_LISTENER =
+        ThreadClickListener { message ->
+            if (message.replyCount > 0) {
+                onStartThreadHandler.invoke(message)
+                onStartThreadListener.invoke(message)
+            }
         }
     private val DEFAULT_ATTACHMENT_CLICK_LISTENER =
         AttachmentClickListener { message, attachment ->
@@ -216,6 +223,7 @@ public class MessageListView : ConstraintLayout {
         messageClickListener = DEFAULT_MESSAGE_CLICK_LISTENER,
         messageLongClickListener = DEFAULT_MESSAGE_LONG_CLICK_LISTENER,
         messageRetryListener = DEFAULT_MESSAGE_RETRY_LISTENER,
+        threadClickListener = DEFAULT_THREAD_CLICK_LISTENER,
         attachmentClickListener = DEFAULT_ATTACHMENT_CLICK_LISTENER,
         reactionViewClickListener = DEFAULT_REACTION_VIEW_CLICK_LISTENER,
         userClickListener = DEFAULT_USER_CLICK_LISTENER,
@@ -744,6 +752,16 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
+     * Sets the thread click listener to be used by MessageListView.
+     *
+     * @param threadClickListener The listener to use. If null, the default will be used instead.
+     */
+    public fun setThreadClickListener(threadClickListener: ThreadClickListener?) {
+        listenerContainer.threadClickListener =
+            threadClickListener ?: DEFAULT_THREAD_CLICK_LISTENER
+    }
+
+    /**
      * Sets the attachment click listener to be used by MessageListView.
      *
      * @param attachmentClickListener The listener to use. If null, the default will be used instead.
@@ -848,6 +866,10 @@ public class MessageListView : ConstraintLayout {
 
     public fun interface MessageLongClickListener {
         public fun onMessageLongClick(message: Message)
+    }
+
+    public fun interface ThreadClickListener {
+        public fun onThreadClick(message: Message)
     }
 
     public fun interface AttachmentClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsView.kt
@@ -43,7 +43,15 @@ public class MessageOptionsView : FrameLayout {
         // binding.replyTV.isVisible = true
         binding.replyTV.configureListItem(configuration.replyText, configuration.replyIcon, iconsTint)
 
-        binding.threadReplyTV.configureListItem(configuration.threadReplyText, configuration.threadReplyIcon, iconsTint)
+        if (configuration.threadEnabled) {
+            binding.threadReplyTV.configureListItem(
+                configuration.threadReplyText,
+                configuration.threadReplyIcon,
+                iconsTint
+            )
+        } else {
+            binding.threadReplyTV.isVisible = false
+        }
 
         configureCopyMessage(iconsTint, configuration)
 
@@ -60,6 +68,16 @@ public class MessageOptionsView : FrameLayout {
         // binding.replyTV.isVisible = true
         binding.replyTV.configureListItem(configuration.replyText, configuration.replyIcon, iconsTint)
 
+        if (configuration.threadEnabled) {
+            binding.threadReplyTV.configureListItem(
+                configuration.threadReplyText,
+                configuration.threadReplyIcon,
+                iconsTint
+            )
+        } else {
+            binding.threadReplyTV.isVisible = false
+        }
+
         when (syncStatus) {
             SyncStatus.FAILED_PERMANENTLY -> {
                 binding.retryTV.configureListItem(
@@ -72,11 +90,7 @@ public class MessageOptionsView : FrameLayout {
                 binding.threadReplyTV.isVisible = false
             }
             SyncStatus.COMPLETED -> {
-                binding.threadReplyTV.configureListItem(
-                    configuration.threadReplyText,
-                    configuration.threadReplyIcon,
-                    iconsTint
-                )
+                // Empty
             }
             SyncStatus.SYNC_NEEDED, SyncStatus.IN_PROGRESS -> {
                 binding.threadReplyTV.isVisible = false
@@ -110,6 +124,7 @@ public class MessageOptionsView : FrameLayout {
         val replyIcon: Int,
         val threadReplyText: String,
         val threadReplyIcon: Int,
+        val threadEnabled: Boolean = true,
         val retryText: String,
         val retryIcon: Int,
         val copyText: String,

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_thread_divider.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_thread_divider.xml
@@ -5,6 +5,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="8dp"
+    android:gravity="center"
     android:paddingVertical="2dp"
     android:textAlignment="center"
     android:textColor="@color/stream_ui_text_color_light"


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-496

### Description

A batch of thread handling implementation bits / improvements. See commit messages for details.

Opening and closing threads is now connected to listeners correctly, albeit still very glitchy. Fixes to follow up later on, in separate PRs.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
