### PR TITLE
Use User.createdAt in last seen text if lastActive is not available

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
@@ -25,15 +25,18 @@ internal fun User.isCurrentUser(): Boolean {
 }
 
 public fun User.getLastSeenText(context: Context): String {
-    return if (online) {
-        context.getString(R.string.stream_ui_message_list_header_online)
-    } else {
-        val lastActive = lastActive ?: return String.EMPTY
-        context.getString(
+    if (online) {
+        return context.getString(R.string.stream_ui_message_list_header_online)
+    }
+
+    (lastActive ?: createdAt)?.let { date ->
+        return context.getString(
             R.string.stream_ui_message_list_header_last_seen,
-            DateUtils.getRelativeTimeSpanString(lastActive.time).toString()
+            DateUtils.getRelativeTimeSpanString(date.time).toString()
         )
     }
+
+    return String.EMPTY
 }
 
 internal fun User.asMention(context: Context): String =


### PR DESCRIPTION

### Description

See title & screenshots

| Before | After |
| --- | --- |
| ![Screenshot_20210115_154416](https://user-images.githubusercontent.com/12054216/104744811-9e029600-574d-11eb-878a-0d5b02a93a37.png) | ![Screenshot_20210115_161822](https://user-images.githubusercontent.com/12054216/104744885-b5418380-574d-11eb-9674-8f34ac0162c9.png)|

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
