### PR TITLE
Initializating listenerContainer

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.ui.databinding.StreamUiDialogMessageOptionsBind
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemViewHolderFactory
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemViewTypeMapper
+import io.getstream.chat.android.ui.messages.adapter.initEmptyListeners
 import io.getstream.chat.android.ui.messages.adapter.viewholder.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
@@ -127,6 +128,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
 
     private fun setupMessageView() {
         viewHolder = MessageListItemViewHolderFactory(MessageOptionsDecoratorProvider())
+            .apply { initEmptyListeners() }
             .createViewHolder(
                 binding.messageContainer,
                 MessageListItemViewTypeMapper.getViewTypeValue(messageItem)


### PR DESCRIPTION
### Description

Initializes `listenerContainer` so we avoid not initialised property exception.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes
- New code is covered by unit tests
- Comparison screenshots added for visual changes
- [x] Reviewers added
