### PR TITLE
CAS-530 Latest message in chat detection

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -44,7 +44,8 @@ public sealed class MessageListItem {
         val message: Message,
         val positions: List<Position> = listOf(),
         val isMine: Boolean = false,
-        val messageReadBy: List<ChannelUserRead> = listOf()
+        val messageReadBy: List<ChannelUserRead> = listOf(),
+        val isLatestMessageInChat: Boolean = false,
     ) : MessageListItem() {
         public val isTheirs: Boolean
             get() = !isMine

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -191,7 +191,7 @@ internal class MessageListItemLiveData(
 
         // Mark the last [MessageListItem.MessageItem] as being the latest one.
         // It needs to be displayed differently on the MessageListView.
-        val lastMessage = items.filterIsInstance(MessageListItem.MessageItem::class.java).lastOrNull()
+        val lastMessage = items.filterIsInstance<MessageListItem.MessageItem>().lastOrNull()
         if (lastMessage != null) {
             items[items.indexOf(lastMessage)] = lastMessage.copy(isLatestMessageInChat = true)
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemAdapter.kt
@@ -54,7 +54,8 @@ public class MessageListItemAdapter(
             syncStatus = true,
             deleted = true,
             positions = true,
-            readBy = true
+            readBy = true,
+            isLatestMessageInChat = true,
         )
         private val EMPTY_MESSAGE_LIST_ITEM_PAYLOAD_DIFF = MessageListItemPayloadDiff(
             text = false,
@@ -64,7 +65,8 @@ public class MessageListItemAdapter(
             syncStatus = false,
             deleted = false,
             positions = false,
-            readBy = false
+            readBy = false,
+            isLatestMessageInChat = false,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
@@ -48,7 +48,8 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                 syncStatus = oldItem.message.syncStatus != newItem.message.syncStatus,
                 deleted = oldItem.message.deletedAt != newItem.message.deletedAt,
                 positions = oldItem.positions != newItem.positions,
-                readBy = oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
+                readBy = oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() },
+                isLatestMessageInChat = oldItem.isLatestMessageInChat != newItem.isLatestMessageInChat,
             )
         } else {
             null

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemPayloadDiff.kt
@@ -9,6 +9,7 @@ public data class MessageListItemPayloadDiff(
     val deleted: Boolean,
     val positions: Boolean,
     val readBy: Boolean,
+    val isLatestMessageInChat: Boolean,
 ) {
     public operator fun plus(other: MessageListItemPayloadDiff): MessageListItemPayloadDiff =
         copy(
@@ -20,5 +21,6 @@ public data class MessageListItemPayloadDiff(
             deleted = deleted || other.deleted,
             positions = positions || other.positions,
             readBy = readBy || other.readBy,
+            isLatestMessageInChat = isLatestMessageInChat || other.isLatestMessageInChat,
         )
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-530

### Description

* Add `MessageListItem.MessageItem.isLatestMessageInChat` property
* Update `MessageListItemLiveData::groupMessages` to mark proper message as the ltest one

The above changes allow providing a unique UI for the latest message on the message list view.

@ogkuzmin will take care of the UI part while introducing a custom view for the message footer.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
