### PR TITLE
[CAS-534] Feature/debounce share icon

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGallery.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGallery.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.ui.databinding.StreamUiAttachmentGalleryBinding
 import io.getstream.chat.android.ui.images.menu.ImagesMenuDialogFragment
 import io.getstream.chat.android.ui.utils.extensions.getFragmentManager
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
 public class AttachmentGallery : ConstraintLayout {
@@ -105,6 +106,7 @@ public class AttachmentGallery : ConstraintLayout {
             GlobalScope.launch(DispatcherProvider.Main) {
                 ImageLoader.getBitmapUri(context, adapter.getItem(binding.attachmentGallery.currentItem))
                     ?.let(onSharePictureListener)
+                delay(500)
                 it.isEnabled = true
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGallery.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/images/AttachmentGallery.kt
@@ -101,9 +101,11 @@ public class AttachmentGallery : ConstraintLayout {
         this.imageList = imageList
 
         binding.shareButton.setOnClickListener {
+            it.isEnabled = false
             GlobalScope.launch(DispatcherProvider.Main) {
                 ImageLoader.getBitmapUri(context, adapter.getItem(binding.attachmentGallery.currentItem))
                     ?.let(onSharePictureListener)
+                it.isEnabled = true
             }
         }
     }


### PR DESCRIPTION
### Description
Share actions needs to generated a file before the intent is generated, and it could spend some time. We need to disable the button during this process to prevent multiple share-process to be executed

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
