### PR TITLE
[CAS-512] Original name for attachments

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -134,9 +134,7 @@ public class StorageHelper {
         return attachments
     }
 
-    private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
-        "${attachmentMetaData.getTitleWithExtension()}_STREAM_${dateFormat.format(Date().time)}"
-}
+    private fun getFileName(attachmentMetaData: AttachmentMetaData): String = attachmentMetaData.getTitleWithExtension()
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {
     val extension = MimeTypeMap.getFileExtensionFromUrl(title)

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -13,6 +13,7 @@ import com.getstream.sdk.chat.model.ModelType
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import java.io.File
 import java.text.SimpleDateFormat
+import java.util.Date
 import java.util.Locale
 
 @InternalStreamChatApi
@@ -133,7 +134,11 @@ public class StorageHelper {
         return attachments
     }
 
-    private fun getFileName(attachmentMetaData: AttachmentMetaData): String = attachmentMetaData.getTitleWithExtension()
+    private fun getFileName(attachmentMetaData: AttachmentMetaData): String {
+        return attachmentMetaData.run {
+            "${title}_STREAM_${dateFormat.format(Date().time)}.${getExtension()}"
+        }
+    }
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {
@@ -144,6 +149,10 @@ private fun AttachmentMetaData.getTitleWithExtension(): String {
         // TODO: Attachment's title should never be null. Review AttachmentMetaData class
         title ?: ""
     }
+}
+
+private fun AttachmentMetaData.getExtension(): String? {
+    return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
 }
 
 internal sealed class MediaType(val contentUri: Uri, val modelType: String)

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -135,7 +135,7 @@ public class StorageHelper {
     }
 
     private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
-        "STREAM_${dateFormat.format(Date().time)}_${attachmentMetaData.getTitleWithExtension()}"
+        "${attachmentMetaData.getTitleWithExtension()}_STREAM_${dateFormat.format(Date().time)}"
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 
 @InternalStreamChatApi
 public class StorageHelper {
-    private val dateFormat = SimpleDateFormat("HHmmssSSS", Locale.US)
+    private val dateFormat = SimpleDateFormat(TIME_FORMAT, Locale.US)
 
     public fun getCachedFileFromUri(
         context: Context,
@@ -135,8 +135,11 @@ public class StorageHelper {
     }
 
     private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
-        "${dateFormat.format(Date().time)}_${attachmentMetaData.getTitleWithExtension()}"
+        "prefix_${dateFormat.format(Date().time)}_stm_${attachmentMetaData.getTitleWithExtension()}"
 
+    public companion object {
+        public const val TIME_FORMAT: String = "HHmmssSSS"
+    }
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -135,7 +135,7 @@ public class StorageHelper {
     }
 
     private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
-        "prefix_${dateFormat.format(Date().time)}_stm_${attachmentMetaData.getTitleWithExtension()}"
+        "STREAM_${dateFormat.format(Date().time)}_prefix_${attachmentMetaData.getTitleWithExtension()}"
 
     public companion object {
         public const val TIME_FORMAT: String = "HHmmssSSS"

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -13,7 +13,6 @@ import com.getstream.sdk.chat.model.ModelType
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import java.io.File
 import java.text.SimpleDateFormat
-import java.util.Date
 import java.util.Locale
 
 @InternalStreamChatApi
@@ -135,6 +134,7 @@ public class StorageHelper {
     }
 
     private fun getFileName(attachmentMetaData: AttachmentMetaData): String = attachmentMetaData.getTitleWithExtension()
+}
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {
     val extension = MimeTypeMap.getFileExtensionFromUrl(title)

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -135,7 +135,7 @@ public class StorageHelper {
     }
 
     private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
-        "STREAM_${dateFormat.format(Date().time)}_prefix_${attachmentMetaData.getTitleWithExtension()}"
+        "STREAM_${dateFormat.format(Date().time)}_${attachmentMetaData.getTitleWithExtension()}"
 
     public companion object {
         public const val TIME_FORMAT: String = "HHmmssSSS"
@@ -150,10 +150,6 @@ private fun AttachmentMetaData.getTitleWithExtension(): String {
         // TODO: Attachment's title should never be null. Review AttachmentMetaData class
         title ?: ""
     }
-}
-
-private fun AttachmentMetaData.getExtension(): String? {
-    return MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)
 }
 
 internal sealed class MediaType(val contentUri: Uri, val modelType: String)

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -18,7 +18,7 @@ import java.util.Locale
 
 @InternalStreamChatApi
 public class StorageHelper {
-    private val dateFormat = SimpleDateFormat("yyyyMMdd_HHmmssSSS", Locale.US)
+    private val dateFormat = SimpleDateFormat("HHmmssSSS", Locale.US)
 
     public fun getCachedFileFromUri(
         context: Context,
@@ -134,11 +134,9 @@ public class StorageHelper {
         return attachments
     }
 
-    private fun getFileName(attachmentMetaData: AttachmentMetaData): String {
-        return attachmentMetaData.run {
-            "${title}_STREAM_${dateFormat.format(Date().time)}.${getExtension()}"
-        }
-    }
+    private fun getFileName(attachmentMetaData: AttachmentMetaData): String =
+        "${dateFormat.format(Date().time)}_${attachmentMetaData.getTitleWithExtension()}"
+
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
@@ -1,0 +1,14 @@
+package com.getstream.sdk.chat.utils
+
+public object StringUtils {
+
+    public fun removeTimePrefix(attachmentName: String?, usedDateFormat: String): String? {
+        val regex = "^prefix_\\S+_stm_".toRegex()
+
+        return if (attachmentName?.contains(regex) == true) {
+            attachmentName.removeRange(0, 12 + usedDateFormat.length)
+        } else {
+            attachmentName
+        }
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
@@ -3,10 +3,11 @@ package com.getstream.sdk.chat.utils
 internal object StringUtils {
 
     fun removeTimePrefix(attachmentName: String?, usedDateFormat: String): String? {
-        val regex = "^prefix_\\S+_stm_".toRegex()
+        val dataFormatSize = usedDateFormat.length + 1
+        val regex = "^prefix_\\S{$dataFormatSize}".toRegex()
 
         return if (attachmentName?.contains(regex) == true) {
-            attachmentName.removeRange(0, 12 + usedDateFormat.length)
+            attachmentName.replaceFirst(regex, "")
         } else {
             attachmentName
         }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StringUtils.kt
@@ -1,8 +1,8 @@
 package com.getstream.sdk.chat.utils
 
-public object StringUtils {
+internal object StringUtils {
 
-    public fun removeTimePrefix(attachmentName: String?, usedDateFormat: String): String? {
+    fun removeTimePrefix(attachmentName: String?, usedDateFormat: String): String? {
         val regex = "^prefix_\\S+_stm_".toRegex()
 
         return if (attachmentName?.contains(regex) == true) {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/AttachmentExtension.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/AttachmentExtension.kt
@@ -1,0 +1,9 @@
+package com.getstream.sdk.chat.utils.extensions
+
+import com.getstream.sdk.chat.utils.StorageHelper
+import com.getstream.sdk.chat.utils.StringUtils
+import io.getstream.chat.android.client.models.Attachment
+
+public fun Attachment.getDisplayableName(): String? {
+    return StringUtils.removeTimePrefix(title ?: name, StorageHelper.TIME_FORMAT)
+}

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
@@ -1,0 +1,28 @@
+package com.getstream.sdk.chat.utils
+
+import io.getstream.chat.android.test.randomString
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+public class StringUtilsTest {
+
+    @Test
+    public fun shouldRemoveAttachmentPrefixFromString() {
+        val dateFormat = "HHmmssSSS"
+
+        val result = StringUtils.removeTimePrefix("prefix_${dateFormat}_stm_file_name", dateFormat)
+
+        assertEquals("file_name", result)
+    }
+
+    @Test
+    public fun shouldNotChangeStringWhenPrefixIsNotPresent() {
+        val dateFormat = "HHmmssSSS"
+        val randomString = randomString(5)
+
+        val result = StringUtils.removeTimePrefix(randomString, dateFormat)
+
+        assertEquals(randomString, result)
+    }
+
+}

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
@@ -9,10 +9,11 @@ public class StringUtilsTest {
     @Test
     public fun shouldRemoveAttachmentPrefixFromString() {
         val dateFormat = "HHmmssSSS"
+        val fileName = randomString(5)
 
-        val result = StringUtils.removeTimePrefix("prefix_${dateFormat}_stm_file_name", dateFormat)
+        val result = StringUtils.removeTimePrefix("prefix_${dateFormat}_$fileName", dateFormat)
 
-        assertEquals("file_name", result)
+        assertEquals(fileName, result)
     }
 
     @Test
@@ -23,5 +24,15 @@ public class StringUtilsTest {
         val result = StringUtils.removeTimePrefix(randomString, dateFormat)
 
         assertEquals(randomString, result)
+    }
+
+    @Test
+    public fun shouldBeAbleNamesWithOurPrefixMark() {
+        val dateFormat = "HHmmssSSS"
+        val fileName = randomString(5)
+
+        val result = StringUtils.removeTimePrefix("prefix_${dateFormat}_$fileName", dateFormat)
+
+        assertEquals(fileName, result)
     }
 }

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StringUtilsTest.kt
@@ -1,7 +1,7 @@
 package com.getstream.sdk.chat.utils
 
 import io.getstream.chat.android.test.randomString
-import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 public class StringUtilsTest {
@@ -24,5 +24,4 @@ public class StringUtilsTest {
 
         assertEquals(randomString, result)
     }
-
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
@@ -9,8 +9,7 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.MediaStringUtil
-import com.getstream.sdk.chat.utils.StorageHelper
-import com.getstream.sdk.chat.utils.StringUtils
+import com.getstream.sdk.chat.utils.extensions.getDisplayableName
 import com.getstream.sdk.chat.utils.extensions.inflater
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -118,8 +117,7 @@ private class FileAttachmentViewHolder(
 
         binding.apply {
             fileTypeIcon.setImageResource(UiUtils.getIcon(attachment.mimeType))
-            fileTitle.text =
-                StringUtils.removeTimePrefix(attachment.title ?: attachment.name, StorageHelper.TIME_FORMAT)
+            fileTitle.text = attachment.getDisplayableName()
             fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/FileAttachmentsView.kt
@@ -9,6 +9,8 @@ import androidx.core.content.ContextCompat
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.MediaStringUtil
+import com.getstream.sdk.chat.utils.StorageHelper
+import com.getstream.sdk.chat.utils.StringUtils
 import com.getstream.sdk.chat.utils.extensions.inflater
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -116,7 +118,8 @@ private class FileAttachmentViewHolder(
 
         binding.apply {
             fileTypeIcon.setImageResource(UiUtils.getIcon(attachment.mimeType))
-            fileTitle.text = attachment.title ?: attachment.name
+            fileTitle.text =
+                StringUtils.removeTimePrefix(attachment.title ?: attachment.name, StorageHelper.TIME_FORMAT)
             fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
@@ -28,8 +28,6 @@
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/stream_ui_spacing_medium"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
-        android:ellipsize="end"
-        android:maxLines="1"
         android:textColor="@color/stream_ui_text_color_strong"
         android:textSize="@dimen/stream_ui_text_medium"
         android:textStyle="bold"


### PR DESCRIPTION
[CAS-512](https://stream-io.atlassian.net/browse/CAS-512)

### Description

This PR removes the timestamp and the STREAM from the name of the attachment file. This way the user sees the original name, instead of just STREAM_202... 

Edit:

Removing `STREAM_` from the prefix and removing the maxline=1 from the textview. Now the item can show files with title with multiple lines. 

_The last one is the name with the change in the code._ 
![Screenshot_20210106-163246](https://user-images.githubusercontent.com/10619102/103786627-ee3a7380-503c-11eb-962b-e58d3e8a5568.png)

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added