### PR TITLE
[CAS-219] Fixing tint few screens

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/add_channel_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/add_channel_view.xml
@@ -105,7 +105,7 @@
         android:layout_height="wrap_content"
         android:drawablePadding="8dp"
         android:text="@string/add_channel_empty_users_title"
-        android:textColor="@color/stream_ui_black_50"
+        android:textColor="@color/stream_ui_text_color_light"
         android:textSize="@dimen/stream_ui_text_medium"
         android:visibility="visible"
         app:drawableTopCompat="@drawable/empty_user_search"

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/chat_info_group_add_users_dialog_fragment.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/chat_info_group_add_users_dialog_fragment.xml
@@ -56,7 +56,7 @@
                 android:layout_gravity="center_horizontal"
                 android:layout_marginBottom="16dp"
                 android:text="@string/add_channel_empty_users_title"
-                android:textColor="@color/stream_ui_black_50"
+                android:textColor="@color/stream_ui_text_color_light"
                 android:textSize="@dimen/stream_ui_text_medium"
                 android:visibility="gone"
                 app:drawableTopCompat="@drawable/empty_user_search"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_attachment_file.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_attachment_file.xml
@@ -52,7 +52,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/stream_ui_no_media_error"
-        android:textColor="@color/stream_ui_black"
+        android:textColor="@color/stream_ui_text_color_strong"
         android:textSize="@dimen/stream_ui_text_large"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_attachment_media.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_attachment_media.xml
@@ -41,6 +41,7 @@
         android:background="@drawable/stream_ui_circle_white"
         android:scaleType="center"
         android:src="@drawable/stream_ui_ic_attachment_check"
+        app:tint="@color/stream_ui_icon_strong_tint"
         app:layout_constraintEnd_toEndOf="@id/mediaThumbnailImageView"
         app:layout_constraintTop_toTopOf="@id/mediaThumbnailImageView"
         tools:ignore="ContentDescription"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_deleted.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_deleted.xml
@@ -21,7 +21,7 @@
         android:paddingRight="@dimen/stream_ui_spacing_medium"
         android:paddingBottom="@dimen/stream_ui_spacing_small"
         android:text="@string/stream_ui_message_deleted_label"
-        android:textColor="@color/stream_ui_black_50"
+        android:textColor="@color/stream_ui_text_color_light"
         />
 
 </LinearLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -67,7 +67,7 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:gravity="center"
-                android:textColor="@color/stream_ui_black"
+                android:textColor="@color/stream_ui_text_color_strong"
                 android:textSize="14sp"
                 android:textStyle="italic"
                 app:layout_constraintBottom_toBottomOf="@id/previousButton"
@@ -95,14 +95,14 @@
                 app:layout_constraintLeft_toRightOf="@id/giphyTextLabel"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="@id/previousButton"
-                />
+                app:tint="@color/stream_ui_icon_strong_tint"/>
 
             <View
                 android:id="@+id/horizontalDivider"
                 android:layout_width="match_parent"
                 android:layout_height="1dp"
                 android:layout_marginTop="8dp"
-                android:background="@color/stream_ui_black_10"
+                android:background="@color/stream_ui_divider"
                 app:layout_constraintLeft_toLeftOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/previousButton"
                 />
@@ -129,7 +129,7 @@
                 android:id="@+id/verticalDivider"
                 android:layout_width="1dp"
                 android:layout_height="0dp"
-                android:background="@color/stream_ui_black_10"
+                android:background="@color/stream_ui_divider"
                 app:layout_constraintBottom_toBottomOf="@id/cancel_button"
                 app:layout_constraintLeft_toRightOf="@id/cancel_button"
                 app:layout_constraintRight_toLeftOf="@id/sendButton"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -98,7 +98,7 @@
             android:paddingRight="@dimen/stream_ui_spacing_medium"
             android:paddingBottom="@dimen/stream_ui_spacing_small"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Body2"
-            android:textColor="@color/stream_ui_black"
+            android:textColor="@color/stream_ui_text_color_strong"
             android:textColorLink="@color/stream_ui_blue"
             />
 


### PR DESCRIPTION
[CAS-229](https://stream-io.atlassian.net/browse/CAS-229)

### Description

Fixing the colour for a small check. 

| Before | After |
| --- | --- |
| ![Screenshot_20210104-174404](https://user-images.githubusercontent.com/10619102/103558521-14cda280-4eb5-11eb-92b7-2d7dcbfb43a0.png) | ![Screenshot_20210104-174053](https://user-images.githubusercontent.com/10619102/103558584-2f078080-4eb5-11eb-82cd-331efe81c041.png) |
| ![Screenshot_20210104-183631](https://user-images.githubusercontent.com/10619102/103563273-cb815100-4ebc-11eb-92ac-113746c2bd33.png) | ![Screenshot_20210104-183757](https://user-images.githubusercontent.com/10619102/103563297-d936d680-4ebc-11eb-90c8-ae36dd92294f.png) |
| ![Screenshot_20210104-183521](https://user-images.githubusercontent.com/10619102/103563469-1c914500-4ebd-11eb-9d7d-abb908d06d38.png)| ![Screenshot_20210104-182651](https://user-images.githubusercontent.com/10619102/103563494-261aad00-4ebd-11eb-8a6c-0564f691cc4b.png) |


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
