### PR TITLE
[CAS-498] ViewHolder listeners

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/GiphyMessageComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/GiphyMessageComponentBrowserFragment.kt
@@ -13,7 +13,7 @@ class GiphyMessageComponentBrowserFragment : BaseMessagesComponentBrowserFragmen
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyMessageList(),
-            { viewGroup -> GiphyViewHolder(viewGroup, decorators) },
+            { viewGroup -> GiphyViewHolder(viewGroup, decorators, null) },
             GiphyViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/file/FileAttachmentAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/file/FileAttachmentAdapter.kt
@@ -1,10 +1,10 @@
 package io.getstream.chat.android.ui.attachments.file
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.utils.MediaStringUtil
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemAttachmentFileBinding
 import io.getstream.chat.android.ui.utils.UiUtils
 
@@ -30,7 +30,7 @@ internal class FileAttachmentAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FileAttachmentViewHolder {
         return StreamUiItemAttachmentFileBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { FileAttachmentViewHolder(it, onAttachmentSelected) }
     }
 
@@ -59,15 +59,24 @@ internal class FileAttachmentAdapter(
         private val onAttachmentClick: (AttachmentMetaData) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(attachment: AttachmentMetaData) {
-            binding.fileTypeImageView.setImageResource(UiUtils.getIcon(attachment.mimeType))
-            binding.fileNameTextView.text = attachment.title
-            binding.fileSizeTextView.text = MediaStringUtil.convertFileSizeByteCount(attachment.size)
+        lateinit var attachment: AttachmentMetaData
+
+        init {
             binding.root.setOnClickListener {
                 onAttachmentClick(attachment)
             }
-            binding.selectionIndicator.isChecked = attachment.isSelected
-            binding.selectionIndicator.text = attachment.selectedPosition.takeIf { it > 0 }?.toString() ?: ""
+        }
+
+        fun bind(attachment: AttachmentMetaData) {
+            this.attachment = attachment
+
+            binding.apply {
+                fileTypeImageView.setImageResource(UiUtils.getIcon(attachment.mimeType))
+                fileNameTextView.text = attachment.title
+                fileSizeTextView.text = MediaStringUtil.convertFileSizeByteCount(attachment.size)
+                selectionIndicator.isChecked = attachment.isSelected
+                selectionIndicator.text = attachment.selectedPosition.takeIf { it > 0 }?.toString() ?: ""
+            }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/media/MediaAttachmentAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/media/MediaAttachmentAdapter.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.ui.attachments.media
 
 import android.graphics.Color
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -11,6 +10,7 @@ import com.getstream.sdk.chat.ImageLoader.loadVideoThumbnail
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
 import com.getstream.sdk.chat.utils.MediaStringUtil
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiItemAttachmentMediaBinding
 
@@ -22,7 +22,7 @@ internal class MediaAttachmentAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MediaAttachmentViewHolder {
         return StreamUiItemAttachmentMediaBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { MediaAttachmentViewHolder(it, onAttachmentSelected) }
     }
 
@@ -59,8 +59,16 @@ internal class MediaAttachmentAdapter(
         private val binding: StreamUiItemAttachmentMediaBinding,
         private val onAttachmentSelected: (attachmentMetaData: AttachmentMetaData) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+
+        lateinit var attachment: AttachmentMetaData
+
+        init {
+            binding.root.setOnClickListener { onAttachmentSelected(attachment) }
+        }
+
         fun bind(attachment: AttachmentMetaData) {
-            bindClickListener(attachment)
+            this.attachment = attachment
+
             bindMediaImage(attachment)
             bindSelectionMark(attachment)
             bindSelectionOverlay(attachment)
@@ -76,10 +84,6 @@ internal class MediaAttachmentAdapter(
                 binding.mediaThumbnailImageView.load(attachment.uri)
                 binding.mediaThumbnailImageView.setBackgroundColor(Color.TRANSPARENT)
             }
-        }
-
-        private fun bindClickListener(attachment: AttachmentMetaData) {
-            itemView.setOnClickListener { onAttachmentSelected(attachment) }
         }
 
         private fun bindSelectionMark(attachment: AttachmentMetaData) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/selected/SelectedFileAttachmentAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/selected/SelectedFileAttachmentAdapter.kt
@@ -1,9 +1,9 @@
 package io.getstream.chat.android.ui.attachments.selected
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.utils.MediaStringUtil
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.databinding.StreamUiItemSelectedAttachmentFileBinding
 import io.getstream.chat.android.ui.utils.SimpleListAdapter
 import io.getstream.chat.android.ui.utils.UiUtils
@@ -14,20 +14,29 @@ internal class SelectedFileAttachmentAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SelectedFileAttachmentViewHolder {
         return StreamUiItemSelectedAttachmentFileBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { SelectedFileAttachmentViewHolder(it, onAttachmentCancelled) }
     }
 
     class SelectedFileAttachmentViewHolder(
         private val binding: StreamUiItemSelectedAttachmentFileBinding,
-        private val onAttachmentCancelled: (AttachmentMetaData) -> Unit
-
+        private val onAttachmentCancelled: (AttachmentMetaData) -> Unit,
     ) : SimpleListAdapter.ViewHolder<AttachmentMetaData>(binding.root) {
-        override fun bind(item: AttachmentMetaData) {
-            binding.ivFileThumb.setImageResource(UiUtils.getIcon(item.mimeType))
-            binding.tvFileTitle.text = item.title
-            binding.tvFileSize.text = MediaStringUtil.convertFileSizeByteCount(item.size)
+
+        lateinit var item: AttachmentMetaData
+
+        init {
             binding.tvClose.setOnClickListener { onAttachmentCancelled(item) }
+        }
+
+        override fun bind(item: AttachmentMetaData) {
+            this.item = item
+
+            binding.apply {
+                ivFileThumb.setImageResource(UiUtils.getIcon(item.mimeType))
+                tvFileTitle.text = item.title
+                tvFileSize.text = MediaStringUtil.convertFileSizeByteCount(item.size)
+            }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/selected/SelectedMediaAttachmentAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/attachments/selected/SelectedMediaAttachmentAdapter.kt
@@ -1,11 +1,11 @@
 package io.getstream.chat.android.ui.attachments.selected
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.getstream.sdk.chat.ImageLoader.load
 import com.getstream.sdk.chat.ImageLoader.loadVideoThumbnail
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
+import com.getstream.sdk.chat.utils.extensions.inflater
 import com.google.android.material.shape.ShapeAppearanceModel
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiItemSelectedAttachmentMediaBinding
@@ -17,7 +17,7 @@ internal class SelectedMediaAttachmentAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SelectedMediaAttachmentViewHolder {
         return StreamUiItemSelectedAttachmentMediaBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { SelectedMediaAttachmentViewHolder(it, onAttachmentCancelled) }
     }
 
@@ -26,9 +26,16 @@ internal class SelectedMediaAttachmentAdapter(
         private val onAttachmentCancelled: (AttachmentMetaData) -> Unit
     ) : SimpleListAdapter.ViewHolder<AttachmentMetaData>(binding.root) {
 
+        lateinit var item: AttachmentMetaData
+
+        init {
+            binding.btnClose.setOnClickListener { onAttachmentCancelled(item) }
+        }
+
         override fun bind(item: AttachmentMetaData) {
+            this.item = item
+
             bindAttachmentImage(item)
-            bindClickListener(item)
         }
 
         private fun bindAttachmentImage(attachment: AttachmentMetaData) {
@@ -41,10 +48,6 @@ internal class SelectedMediaAttachmentAdapter(
             } else {
                 binding.ivMedia.load(attachment.uri)
             }
-        }
-
-        private fun bindClickListener(attachment: AttachmentMetaData) {
-            binding.btnClose.setOnClickListener { onAttachmentCancelled(attachment) }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/actions/ChannelMembersAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/actions/ChannelMembersAdapter.kt
@@ -1,10 +1,10 @@
 package io.getstream.chat.android.ui.channel.actions
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.ui.databinding.StreamUiItemChannelMemberBinding
@@ -15,7 +15,7 @@ internal class ChannelMembersAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ChannelMemberViewHolder {
         return StreamUiItemChannelMemberBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { ChannelMemberViewHolder(it, onMemberClicked) }
     }
 
@@ -37,13 +37,19 @@ internal class ChannelMembersAdapter(
         private val binding: StreamUiItemChannelMemberBinding,
         private val onMemberClicked: (Member) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
+        lateinit var member: Member
+
+        init {
+            binding.root.setOnClickListener { onMemberClicked(member) }
+        }
 
         fun bind(member: Member) {
+            this.member = member
+            val user = member.user
+
             binding.apply {
-                val user = member.user
                 avatarView.setUserData(user)
                 userNameTextView.text = user.name
-                root.setOnClickListener { onMemberClicked(member) }
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.channel.list.adapter.viewholder
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.extensions.inflater
@@ -53,9 +54,50 @@ public class ChannelViewHolder @JvmOverloads constructor(
     private val optionsMenuWidth
         get() = menuItemWidth * optionsCount
 
+    private lateinit var channel: Channel
+
+    init {
+        binding.apply {
+            root.setOnClickListener {
+                channelClickListener.onClick(channel)
+            }
+            root.setOnLongClickListener {
+                channelLongClickListener.onClick(channel)
+                true
+            }
+
+            itemBackgroundView.apply {
+                moreOptionsImageView.setOnClickListener {
+                    channelMoreOptionsListener.onClick(channel)
+                    swipeListener.onSwipeCanceled(this@ChannelViewHolder, absoluteAdapterPosition)
+                }
+                deleteImageView.setOnClickListener {
+                    channelDeleteListener.onClick(channel)
+                }
+            }
+
+            itemForegroundView.apply {
+                avatarView.setOnClickListener {
+                    when {
+                        channel.isDirectMessaging() -> userClickListener.onClick(currentUser)
+                        else -> channelClickListener.onClick(channel)
+                    }
+                }
+
+                applyStyle(style)
+            }
+
+            root.doOnNextLayout {
+                setSwipeListener(root, swipeListener)
+            }
+        }
+    }
+
     public override fun bind(channel: Channel, diff: ChannelDiff) {
-        configureForeground(diff, channel)
-        configureBackground(channel)
+        this.channel = channel
+
+        configureForeground(diff)
+        configureBackground()
     }
 
     override fun getSwipeView(): View {
@@ -76,25 +118,16 @@ public class ChannelViewHolder @JvmOverloads constructor(
         return openedX.coerceAtMost(closedX)..openedX.coerceAtLeast(closedX)
     }
 
-    private fun configureBackground(channel: Channel) {
-        binding.itemBackgroundView.apply {
-            moreOptionsImageView.setOnClickListener {
-                channelMoreOptionsListener.onClick(channel)
-                swipeListener.onSwipeCanceled(this@ChannelViewHolder, absoluteAdapterPosition)
-            }
-        }
-        configureDeleteButton(channel)
+    private fun configureBackground() {
+        configureDeleteButton()
     }
 
-    private fun configureDeleteButton(channel: Channel) {
+    private fun configureDeleteButton() {
         val canDeleteChannel = channel.members.isCurrentUserOwnerOrAdmin()
         binding.itemBackgroundView.deleteImageView.apply {
             if (canDeleteChannel) {
                 optionsCount = 2
                 isVisible = true
-                setOnClickListener {
-                    channelDeleteListener.onClick(channel)
-                }
             } else {
                 optionsCount = 1
                 isVisible = false
@@ -102,74 +135,51 @@ public class ChannelViewHolder @JvmOverloads constructor(
         }
     }
 
-    private fun configureForeground(diff: ChannelDiff, channel: Channel) {
+    private fun configureForeground(diff: ChannelDiff) {
         binding.itemForegroundView.apply {
-
-            setSwipeListener(root, swipeListener)
-
             diff.run {
                 if (nameChanged) {
-                    configureChannelNameLabel(channel)
+                    configureChannelNameLabel()
                 }
 
                 if (avatarViewChanged) {
-                    configureAvatarView(channel, userClickListener, channelClickListener)
+                    configureAvatarView()
                 }
 
                 val lastMessage = channel.getLastMessage()
                 if (lastMessageChanged) {
-                    configureLastMessageLabel(channel, lastMessage)
-                    configureLastMessageTimestamp(lastMessage)
-                    configureUnreadCountBadge(channel)
+                    configureLastMessageLabelAndTimestamp(lastMessage)
+                    configureUnreadCountBadge()
                 }
 
                 if (readStateChanged) {
-                    configureCurrentUserLastMessageStatus(channel, lastMessage)
+                    configureCurrentUserLastMessageStatus(lastMessage)
                 }
             }
-
-            configureClickListeners(channel, channelClickListener, channelLongClickListener)
-
-            applyStyle(style)
         }
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureClickListeners(
-        channel: Channel,
-        channelClickListener: ChannelListView.ChannelClickListener,
-        channelLongClickListener: ChannelListView.ChannelClickListener
-    ) {
-        root.setOnClickListener {
-            channelClickListener.onClick(channel)
-        }
-
-        root.setOnLongClickListener {
-            channelLongClickListener.onClick(channel)
-            true
-        }
-    }
-
-    private fun StreamUiChannelListItemForegroundViewBinding.configureChannelNameLabel(channel: Channel) {
+    private fun StreamUiChannelListItemForegroundViewBinding.configureChannelNameLabel() {
         channelNameLabel.text = channel.getDisplayName(context)
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureAvatarView(
-        channel: Channel,
-        userClickListener: ChannelListView.UserClickListener,
-        channelClickListener: ChannelListView.ChannelClickListener
-    ) {
-        avatarView.apply {
-            setChannelData(channel)
-            setOnClickListener {
-                when {
-                    channel.isDirectMessaging() -> userClickListener.onClick(currentUser)
-                    else -> channelClickListener.onClick(channel)
-                }
-            }
-        }
+    private fun StreamUiChannelListItemForegroundViewBinding.configureAvatarView() {
+        avatarView.setChannelData(channel)
     }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.configureUnreadCountBadge(channel: Channel) {
+    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabelAndTimestamp(
+        lastMessage: Message?
+    ) {
+        lastMessageLabel.isVisible = lastMessage.isNotNull()
+        lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
+
+        lastMessage ?: return
+
+        lastMessageLabel.text = channel.getLastMessagePreviewText(context, channel.isDirectMessaging())
+        lastMessageTimeLabel.text = dateFormatter.formatDate(lastMessage.getCreatedAtOrThrow())
+    }
+
+    private fun StreamUiChannelListItemForegroundViewBinding.configureUnreadCountBadge() {
         val haveUnreadMessages = channel.unreadCount ?: 0 > 0
         unreadCountBadge.isVisible = haveUnreadMessages
 
@@ -177,35 +187,12 @@ public class ChannelViewHolder @JvmOverloads constructor(
             return
         }
 
-        unreadCountBadge.apply {
-            text = channel.unreadCount.toString()
-        }
-    }
-
-    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageTimestamp(lastMessage: Message?) {
-        lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
-
-        lastMessage ?: return
-
-        lastMessageTimeLabel.text = dateFormatter.formatDate(lastMessage.getCreatedAtOrThrow())
-    }
-
-    private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabel(
-        channel: Channel,
-        lastMessage: Message?
-    ) {
-        lastMessageLabel.isVisible = lastMessage.isNotNull()
-
-        lastMessage ?: return
-
-        lastMessageLabel.text = channel.getLastMessagePreviewText(context, channel.isDirectMessaging())
+        unreadCountBadge.text = channel.unreadCount.toString()
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureCurrentUserLastMessageStatus(
-        channel: Channel,
         lastMessage: Message?
     ) {
-
         messageStatusImageView.isVisible = lastMessage != null
 
         lastMessage ?: return
@@ -245,13 +232,7 @@ public class ChannelViewHolder @JvmOverloads constructor(
         }
     }
 
-    private var styleApplied = false
-
     private fun StreamUiChannelListItemForegroundViewBinding.applyStyle(style: ChannelListViewStyle) {
-        if (styleApplied) {
-            return
-        }
-
         binding.apply {
             channelNameLabel.setTextSizePx(style.channelTitleTextSize)
             lastMessageLabel.setTextSizePx(style.lastMessageSize)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/mentions/MentionsListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/mentions/MentionsListAdapter.kt
@@ -1,12 +1,12 @@
 package io.getstream.chat.android.ui.mentions
 
 import android.content.Context
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.DateFormatter
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionListBinding
@@ -26,7 +26,7 @@ public class MentionsListAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessagePreviewViewHolder {
         return StreamUiItemMentionListBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { binding ->
                 binding.root.dateFormatter = dateFormatter
                 MessagePreviewViewHolder(binding.root)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
@@ -82,22 +82,27 @@ private class FileAttachmentViewHolder(
     }
 
     init {
-        binding.root.background =
-            ShapeAppearanceModel.builder().setAllCornerSizes(CORNER_SIZE_PX).build().let(::MaterialShapeDrawable)
-                .apply {
-                    setStroke(
-                        STROKE_WIDTH_PX,
-                        ContextCompat.getColor(itemView.context, R.color.stream_ui_border_stroke)
-                    )
-                    setTint(ContextCompat.getColor(itemView.context, R.color.stream_ui_white))
-                }
+        binding.root.background = ShapeAppearanceModel.builder()
+            .setAllCornerSizes(CORNER_SIZE_PX)
+            .build()
+            .let(::MaterialShapeDrawable)
+            .apply {
+                setStroke(
+                    STROKE_WIDTH_PX,
+                    ContextCompat.getColor(itemView.context, R.color.stream_ui_border_stroke)
+                )
+                setTint(ContextCompat.getColor(itemView.context, R.color.stream_ui_white))
+            }
     }
 
-    override fun bind(attachment: Attachment) {
-        this.attachment = attachment
-        binding.fileTypeIcon.setImageResource(UiUtils.getIcon(attachment.mimeType))
-        binding.fileTitle.text = attachment.title ?: attachment.name
-        binding.fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
+    override fun bind(item: Attachment) {
+        this.attachment = item
+
+        binding.apply {
+            fileTypeIcon.setImageResource(UiUtils.getIcon(attachment.mimeType))
+            fileTitle.text = attachment.title ?: attachment.name
+            fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
+        }
     }
 
     companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
@@ -13,7 +13,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class GiphyViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer? = null,
+    listenerContainer: MessageListListenerContainer?,
     internal val binding: StreamUiItemMessageGiphyBinding = StreamUiItemMessageGiphyBinding.inflate(
         parent.inflater,
         parent,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
@@ -13,39 +13,34 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class GiphyViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    private val listenerContainer: MessageListListenerContainer? = null,
+    listenerContainer: MessageListListenerContainer? = null,
     internal val binding: StreamUiItemMessageGiphyBinding = StreamUiItemMessageGiphyBinding.inflate(
         parent.inflater,
         parent,
         false
     )
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
+
+    init {
+        listenerContainer?.also { listeners ->
+            binding.run {
+                cancelButton.setOnClickListener {
+                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.CANCEL)
+                }
+                sendButton.setOnClickListener {
+                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SEND)
+                }
+                nextButton.setOnClickListener {
+                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SHUFFLE)
+                }
+            }
+        }
+    }
+
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         if (data.isMine) {
             data.message.attachments.firstOrNull()?.let(binding.mediaAttachmentView::showAttachment)
-
             binding.giphyTextLabel.text = trimText(data.message.text)
-
-            listenerContainer?.also { listeners ->
-                binding.cancelButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(
-                        data.message,
-                        GiphyAction.CANCEL
-                    )
-                }
-                binding.sendButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(
-                        data.message,
-                        GiphyAction.SEND
-                    )
-                }
-                binding.nextButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(
-                        data.message,
-                        GiphyAction.SHUFFLE
-                    )
-                }
-            }
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/ReactionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/ReactionsAdapter.kt
@@ -1,11 +1,11 @@
 package io.getstream.chat.android.ui.messages.reactions
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.annotation.Px
 import androidx.core.view.updateLayoutParams
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiItemMessageReactionBinding
 import io.getstream.chat.android.ui.utils.UiUtils
@@ -19,7 +19,7 @@ internal class ReactionsAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ReactionViewHolder {
         return StreamUiItemMessageReactionBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { ReactionViewHolder(it, itemSize, reactionClickListener) }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchResultListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchResultListAdapter.kt
@@ -1,12 +1,12 @@
 package io.getstream.chat.android.ui.search
 
 import android.content.Context
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.DateFormatter
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionListBinding
@@ -25,7 +25,7 @@ public class SearchResultListAdapter(
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MessagePreviewViewHolder {
         return StreamUiItemMentionListBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { binding ->
                 binding.root.dateFormatter = dateFormatter
                 MessagePreviewViewHolder(binding)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestions/CommandsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestions/CommandsAdapter.kt
@@ -1,10 +1,10 @@
 package io.getstream.chat.android.ui.suggestions
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiItemCommandBinding
@@ -24,7 +24,7 @@ internal class CommandsAdapter(
 ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommandViewHolder {
         return StreamUiItemCommandBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { CommandViewHolder(it, onCommandSelected) }
     }
 
@@ -37,14 +37,22 @@ internal class CommandsAdapter(
         private val onCommandClicked: (Command) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(command: Command) {
-            binding.commandNameTextView.text = command.name.capitalize()
-            binding.commandQueryTextView.text = itemView.context.getString(
-                R.string.stream_ui_command_command_template,
-                command.name,
-                command.args
-            )
+        lateinit var command: Command
+
+        init {
             binding.root.setOnClickListener { onCommandClicked(command) }
+        }
+
+        fun bind(command: Command) {
+            this.command = command
+            binding.apply {
+                commandNameTextView.text = command.name.capitalize()
+                commandQueryTextView.text = itemView.context.getString(
+                    R.string.stream_ui_command_command_template,
+                    command.name,
+                    command.args
+                )
+            }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestions/MentionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestions/MentionsAdapter.kt
@@ -1,10 +1,10 @@
 package io.getstream.chat.android.ui.suggestions
 
-import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.ui.R
@@ -25,7 +25,7 @@ internal class MentionsAdapter(
 ) {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MentionViewHolder {
         return StreamUiItemMentionBinding
-            .inflate(LayoutInflater.from(parent.context), parent, false)
+            .inflate(parent.inflater, parent, false)
             .let { MentionViewHolder(it, onMentionSelected) }
     }
 
@@ -38,14 +38,23 @@ internal class MentionsAdapter(
         private val onUserClicked: (User) -> Unit
     ) : RecyclerView.ViewHolder(binding.root) {
 
-        fun bind(user: User) {
-            binding.avatarView.setUserData(user)
-            binding.usernameTextView.text = user.name
-            binding.mentionNameTextView.text = itemView.context.getString(
-                R.string.stream_ui_mention_user_name_template,
-                user.name.toLowerCase()
-            )
+        lateinit var user: User
+
+        init {
             binding.root.setOnClickListener { onUserClicked(user) }
+        }
+
+        fun bind(user: User) {
+            this.user = user
+
+            binding.apply {
+                avatarView.setUserData(user)
+                usernameTextView.text = user.name
+                mentionNameTextView.text = itemView.context.getString(
+                    R.string.stream_ui_mention_user_name_template,
+                    user.name.toLowerCase()
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-498

### Description

Refactors our ViewHolders so that they create all listeners when initialized, and store the current model in a property so that listeners can reference it.

Also adjusts some code style so that all ViewHolders use inflaters and `binding.apply` calls in the same way.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
