### PR TITLE
Enable trailing commas in code style

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -34,6 +34,7 @@
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
+      <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
     <codeStyleSettings language="XML">


### PR DESCRIPTION
### Description

This changes the IDE behaviour so that running auto-formatting on a file will add trailing commas to appropriate places. I didn't want to reformat the entire project and touch all files this PR, but hopefully we'll have more and more trailing commas in the project with this change over time, as we format the files that we touch (please run IDE formatting before commits!).

ktlint, unfortunately, doesn't pick this up yet (see https://github.com/pinterest/ktlint/issues/709).

| Before | After |
| --- | --- |
| ![Screenshot 2021-01-07 at 16 18 50](https://user-images.githubusercontent.com/12054216/103909626-3bcde380-5104-11eb-8295-287fb9e5d62f.png) | ![Screenshot 2021-01-07 at 16 18 40](https://user-images.githubusercontent.com/12054216/103909634-3cff1080-5104-11eb-9c40-ccaef517d603.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes ✅
- [x] Reviewers added
