### PR TITLE
CAS-493 Show options overlay on long press for all view holders

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
@@ -10,6 +10,7 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
     private val decorators: List<Decorator>
 ) : RecyclerView.ViewHolder(itemView) {
     protected lateinit var data: T
+        private set
 
     public fun bind(data: T, diff: MessageListItemPayloadDiff? = null) {
         this.data = data

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
@@ -9,8 +9,10 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
     itemView: View,
     private val decorators: List<Decorator>
 ) : RecyclerView.ViewHolder(itemView) {
+    protected lateinit var data: T
 
     public fun bind(data: T, diff: MessageListItemPayloadDiff? = null) {
+        this.data = data
         decorators.forEach { it.decorate(this, data) }
         bindData(data, diff)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/AttachmentClickListener.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/AttachmentClickListener.kt
@@ -1,0 +1,11 @@
+package io.getstream.chat.android.ui.messages.adapter.view
+
+import io.getstream.chat.android.client.models.Attachment
+
+internal fun interface AttachmentClickListener {
+    fun onAttachmentClick(attachment: Attachment)
+}
+
+internal fun interface AttachmentLongClickListener {
+    fun onAttachmentLongClick()
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentView.kt
@@ -19,15 +19,8 @@ import io.getstream.chat.android.ui.utils.ModelType
 import io.getstream.chat.android.ui.utils.extensions.dpToPx
 
 internal class MediaAttachmentView : ConstraintLayout {
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
-    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
-        context,
-        attrs,
-        defStyleAttr,
-        defStyleRes
-    )
+    var attachmentClickListener: AttachmentClickListener? = null
+    var attachmentLongClickListener: AttachmentLongClickListener? = null
 
     internal val binding: StreamUiMediaAttachmentViewBinding =
         StreamUiMediaAttachmentViewBinding.inflate(LayoutInflater.from(context)).also {
@@ -41,7 +34,15 @@ internal class MediaAttachmentView : ConstraintLayout {
             }
         }
 
-    var clickListener: (Attachment) -> Unit = {}
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
+        context,
+        attrs,
+        defStyleAttr,
+        defStyleRes
+    )
 
     fun showAttachment(attachment: Attachment, andMoreCount: Int = NO_MORE_COUNT) {
         val url = attachment.thumbUrl ?: attachment.imageUrl ?: attachment.ogUrl ?: return
@@ -62,7 +63,11 @@ internal class MediaAttachmentView : ConstraintLayout {
         }
 
         if (attachment.type != ModelType.attach_giphy) {
-            setOnClickListener { clickListener(attachment) }
+            setOnClickListener { attachmentClickListener?.onAttachmentClick(attachment) }
+            setOnLongClickListener {
+                attachmentLongClickListener?.onAttachmentLongClick()
+                true
+            }
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
@@ -34,7 +34,7 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
         defStyleRes
     )
 
-    fun showAttachments(vararg attachments: Attachment) {
+    fun showAttachments(attachments: List<Attachment>) {
         when (attachments.size) {
             0 -> Unit
             1 -> showOne(attachments.first())

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
@@ -19,6 +19,10 @@ import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
 import io.getstream.chat.android.ui.utils.extensions.getOrDefault
 
 internal class MediaAttachmentsGroupView : ConstraintLayout {
+    var attachmentClickListener: AttachmentClickListener? = null
+    var attachmentLongClickListener: AttachmentLongClickListener? = null
+
+    private var state: State = State.Empty
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
@@ -29,10 +33,6 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
         defStyleAttr,
         defStyleRes
     )
-
-    private var state: State = State.Empty
-
-    var listener: (Attachment) -> Unit = {}
 
     fun showAttachments(vararg attachments: Attachment) {
         when (attachments.size) {
@@ -53,7 +53,7 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
 
     private fun showOne(first: Attachment) {
         removeAllViews()
-        val mediaAttachmentView = createMediaAttachmentView(context, listener)
+        val mediaAttachmentView = createMediaAttachmentView()
         addView(mediaAttachmentView)
         state = State.OneView(mediaAttachmentView)
         ConstraintSet().apply {
@@ -68,8 +68,8 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
 
     private fun showTwo(first: Attachment, second: Attachment) {
         removeAllViews()
-        val viewOne = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewTwo = createMediaAttachmentView(context, listener).also { addView(it) }
+        val viewOne = createMediaAttachmentView().also { addView(it) }
+        val viewTwo = createMediaAttachmentView().also { addView(it) }
         state = State.TwoViews(viewOne, viewTwo)
         ConstraintSet().apply {
             setupMinHeight(viewOne, false)
@@ -87,9 +87,9 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
 
     private fun showThree(first: Attachment, second: Attachment, third: Attachment) {
         removeAllViews()
-        val viewOne = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewTwo = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewThree = createMediaAttachmentView(context, listener).also { addView(it) }
+        val viewOne = createMediaAttachmentView().also { addView(it) }
+        val viewTwo = createMediaAttachmentView().also { addView(it) }
+        val viewThree = createMediaAttachmentView().also { addView(it) }
         state = State.ThreeViews(viewOne, viewTwo, viewThree)
         ConstraintSet().apply {
             setupMinHeight(viewTwo, true)
@@ -114,10 +114,10 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
         andMoreCount: Int = 0
     ) {
         removeAllViews()
-        val viewOne = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewTwo = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewThree = createMediaAttachmentView(context, listener).also { addView(it) }
-        val viewFour = createMediaAttachmentView(context, listener).also { addView(it) }
+        val viewOne = createMediaAttachmentView().also { addView(it) }
+        val viewTwo = createMediaAttachmentView().also { addView(it) }
+        val viewThree = createMediaAttachmentView().also { addView(it) }
+        val viewFour = createMediaAttachmentView().also { addView(it) }
         state = State.FourViews(viewOne, viewTwo, viewThree, viewFour)
         ConstraintSet().apply {
             setupMinHeight(viewOne, true)
@@ -178,6 +178,14 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
             .getOrDefault(0f)
     }
 
+    private fun createMediaAttachmentView(): MediaAttachmentView {
+        return MediaAttachmentView(context).also {
+            it.id = generateViewId()
+            it.attachmentClickListener = attachmentClickListener
+            it.attachmentLongClickListener = attachmentLongClickListener
+        }
+    }
+
     private sealed class State {
         object Empty : State()
         data class OneView(val view: MediaAttachmentView) : State()
@@ -200,12 +208,6 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
         private const val MAX_PREVIEW_COUNT = 4
         private val MIN_HEIGHT_PX = 95.dpToPx()
         private val STROKE_WIDTH = 2.dpToPxPrecise()
-
-        private fun createMediaAttachmentView(context: Context, listener: (Attachment) -> Unit): MediaAttachmentView =
-            MediaAttachmentView(context).apply {
-                id = generateViewId()
-                clickListener = listener
-            }
 
         private fun ConstraintSet.setupMinHeight(view: View, isQuarter: Boolean) {
             this.constrainMinHeight(view.id, if (isQuarter) MIN_HEIGHT_PX else 2 * MIN_HEIGHT_PX)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -12,7 +12,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class MessagePlainTextViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    private val listenerContainer: MessageListListenerContainer?,
+    listenerContainer: MessageListListenerContainer?,
     internal val binding: StreamUiItemMessagePlainTextBinding =
         StreamUiItemMessagePlainTextBinding.inflate(
             parent.inflater,
@@ -21,14 +21,21 @@ public class MessagePlainTextViewHolder(
         )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
+    init {
+        listenerContainer?.let { listeners ->
+            binding.run {
+                reactionsView.setReactionClickListener {
+                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
+                }
+                messageContainer.setOnLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                    true
+                }
+            }
+        }
+    }
+
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
-        binding.messageContainer.setOnLongClickListener {
-            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
-            true
-        }
-        binding.reactionsView.setReactionClickListener {
-            listenerContainer?.reactionViewClickListener?.onReactionViewClick(data.message)
-        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -7,29 +7,44 @@ import io.getstream.chat.android.ui.databinding.StreamUiItemMessageFileAttachmen
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentLongClickListener
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 
 public class OnlyFileAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    private val listenerContainer: MessageListListenerContainer?,
-    internal val binding: StreamUiItemMessageFileAttachmentsBinding = StreamUiItemMessageFileAttachmentsBinding.inflate(
-        parent.inflater,
-        parent,
-        false
-    )
+    listenerContainer: MessageListListenerContainer?,
+    internal val binding: StreamUiItemMessageFileAttachmentsBinding =
+        StreamUiItemMessageFileAttachmentsBinding.inflate(
+            parent.inflater,
+            parent,
+            false
+        )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
+    init {
+        listenerContainer?.let { listeners ->
+            binding.run {
+                reactionsView.setReactionClickListener {
+                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
+                }
+                fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
+                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+                }
+
+                fileAttachmentsView.setOnLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                    true
+                }
+                fileAttachmentsView.attachmentLongClickListener = AttachmentLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                }
+            }
+        }
+    }
+
     public override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
-        binding.fileAttachmentsView.setAttachments(
-            data.message.attachments
-        ) { attachment -> listenerContainer?.attachmentClickListener?.onAttachmentClick(data.message, attachment) }
-        binding.fileAttachmentsView.setOnLongClickListener {
-            listenerContainer?.messageLongClickListener?.onMessageLongClick(data.message)
-            true
-        }
-        binding.reactionsView.setReactionClickListener {
-            listenerContainer?.reactionViewClickListener?.onReactionViewClick(data.message)
-        }
+        binding.fileAttachmentsView.setAttachments(data.message.attachments)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -3,48 +3,55 @@ package io.getstream.chat.android.ui.messages.adapter.viewholder
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.inflater
-import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageMediaAttachmentsBinding
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemViewTypeMapper.isMedia
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentLongClickListener
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 
 public class OnlyMediaAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    private val listenerContainer: MessageListListenerContainer?,
-    internal val binding: StreamUiItemMessageMediaAttachmentsBinding = StreamUiItemMessageMediaAttachmentsBinding.inflate(
-        parent.inflater,
-        parent,
-        false
-    )
+    listenerContainer: MessageListListenerContainer?,
+    internal val binding: StreamUiItemMessageMediaAttachmentsBinding =
+        StreamUiItemMessageMediaAttachmentsBinding.inflate(
+            parent.inflater,
+            parent,
+            false
+        )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
-    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+    init {
         listenerContainer?.let { listeners ->
             binding.run {
-                mediaAttachmentsGroupView.listener =
-                    { attachment -> listeners.attachmentClickListener.onAttachmentClick(data.message, attachment) }
-
-                mediaAttachmentsGroupView.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
+                mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
+                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
                 }
-
                 reactionsView.setReactionClickListener {
                     listeners.reactionViewClickListener.onReactionViewClick(data.message)
                 }
-            }
-        }
 
-        if (data.message.attachments.isMedia()) {
-            showAttachments(data.message.attachments)
+                backgroundView.setOnLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                    true
+                }
+                mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                }
+            }
         }
     }
 
-    private fun showAttachments(imageAttachments: Collection<Attachment>) {
-        binding.mediaAttachmentsGroupView.showAttachments(*imageAttachments.toTypedArray())
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        if (data.message.attachments.isMedia()) {
+            binding.mediaAttachmentsGroupView.showAttachments(
+                *data.message
+                    .attachments
+                    .toTypedArray()
+            )
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -53,11 +53,7 @@ public class OnlyMediaAttachmentsViewHolder(
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         if (data.message.attachments.isMedia()) {
-            binding.mediaAttachmentsGroupView.showAttachments(
-                *data.message
-                    .attachments
-                    .toTypedArray()
-            )
+            binding.mediaAttachmentsGroupView.showAttachments(data.message.attachments)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -7,37 +7,51 @@ import io.getstream.chat.android.ui.databinding.StreamUiItemMessagePlainTextWith
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentLongClickListener
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 
 public class PlainTextWithMediaAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    private val listenerContainer: MessageListListenerContainer?,
-    internal val binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding = StreamUiItemMessagePlainTextWithMediaAttachmentsBinding.inflate(
-        parent.inflater,
-        parent,
-        false
-    )
+    listenerContainer: MessageListListenerContainer?,
+    internal val binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding =
+        StreamUiItemMessagePlainTextWithMediaAttachmentsBinding.inflate(
+            parent.inflater,
+            parent,
+            false
+        )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
-    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+
+    init {
         listenerContainer?.let { listeners ->
             binding.run {
-                mediaAttachmentsGroupView.listener = { attachment ->
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, attachment)
-                }
-                backgroundView.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
+                mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
+                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
                 }
                 reactionsView.setReactionClickListener {
                     listeners.reactionViewClickListener.onReactionViewClick(data.message)
                 }
+
+                backgroundView.setOnLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                    true
+                }
+                mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
+                    listeners.messageLongClickListener.onMessageLongClick(data.message)
+                }
             }
         }
+    }
 
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
-        val mediaAttachments = data.message.attachments.filter { attachment -> attachment.hasLink().not() }
-        binding.mediaAttachmentsGroupView.showAttachments(*mediaAttachments.toTypedArray())
+        binding.mediaAttachmentsGroupView.showAttachments(
+            *data.message
+                .attachments
+                .filter { attachment -> attachment.hasLink().not() }
+                .toTypedArray()
+        )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -54,10 +54,9 @@ public class PlainTextWithMediaAttachmentsViewHolder(
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         binding.messageText.text = data.message.text
         binding.mediaAttachmentsGroupView.showAttachments(
-            *data.message
+            data.message
                 .attachments
                 .filter { attachment -> attachment.hasLink().not() }
-                .toTypedArray()
         )
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-493

### Description

This PR ensures that options overlay is shown on long press regardless of the touch area in message bubble (text, file/media attachment).

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
