### PR TITLE
[CAS-513] Change unmuting user related methods return type to Call<Unit>

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -8,6 +8,8 @@
 - Add filtering non image attachments in ChatClient::getImageAttachments
 - Add a `channel` property to `notification.message_new` events
 - Fix deleting channel error
+- 🚨 Breaking change: ChatClient::unmuteUser, ChatClient::unmuteCurrentUser,
+ChannelClient::unmuteUser, and ChannelClient::unmuteCurrentUser now return Unit instead of Mute
 
 ## stream-chat-android-offline
 - Add LeaveChannel use case

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -666,9 +666,9 @@ public class ChatClient internal constructor(
         return api.unMuteChannel(channelType, channelId)
     }
 
-    public fun unmuteUser(userId: String): Call<Mute> = api.unmuteUser(userId)
+    public fun unmuteUser(userId: String): Call<Unit> = api.unmuteUser(userId)
 
-    public fun unmuteCurrentUser(): Call<Mute> = api.unmuteCurrentUser()
+    public fun unmuteCurrentUser(): Call<Unit> = api.unmuteCurrentUser()
 
     public fun muteCurrentUser(): Call<Mute> = api.muteCurrentUser()
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -480,7 +480,7 @@ internal class ChatApi(
         return muteUser(userId)
     }
 
-    fun unmuteCurrentUser(): Call<Mute> {
+    fun unmuteCurrentUser(): Call<Unit> {
         return unmuteUser(userId)
     }
 
@@ -594,13 +594,13 @@ internal class ChatApi(
 
     fun unmuteUser(
         userId: String
-    ): Call<Mute> {
+    ): Call<Unit> {
         return retrofitApi.unMuteUser(
             apiKey,
             this.userId,
             connectionId,
             MuteUserRequest(userId, this.userId)
-        ).map { it.mute }
+        ).map { Unit }
     }
 
     @Deprecated(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -256,7 +256,7 @@ internal interface RetrofitApi {
         @Query("user_id") userId: String,
         @Query("client_id") connectionId: String,
         @Body body: MuteUserRequest
-    ): RetrofitCall<MuteUserResponse>
+    ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/flag")
     fun flag(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -395,11 +395,11 @@ public class ChannelClient internal constructor(
         return client.muteUser(userId)
     }
 
-    override fun unmuteUser(userId: String): Call<Mute> {
+    override fun unmuteUser(userId: String): Call<Unit> {
         return client.unmuteUser(userId)
     }
 
-    override fun unmuteCurrentUser(): Call<Mute> {
+    override fun unmuteCurrentUser(): Call<Unit> {
         return client.unmuteCurrentUser()
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -125,8 +125,8 @@ public interface ChannelController {
     public fun unmute(): Call<Unit>
     public fun muteCurrentUser(): Call<Mute>
     public fun muteUser(userId: String): Call<Mute>
-    public fun unmuteUser(userId: String): Call<Mute>
-    public fun unmuteCurrentUser(): Call<Mute>
+    public fun unmuteUser(userId: String): Call<Unit>
+    public fun unmuteCurrentUser(): Call<Unit>
     public fun watch(data: Map<String, Any>): Call<Channel>
     public fun stopTyping(): Call<ChatEvent>
     public fun keystroke(): Call<ChatEvent>

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -263,12 +263,6 @@ internal class UsersApiCallsTests {
     fun unMuteUserSuccess() {
 
         val targetUser = User().apply { id = "target-id" }
-        val mute = Mute(
-            mock.user,
-            targetUser,
-            Date(1),
-            Date(2)
-        )
 
         Mockito.`when`(
             mock.retrofitApi.unMuteUser(
@@ -277,10 +271,10 @@ internal class UsersApiCallsTests {
                 mock.connectionId,
                 MuteUserRequest(targetUser.id, mock.userId)
             )
-        ).thenReturn(RetroSuccess(MuteUserResponse(mute, mock.user)).toRetrofitCall())
+        ).thenReturn(RetroSuccess(CompletableResponse()).toRetrofitCall())
 
         val result = client.unmuteUser(targetUser.id).execute()
 
-        verifySuccess(result, mute)
+        verifySuccess(result, Unit)
     }
 }


### PR DESCRIPTION
Unmuting user was causing a crash because of the wrong return type.
We are getting `{"duration":"10.63ms"}` response instead of `Mute` class.
It was working "fine" before fixing `Result` class in #1069 just because we were able to create `Result` with both `data` and `error` as nulls

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
