### PR TITLE
[CAS-508] Improve shared media screen

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -98,7 +97,7 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showLoading() {
-        setActionBarElevation(ACTION_BAR_ELEVATION)
+        binding.toolbar.elevation = ACTION_BAR_ELEVATION
         binding.progressBar.isVisible = true
         binding.mediaRecyclerView.isVisible = false
         binding.dateView.isVisible = false
@@ -107,7 +106,7 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showResults(attachments: List<SharedAttachment.AttachmentItem>) {
-        setActionBarElevation(0f)
+        binding.toolbar.elevation = 0f
         binding.progressBar.isVisible = false
         binding.mediaRecyclerView.isVisible = true
         binding.dateView.isVisible = true
@@ -122,18 +121,12 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showEmptyState() {
-        setActionBarElevation(ACTION_BAR_ELEVATION)
+        binding.toolbar.elevation = ACTION_BAR_ELEVATION
         binding.progressBar.isVisible = false
         binding.mediaRecyclerView.isVisible = false
         binding.dateView.isVisible = false
         binding.emptyStateView.isVisible = true
         scrollListener.disablePagination()
-    }
-
-    private fun setActionBarElevation(elevation: Float) {
-        (requireActivity() as AppCompatActivity).run {
-            supportActionBar?.elevation = elevation
-        }
     }
 
     private class MediaDateScrollListener(

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
@@ -97,6 +98,7 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showLoading() {
+        setActionBarElevation(ACTION_BAR_ELEVATION)
         binding.progressBar.isVisible = true
         binding.mediaRecyclerView.isVisible = false
         binding.dateView.isVisible = false
@@ -105,6 +107,7 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showResults(attachments: List<SharedAttachment.AttachmentItem>) {
+        setActionBarElevation(0f)
         binding.progressBar.isVisible = false
         binding.mediaRecyclerView.isVisible = true
         binding.dateView.isVisible = true
@@ -119,11 +122,18 @@ class ChatInfoSharedMediaFragment : Fragment() {
     }
 
     private fun showEmptyState() {
+        setActionBarElevation(ACTION_BAR_ELEVATION)
         binding.progressBar.isVisible = false
         binding.mediaRecyclerView.isVisible = false
         binding.dateView.isVisible = false
         binding.emptyStateView.isVisible = true
         scrollListener.disablePagination()
+    }
+
+    private fun setActionBarElevation(elevation: Float) {
+        (requireActivity() as AppCompatActivity).run {
+            supportActionBar?.elevation = elevation
+        }
     }
 
     private class MediaDateScrollListener(
@@ -198,5 +208,6 @@ class ChatInfoSharedMediaFragment : Fragment() {
         private const val LOAD_MORE_THRESHOLD = 10
         private const val SPAN_COUNT = 3
         private val MEDIA_ITEM_SPACE = Utils.dpToPx(2)
+        private val ACTION_BAR_ELEVATION = Utils.dpToPx(4).toFloat()
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_media.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_media.xml
@@ -44,13 +44,13 @@
         android:id="@+id/dateView"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:background="@drawable/stream_ui_date_divider_background"
         android:paddingHorizontal="8dp"
         android:paddingVertical="4dp"
-        android:layout_marginTop="16dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="@id/mediaRecyclerView"
-        android:background="@drawable/stream_ui_date_divider_background"
         >
 
         <TextView
@@ -59,7 +59,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-            android:textColor="@color/stream_ui_text_color_strong"
+            android:textColor="@color/stream_ui_text_color_date_divider"
             />
     </FrameLayout>
 

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_date_divider_background.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_date_divider_background.xml
@@ -3,5 +3,5 @@
     android:shape="rectangle"
     >
     <corners android:radius="16dp" />
-    <solid android:color="@color/stream_ui_black_60" />
+    <solid android:color="@color/stream_ui_background_date_divider" />
 </shape>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_date_divider.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_date_divider.xml
@@ -15,7 +15,7 @@
         android:paddingHorizontal="@dimen/stream_ui_spacing_medium"
         android:paddingVertical="2dp"
         android:textAppearance="@style/TextAppearance.MaterialComponents.Caption"
-        android:textColor="@color/stream_ui_white"
+        android:textColor="@color/stream_ui_text_color_date_divider"
         tools:text="Today"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
@@ -18,6 +18,7 @@
     <color name="stream_ui_background_default">@color/stream_ui_black</color>
     <color name="stream_ui_background_alabaster">@color/stream_ui_background_light</color>
     <color name="stream_ui_background_alabaster_black">@color/stream_ui_black</color>
+    <color name="stream_ui_background_date_divider">@color/stream_ui_white_60</color>
 
     <color name="stream_ui_icon_default_tint">@color/stream_ui_white</color>
     <color name="stream_ui_icon_light_tint">@color/stream_ui_white</color>
@@ -25,6 +26,7 @@
 
     <color name="stream_ui_text_color_light">@color/stream_ui_grey_dark</color>
     <color name="stream_ui_text_color_strong">@color/stream_ui_white</color>
+    <color name="stream_ui_text_color_date_divider">@color/stream_ui_bunker</color>
 
     <color name="stream_ui_divider">@color/stream_ui_mirage</color>
 

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -39,6 +39,7 @@
     <color name="stream_ui_black_30">#4D000000</color>
     <color name="stream_ui_black_50">#80000000</color>
     <color name="stream_ui_black_60">#99000000</color>
+    <color name="stream_ui_white_60">#99FFFFFF</color>
     <color name="stream_ui_grey_90">#E6E6E6</color>
     <color name="stream_ui_boulder">#7A7A7A</color>
     <color name="stream_ui_border_stroke">#14000000</color>
@@ -73,6 +74,7 @@
     <color name="stream_ui_background_light">@color/stream_ui_white</color>
     <color name="stream_ui_background_alabaster">@color/stream_ui_alabaster</color>
     <color name="stream_ui_background_alabaster_black">@color/stream_ui_alabaster</color>
+    <color name="stream_ui_background_date_divider">@color/stream_ui_black_60</color>
 
     <color name="stream_ui_icon_default_tint">@color/stream_ui_boulder</color>
     <color name="stream_ui_icon_light_tint">@color/stream_ui_grey_dark</color>
@@ -81,6 +83,7 @@
     <color name="stream_ui_text_color_light">@color/stream_ui_grey_dark</color>
     <color name="stream_ui_text_color_strong">@color/stream_ui_black</color>
     <color name="stream_ui_text_color_subtitle">#7A7A7A</color>
+    <color name="stream_ui_text_color_date_divider">@color/stream_ui_white</color>
 
     <color name="stream_ui_divider">@color/stream_ui_gray_light</color>
 


### PR DESCRIPTION
- Add elevation when showing loading or empty state on SharedMedia screen
- Improve date divider colors in both day and night modes


| Before | After |
| --- | --- |
|<img width="312" alt="Screenshot 2021-01-06 at 12 51 51" src="https://user-images.githubusercontent.com/17440581/103766430-1e731980-501f-11eb-85c8-8703bffa4fa9.png">|<img width="312" alt="Screenshot 2021-01-06 at 12 54 40" src="https://user-images.githubusercontent.com/17440581/103766444-23d06400-501f-11eb-8f33-183c9322f0dd.png">|
|<img width="310" alt="Screenshot 2021-01-06 at 12 52 17" src="https://user-images.githubusercontent.com/17440581/103766432-203cdd00-501f-11eb-8009-96377f3b4001.png">|<img width="313" alt="Screenshot 2021-01-06 at 12 55 01" src="https://user-images.githubusercontent.com/17440581/103766446-23d06400-501f-11eb-98d1-b032b4885d44.png">|
|<img width="311" alt="Screenshot 2021-01-06 at 12 52 33" src="https://user-images.githubusercontent.com/17440581/103766440-229f3700-501f-11eb-9179-7fbfe5e634b7.png">|<img width="310" alt="Screenshot 2021-01-06 at 12 55 28" src="https://user-images.githubusercontent.com/17440581/103766449-2468fa80-501f-11eb-9150-4693ae453911.png">|



### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
