### PR TITLE
Improve error handling for attachments

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.java
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.java
@@ -33,7 +33,7 @@ public class AttachmentActivity extends AppCompatActivity {
     ImageView iv_image;
     ProgressBar progressBar;
 
-    private TaggedLogger logger = ChatLogger.Companion.get("AttachmentActivity");
+    private final TaggedLogger logger = ChatLogger.Companion.get("AttachmentActivity");
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,7 +50,8 @@ public class AttachmentActivity extends AppCompatActivity {
         String type = intent.getStringExtra("type");
         String url = intent.getStringExtra("url");
         if (TextUtils.isEmpty(type) || TextUtils.isEmpty(url)) {
-            Toast.makeText(this, "Something error!", Toast.LENGTH_SHORT).show();
+            logger.logE("This file can't be displayed. The TYPE or the URL are null");
+            Toast.makeText(this, getString(R.string.stream_ui_attachment_display_error), Toast.LENGTH_SHORT).show();
             return;
         }
         showAttachment(type, url);

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentMediaActivity.java
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentMediaActivity.java
@@ -13,6 +13,8 @@ import androidx.appcompat.app.AppCompatActivity;
 import com.getstream.sdk.chat.ChatUI;
 import com.getstream.sdk.chat.utils.exomedia.ui.widget.VideoView;
 
+import io.getstream.chat.android.client.logger.ChatLogger;
+import io.getstream.chat.android.client.logger.TaggedLogger;
 import io.getstream.chat.android.ui.common.R;
 
 /**
@@ -25,6 +27,8 @@ public class AttachmentMediaActivity extends AppCompatActivity {
 
     VideoView videoView;
     ImageView iv_audio;
+
+    private final TaggedLogger logger = ChatLogger.Companion.get("AttachmentMediaActivity");
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -40,7 +44,8 @@ public class AttachmentMediaActivity extends AppCompatActivity {
         String type = intent.getStringExtra(TYPE_KEY);
         String url = intent.getStringExtra(URL_KEY);
         if (TextUtils.isEmpty(type) || TextUtils.isEmpty(url)) {
-            Toast.makeText(this, "Something error!", Toast.LENGTH_SHORT).show();
+            logger.logE("This file can't be displayed. The TYPE or the URL are null");
+            Toast.makeText(this, getString(R.string.stream_ui_attachment_display_error), Toast.LENGTH_SHORT).show();
             return;
         }
         if (type.contains("audio"))

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -18,4 +18,5 @@
 
     <!--Message Date-->
     <string name="stream_date_yesterday">Yesterday</string>
+    <string name="stream_ui_attachment_display_error">File can\'t be displayed</string>
 </resources>

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -18,5 +18,7 @@
 
     <!--Message Date-->
     <string name="stream_date_yesterday">Yesterday</string>
+
+    <!--Attachment Display-->
     <string name="stream_ui_attachment_display_error">Error. File can\'t be displayed</string>
 </resources>

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -18,5 +18,5 @@
 
     <!--Message Date-->
     <string name="stream_date_yesterday">Yesterday</string>
-    <string name="stream_ui_attachment_display_error">File can\'t be displayed</string>
+    <string name="stream_ui_attachment_display_error">Error. File can\'t be displayed</string>
 </resources>


### PR DESCRIPTION
### Description

Better error message when we can't display attachment. Logging added. 

### Checklist
| Before | After |
| --- | --- |
| ![Screenshot_20210113-145030](https://user-images.githubusercontent.com/10619102/104461749-087dcf80-55b0-11eb-8808-cea0a83624bc.png) | ![Screenshot_20210113-134831](https://user-images.githubusercontent.com/10619102/104461797-13386480-55b0-11eb-8315-1f8499f37727.png) | 

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added

