### PR TITLE
Add padding to the navbar that add some space between icon badge and the top border

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_home.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_home.xml
@@ -37,6 +37,7 @@
             android:id="@+id/bottomNavigationView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingTop="8dp"
             app:elevation="0dp"
             app:itemIconSize="20dp"
             app:itemIconTint="@color/bottom_nav_item_color"


### PR DESCRIPTION
### Description

Add padding to the navbar that add some space between icon badge and the top border

| Before | After |
| --- | --- |
| ![photo_2021-01-21_12-52-12](https://user-images.githubusercontent.com/4047514/105347890-d12ea480-5be7-11eb-95ee-c5b48165d8b8.jpg)  |  ![photo_2021-01-21_12-52-13](https://user-images.githubusercontent.com/4047514/105347904-d55ac200-5be7-11eb-9b74-6c24d6c9b7d6.jpg) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
