### PR TITLE
Fix/failure message vh update behaviour

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
+- Fix `MessageListItemViewHolder::bind` behavior
 
 ## stream-chat-android-client
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/viewholder/message/MessageListItemViewHolder.kt
@@ -93,7 +93,7 @@ public open class MessageListItemViewHolder(
         listOfNotNull(
             spaceConfigurator,
             marginConfigurator,
-            messageTextConfigurator.takeIf { diff.text || diff.positions || diff.deleted || diff.reactions },
+            messageTextConfigurator.takeIf { diff.text || diff.positions || diff.deleted || diff.reactions || diff.syncStatus },
             attachmentConfigurator.takeIf { diff.attachments },
             reactionConfigurator.takeIf { diff.reactions },
             replyConfigurator.takeIf { diff.replies },


### PR DESCRIPTION
### Description
Update `MessageListItemViewHolder::bind` behavior to render failure states when Sync Status has changed.
This PR fixes #1048 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
