### PR TITLE
Fix deleting channel error

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -7,6 +7,7 @@
 ## stream-chat-android-client
 - Add filtering non image attachments in ChatClient::getImageAttachments
 - Add a `channel` property to `notification.message_new` events
+- Fix deleting channel error
 
 ## stream-chat-android-offline
 - Add LeaveChannel use case

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/MapAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/MapAdapter.kt
@@ -5,7 +5,7 @@ import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
 
 internal class MapAdapter(private val delegateMapAdapter: TypeAdapter<Map<*, *>>) : TypeAdapter<Map<*, *>>() {
-    override fun read(reader: JsonReader?): Map<*, *> = delegateMapAdapter.read(reader)
+    override fun read(reader: JsonReader?): Map<*, *>? = delegateMapAdapter.read(reader)
     override fun write(writer: JsonWriter?, value: Map<*, *>?) =
         delegateMapAdapter.write(writer, value?.filterValues { it != null }?.takeIf { it.isNotEmpty() })
 }


### PR DESCRIPTION
`delegateMapAdapter ` can return `null` during JSON reading.

Fixes #1127 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
