### PR TITLE
fixing locale compatibility problem

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
@@ -10,7 +10,6 @@ import com.getstream.sdk.chat.utils.formatTime
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiActivityAttachmentGalleryBinding
 import java.util.Date
-import java.util.Locale
 
 public class AttachmentGalleryActivity : AppCompatActivity() {
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
@@ -45,7 +45,7 @@ public class AttachmentGalleryActivity : AppCompatActivity() {
             DateUtils.FORMAT_ABBREV_RELATIVE
         )
             .toString()
-            .decapitalize(Locale.getDefault())
+            .decapitalize()
 
         return getString(
             R.string.stream_ui_date_and_time_pattern,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGalleryActivity.kt
@@ -10,6 +10,7 @@ import com.getstream.sdk.chat.utils.formatTime
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiActivityAttachmentGalleryBinding
 import java.util.Date
+import java.util.Locale
 
 public class AttachmentGalleryActivity : AppCompatActivity() {
 
@@ -44,7 +45,7 @@ public class AttachmentGalleryActivity : AppCompatActivity() {
             DateUtils.FORMAT_ABBREV_RELATIVE
         )
             .toString()
-            .decapitalize(resources.configuration.locales.get(0))
+            .decapitalize(Locale.getDefault())
 
         return getString(
             R.string.stream_ui_date_and_time_pattern,


### PR DESCRIPTION
### Description

`resources.configuration.locales` is only available prior to 24 API, we support 21+

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes
- New code is covered by unit tests
- Comparison screenshots added for visual changes
- [x] Reviewers added
