### PR TITLE
Remove unused ReadStateItem message type

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -3,7 +3,6 @@ package com.getstream.sdk.chat.adapter
 import com.getstream.sdk.chat.adapter.MessageListItem.DateSeparatorItem
 import com.getstream.sdk.chat.adapter.MessageListItem.LoadingMoreIndicatorItem
 import com.getstream.sdk.chat.adapter.MessageListItem.MessageItem
-import com.getstream.sdk.chat.adapter.MessageListItem.ReadStateItem
 import com.getstream.sdk.chat.adapter.MessageListItem.ThreadSeparatorItem
 import com.getstream.sdk.chat.adapter.MessageListItem.TypingItem
 import io.getstream.chat.android.client.models.ChannelUserRead
@@ -20,7 +19,6 @@ import java.util.zip.Checksum
  * - [MessageItem]
  * - [TypingItem]
  * - [ThreadSeparatorItem]
- * - [ReadStateItem]
  * - [LoadingMoreIndicatorItem]
  */
 public sealed class MessageListItem {
@@ -32,7 +30,6 @@ public sealed class MessageListItem {
             is ThreadSeparatorItem -> "id_thread_separator"
             is MessageItem -> message.id
             is DateSeparatorItem -> date.toString()
-            is ReadStateItem -> "read_" + reads.map { it.user.id }.joinToString { "," }
             is LoadingMoreIndicatorItem -> "id_loading_more_indicator"
         }
         checksum.update(plaintext.toByteArray(), 0, plaintext.toByteArray().size)
@@ -55,10 +52,6 @@ public sealed class MessageListItem {
 
     public data class TypingItem(
         val users: List<User>,
-    ) : MessageListItem()
-
-    public data class ReadStateItem(
-        val reads: List<ChannelUserRead>,
     ) : MessageListItem()
 
     public data class ThreadSeparatorItem(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
@@ -35,7 +35,6 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
             is MessageListItem.ThreadSeparatorItem -> oldItem == (newItem as? MessageListItem.ThreadSeparatorItem)
             is MessageListItem.LoadingMoreIndicatorItem -> true
             is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(User::id)
-            is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as? MessageListItem.ReadStateItem)?.reads?.map { it.getUserId() }
         }
 
     override fun getChangePayload(oldItem: MessageListItem, newItem: MessageListItem): Any? {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -32,7 +32,6 @@ public open class MessageListItemViewHolderFactory(
             MessageListItemViewType.LOADING_INDICATOR -> createLoadingIndicatorViewHolder(parentView)
             MessageListItemViewType.THREAD_SEPARATOR -> createThreadSeparatorViewHolder(parentView)
             MessageListItemViewType.TYPING_INDICATOR -> createEmptyMessageItemViewHolder(parentView)
-            MessageListItemViewType.READ_STATE -> createEmptyMessageItemViewHolder(parentView)
             MessageListItemViewType.GIPHY -> createGiphyMessageItemViewHolder(parentView)
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewType.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewType.kt
@@ -11,6 +11,5 @@ public enum class MessageListItemViewType {
     LOADING_INDICATOR,
     THREAD_SEPARATOR,
     TYPING_INDICATOR,
-    READ_STATE,
     GIPHY
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewTypeMapper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewTypeMapper.kt
@@ -23,7 +23,6 @@ public object MessageListItemViewTypeMapper {
             is MessageListItem.DateSeparatorItem -> MessageListItemViewType.DATE_DIVIDER
             is MessageListItem.LoadingMoreIndicatorItem -> MessageListItemViewType.LOADING_INDICATOR
             is MessageListItem.ThreadSeparatorItem -> MessageListItemViewType.THREAD_SEPARATOR
-            is MessageListItem.ReadStateItem -> MessageListItemViewType.READ_STATE
             is MessageListItem.MessageItem -> messageItemToViewType(messageListItem)
             is MessageListItem.TypingItem -> MessageListItemViewType.TYPING_INDICATOR
         }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageListItemDiffCallback.kt
@@ -34,7 +34,6 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
             is MessageListItem.ThreadSeparatorItem -> oldItem.date == (newItem as? MessageListItem.ThreadSeparatorItem)?.date
             is MessageListItem.LoadingMoreIndicatorItem -> true
             is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(User::id)
-            is MessageListItem.ReadStateItem -> oldItem.reads.map { it.getUserId() } == ((newItem) as? MessageListItem.ReadStateItem)?.reads?.map { it.getUserId() }
         }
 
     override fun getChangePayload(oldItem: MessageListItem, newItem: MessageListItem): Any? {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/MessageViewHolderFactory.kt
@@ -36,14 +36,13 @@ public open class MessageViewHolderFactory {
 
     public lateinit var messageDateFormatter: DateFormatter
 
-    public open fun getMessageViewType(messageListItem: MessageListItem?): Int {
+    public open fun getMessageViewType(messageListItem: MessageListItem): Int {
         return when (messageListItem) {
             is DateSeparatorItem -> MESSAGEITEM_DATE_SEPARATOR
             is TypingItem -> MESSAGEITEM_TYPING
             is MessageItem -> MESSAGEITEM_MESSAGE
             is ThreadSeparatorItem -> MESSAGEITEM_THREAD_SEPARATOR
             is MessageListItem.LoadingMoreIndicatorItem -> MESSAGEITEM_LOADING_MORE
-            else -> throw IllegalArgumentException("MessageListItem type could not be determined")
         }
     }
 


### PR DESCRIPTION
### Description

We never created instances of this class, we just had a bunch of code handling its diffing. In the old UI, having one in the list would've resulted in a crash in the ViewModel factory, in the new UI, we were using a blank View to display it.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
