### PR TITLE
Fix channel list badges

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -181,14 +181,20 @@ public class ChannelViewHolder @JvmOverloads constructor(
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureUnreadCountBadge() {
-        val haveUnreadMessages = channel.unreadCount ?: 0 > 0
+        val count = channel.unreadCount ?: 0
+
+        val haveUnreadMessages = count > 0
         unreadCountBadge.isVisible = haveUnreadMessages
 
         if (!haveUnreadMessages) {
             return
         }
 
-        unreadCountBadge.text = channel.unreadCount.toString()
+        unreadCountBadge.text = if (count > 99) {
+            "99+"
+        } else {
+            count.toString()
+        }
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureCurrentUserLastMessageStatus(

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -24,11 +24,11 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="8dp"
-        android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
-        android:maxLines="1"
         android:ellipsize="end"
-        app:layout_constraintEnd_toEndOf="parent"
+        android:maxLines="1"
+        android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
         app:layout_constraintBottom_toTopOf="@+id/last_message_label"
+        app:layout_constraintEnd_toStartOf="@+id/unread_count_badge"
         app:layout_constraintStart_toEndOf="@+id/avatar_view"
         app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
@@ -56,9 +56,8 @@
         android:layout_height="wrap_content"
         android:layout_marginEnd="8dp"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
-        app:layout_constraintBottom_toBottomOf="@+id/message_status_image_view"
+        app:layout_constraintBaseline_toBaselineOf="@+id/last_message_label"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/message_status_image_view"
         tools:text="3:00PM"
         />
 
@@ -70,14 +69,15 @@
         app:layout_constraintBottom_toBottomOf="@+id/last_message_label"
         app:layout_constraintEnd_toStartOf="@+id/last_message_time_label"
         app:layout_constraintTop_toTopOf="@+id/last_message_label"
-        tools:src="@drawable/stream_ui_ic_check_double"
         tools:ignore="ContentDescription"
+        tools:src="@drawable/stream_ui_ic_check_double"
         />
 
     <TextView
         android:id="@+id/unread_count_badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginBottom="4dp"
         android:background="@drawable/stream_ui_shape_badge_background"
         android:fontFamily="sans-serif-medium"
         android:gravity="center"
@@ -87,8 +87,6 @@
         android:textSize="@dimen/stream_ui_text_small"
         app:layout_constraintBottom_toTopOf="@+id/last_message_time_label"
         app:layout_constraintEnd_toEndOf="@+id/last_message_time_label"
-        app:layout_constraintStart_toStartOf="@+id/last_message_time_label"
-        app:layout_constraintTop_toTopOf="parent"
         tools:text="99"
         />
 


### PR DESCRIPTION

### Description

Fixes a bunch of things around the unread count badges on the channel list:

- Vertically aligns them to the _end_ of the timestamp instead of the _center_ of it
- Doesn't let the channel name and the badge overlap
- Fixes vertical alignment of timestamp and vadge
- Uses "99+" for large unread counts as per the design

| Before | After |
| --- | --- |
|  ![Screenshot_20210115_095347](https://user-images.githubusercontent.com/12054216/104706498-772b6c00-571b-11eb-800c-37dc6989cc31.png) | ![Screenshot_20210115_101141](https://user-images.githubusercontent.com/12054216/104706515-7db9e380-571b-11eb-9797-91be9db630b5.png) |


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
