### PR TITLE
Update delete message background

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
@@ -36,8 +36,8 @@
     <color name="stream_ui_section_item_color">@color/stream_ui_woodsmoke</color>
     <color name="stream_ui_attachment_dialog_header_color">@color/stream_ui_background_light</color>
 
-    <color name="stream_ui_send_button">#2D2E2E</color>
-    <color name="stream_ui_send_button_disabled">#2D2E2E</color>
+    <color name="stream_ui_send_button">@color/stream_ui_outer_space</color>
+    <color name="stream_ui_send_button_disabled">@color/stream_ui_outer_space</color>
 
     <color name="stream_ui_search_input_border">#1C1E22</color>
 
@@ -45,12 +45,12 @@
     <color name="stream_ui_material_button_text_color">@color/stream_ui_blue</color>
     <color name="stream_ui_sdk_version_color">@color/stream_ui_outer_space</color>
 
-    <color name="stream_ui_current_user_background">#2D2E2E</color>
+    <color name="stream_ui_current_user_background">@color/stream_ui_outer_space</color>
 
     <color name="stream_ui_other_message_stroke">#1C1E22</color>
 
-    <color name="stream_ui_thread_reply_stroke">#2D2E2E</color>
+    <color name="stream_ui_thread_reply_stroke">@color/stream_ui_outer_space</color>
 
-    <color name="stream_ui_deleted_message_background">#802D2E2E</color>
+    <color name="stream_ui_deleted_message_background">@color/stream_ui_outer_space</color>
     <color name="stream_ui_link_attachment_background">#001A3D</color>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -109,7 +109,7 @@
 
     <color name="stream_ui_thread_reply_stroke">#DBDBDB</color>
 
-    <color name="stream_ui_current_user_background">#E6E6E6</color>
-    <color name="stream_ui_deleted_message_background">@color/stream_ui_grey_light_opacity_50</color>
+    <color name="stream_ui_current_user_background">@color/stream_ui_grey_gainsboro</color>
+    <color name="stream_ui_deleted_message_background">@color/stream_ui_grey_gainsboro</color>
     <color name="stream_ui_link_attachment_background">#E9F2FF</color>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -8,6 +8,7 @@
     <color name="stream_ui_woodsmoke">#13151B</color>
     <color name="stream_ui_mirage">#141924</color>
     <color name="stream_ui_grey_gainsboro">#DBDBDB</color>
+    <color name="stream_ui_grey_whisper">#ECEBEB</color>
     <color name="stream_ui_grey">#808080</color>
     <color name="stream_ui_grey_medium_light">#CCCCCC</color>
     <color name="stream_ui_grey_light">#F5F5F5</color>
@@ -105,11 +106,11 @@
     <color name="stream_ui_material_button_background_color">@color/stream_ui_blue</color>
     <color name="stream_ui_material_button_text_color">@color/stream_ui_white</color>
     <color name="stream_ui_sdk_version_color">@color/stream_ui_grey_gainsboro</color>
-    <color name="stream_ui_other_message_stroke">#ECEBEB</color>
+    <color name="stream_ui_other_message_stroke">@color/stream_ui_grey_whisper</color>
 
     <color name="stream_ui_thread_reply_stroke">#DBDBDB</color>
 
     <color name="stream_ui_current_user_background">@color/stream_ui_grey_gainsboro</color>
-    <color name="stream_ui_deleted_message_background">@color/stream_ui_grey_gainsboro</color>
+    <color name="stream_ui_deleted_message_background">@color/stream_ui_grey_whisper</color>
     <color name="stream_ui_link_attachment_background">#E9F2FF</color>
 </resources>


### PR DESCRIPTION
### Description

Deleted messages have the same background color of normal messages. Only the text color changes (from black to grey).

| Before | After |
| --- | --- |
|  ![photo_2021-01-08_17-36-01](https://user-images.githubusercontent.com/4047514/104040531-0abee300-51d8-11eb-8e4e-cb95acad6900.jpg) |  ![photo_2021-01-08_17-36-04](https://user-images.githubusercontent.com/4047514/104040516-0692c580-51d8-11eb-836d-0ac6d2eae69b.jpg)  |

### Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
