### PR TITLE
Ignore benchmark test

### DIFF
--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveDataBenchmark.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveDataBenchmark.kt
@@ -12,10 +12,12 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.test.createDate
 import io.getstream.chat.android.test.getOrAwaitValue
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import kotlin.system.measureTimeMillis
 
+@Ignore("Flaky on CI")
 internal class MessageListItemLiveDataBenchmark {
 
     @get:Rule


### PR DESCRIPTION
### Description

This test currently measures the performance of GitHub Actions instead of our `MessageListItemLiveData` class, as it breaks randomly on CI, without us making any relevant changes to it at all. This PR ignores the test for now (can still be checked locally after making changes to the LiveData).

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
