### PR TITLE
Apply channel click listeners to foreground view only

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -82,12 +82,11 @@ public class ChannelViewHolder @JvmOverloads constructor(
                     channelLongClickListener.onClick(channel)
                     true
                 }
+                root.doOnNextLayout {
+                    setSwipeListener(root, swipeListener)
+                }
 
                 applyStyle(style)
-            }
-
-            root.doOnNextLayout {
-                setSwipeListener(root, swipeListener)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -58,14 +58,6 @@ public class ChannelViewHolder @JvmOverloads constructor(
 
     init {
         binding.apply {
-            root.setOnClickListener {
-                channelClickListener.onClick(channel)
-            }
-            root.setOnLongClickListener {
-                channelLongClickListener.onClick(channel)
-                true
-            }
-
             itemBackgroundView.apply {
                 moreOptionsImageView.setOnClickListener {
                     channelMoreOptionsListener.onClick(channel)
@@ -82,6 +74,13 @@ public class ChannelViewHolder @JvmOverloads constructor(
                         channel.isDirectMessaging() -> userClickListener.onClick(currentUser)
                         else -> channelClickListener.onClick(channel)
                     }
+                }
+                root.setOnClickListener {
+                    channelClickListener.onClick(channel)
+                }
+                root.setOnLongClickListener {
+                    channelLongClickListener.onClick(channel)
+                    true
                 }
 
                 applyStyle(style)


### PR DESCRIPTION

### Description

Fixes a bug I introduced in https://github.com/GetStream/stream-chat-android/pull/1140, where the click and long click listeners for channel items were applied to the root of their entire layout, instead of the root of the foreground layer.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
