### PR TITLE
Dismiss message options when the message container is clicked

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
@@ -136,6 +136,9 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                 binding.messageContainer,
                 MessageListItemViewTypeMapper.getViewTypeValue(messageItem)
             ).also { viewHolder ->
+                viewHolder.itemView.setOnClickListener {
+                    dismiss()
+                }
                 binding.messageContainer.addView(
                     viewHolder.itemView,
                     FrameLayout.LayoutParams(


### PR DESCRIPTION
### Description

Lets users close the message options dialog by clicking to the side of the selected message. This was previously consumed by the ViewHolder's root click listener, and would do nothing.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
