### PR TITLE
Set ChatMode in MessageInputView

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1760,6 +1760,10 @@ public final class com/getstream/sdk/chat/utils/extensions/AttachmentExtensionKt
 	public static final fun getDisplayableName (Lio/getstream/chat/android/client/models/Attachment;)Ljava/lang/String;
 }
 
+public final class com/getstream/sdk/chat/utils/extensions/ChannelKt {
+	public static synthetic fun getUsers$default (Lio/getstream/chat/android/client/models/Channel;ZILjava/lang/Object;)Ljava/util/List;
+}
+
 public final class com/getstream/sdk/chat/utils/extensions/ConstraintLayoutKt {
 }
 
@@ -1985,6 +1989,7 @@ public final class com/getstream/sdk/chat/viewmodel/MessageInputViewModel : andr
 	public final fun getMaxMessageLength ()Landroidx/lifecycle/LiveData;
 	public final fun getMembers ()Landroidx/lifecycle/LiveData;
 	public final fun getRepliedMessage ()Landroidx/lifecycle/MediatorLiveData;
+	public final fun isDirectMessage ()Landroidx/lifecycle/LiveData;
 	public final fun keystroke ()V
 	public final fun resetThread ()V
 	public final fun sendMessage (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Channel.kt
@@ -1,6 +1,32 @@
 package com.getstream.sdk.chat.utils.extensions
 
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.livedata.ChatDomain
 
 internal val Channel.isDraft: Boolean
     get() = getExtraValue("draft", false)
+
+@InternalStreamChatApi
+public fun Channel.isDirectMessaging(): Boolean = getUsers().size == 1
+
+@InternalStreamChatApi
+public fun Channel.getUsers(excludeCurrentUser: Boolean = true): List<User> =
+    members
+        .map { it.user }
+        .let { users ->
+            when {
+                excludeCurrentUser -> users.withoutCurrentUser()
+                else -> users
+            }
+        }
+
+private fun List<User>.withoutCurrentUser(): List<User> {
+    return if (ChatDomain.isInitialized) {
+        val currentUser = ChatDomain.instance().currentUser
+        filter { it.id != currentUser.id }
+    } else {
+        this
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Command
@@ -33,6 +34,9 @@ public class MessageInputViewModel @JvmOverloads constructor(
     public val editMessage: MutableLiveData<Message?> = MutableLiveData()
     public val repliedMessage: MediatorLiveData<Message?> = MediatorLiveData()
 
+    private val _isDirectMessage: MutableLiveData<Boolean> = MutableLiveData()
+    public val isDirectMessage: LiveData<Boolean> = _isDirectMessage
+
     init {
         chatDomain.useCases.watchChannel(cid, 0).enqueue { channelControllerResult ->
             if (channelControllerResult.isSuccess) {
@@ -41,6 +45,7 @@ public class MessageInputViewModel @JvmOverloads constructor(
                 _maxMessageLength.value = channel.config.maxMessageLength
                 _commands.value = channel.config.commands
                 _members.addSource(channelController.members) { _members.value = it }
+                _isDirectMessage.value = channel.isDirectMessaging()
                 repliedMessage.addSource(channelController.repliedMessage) { repliedMessage.value = it }
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelsView.kt
@@ -10,6 +10,7 @@ import android.widget.TextView
 import androidx.annotation.DrawableRes
 import androidx.core.content.res.use
 import androidx.core.view.isVisible
+import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.actions.ChannelActionsDialogFragment
@@ -17,7 +18,6 @@ import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
 import io.getstream.chat.android.ui.utils.extensions.dpToPx
 import io.getstream.chat.android.ui.utils.extensions.getFragmentManager
-import io.getstream.chat.android.ui.utils.extensions.isDirectMessaging
 
 public class ChannelsView @JvmOverloads constructor(
     context: Context,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelViewHolder.kt
@@ -6,6 +6,7 @@ import androidx.core.view.doOnNextLayout
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.extensions.inflater
+import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import com.getstream.sdk.chat.utils.formatDate
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
@@ -24,7 +25,6 @@ import io.getstream.chat.android.ui.utils.extensions.getDisplayName
 import io.getstream.chat.android.ui.utils.extensions.getLastMessage
 import io.getstream.chat.android.ui.utils.extensions.getLastMessagePreviewText
 import io.getstream.chat.android.ui.utils.extensions.isCurrentUserOwnerOrAdmin
-import io.getstream.chat.android.ui.utils.extensions.isDirectMessaging
 import io.getstream.chat.android.ui.utils.extensions.isMessageRead
 import io.getstream.chat.android.ui.utils.extensions.isNotNull
 import io.getstream.chat.android.ui.utils.extensions.setTextSizePx

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/coil/AvatarFetcher.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/coil/AvatarFetcher.kt
@@ -9,12 +9,12 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.size.PixelSize
 import coil.size.Size
+import com.getstream.sdk.chat.utils.extensions.getUsers
 import io.getstream.chat.android.client.models.image
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.ui.avatar.Avatar
 import io.getstream.chat.android.ui.avatar.AvatarBitmapCombiner
 import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory
-import io.getstream.chat.android.ui.utils.extensions.getUsers
 
 internal class AvatarFetcher(
     private val avatarBitmapFactory: AvatarBitmapFactory

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderViewBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderViewBinding.kt
@@ -3,10 +3,10 @@
 package io.getstream.chat.android.ui.messages.header
 
 import androidx.lifecycle.LifecycleOwner
+import com.getstream.sdk.chat.utils.extensions.getUsers
 import com.getstream.sdk.chat.viewmodel.ChannelHeaderViewModel
 import io.getstream.chat.android.ui.utils.extensions.getDisplayName
 import io.getstream.chat.android.ui.utils.extensions.getOnlineStateSubtitle
-import io.getstream.chat.android.ui.utils.extensions.getUsers
 
 /**
  * Binds [MessagesHeaderView] with [ChannelHeaderViewModel], updating the view's state

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -21,6 +21,7 @@ import com.getstream.sdk.chat.navigation.destinations.WebLinkDestination
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.StartStopBuffer
 import com.getstream.sdk.chat.utils.extensions.inflater
+import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import com.getstream.sdk.chat.view.EndlessScrollListener
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper
 import io.getstream.chat.android.chat.navigation.GalleryImageAttachmentDestination
@@ -48,7 +49,6 @@ import io.getstream.chat.android.ui.messages.view.MessageListView.UserClickListe
 import io.getstream.chat.android.ui.options.MessageOptionsDialogFragment
 import io.getstream.chat.android.ui.options.MessageOptionsView
 import io.getstream.chat.android.ui.utils.extensions.getFragmentManager
-import io.getstream.chat.android.ui.utils.extensions.isDirectMessaging
 import io.getstream.chat.android.ui.utils.extensions.isInThread
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputViewModelBinding.kt
@@ -5,6 +5,8 @@ package io.getstream.chat.android.ui.textinput
 import androidx.lifecycle.LifecycleOwner
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.ui.textinput.MessageInputView.ChatMode.DIRECT_CHAT
+import io.getstream.chat.android.ui.textinput.MessageInputView.ChatMode.GROUP_CHAT
 import java.io.File
 
 /**
@@ -27,6 +29,9 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
         message?.let {
             view.inputMode = MessageInputView.InputMode.Edit(it)
         }
+    }
+    isDirectMessage.observe(lifecycleOwner) { isDirectMessage ->
+        view.chatMode = if (isDirectMessage) DIRECT_CHAT else GROUP_CHAT
     }
 
     view.setSendMessageHandler(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -3,25 +3,15 @@ package io.getstream.chat.android.ui.utils.extensions
 import android.content.Context
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
+import com.getstream.sdk.chat.utils.extensions.getUsers
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.utils.ModelType
-
-internal fun Channel.getUsers(excludeCurrentUser: Boolean = true): List<User> =
-    members
-        .map { it.user }
-        .let { users ->
-            when {
-                excludeCurrentUser -> users.withoutCurrentUser()
-                else -> users
-            }
-        }
 
 public fun Channel.getDisplayName(context: Context): String =
     name.takeIf { it.isNotEmpty() }
@@ -94,8 +84,6 @@ internal fun Channel.isMessageRead(message: Message): Boolean {
         .mapNotNull { it.lastRead }
         .any { it.time >= message.getCreatedAtOrThrow().time }
 }
-
-internal fun Channel.isDirectMessaging(): Boolean = getUsers().size == 1
 
 // None of the strings used to assemble the preview message are translatable - concatenation here should be fine
 internal fun Channel.getLastMessagePreviewText(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/User.kt
@@ -7,15 +7,6 @@ import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.R
 
-internal fun List<User>.withoutCurrentUser(): List<User> {
-    return if (ChatDomain.isInitialized) {
-        val currentUser = ChatDomain.instance().currentUser
-        filter { it.id != currentUser.id }
-    } else {
-        this
-    }
-}
-
 internal fun User.isCurrentUser(): Boolean {
     return if (ChatDomain.isInitialized) {
         id == ChatDomain.instance().currentUser.id


### PR DESCRIPTION
### Description

Expose `isDirectMessage` about current channel from `MessageInputViewModel`, and set the `chatMode` in `MessageInputView` based on it.

This affects what copy we show next to the "Also send" checkbox:

| Group | Direct message |
| --- | --- |
| ![Screenshot_20210121_093909](https://user-images.githubusercontent.com/12054216/105325170-95d2ac80-5bcc-11eb-92db-0225e1ab6bc8.png) | ![Screenshot_20210121_093933](https://user-images.githubusercontent.com/12054216/105325178-979c7000-5bcc-11eb-84db-bde7365f36a5.png) |

The PR moves some utility methods to the `common` module as that's where the ViewModel lives.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
