### PR TITLE
Fix corner size apply to MediaAttachmentsGroupView

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/MediaAttachmentsGroupView.kt
@@ -174,7 +174,7 @@ internal class MediaAttachmentsGroupView : ConstraintLayout {
     }
 
     private fun ShapeAppearanceModel.getCornerSize(selector: (ShapeAppearanceModel) -> CornerSize): Float {
-        return ((selector(this) as? AbsoluteCornerSize)?.cornerSize ?: 0f - STROKE_WIDTH).takeIf { it >= 0f }
+        return (((selector(this) as? AbsoluteCornerSize)?.cornerSize ?: 0f) - STROKE_WIDTH).takeIf { it >= 0f }
             .getOrDefault(0f)
     }
 


### PR DESCRIPTION
### Description
Fix corner size apply to MediaAttachmentsGroupView

| Before | After |
| --- | --- |
| ![photo_2021-01-13_13-36-08](https://user-images.githubusercontent.com/4047514/104453271-715f4a80-55a4-11eb-82ee-10a6e69f35c8.jpg)  | ![photo_2021-01-13_13-36-09](https://user-images.githubusercontent.com/4047514/104453279-745a3b00-55a4-11eb-8eff-9afca4df5d36.jpg) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
