### PR TITLE
Add channel property to notification.message_new events

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## stream-chat-android-client
 - Add filtering non image attachments in ChatClient::getImageAttachments
+- Add a `channel` property to `notification.message_new` events
 
 ## stream-chat-android-offline
 - Add LeaveChannel use case

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -281,6 +281,7 @@ public data class NotificationMessageNewEvent(
     override val cid: String,
     @SerializedName("channel_type") val channelType: String,
     @SerializedName("channel_id") val channelId: String,
+    val channel: Channel,
     val message: Message,
     @SerializedName("watcher_count") val watcherCount: Int?,
     @SerializedName("total_unread_count") val totalUnreadCount: Int?,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -273,6 +273,7 @@ internal fun createNotificationMessageNewEventStringJson() =
             "user": ${createUserJsonString()},
             "channel_type": "channelType",
             "channel_id": "channelId",
+            "channel": ${createChannelJsonString()},
             "cid": "channelType:channelId",
             "watcher_count": 3,
             "total_unread_count": 4,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -206,7 +206,7 @@ internal object EventArguments {
     private val notificationInviteAcceptedEvent = NotificationInviteAcceptedEvent(EventType.NOTIFICATION_INVITE_ACCEPTED, date, cid, channelType, channelId, user, member)
     private val notificationInvitedEvent = NotificationInvitedEvent(EventType.NOTIFICATION_INVITED, date, cid, channelType, channelId, user, member)
     private val notificationMarkReadEvent = NotificationMarkReadEvent(EventType.NOTIFICATION_MARK_READ, date, user, cid, channelType, channelId, watcherCount, totalUnreadCount, unreadChannels)
-    private val notificationMessageNewEvent = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, date, user, cid, channelType, channelId, message, watcherCount, totalUnreadCount, unreadChannels)
+    private val notificationMessageNewEvent = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, date, user, cid, channelType, channelId, channel, message, watcherCount, totalUnreadCount, unreadChannels)
     private val notificationRemovedFromChannelEvent = NotificationRemovedFromChannelEvent(EventType.NOTIFICATION_REMOVED_FROM_CHANNEL, date, user, cid, channelType, channelId)
     private val reactionDeletedEvent = ReactionDeletedEvent(EventType.REACTION_DELETED, date, user, cid, channelType, channelId, message, reaction)
     private val reactionNewEvent = ReactionNewEvent(EventType.REACTION_NEW, date, user, cid, channelType, channelId, message, reaction)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
@@ -218,7 +218,7 @@ internal class TestDataHelper {
     val newMessageEvent2 = NewMessageEvent(EventType.MESSAGE_NEW, Date(), user1, channel1.cid, channel1.type, channel1.id, message2Older, null, null, null)
     val newMessageFromUser2 = NewMessageEvent(EventType.MESSAGE_NEW, Date(), user2, channel1.cid, channel1.type, channel1.id, messageFromUser2, null, null, null)
 
-    val newMessageEventNotification = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, Date(), user1, channel1.cid, channel1.type, channel1.id, message1WithoutChannelAndCid, null, null, null)
+    val newMessageEventNotification = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, Date(), user1, channel1.cid, channel1.type, channel1.id, channel1, message1WithoutChannelAndCid, null, null, null)
 
     val messageUpdatedEvent = MessageUpdatedEvent(EventType.MESSAGE_UPDATED, Date(), user1, channel1.cid, channel1.type, channel1.id, message1Updated, null)
     val userStartWatchingEvent = UserStartWatchingEvent(EventType.USER_WATCHING_START, Date(), channel1.cid, 1, channel1.type, channel1.id, user1)


### PR DESCRIPTION

### Description

Start parsing the `channel` inside `notification.message_new` events, as it's included in the event we receive, as a fix for #1045 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
