### PR TITLE
Fix CardView related crash in Giphy ViewHolder

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -16,9 +16,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
-import io.getstream.chat.android.ui.utils.extensions.context
 import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
-import io.getstream.chat.android.ui.utils.extensions.getColorCompat
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 import io.getstream.chat.android.ui.utils.extensions.withReply
 import io.getstream.chat.android.ui.utils.extensions.withText
@@ -78,14 +76,10 @@ internal class BackgroundDecorator : BaseDecorator() {
     )
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
-        viewHolder.binding.cardView.background = ShapeAppearanceModel.builder()
+        viewHolder.binding.cardView.shapeAppearanceModel = ShapeAppearanceModel.builder()
             .setAllCornerSizes(DEFAULT_CORNER_RADIUS)
             .setBottomRightCornerSize(SMALL_CARD_VIEW_CORNER_RADIUS)
             .build()
-            .let(::MaterialShapeDrawable)
-            .apply {
-                setTint(viewHolder.context.getColorCompat(R.color.stream_ui_background_default))
-            }
         viewHolder.binding.mediaAttachmentView.setImageShapeByCorners(
             IMAGE_VIEW_CORNER_RADIUS,
             IMAGE_VIEW_CORNER_RADIUS,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -18,6 +18,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFil
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.utils.extensions.context
 import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
+import io.getstream.chat.android.ui.utils.extensions.getColorCompat
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 import io.getstream.chat.android.ui.utils.extensions.withReply
 import io.getstream.chat.android.ui.utils.extensions.withText
@@ -83,7 +84,7 @@ internal class BackgroundDecorator : BaseDecorator() {
             .build()
             .let(::MaterialShapeDrawable)
             .apply {
-                setTint(ContextCompat.getColor(viewHolder.context, R.color.stream_ui_background_default))
+                setTint(viewHolder.context.getColorCompat(R.color.stream_ui_background_default))
             }
         viewHolder.binding.mediaAttachmentView.setImageShapeByCorners(
             IMAGE_VIEW_CORNER_RADIUS,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.utils.extensions.context
 import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 import io.getstream.chat.android.ui.utils.extensions.withReply
@@ -34,14 +35,14 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setDefaultBackgroundDrawable(viewHolder.binding.messageContainer, data)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.mediaAttachmentsGroupView,
@@ -50,7 +51,7 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.mediaAttachmentsGroupView,
@@ -59,7 +60,7 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.fileAttachmentsView,
@@ -68,7 +69,7 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.fileAttachmentsView,
@@ -76,10 +77,14 @@ internal class BackgroundDecorator : BaseDecorator() {
     )
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
-        viewHolder.binding.cardView.shapeAppearanceModel = ShapeAppearanceModel.builder()
+        viewHolder.binding.cardView.background = ShapeAppearanceModel.builder()
             .setAllCornerSizes(DEFAULT_CORNER_RADIUS)
             .setBottomRightCornerSize(SMALL_CARD_VIEW_CORNER_RADIUS)
             .build()
+            .let(::MaterialShapeDrawable)
+            .apply {
+                setTint(ContextCompat.getColor(viewHolder.context, R.color.stream_ui_background_default))
+            }
         viewHolder.binding.mediaAttachmentView.setImageShapeByCorners(
             IMAGE_VIEW_CORNER_RADIUS,
             IMAGE_VIEW_CORNER_RADIUS,
@@ -91,7 +96,7 @@ internal class BackgroundDecorator : BaseDecorator() {
     private fun decorateAttachmentsAndBackground(
         background: View,
         attachmentView: View,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setDefaultBackgroundDrawable(background, data)
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -14,12 +14,11 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <com.google.android.material.card.MaterialCardView
+    <androidx.cardview.widget.CardView
         android:id="@+id/cardView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
-        android:background="@color/stream_ui_background_default_selector"
         android:clipToPadding="false"
         app:cardElevation="@dimen/stream_ui_elevation_small"
         app:layout_constraintEnd_toStartOf="@id/marginEnd"
@@ -154,7 +153,7 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </com.google.android.material.card.MaterialCardView>
+    </androidx.cardview.widget.CardView>
 
     <include
         android:id="@+id/footnote"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -14,12 +14,13 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <androidx.cardview.widget.CardView
+    <com.google.android.material.card.MaterialCardView
         android:id="@+id/cardView"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
         android:clipToPadding="false"
+        app:cardBackgroundColor="@color/stream_ui_current_user_background"
         app:cardElevation="@dimen/stream_ui_elevation_small"
         app:layout_constraintEnd_toStartOf="@id/marginEnd"
         app:layout_constraintStart_toEndOf="@id/marginStart"
@@ -153,7 +154,7 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </androidx.cardview.widget.CardView>
+    </com.google.android.material.card.MaterialCardView>
 
     <include
         android:id="@+id/footnote"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_message_giphy.xml
@@ -20,7 +20,7 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="@dimen/stream_ui_spacing_small"
         android:clipToPadding="false"
-        app:cardBackgroundColor="@color/stream_ui_current_user_background"
+        app:cardBackgroundColor="@color/stream_ui_background_light"
         app:cardElevation="@dimen/stream_ui_elevation_small"
         app:layout_constraintEnd_toStartOf="@id/marginEnd"
         app:layout_constraintStart_toEndOf="@id/marginStart"


### PR DESCRIPTION
[CAS-525](https://stream-io.atlassian.net/browse/CAS-525?atlOrigin=eyJpIjoiMWE2YTJiZjkzNDk1NDBmMWJhNDVjZjA4OTExMTEwZGYiLCJwIjoiaiJ9)

### Description

Fix crash with MaterialCardView for old android versions, by using `app:cardBackgroundColor` instead of `android:background`. Also fix the colour being used for the background.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] <del> Changelog updated with client-facing changes </del>
- [ ] <del> New code is covered by unit tests </del>
- [ ] <del> Comparison screenshots added for visual changes </del>
- [x] Reviewers added
