### PR TITLE
Move coroutines-android dependency to client module

### DIFF
--- a/stream-chat-android-client/build.gradle
+++ b/stream-chat-android-client/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation Dependencies.androidxLifecycleExtensions
     implementation Dependencies.constraintLayout
     implementation Dependencies.coroutinesCore
+    implementation Dependencies.coroutinesAndroid
     implementation Dependencies.firebaseMessaging
     implementation Dependencies.retrofit
     implementation Dependencies.retrofitGsonConverter

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -82,7 +82,6 @@ dependencies {
     implementation Dependencies.kotlinStdLib
     implementation Dependencies.kotlinReflect
     implementation Dependencies.coroutinesCore
-    implementation Dependencies.coroutinesAndroid
 
     // Google libs
     implementation Dependencies.androidxAppCompat


### PR DESCRIPTION

### Description

Users who include only our client dependency and don't include `couroutines-android` themselves would get a crash when performing calls with our SDK, as the platform specific Main dispatcher wouldn't be found at runtime 😢 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
