### PR TITLE
Prevent long press consumption in channel list when using default long press listener

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -68,8 +68,8 @@ public class ChannelListView @JvmOverloads constructor(
         requireAdapter().listenerContainer.channelClickListener = listener ?: ChannelClickListener.DEFAULT
     }
 
-    public fun setChannelLongClickListener(listener: ChannelClickListener?) {
-        requireAdapter().listenerContainer.channelLongClickListener = listener ?: ChannelClickListener.DEFAULT
+    public fun setChannelLongClickListener(listener: ChannelLongClickListener?) {
+        requireAdapter().listenerContainer.channelLongClickListener = listener ?: ChannelLongClickListener.DEFAULT
     }
 
     public fun setUserClickListener(listener: UserClickListener?) {
@@ -162,6 +162,19 @@ public class ChannelListView @JvmOverloads constructor(
         public fun onClick(channel: Channel)
     }
 
+    public fun interface ChannelLongClickListener {
+        public companion object {
+            public val DEFAULT: ChannelLongClickListener = ChannelLongClickListener { false }
+        }
+
+        /**
+         * Called when a channel has been clicked and held.
+         *
+         * @return true if the callback consumed the long click, false otherwise.
+         */
+        public fun onLongClick(channel: Channel): Boolean
+    }
+
     public fun interface EndReachedListener {
         public fun onEndReached()
     }
@@ -217,7 +230,7 @@ public class ChannelListView @JvmOverloads constructor(
             viewHolder: SwipeViewHolder,
             adapterPosition: Int,
             x: Float? = null,
-            y: Float? = null
+            y: Float? = null,
         )
 
         /**
@@ -231,7 +244,7 @@ public class ChannelListView @JvmOverloads constructor(
             viewHolder: SwipeViewHolder,
             adapterPosition: Int,
             x: Float? = null,
-            y: Float? = null
+            y: Float? = null,
         )
 
         /**
@@ -252,28 +265,28 @@ public class ChannelListView @JvmOverloads constructor(
                     viewHolder: SwipeViewHolder,
                     adapterPosition: Int,
                     x: Float?,
-                    y: Float?
+                    y: Float?,
                 ) = Unit
 
                 override fun onSwipeChanged(
                     viewHolder: SwipeViewHolder,
                     adapterPosition: Int,
                     dX: Float,
-                    totalDeltaX: Float
+                    totalDeltaX: Float,
                 ) = Unit
 
                 override fun onSwipeCompleted(
                     viewHolder: SwipeViewHolder,
                     adapterPosition: Int,
                     x: Float?,
-                    y: Float?
+                    y: Float?,
                 ) = Unit
 
                 override fun onSwipeCanceled(
                     viewHolder: SwipeViewHolder,
                     adapterPosition: Int,
                     x: Float?,
-                    y: Float?
+                    y: Float?,
                 ) = Unit
 
                 override fun onRestoreSwipePosition(viewHolder: SwipeViewHolder, adapterPosition: Int) = Unit

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
@@ -139,7 +139,7 @@ public class ChannelsView @JvmOverloads constructor(
      *
      * @param listener the callback to be invoked on channel long click
      */
-    public fun setChannelLongClickListener(listener: ChannelListView.ChannelClickListener?) {
+    public fun setChannelLongClickListener(listener: ChannelListView.ChannelLongClickListener?) {
         channelListView.setChannelLongClickListener(listener)
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolderFactory.kt
@@ -11,7 +11,7 @@ public open class ChannelListItemViewHolderFactory {
         parentView: ViewGroup,
         channelItemType: ChannelItemType,
         channelClickListener: ChannelListView.ChannelClickListener,
-        channelLongClickListener: ChannelListView.ChannelClickListener,
+        channelLongClickListener: ChannelListView.ChannelLongClickListener,
         deleteClickListener: ChannelListView.ChannelClickListener,
         moreOptionsClickListener: ChannelListView.ChannelClickListener,
         userClickListener: ChannelListView.UserClickListener,
@@ -37,7 +37,7 @@ public open class ChannelListItemViewHolderFactory {
     public open fun createChannelViewHolder(
         parentView: ViewGroup,
         channelClickListener: ChannelListView.ChannelClickListener,
-        channelLongClickListener: ChannelListView.ChannelClickListener,
+        channelLongClickListener: ChannelListView.ChannelLongClickListener,
         deleteClickListener: ChannelListView.ChannelClickListener,
         moreOptionsClickListener: ChannelListView.ChannelClickListener,
         userClickListener: ChannelListView.UserClickListener,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListListenerContainer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListListenerContainer.kt
@@ -5,7 +5,7 @@ import io.getstream.chat.android.ui.channel.list.ChannelListView
 
 internal class ChannelListListenerContainer(
     channelClickListener: ChannelListView.ChannelClickListener = ChannelListView.ChannelClickListener.DEFAULT,
-    channelLongClickListener: ChannelListView.ChannelClickListener = ChannelListView.ChannelClickListener.DEFAULT,
+    channelLongClickListener: ChannelListView.ChannelLongClickListener = ChannelListView.ChannelLongClickListener.DEFAULT,
     deleteClickListener: ChannelListView.ChannelClickListener = ChannelListView.ChannelClickListener.DEFAULT,
     moreOptionsClickListener: ChannelListView.ChannelClickListener = ChannelListView.ChannelClickListener.DEFAULT,
     userClickListener: ChannelListView.UserClickListener = ChannelListView.UserClickListener.DEFAULT,
@@ -17,11 +17,11 @@ internal class ChannelListListenerContainer(
         }
     }
 
-    var channelLongClickListener: ChannelListView.ChannelClickListener by ListenerDelegate(
+    var channelLongClickListener: ChannelListView.ChannelLongClickListener by ListenerDelegate(
         channelLongClickListener
     ) { realListener ->
-        ChannelListView.ChannelClickListener { channel ->
-            realListener().onClick(channel)
+        ChannelListView.ChannelLongClickListener { channel ->
+            realListener().onLongClick(channel)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.ui.utils.extensions.setTextSizePx
 public class ChannelViewHolder @JvmOverloads constructor(
     parent: ViewGroup,
     private val channelClickListener: ChannelListView.ChannelClickListener,
-    private val channelLongClickListener: ChannelListView.ChannelClickListener,
+    private val channelLongClickListener: ChannelListView.ChannelLongClickListener,
     private val channelDeleteListener: ChannelListView.ChannelClickListener,
     private val channelMoreOptionsListener: ChannelListView.ChannelClickListener,
     private val userClickListener: ChannelListView.UserClickListener,
@@ -42,7 +42,7 @@ public class ChannelViewHolder @JvmOverloads constructor(
         parent.inflater,
         parent,
         false
-    )
+    ),
 ) : SwipeViewHolder(binding.root) {
 
     private val dateFormatter = DateFormatter.from(context)
@@ -80,8 +80,7 @@ public class ChannelViewHolder @JvmOverloads constructor(
                         channelClickListener.onClick(channel)
                     }
                     setOnLongClickListener {
-                        channelLongClickListener.onClick(channel)
-                        true
+                        channelLongClickListener.onLongClick(channel)
                     }
                     doOnNextLayout {
                         setSwipeListener(root, swipeListener)
@@ -170,7 +169,7 @@ public class ChannelViewHolder @JvmOverloads constructor(
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabelAndTimestamp(
-        lastMessage: Message?
+        lastMessage: Message?,
     ) {
         lastMessageLabel.isVisible = lastMessage.isNotNull()
         lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
@@ -193,7 +192,7 @@ public class ChannelViewHolder @JvmOverloads constructor(
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureCurrentUserLastMessageStatus(
-        lastMessage: Message?
+        lastMessage: Message?,
     ) {
         messageStatusImageView.isVisible = lastMessage != null
 


### PR DESCRIPTION
### Description

Disabled long press effect (vibration) when there is a long press on channel item and custom long press listener has not been set.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
