### PR TITLE
Make download attachment user case internal

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
@@ -9,9 +9,11 @@ import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomainImpl
 import java.lang.Exception
 
+@InternalStreamChatApi
 public interface DownloadAttachment {
     /**
      * Downloads the selected attachment to the "Download" folder in the public external storage directory.


### PR DESCRIPTION
### Description

Making `DownloadAttachment` use case `internal` as its implementation is not complete.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
