### PR TITLE
Add suspending setUserAndAwait extensions for ChatClient

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -6,6 +6,7 @@
 - Use proper data on `ChatClient::reconnectSocket` to reconnect normal/anonymous user
 - Add `enforceUnique` parameter to `ChatClient::sendReaction` and `ChannelClient::sendReaction` methods .
 If reaction is sent with `enforceUnique` set to true, new reaction will replace all reactions the user has on this message.
+- Add suspending `setUserAndAwait` extension for `ChatClient`
 
 ## stream-chat-android-offline
 - Add `enforceUnique` parameter to `SendReaction` use case. If reaction is sent with `enforceUnique` set to true,

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -146,6 +146,8 @@ public final class io/getstream/chat/android/client/ChatClient$Companion {
 }
 
 public final class io/getstream/chat/android/client/ClientExtensionsKt {
+	public static final fun setUserAndAwait (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun setUserAndAwait (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun subscribeFor (Lio/getstream/chat/android/client/ChatClient;Landroidx/lifecycle/LifecycleOwner;[Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public static final fun subscribeFor (Lio/getstream/chat/android/client/ChatClient;[Lkotlin/reflect/KClass;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ClientExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ClientExtensions.kt
@@ -1,15 +1,23 @@
 package io.getstream.chat.android.client
 
 import androidx.lifecycle.LifecycleOwner
+import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.socket.InitConnectionListener
+import io.getstream.chat.android.client.token.TokenProvider
 import io.getstream.chat.android.client.utils.observable.Disposable
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
 import kotlin.reflect.KClass
 
 /**
  * Subscribes to client events of type [T].
  */
 public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
-    crossinline listener: (event: T) -> Unit
+    crossinline listener: (event: T) -> Unit,
 ): Disposable {
     return this.subscribeFor(
         T::class.java,
@@ -24,7 +32,7 @@ public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
  */
 public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
     lifecycleOwner: LifecycleOwner,
-    crossinline listener: (event: T) -> Unit
+    crossinline listener: (event: T) -> Unit,
 ): Disposable {
     return this.subscribeFor(
         lifecycleOwner,
@@ -38,7 +46,7 @@ public inline fun <reified T : ChatEvent> ChatClient.subscribeFor(
  */
 public fun ChatClient.subscribeFor(
     vararg eventTypes: KClass<out ChatEvent>,
-    listener: (event: ChatEvent) -> Unit
+    listener: (event: ChatEvent) -> Unit,
 ): Disposable {
     val javaClassTypes: Array<Class<out ChatEvent>> = eventTypes.map { it.java }.toTypedArray()
     return subscribeFor(*javaClassTypes, listener = listener)
@@ -52,7 +60,7 @@ public fun ChatClient.subscribeFor(
 public fun ChatClient.subscribeFor(
     lifecycleOwner: LifecycleOwner,
     vararg eventTypes: KClass<out ChatEvent>,
-    listener: (event: ChatEvent) -> Unit
+    listener: (event: ChatEvent) -> Unit,
 ): Disposable {
     val javaClassTypes: Array<Class<out ChatEvent>> = eventTypes.map { it.java }.toTypedArray()
     return subscribeFor(lifecycleOwner, *javaClassTypes, listener = listener)
@@ -62,7 +70,40 @@ public fun ChatClient.subscribeFor(
  * Subscribes for the next client event of type [T].
  */
 public inline fun <reified T : ChatEvent> ChatClient.subscribeForSingle(
-    noinline listener: (event: T) -> Unit
+    noinline listener: (event: T) -> Unit,
 ): Disposable {
     return this.subscribeForSingle(T::class.java, listener)
 }
+
+/**
+ * Runs [ChatClient.setUser] in a suspending way.
+ * Throws exceptions if errors occur during the call.
+ */
+public suspend fun ChatClient.setUserAndAwait(
+    user: User,
+    token: String,
+): InitConnectionListener.ConnectionData = suspendCoroutine { cont ->
+    setUser(user, token, initConnectionListener(cont))
+}
+
+/**
+ * Runs [ChatClient.setUser] in a suspending way.
+ * Throws exceptions if errors occur during the call.
+ */
+public suspend fun ChatClient.setUserAndAwait(
+    user: User,
+    tokenProvider: TokenProvider,
+): InitConnectionListener.ConnectionData = suspendCoroutine { cont ->
+    setUser(user, tokenProvider, initConnectionListener(cont))
+}
+
+private fun initConnectionListener(cont: Continuation<InitConnectionListener.ConnectionData>) =
+    object : InitConnectionListener() {
+        override fun onSuccess(data: ConnectionData) {
+            cont.resume(data)
+        }
+
+        override fun onError(error: ChatError) {
+            cont.resumeWithException(error.cause ?: RuntimeException(error.message))
+        }
+    }


### PR DESCRIPTION
### Description

Adds a `setUserAndAwait` extension so that coroutine users can easily wait for `setUser` to complete, and don't need to use a callback

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
