### PR TITLE
[CAS-537] Open Attachments with `ChatUI::navigator`

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/files/ChatInfoSharedFilesFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/files/ChatInfoSharedFilesFragment.kt
@@ -1,7 +1,5 @@
 package io.getstream.chat.ui.sample.feature.chat.info.shared.files
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -10,7 +8,10 @@ import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.navArgs
+import com.getstream.sdk.chat.ChatUI
+import com.getstream.sdk.chat.navigation.destinations.AttachmentDestination
 import com.getstream.sdk.chat.view.EndlessScrollListener
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.ui.sample.common.initToolbar
 import io.getstream.chat.ui.sample.databinding.FragmentChatInfoSharedFilesBinding
 import io.getstream.chat.ui.sample.feature.chat.info.shared.ChatInfoSharedAttachmentsViewModel
@@ -50,13 +51,7 @@ class ChatInfoSharedFilesFragment : Fragment() {
         binding.filesRecyclerView.adapter = adapter
         binding.filesRecyclerView.addOnScrollListener(scrollListener)
         adapter.setAttachmentClickListener { attachmentItem ->
-            attachmentItem.attachmentWithDate.attachment.url?.let { url ->
-                startActivity(
-                    Intent.makeMainSelectorActivity(Intent.ACTION_MAIN, Intent.CATEGORY_APP_BROWSER).apply {
-                        data = Uri.parse(url)
-                    }
-                )
-            }
+            ChatUI.instance().navigator.navigate(AttachmentDestination(Message(), attachmentItem.attachmentWithDate.attachment, requireContext()))
         }
         bindViewModel()
     }


### PR DESCRIPTION
### Description
Use `ChatUI::navigator` to open attachments

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
