### PR TITLE
Thread reply options improvement

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -49,6 +49,7 @@ import io.getstream.chat.android.ui.options.MessageOptionsDialogFragment
 import io.getstream.chat.android.ui.options.MessageOptionsView
 import io.getstream.chat.android.ui.utils.extensions.getFragmentManager
 import io.getstream.chat.android.ui.utils.extensions.isDirectMessaging
+import io.getstream.chat.android.ui.utils.extensions.isInThread
 import kotlin.math.max
 
 /**
@@ -164,7 +165,7 @@ public class MessageListView : ConstraintLayout {
                     .newMessageOptionsInstance(
                         message,
                         messageOptionsConfiguration.copy(
-                            threadEnabled = !adapter.isThread,
+                            threadEnabled = !adapter.isThread && !message.isInThread(),
                         )
                     )
                     .apply {


### PR DESCRIPTION
### Description

Don't show Thread reply option if a message is in a thread and was "also sent to channel"

<img width="413" alt="Screenshot 2021-01-05 at 13 04 18" src="https://user-images.githubusercontent.com/4527432/103644370-8e699d00-4f56-11eb-9184-8292dc24ef8d.png">

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
