### PR TITLE
[CAS-515] Basic download functionality

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
@@ -1,0 +1,40 @@
+package io.getstream.chat.android.livedata.usecase
+
+import android.app.DownloadManager
+import android.content.Context
+import android.net.Uri
+import android.os.Environment
+import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.call.CoroutineCall
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.models.Attachment
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import java.lang.Exception
+
+public interface DownloadAttachment {
+    /**
+     * Downloads the selected attachment to the "Download" folder in the public external storage directory.
+     *
+     * @param attachment the attachment to download
+     */
+    public operator fun invoke(attachment: Attachment): Call<Unit>
+}
+
+internal class DownloadAttachmentImpl(private val domainImpl: ChatDomainImpl) : DownloadAttachment {
+    override operator fun invoke(attachment: Attachment): Call<Unit> {
+        val result: Result<Unit> = try {
+            val downloadManager = domainImpl.appContext.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+            downloadManager.enqueue(
+                DownloadManager.Request(Uri.parse(attachment.assetUrl))
+                    .setTitle(attachment.name)
+                    .setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, attachment.name)
+                    .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+            )
+            Result(Unit)
+        } catch (e: Exception) {
+            Result(ChatError(cause = e))
+        }
+        return CoroutineCall(domainImpl.scope) { result }
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/UseCaseHelper.kt
@@ -154,4 +154,9 @@ public class UseCaseHelper internal constructor(chatDomainImpl: ChatDomainImpl) 
     public val deleteChannel: DeleteChannel = DeleteChannelImpl(chatDomainImpl)
 
     public val setMessageForReply: SetMessageForReply = SetMessageForReplyImpl(chatDomainImpl)
+
+    /**
+     * Downloads selected attachment
+     */
+    public val downloadAttachment: DownloadAttachment = DownloadAttachmentImpl(chatDomainImpl)
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModel
 import com.getstream.sdk.chat.enums.GiphyAction
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Message
@@ -199,6 +200,9 @@ public class MessageListViewModel @JvmOverloads constructor(
             is Event.ReplyMessage -> {
                 domain.useCases.setMessageForReply(event.cid, event.repliedMessage).enqueue()
             }
+            is Event.AttachmentDownload -> {
+                domain.useCases.downloadAttachment.invoke(event.attachment).enqueue()
+            }
         }.exhaustive
     }
 
@@ -298,6 +302,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         public data class MuteUser(val user: User) : Event()
         public data class BlockUser(val user: User, val channel: Channel) : Event()
         public data class ReplyMessage(val cid: String, val repliedMessage: Message) : Event()
+        public data class AttachmentDownload(val attachment: Attachment) : Event()
     }
 
     public sealed class Mode {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainer.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.messages.adapter
 
 import io.getstream.chat.android.ui.messages.view.MessageListView
 import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentDownloadClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.GiphySendListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageLongClickListener
@@ -16,6 +17,7 @@ public interface MessageListListenerContainer {
     public val messageRetryListener: MessageRetryListener
     public val threadClickListener: MessageListView.ThreadClickListener
     public val attachmentClickListener: AttachmentClickListener
+    public val attachmentDownloadClickListener: AttachmentDownloadClickListener
     public val reactionViewClickListener: ReactionViewClickListener
     public val userClickListener: UserClickListener
     public val readStateClickListener: ReadStateClickListener

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainerImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListListenerContainerImpl.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.messages.adapter
 
 import com.getstream.sdk.chat.utils.ListenerDelegate
 import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentDownloadClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.GiphySendListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageClickListener
 import io.getstream.chat.android.ui.messages.view.MessageListView.MessageLongClickListener
@@ -17,6 +18,7 @@ internal class MessageListListenerContainerImpl(
     messageRetryListener: MessageRetryListener = MessageRetryListener(EmptyFunctions.ONE_PARAM),
     threadClickListener: ThreadClickListener = ThreadClickListener(EmptyFunctions.ONE_PARAM),
     attachmentClickListener: AttachmentClickListener = AttachmentClickListener(EmptyFunctions.TWO_PARAM),
+    attachmentDownloadClickListener: AttachmentDownloadClickListener = AttachmentDownloadClickListener(EmptyFunctions.ONE_PARAM),
     reactionViewClickListener: ReactionViewClickListener = ReactionViewClickListener(EmptyFunctions.ONE_PARAM),
     userClickListener: UserClickListener = UserClickListener(EmptyFunctions.ONE_PARAM),
     readStateClickListener: ReadStateClickListener = ReadStateClickListener(EmptyFunctions.ONE_PARAM),
@@ -64,6 +66,14 @@ internal class MessageListListenerContainerImpl(
     ) { realListener ->
         AttachmentClickListener { message, attachment ->
             realListener().onAttachmentClick(message, attachment)
+        }
+    }
+
+    override var attachmentDownloadClickListener: AttachmentDownloadClickListener by ListenerDelegate(
+        attachmentDownloadClickListener
+    ) { realListener ->
+        AttachmentDownloadClickListener { attachment ->
+            realListener().onAttachmentDownloadClick(attachment)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/AttachmentClickListener.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/AttachmentClickListener.kt
@@ -9,3 +9,7 @@ internal fun interface AttachmentClickListener {
 internal fun interface AttachmentLongClickListener {
     fun onAttachmentLongClick()
 }
+
+internal fun interface AttachmentDownloadClickListener {
+    fun onAttachmentDownloadClick(attachment: Attachment)
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
@@ -23,10 +23,12 @@ import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
 internal class FileAttachmentsView : RecyclerView {
     var attachmentClickListener: AttachmentClickListener? = null
     var attachmentLongClickListener: AttachmentLongClickListener? = null
+    var attachmentDownloadClickListener: AttachmentDownloadClickListener? = null
 
     private val fileAttachmentsAdapter = FileAttachmentsAdapter(
         attachmentClickListener = { attachmentClickListener?.onAttachmentClick(it) },
-        attachmentLongClickListener = { attachmentLongClickListener?.onAttachmentLongClick() }
+        attachmentLongClickListener = { attachmentLongClickListener?.onAttachmentLongClick() },
+        attachmentDownloadClickListener = { attachmentDownloadClickListener?.onAttachmentDownloadClick(it) }
     )
 
     constructor(context: Context) : super(context)
@@ -56,28 +58,42 @@ private class VerticalSpaceItemDecorator(private val marginPx: Int) : RecyclerVi
 
 private class FileAttachmentsAdapter(
     private val attachmentClickListener: AttachmentClickListener,
-    private val attachmentLongClickListener: AttachmentLongClickListener
+    private val attachmentLongClickListener: AttachmentLongClickListener,
+    private val attachmentDownloadClickListener: AttachmentDownloadClickListener
 ) : SimpleListAdapter<Attachment, FileAttachmentViewHolder>() {
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FileAttachmentViewHolder {
         return StreamUiItemFileAttachmentBinding
             .inflate(parent.inflater, parent, false)
-            .let { FileAttachmentViewHolder(it, attachmentClickListener, attachmentLongClickListener) }
+            .let {
+                FileAttachmentViewHolder(
+                    it,
+                    attachmentClickListener,
+                    attachmentLongClickListener,
+                    attachmentDownloadClickListener
+                )
+            }
     }
 }
 
 private class FileAttachmentViewHolder(
     private val binding: StreamUiItemFileAttachmentBinding,
     private val attachmentClickListener: AttachmentClickListener,
-    private val attachmentLongClickListener: AttachmentLongClickListener
+    private val attachmentLongClickListener: AttachmentLongClickListener,
+    private val attachmentDownloadClickListener: AttachmentDownloadClickListener
 ) : SimpleListAdapter.ViewHolder<Attachment>(binding.root) {
-    private lateinit var attachment: Attachment
+    private lateinit var item: Attachment
 
     init {
-        binding.root.setOnClickListener { attachmentClickListener.onAttachmentClick(attachment) }
+        binding.root.setOnClickListener {
+            attachmentClickListener.onAttachmentClick(item)
+        }
         binding.root.setOnLongClickListener {
             attachmentLongClickListener.onAttachmentLongClick()
             true
+        }
+        binding.actionButton.setOnClickListener {
+            attachmentDownloadClickListener.onAttachmentDownloadClick(item)
         }
     }
 
@@ -93,11 +109,11 @@ private class FileAttachmentViewHolder(
                 }
     }
 
-    override fun bind(attachment: Attachment) {
-        this.attachment = attachment
-        binding.fileTypeIcon.setImageResource(UiUtils.getIcon(attachment.mimeType))
-        binding.fileTitle.text = attachment.title ?: attachment.name
-        binding.fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
+    override fun bind(item: Attachment) {
+        this.item = item
+        binding.fileTypeIcon.setImageResource(UiUtils.getIcon(item.mimeType))
+        binding.fileTitle.text = item.title ?: item.name
+        binding.fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.fileSize.toLong())
     }
 
     companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -8,6 +8,7 @@ import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.messages.adapter.view.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentDownloadClickListener
 import io.getstream.chat.android.ui.messages.adapter.view.AttachmentLongClickListener
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 
@@ -37,6 +38,9 @@ public class OnlyFileAttachmentsViewHolder(
                 }
                 fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
                     listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+                }
+                fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
+                    listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
                 }
 
                 root.setOnLongClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -8,6 +8,7 @@ import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.messages.adapter.view.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.adapter.view.AttachmentDownloadClickListener
 import io.getstream.chat.android.ui.messages.adapter.view.AttachmentLongClickListener
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
 import io.getstream.chat.android.ui.utils.extensions.hasLink
@@ -38,6 +39,9 @@ public class PlainTextWithFileAttachmentsViewHolder(
                 }
                 threadRepliesFootnote.root.setOnClickListener {
                     listeners.threadClickListener.onThreadClick(data.message)
+                }
+                fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
+                    listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
                 }
 
                 root.setOnLongClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.TextView
+import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -136,6 +137,9 @@ public class MessageListView : ConstraintLayout {
     private var onReplyMessageHandler: (cid: String, Message) -> Unit = { _, _ ->
         throw IllegalStateException("onReplyMessageHandler must be set")
     }
+    private var onAttachmentDownloadHandler: (Attachment) -> Unit = {
+        throw IllegalStateException("onAttachmentDownloadHandler must be set")
+    }
 
     private lateinit var messageOptionsConfiguration: MessageOptionsView.Configuration
 
@@ -203,6 +207,15 @@ public class MessageListView : ConstraintLayout {
                 .navigator
                 .navigate(GalleryImageAttachmentDestination(message, attachment, context))
         }
+    private val DEFAULT_ATTACHMENT_DOWNLOAD_CLICK_LISTENER =
+        AttachmentDownloadClickListener { attachment ->
+            onAttachmentDownloadHandler.invoke(attachment)
+            Toast.makeText(
+                context,
+                context.getString(R.string.stream_ui_attachment_downloading_started),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
     private val DEFAULT_REACTION_VIEW_CLICK_LISTENER =
         ReactionViewClickListener { message: Message ->
             context.getFragmentManager()?.let {
@@ -231,6 +244,7 @@ public class MessageListView : ConstraintLayout {
         messageRetryListener = DEFAULT_MESSAGE_RETRY_LISTENER,
         threadClickListener = DEFAULT_THREAD_CLICK_LISTENER,
         attachmentClickListener = DEFAULT_ATTACHMENT_CLICK_LISTENER,
+        attachmentDownloadClickListener = DEFAULT_ATTACHMENT_DOWNLOAD_CLICK_LISTENER,
         reactionViewClickListener = DEFAULT_REACTION_VIEW_CLICK_LISTENER,
         userClickListener = DEFAULT_USER_CLICK_LISTENER,
         readStateClickListener = DEFAULT_READ_STATE_CLICK_LISTENER,
@@ -778,6 +792,14 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
+     *
+     */
+    public fun setAttachmentDownloadClickListener(attachmentDownloadClickListener: AttachmentDownloadClickListener?) {
+        listenerContainer.attachmentDownloadClickListener =
+            attachmentDownloadClickListener ?: DEFAULT_ATTACHMENT_DOWNLOAD_CLICK_LISTENER
+    }
+
+    /**
      * Sets the reaction view click listener to be used by MessageListView.
      *
      * @param reactionViewClickListener The listener to use. If null, the default will be used instead.
@@ -862,6 +884,10 @@ public class MessageListView : ConstraintLayout {
         this.onReplyMessageHandler = onReplyMessageHandler
     }
 
+    public fun setOnAttachmentDownloadHandler(onAttachmentDownloadHandler: (Attachment) -> Unit) {
+        this.onAttachmentDownloadHandler = onAttachmentDownloadHandler
+    }
+
     public fun interface MessageClickListener {
         public fun onMessageClick(message: Message)
     }
@@ -880,6 +906,10 @@ public class MessageListView : ConstraintLayout {
 
     public fun interface AttachmentClickListener {
         public fun onAttachmentClick(message: Message, attachment: Attachment)
+    }
+
+    public fun interface AttachmentDownloadClickListener {
+        public fun onAttachmentDownloadClick(attachment: Attachment)
     }
 
     public fun interface GiphySendListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -792,7 +792,9 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
+     * Sets the attachment download click listener to be used by MessageListView.
      *
+     * @param attachmentDownloadClickListener The listener to use. If null, the default will be used instead.
      */
     public fun setAttachmentDownloadClickListener(attachmentDownloadClickListener: AttachmentDownloadClickListener?) {
         listenerContainer.attachmentDownloadClickListener =

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
@@ -4,6 +4,7 @@ package io.getstream.chat.android.ui.messages.view
 
 import androidx.lifecycle.LifecycleOwner
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.AttachmentDownload
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.BlockUser
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.DeleteMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.EndRegionReached
@@ -40,6 +41,7 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
     view.setOnMuteUserHandler { onEvent(MuteUser(it)) }
     view.setOnBlockUserHandler { user, channel -> onEvent(BlockUser(user, channel)) }
     view.setOnReplyMessageHandler { cid, message -> onEvent(ReplyMessage(cid, message)) }
+    view.setOnAttachmentDownloadHandler { attachment -> onEvent(AttachmentDownload(attachment)) }
 
     state.observe(lifecycleOwner) { state ->
         when (state) {

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="8dp"
-    android:foreground="?selectableItemBackground"
     android:background="@drawable/stream_ui_shape_selected_media_round"
+    android:foreground="?selectableItemBackground"
+    android:padding="8dp"
     >
 
     <ImageView
@@ -50,11 +49,11 @@
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:textColor="@color/stream_ui_text_grey"
         android:textSize="@dimen/stream_ui_text_small"
-        app:layout_goneMarginStart="0dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/actionButton"
         app:layout_constraintStart_toEndOf="@id/progressBar"
         app:layout_constraintTop_toBottomOf="@id/fileTitle"
+        app:layout_goneMarginStart="0dp"
         tools:text="123 KB"
         />
 
@@ -63,18 +62,19 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:indeterminateDrawable="@drawable/stream_ui_rotating_indeterminate_progress_gradient"
-        app:layout_constraintTop_toBottomOf="@id/fileTitle"
+        android:visibility="gone"
         app:layout_constraintStart_toStartOf="@id/fileTitle"
-        android:visibility="gone"/>
+        app:layout_constraintTop_toBottomOf="@id/fileTitle"
+        />
 
     <ImageView
         android:id="@+id/actionButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:background="?attr/selectableItemBackgroundBorderless"
         android:src="@drawable/stream_ui_ic_icon_download"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        android:visibility="gone"
         tools:ignore="ContentDescription"
         />
 

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -76,6 +76,7 @@
     <string name="stream_ui_attachments_more_count_prefix">+%d</string>
     <string name="stream_ui_send_label">Send</string>
     <string name="stream_ui_cancel_label">Cancel</string>
+    <string name="stream_ui_attachment_downloading_started">Downloading started</string>
 
     <!-- Message options -->
     <string name="stream_ui_message_option_reply">Reply</string>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-515

### Description

This PR adds a possibility to download a file from the message list.

What's covered:
- User is able to download any file from the message list via standard Android `DownloadManager`

What's not covered (almost everything):
- Persistent storage for downloads with download status (started/completed/failed) and download progress
- Possibility to observe download state in `ChannelController`. 
- UI that reflects the current state of particular download (able to download / downloading is in progress / downloading completed)
- Possibility to cancel ongoing downloads
- Possibility to navigate to downloaded file directly from the message list

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

https://user-images.githubusercontent.com/9600921/103778724-b682fa00-5043-11eb-820d-4510b590f6d2.mov

