### PR TITLE
[CAS-545] Incorrect unread counts in channel list

### DIFF
--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelItemPayloadDiff.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelItemPayloadDiff.kt
@@ -6,6 +6,7 @@ public data class ChannelItemPayloadDiff(
     val lastMessage: Boolean,
     val lastMessageDate: Boolean,
     val readState: Boolean,
+    val unreadCount: Boolean,
 ) {
     public operator fun plus(other: ChannelItemPayloadDiff): ChannelItemPayloadDiff =
         ChannelItemPayloadDiff(
@@ -14,5 +15,6 @@ public data class ChannelItemPayloadDiff(
             lastMessage = lastMessage || other.lastMessage,
             lastMessageDate = lastMessageDate || other.lastMessageDate,
             readState = readState || other.readState,
+            unreadCount = unreadCount || other.unreadCount
         )
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.kt
@@ -12,7 +12,7 @@ import io.getstream.chat.android.livedata.ChatDomain
 internal class ChannelListDiffCallback @JvmOverloads constructor(
     private val oldList: List<Channel>,
     private val newList: List<Channel>,
-    private val currentUser: User = ChatDomain.instance().currentUser
+    private val currentUser: User = ChatDomain.instance().currentUser,
 ) : DiffUtil.Callback() {
 
     override fun getOldListSize(): Int = oldList.size
@@ -31,8 +31,9 @@ internal class ChannelListDiffCallback @JvmOverloads constructor(
             (oldChannel.updatedAt == null && newChannel.updatedAt != null) ||
             (newChannel.updatedAt != null && oldChannel.updatedAt!!.time < newChannel.updatedAt!!.time) ||
             (oldChannel.extraData != newChannel.extraData) ||
-            (!lastMessagesAreTheSame(oldChannel, newChannel)) ||
-            (channelUserReadIsDifferent(oldChannel, newChannel))
+            !lastMessagesAreTheSame(oldChannel, newChannel) ||
+            channelUserReadIsDifferent(oldChannel, newChannel) ||
+            unreadCountIsDifferent(oldChannel, newChannel)
         ) {
             return false
         }
@@ -47,7 +48,8 @@ internal class ChannelListDiffCallback @JvmOverloads constructor(
             name = !channelNameIsTheSame(newChannel, oldChannel),
             avatarView = !channelUsersAreTheSame(newChannel, oldChannel),
             readState = channelUserReadIsDifferent(oldChannel, newChannel),
-            lastMessageDate = !channelLastMessageDatesAreTheSame(oldChannel, newChannel)
+            lastMessageDate = !channelLastMessageDatesAreTheSame(oldChannel, newChannel),
+            unreadCount = unreadCountIsDifferent(oldChannel, newChannel)
         )
     }
 
@@ -76,6 +78,10 @@ internal class ChannelListDiffCallback @JvmOverloads constructor(
 
     private fun channelLastMessageDatesAreTheSame(oldChannel: Channel, newChannel: Channel): Boolean {
         return oldChannel.lastMessageAt == newChannel.lastMessageAt
+    }
+
+    private fun unreadCountIsDifferent(oldChannel: Channel, newChannel: Channel): Boolean {
+        return oldChannel.unreadCount != newChannel.unreadCount
     }
 
     private fun channelUserReadIsDifferent(oldChannel: Channel, newChannel: Channel): Boolean {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallback.kt
@@ -49,7 +49,7 @@ internal class ChannelListDiffCallback @JvmOverloads constructor(
             avatarView = !channelUsersAreTheSame(newChannel, oldChannel),
             readState = channelUserReadIsDifferent(oldChannel, newChannel),
             lastMessageDate = !channelLastMessageDatesAreTheSame(oldChannel, newChannel),
-            unreadCount = unreadCountIsDifferent(oldChannel, newChannel)
+            unreadCount = unreadCountIsDifferent(oldChannel, newChannel),
         )
     }
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemAdapter.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelListItemAdapter.java
@@ -16,9 +16,9 @@ import io.getstream.chat.android.client.models.Channel;
 
 public class ChannelListItemAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     private static final ChannelItemPayloadDiff FULL_CHANNEL_ITEM_PAYLOAD_DIFF =
-            new ChannelItemPayloadDiff(true, true, true, true, true);
+            new ChannelItemPayloadDiff(true, true, true, true, true, true);
     private static final ChannelItemPayloadDiff EMPTY_CHANNEL_ITEM_PAYLOAD_DIFF =
-            new ChannelItemPayloadDiff(false, false, false, false, false);
+            new ChannelItemPayloadDiff(false, false, false, false, false, false);
     private List<Channel> channels; // cached list of channels
     private ChannelListView.ChannelClickListener channelClickListener;
     private ChannelListView.ChannelClickListener channelLongClickListener;

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallbackTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/adapter/ChannelListDiffCallbackTest.kt
@@ -119,6 +119,7 @@ internal class ChannelListDiffCallbackTest {
         val channel2 = channel1.copy()
 
         val expectedDiff = ChannelItemPayloadDiff(
+            unreadCount = false,
             lastMessage = false,
             name = false,
             avatarView = false,


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-545
https://github.com/GetStream/stream-chat-android/issues/1226

### Description

`ChannelListDiffCallback` was not taking into account `unreadCount` field. As a result, unread counts could be stale in the channel list. 

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
