### PR TITLE
Fix duplicate AvatarView layout ID in ReplyView

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MessageReplyView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MessageReplyView.kt
@@ -60,8 +60,8 @@ public class MessageReplyView : FrameLayout {
     }
 
     private fun setUserAvatar(message: Message) {
-        binding.avatarView.setUserData(message.user)
-        binding.avatarView.isVisible = true
+        binding.replyAvatarView.setUserData(message.user)
+        binding.replyAvatarView.isVisible = true
     }
 
     private fun setAvatarPosition(isMine: Boolean) {
@@ -71,7 +71,7 @@ public class MessageReplyView : FrameLayout {
             clear(R.id.replyContainer, ConstraintSet.START)
             clear(R.id.replyContainer, ConstraintSet.END)
         }
-        binding.avatarView.updateLayoutParams<ConstraintLayout.LayoutParams> {
+        binding.replyAvatarView.updateLayoutParams<ConstraintLayout.LayoutParams> {
             if (isMine) {
                 endToEnd = ConstraintLayout.LayoutParams.PARENT_ID
                 startToEnd = R.id.replyContainer

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
@@ -14,7 +14,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMed
 internal class AvatarDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
@@ -25,21 +25,21 @@ internal class AvatarDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
@@ -47,13 +47,11 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun setupAvatar(avatarView: AvatarView, data: MessageListItem.MessageItem) {
-        if (data.isTheirs) {
+        if (data.isTheirs && data.isTheirs && data.isBottomPosition()) {
+            avatarView.isVisible = true
             avatarView.setUserData(data.message.user)
-        }
-
-        avatarView.isVisible = when {
-            data.isTheirs && data.isBottomPosition() -> true
-            else -> false
+        } else {
+            avatarView.isVisible = false
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_reply_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_reply_view.xml
@@ -9,7 +9,7 @@
     >
 
     <io.getstream.chat.android.ui.avatar.AvatarView
-        android:id="@+id/avatarView"
+        android:id="@+id/replyAvatarView"
         style="@style/StreamUiReplyAvatarStyle"
         android:layout_marginHorizontal="@dimen/stream_ui_spacing_tiny"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -25,7 +25,7 @@
         android:padding="@dimen/stream_ui_spacing_tiny"
         app:layout_constrainedWidth="true"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@id/avatarView"
+        app:layout_constraintStart_toEndOf="@id/replyAvatarView"
         app:layout_constraintTop_toTopOf="parent"
         >
 


### PR DESCRIPTION
### Description

Was surprised to find out that `findViewById` performs DFS and not BFS. Therefore, for most of our message list view holders, `AvatarDecorator` was updating invisible avatar in inner `ReplyView` layout instead of message avatar.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
| ![photo_2021-01-13 00 31 23](https://user-images.githubusercontent.com/9600921/104376885-b056b700-5536-11eb-9c4d-72609eb6e1de.jpeg) | ![photo_2021-01-13 00 31 19](https://user-images.githubusercontent.com/9600921/104376890-b2207a80-5536-11eb-8178-299986fb05da.jpeg) |




