### PR TITLE
Hide replies footer by default

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_file_attachments.xml
@@ -100,9 +100,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/fileAttachmentsView"
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -95,7 +95,8 @@
                 app:layout_constraintLeft_toRightOf="@id/giphyTextLabel"
                 app:layout_constraintRight_toRightOf="parent"
                 app:layout_constraintTop_toTopOf="@id/previousButton"
-                app:tint="@color/stream_ui_icon_strong_tint"/>
+                app:tint="@color/stream_ui_icon_strong_tint"
+                />
 
             <View
                 android:id="@+id/horizontalDivider"
@@ -169,9 +170,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/cardView"
         app:layout_constraintTop_toBottomOf="@+id/cardView"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_media_attachments.xml
@@ -43,14 +43,15 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
+        android:visibility="gone"
         app:layout_constrainedWidth="true"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@id/mediaAttachmentsGroupView"
         app:layout_constraintRight_toRightOf="@id/mediaAttachmentsGroupView"
         app:layout_constraintTop_toBottomOf="@id/reactionsSpace"
-        android:visibility="gone"
+        tools:streamUiEllipsize="false"
         tools:visibility="visible"
-        tools:streamUiEllipsize="false"/>
+        />
 
     <io.getstream.chat.android.ui.messages.adapter.view.MediaAttachmentsGroupView
         android:id="@+id/mediaAttachmentsGroupView"
@@ -110,9 +111,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/mediaAttachmentsGroupView"
         app:layout_constraintTop_toBottomOf="@+id/mediaAttachmentsGroupView"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_file_attachments.xml
@@ -43,12 +43,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
-        app:layout_constraintHorizontal_bias="0"
+        android:visibility="gone"
         app:layout_constrainedWidth="true"
+        app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@id/fileAttachmentsView"
         app:layout_constraintRight_toRightOf="@id/fileAttachmentsView"
         app:layout_constraintTop_toBottomOf="@id/reactionsSpace"
-        android:visibility="gone"
         tools:visibility="visible"
         />
 
@@ -137,9 +137,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/fileAttachmentsView"
         app:layout_constraintTop_toBottomOf="@+id/fileAttachmentsView"
         />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_plain_text_with_media_attachments.xml
@@ -43,12 +43,12 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
+        android:visibility="gone"
         app:layout_constrainedWidth="true"
         app:layout_constraintHorizontal_bias="0"
         app:layout_constraintLeft_toLeftOf="@id/backgroundView"
         app:layout_constraintRight_toRightOf="@id/backgroundView"
         app:layout_constraintTop_toBottomOf="@id/reactionsSpace"
-        android:visibility="gone"
         tools:visibility="visible"
         />
 
@@ -126,9 +126,10 @@
 
     <include
         android:id="@+id/threadRepliesFootnote"
+        layout="@layout/stream_ui_message_threads_footnote"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        layout="@layout/stream_ui_message_threads_footnote"
+        android:visibility="gone"
         app:layout_constraintLeft_toLeftOf="@id/messageContainer"
         app:layout_constraintTop_toBottomOf="@+id/messageContainer"
         />


### PR DESCRIPTION
### Description

By default replies footnote should be hidden, so that it works on message options screen without corresponding decorator.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
| ![photo_2021-01-05 23 48 40](https://user-images.githubusercontent.com/9600921/103697137-8d655980-4fb0-11eb-80b9-b3654bcfc85a.jpeg) | ![photo_2021-01-05 23 48 37](https://user-images.githubusercontent.com/9600921/103697149-90f8e080-4fb0-11eb-8df6-2362ebace0cd.jpeg) |



