### PR TITLE
Make message listener container non-nullable

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/EmptyMessageListListenerContainer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/EmptyMessageListListenerContainer.kt
@@ -1,0 +1,36 @@
+package io.getstream.chat.ui.sample.feature.component_browser.messages.viewholder
+
+import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
+import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.AttachmentDownloadClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.GiphySendListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.MessageClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.MessageLongClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.MessageRetryListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.ReactionViewClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.ThreadClickListener
+import io.getstream.chat.android.ui.messages.view.MessageListView.UserClickListener
+
+/**
+ * Dummy implementation for Component Browser use only
+ */
+internal object EmptyMessageListListenerContainer : MessageListListenerContainer {
+    override val messageClickListener: MessageClickListener =
+        MessageClickListener {}
+    override val messageLongClickListener: MessageLongClickListener =
+        MessageLongClickListener {}
+    override val messageRetryListener: MessageRetryListener =
+        MessageRetryListener {}
+    override val threadClickListener: ThreadClickListener =
+        ThreadClickListener {}
+    override val attachmentClickListener: AttachmentClickListener =
+        AttachmentClickListener { _, _ -> }
+    override val attachmentDownloadClickListener: AttachmentDownloadClickListener =
+        AttachmentDownloadClickListener {}
+    override val reactionViewClickListener: ReactionViewClickListener =
+        ReactionViewClickListener {}
+    override val userClickListener: UserClickListener =
+        UserClickListener {}
+    override val giphySendListener: GiphySendListener =
+        GiphySendListener { _, _ -> }
+}

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/GiphyMessageComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/GiphyMessageComponentBrowserFragment.kt
@@ -13,7 +13,7 @@ class GiphyMessageComponentBrowserFragment : BaseMessagesComponentBrowserFragmen
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyMessageList(),
-            { viewGroup -> GiphyViewHolder(viewGroup, decorators, null) },
+            { viewGroup -> GiphyViewHolder(viewGroup, decorators, EmptyMessageListListenerContainer) },
             GiphyViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyFileAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyFileAttachmentsMessagesComponentBrowserFragment.kt
@@ -17,7 +17,7 @@ class OnlyFileAttachmentsMessagesComponentBrowserFragment : BaseMessagesComponen
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyDeletedMessagesList(),
-            { viewGroup -> OnlyFileAttachmentsViewHolder(viewGroup, decorators, null) },
+            { viewGroup -> OnlyFileAttachmentsViewHolder(viewGroup, decorators, EmptyMessageListListenerContainer) },
             OnlyFileAttachmentsViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyMediaAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/OnlyMediaAttachmentsMessagesComponentBrowserFragment.kt
@@ -14,7 +14,7 @@ class OnlyMediaAttachmentsMessagesComponentBrowserFragment : BaseMessagesCompone
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyDeletedMessagesList(requireContext()),
-            { viewGroup -> OnlyMediaAttachmentsViewHolder(viewGroup, decorators, null) },
+            { viewGroup -> OnlyMediaAttachmentsViewHolder(viewGroup, decorators, EmptyMessageListListenerContainer) },
             OnlyMediaAttachmentsViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
@@ -14,7 +14,7 @@ class PlainTextMessagesComponentBrowserFragment : BaseMessagesComponentBrowserFr
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyMessageList(),
-            { viewGroup -> MessagePlainTextViewHolder(viewGroup, decorators, null) },
+            { viewGroup -> MessagePlainTextViewHolder(viewGroup, decorators, EmptyMessageListListenerContainer) },
             MessagePlainTextViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
@@ -16,7 +16,11 @@ class PlainTextWithFileAttachmentsMessagesComponentBrowserFragment : BaseMessage
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyDeletedMessagesList(),
-            { viewGroup -> PlainTextWithFileAttachmentsViewHolder(viewGroup, decorators, null) },
+            { viewGroup ->
+                PlainTextWithFileAttachmentsViewHolder(viewGroup,
+                    decorators,
+                    EmptyMessageListListenerContainer)
+            },
             PlainTextWithFileAttachmentsViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
@@ -17,9 +17,11 @@ class PlainTextWithFileAttachmentsMessagesComponentBrowserFragment : BaseMessage
         return DefaultAdapter(
             getDummyDeletedMessagesList(),
             { viewGroup ->
-                PlainTextWithFileAttachmentsViewHolder(viewGroup,
+                PlainTextWithFileAttachmentsViewHolder(
+                    viewGroup,
                     decorators,
-                    EmptyMessageListListenerContainer)
+                    EmptyMessageListListenerContainer
+                )
             },
             PlainTextWithFileAttachmentsViewHolder::bind
         )

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
@@ -15,7 +15,11 @@ class PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment : BaseMessag
     override fun createAdapter(): RecyclerView.Adapter<*> {
         return DefaultAdapter(
             getDummyDeletedMessagesList(requireContext()),
-            { viewGroup -> PlainTextWithMediaAttachmentsViewHolder(viewGroup, decorators, null) },
+            { viewGroup ->
+                PlainTextWithMediaAttachmentsViewHolder(viewGroup,
+                    decorators,
+                    EmptyMessageListListenerContainer)
+            },
             PlainTextWithMediaAttachmentsViewHolder::bind
         )
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
@@ -16,9 +16,11 @@ class PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment : BaseMessag
         return DefaultAdapter(
             getDummyDeletedMessagesList(requireContext()),
             { viewGroup ->
-                PlainTextWithMediaAttachmentsViewHolder(viewGroup,
+                PlainTextWithMediaAttachmentsViewHolder(
+                    viewGroup,
                     decorators,
-                    EmptyMessageListListenerContainer)
+                    EmptyMessageListListenerContainer
+                )
             },
             PlainTextWithMediaAttachmentsViewHolder::bind
         )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
@@ -13,26 +13,24 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class GiphyViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessageGiphyBinding = StreamUiItemMessageGiphyBinding.inflate(
         parent.inflater,
         parent,
         false
-    )
+    ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.also { listeners ->
-            binding.run {
-                cancelButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.CANCEL)
-                }
-                sendButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SEND)
-                }
-                nextButton.setOnClickListener {
-                    listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SHUFFLE)
-                }
+        binding.run {
+            cancelButton.setOnClickListener {
+                listeners.giphySendListener.onGiphySend(data.message, GiphyAction.CANCEL)
+            }
+            sendButton.setOnClickListener {
+                listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SEND)
+            }
+            nextButton.setOnClickListener {
+                listeners.giphySendListener.onGiphySend(data.message, GiphyAction.SHUFFLE)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -12,32 +12,30 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class MessagePlainTextViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessagePlainTextBinding =
         StreamUiItemMessagePlainTextBinding.inflate(
             parent.inflater,
             parent,
             false
-        )
+        ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.let { listeners ->
-            binding.run {
-                root.setOnClickListener {
-                    listeners.messageClickListener.onMessageClick(data.message)
-                }
-                reactionsView.setReactionClickListener {
-                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
-                }
-                threadRepliesFootnote.root.setOnClickListener {
-                    listeners.threadClickListener.onThreadClick(data.message)
-                }
+        binding.run {
+            root.setOnClickListener {
+                listeners.messageClickListener.onMessageClick(data.message)
+            }
+            reactionsView.setReactionClickListener {
+                listeners.reactionViewClickListener.onReactionViewClick(data.message)
+            }
+            threadRepliesFootnote.root.setOnClickListener {
+                listeners.threadClickListener.onThreadClick(data.message)
+            }
 
-                root.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
-                }
+            root.setOnLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
+                true
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -15,41 +15,39 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class OnlyFileAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessageFileAttachmentsBinding =
         StreamUiItemMessageFileAttachmentsBinding.inflate(
             parent.inflater,
             parent,
             false
-        )
+        ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.let { listeners ->
-            binding.run {
-                root.setOnClickListener {
-                    listeners.messageClickListener.onMessageClick(data.message)
-                }
-                threadRepliesFootnote.root.setOnClickListener {
-                    listeners.threadClickListener.onThreadClick(data.message)
-                }
-                reactionsView.setReactionClickListener {
-                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
-                }
-                fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
-                }
-                fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
-                    listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
-                }
+        binding.run {
+            root.setOnClickListener {
+                listeners.messageClickListener.onMessageClick(data.message)
+            }
+            threadRepliesFootnote.root.setOnClickListener {
+                listeners.threadClickListener.onThreadClick(data.message)
+            }
+            reactionsView.setReactionClickListener {
+                listeners.reactionViewClickListener.onReactionViewClick(data.message)
+            }
+            fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
+                listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+            }
+            fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
+                listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
+            }
 
-                root.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
-                }
-                fileAttachmentsView.attachmentLongClickListener = AttachmentLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                }
+            root.setOnLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
+                true
+            }
+            fileAttachmentsView.attachmentLongClickListener = AttachmentLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -15,38 +15,36 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decora
 public class OnlyMediaAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessageMediaAttachmentsBinding =
         StreamUiItemMessageMediaAttachmentsBinding.inflate(
             parent.inflater,
             parent,
             false
-        )
+        ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.let { listeners ->
-            binding.run {
-                root.setOnClickListener {
-                    listeners.messageClickListener.onMessageClick(data.message)
-                }
-                mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
-                }
-                reactionsView.setReactionClickListener {
-                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
-                }
-                threadRepliesFootnote.root.setOnClickListener {
-                    listeners.threadClickListener.onThreadClick(data.message)
-                }
+        binding.run {
+            root.setOnClickListener {
+                listeners.messageClickListener.onMessageClick(data.message)
+            }
+            mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
+                listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+            }
+            reactionsView.setReactionClickListener {
+                listeners.reactionViewClickListener.onReactionViewClick(data.message)
+            }
+            threadRepliesFootnote.root.setOnClickListener {
+                listeners.threadClickListener.onThreadClick(data.message)
+            }
 
-                root.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
-                }
-                mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                }
+            root.setOnLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
+                true
+            }
+            mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -16,41 +16,39 @@ import io.getstream.chat.android.ui.utils.extensions.hasLink
 public class PlainTextWithFileAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessagePlainTextWithFileAttachmentsBinding =
         StreamUiItemMessagePlainTextWithFileAttachmentsBinding.inflate(
             parent.inflater,
             parent,
             false
-        )
+        ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.let { listeners ->
-            binding.run {
-                root.setOnClickListener {
-                    listeners.messageClickListener.onMessageClick(data.message)
-                }
-                reactionsView.setReactionClickListener {
-                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
-                }
-                fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
-                }
-                threadRepliesFootnote.root.setOnClickListener {
-                    listeners.threadClickListener.onThreadClick(data.message)
-                }
-                fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
-                    listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
-                }
+        binding.run {
+            root.setOnClickListener {
+                listeners.messageClickListener.onMessageClick(data.message)
+            }
+            reactionsView.setReactionClickListener {
+                listeners.reactionViewClickListener.onReactionViewClick(data.message)
+            }
+            fileAttachmentsView.attachmentClickListener = AttachmentClickListener {
+                listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+            }
+            threadRepliesFootnote.root.setOnClickListener {
+                listeners.threadClickListener.onThreadClick(data.message)
+            }
+            fileAttachmentsView.attachmentDownloadClickListener = AttachmentDownloadClickListener {
+                listeners.attachmentDownloadClickListener.onAttachmentDownloadClick(it)
+            }
 
-                root.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
-                }
-                fileAttachmentsView.attachmentLongClickListener = AttachmentLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                }
+            root.setOnLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
+                true
+            }
+            fileAttachmentsView.attachmentLongClickListener = AttachmentLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -15,38 +15,36 @@ import io.getstream.chat.android.ui.utils.extensions.hasLink
 public class PlainTextWithMediaAttachmentsViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
-    listenerContainer: MessageListListenerContainer?,
+    listeners: MessageListListenerContainer,
     internal val binding: StreamUiItemMessagePlainTextWithMediaAttachmentsBinding =
         StreamUiItemMessagePlainTextWithMediaAttachmentsBinding.inflate(
             parent.inflater,
             parent,
             false
-        )
+        ),
 ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
     init {
-        listenerContainer?.let { listeners ->
-            binding.run {
-                root.setOnClickListener {
-                    listeners.messageClickListener.onMessageClick(data.message)
-                }
-                mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
-                    listeners.attachmentClickListener.onAttachmentClick(data.message, it)
-                }
-                reactionsView.setReactionClickListener {
-                    listeners.reactionViewClickListener.onReactionViewClick(data.message)
-                }
-                threadRepliesFootnote.root.setOnClickListener {
-                    listeners.threadClickListener.onThreadClick(data.message)
-                }
+        binding.run {
+            root.setOnClickListener {
+                listeners.messageClickListener.onMessageClick(data.message)
+            }
+            mediaAttachmentsGroupView.attachmentClickListener = AttachmentClickListener {
+                listeners.attachmentClickListener.onAttachmentClick(data.message, it)
+            }
+            reactionsView.setReactionClickListener {
+                listeners.reactionViewClickListener.onReactionViewClick(data.message)
+            }
+            threadRepliesFootnote.root.setOnClickListener {
+                listeners.threadClickListener.onThreadClick(data.message)
+            }
 
-                root.setOnLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                    true
-                }
-                mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
-                    listeners.messageLongClickListener.onMessageLongClick(data.message)
-                }
+            root.setOnLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
+                true
+            }
+            mediaAttachmentsGroupView.attachmentLongClickListener = AttachmentLongClickListener {
+                listeners.messageLongClickListener.onMessageLongClick(data.message)
             }
         }
     }


### PR DESCRIPTION
### Description

Removes some `null` handling we were only doing to support using message ViewHolders in the component browser.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
