### PR TITLE
Fixing text alignment

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_mentions_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_mentions_list_view.xml
@@ -41,8 +41,8 @@
             android:layout_marginEnd="24dp"
             android:ellipsize="end"
             android:maxLines="1"
+            android:gravity="center"
             android:text="@string/stream_ui_mentions_list_empty"
-            android:textAlignment="center"
             android:textColor="@color/stream_ui_text_color_light"
             android:textSize="@dimen/stream_ui_text_medium"
             />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_search_result_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_search_result_list_view.xml
@@ -62,7 +62,6 @@
             android:ellipsize="end"
             android:gravity="center"
             android:maxLines="1"
-            android:textAlignment="center"
             android:textColor="@color/stream_ui_text_color_light"
             android:textSize="@dimen/stream_ui_text_medium"
             tools:text="No result for 'query'"


### PR DESCRIPTION
### Description

Just a small correction in the XML. The text for "No results found for [search here]" and "No mentions exist yet…" was aligned to the left, not the center.  💅 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **No need**
- New code is covered by unit tests. **No need**
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
