### PR TITLE
Add 1-param overload of SendMessage#invoke for Java clients

### DIFF
--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -392,11 +392,12 @@ public abstract interface class io/getstream/chat/android/livedata/usecase/SendG
 }
 
 public abstract interface class io/getstream/chat/android/livedata/usecase/SendMessage {
+	public abstract fun invoke (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun invoke (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function2;)Lio/getstream/chat/android/client/call/Call;
 }
 
 public final class io/getstream/chat/android/livedata/usecase/SendMessage$DefaultImpls {
-	public static synthetic fun invoke$default (Lio/getstream/chat/android/livedata/usecase/SendMessage;Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
+	public static fun invoke (Lio/getstream/chat/android/livedata/usecase/SendMessage;Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 }
 
 public abstract interface class io/getstream/chat/android/livedata/usecase/SendMessageWithAttachments {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
@@ -19,14 +19,24 @@ public interface SendMessage {
      */
     public operator fun invoke(
         message: Message,
-        attachmentTransformer: ((at: Attachment, file: File) -> Attachment)? = null
+    ): Call<Message> = invoke(message, null)
+
+    /**
+     * Sends the message. Immediately adds the message to local storage
+     * API call to send the message is retried according to the retry policy specified on the chatDomain
+     * @param message the message to send
+     * @see io.getstream.chat.android.livedata.utils.RetryPolicy
+     */
+    public operator fun invoke(
+        message: Message,
+        attachmentTransformer: ((at: Attachment, file: File) -> Attachment)?,
     ): Call<Message>
 }
 
 internal class SendMessageImpl(private val domainImpl: ChatDomainImpl) : SendMessage {
     override operator fun invoke(
         message: Message,
-        attachmentTransformer: ((at: Attachment, file: File) -> Attachment)?
+        attachmentTransformer: ((at: Attachment, file: File) -> Attachment)?,
     ): Call<Message> {
         val cid = message.cid
         validateCid(cid)


### PR DESCRIPTION


### Description

Default parameter values don't work in Java by default, and interfaces can't have `@JvmOverloads` methods. This PR adds a manual single-param overload, so that Java clients are not forced to always provide the second parameter.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
