### PR TITLE
[CAS-505] Fixing icon tint for advanced options

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/item_options.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/item_options.xml
@@ -15,6 +15,7 @@
         android:background="@drawable/shape_circle_grey"
         android:padding="6dp"
         android:src="@drawable/ic_settings"
+        app:tint="@color/stream_ui_icon_strong_tint"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
[CAS-505](https://stream-io.atlassian.net/browse/CAS-505)

### Description

Tinting the icon with white in the dark mode. Before it was black in a black background, impossible to see the icon. 

![Screenshot_20210106-132441](https://user-images.githubusercontent.com/10619102/103768598-15844700-5023-11eb-902a-c33ce28eb29c.png)

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
