### PR TITLE
Fixing some colours related to attachments

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_attachment_cancel_background.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_attachment_cancel_background.xml
@@ -2,5 +2,5 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval"
     >
-    <solid android:color="@color/stream_ui_black_transparent" />
+    <solid android:color="@color/stream_ui_black_50" />
 </shape>

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_circle_white_attachment_check.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_circle_white_attachment_check.xml
@@ -2,5 +2,9 @@
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
     android:shape="oval"
     >
-    <solid android:color="@color/stream_ui_black_transparent" />
+    <solid android:color="@color/stream_ui_white" />
+    <size
+        android:width="24dp"
+        android:height="24dp"
+        />
 </shape>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_attachment_media.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_attachment_media.xml
@@ -38,7 +38,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_margin="@dimen/stream_ui_spacing_small"
-        android:background="@drawable/stream_ui_circle_white"
+        android:background="@drawable/stream_ui_circle_white_attachment_check"
         android:scaleType="center"
         android:src="@drawable/stream_ui_ic_attachment_check"
         app:tint="@color/stream_ui_black"

--- a/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
@@ -2,6 +2,7 @@
 <resources>
     <!-- Greys -->
     <color name="stream_ui_black">#FFFFFF</color>
+    <color name="stream_ui_black_50">#80FFFFFF</color>
     <color name="stream_ui_grey">#7A7A7A</color>
     <color name="stream_ui_grey_gainsboro">#2D2F2F</color>
     <color name="stream_ui_grey_whisper">#1C1E22</color>
@@ -9,7 +10,6 @@
     <color name="stream_ui_white_snow">#070A0D</color>
     <color name="stream_ui_white">#101418</color>
     <color name="stream_ui_blue_alice">#00193D</color>
-    <color name="stream_ui_black_transparent">#80FFFFFF</color>
 
     <!-- Specials -->
     <color name="stream_ui_overlay">#66000000</color>

--- a/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
@@ -9,6 +9,7 @@
     <color name="stream_ui_white_snow">#070A0D</color>
     <color name="stream_ui_white">#101418</color>
     <color name="stream_ui_blue_alice">#00193D</color>
+    <color name="stream_ui_black_transparent">#80FFFFFF</color>
 
     <!-- Specials -->
     <color name="stream_ui_overlay">#66000000</color>

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
 
     <!-- Greys -->
     <color name="stream_ui_black">#000000</color>
+    <color name="stream_ui_black_50">#80000000</color>
     <color name="stream_ui_grey">#7A7A7A</color>
     <color name="stream_ui_grey_gainsboro">#DBDBDB</color>
     <color name="stream_ui_grey_whisper">#ECEBEB</color>
@@ -14,7 +15,6 @@
     <color name="stream_ui_white_snow">#FCFCFC</color>
     <color name="stream_ui_white">#FFFFFF</color>
     <color name="stream_ui_blue_alice">#E9F2FF</color>
-    <color name="stream_ui_black_transparent">#80000000</color>
 
     <!-- Specials -->
     <color name="stream_ui_overlay">#33000000</color>

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -14,6 +14,7 @@
     <color name="stream_ui_white_snow">#FCFCFC</color>
     <color name="stream_ui_white">#FFFFFF</color>
     <color name="stream_ui_blue_alice">#E9F2FF</color>
+    <color name="stream_ui_black_transparent">#80000000</color>
 
     <!-- Specials -->
     <color name="stream_ui_overlay">#33000000</color>


### PR DESCRIPTION
### Description

This PR creates a small colour fix related to attachments. 

| Before | After |
|---|---|
| ![Untitled3](https://user-images.githubusercontent.com/10619102/104957382-5b032580-59ce-11eb-849f-4edd0fc36f87.png) | ![Untitled](https://user-images.githubusercontent.com/10619102/104957412-68201480-59ce-11eb-8ca9-9ba1e7718330.png) | 
| ![Untitled2](https://user-images.githubusercontent.com/10619102/104957517-9998e000-59ce-11eb-92a2-97520ed34c72.png) | ![Untitled4](https://user-images.githubusercontent.com/10619102/104957582-b503eb00-59ce-11eb-8c9f-66f139e0a762.png) | 



### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
