### PR TITLE
Fix badge position in bottom menu

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/common/Extensions.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/common/Extensions.kt
@@ -92,14 +92,13 @@ fun Fragment.initToolbar(toolbar: Toolbar) {
 }
 
 fun BottomNavigationView.setBadgeNumber(@IdRes menuItemId: Int, badgeNumber: Int) {
-    val badge = getBadge(menuItemId)
-        ?: getOrCreateBadge(menuItemId).apply {
-            horizontalOffset = -context.getDimensionPixelSize(R.dimen.badge_horizontal_offset)
-            verticalOffset = context.getDimensionPixelSize(R.dimen.badge_vertical_offset)
-            backgroundColor = context.getColorFromRes(R.color.bottom_nav_badge_color)
-        }
-    badge.isVisible = badgeNumber > 0
-    badge.number = badgeNumber
+    getOrCreateBadge(menuItemId).apply {
+        horizontalOffset = -context.getDimensionPixelSize(R.dimen.badge_horizontal_offset)
+        verticalOffset = context.getDimensionPixelSize(R.dimen.badge_vertical_offset)
+        backgroundColor = context.getColorFromRes(R.color.bottom_nav_badge_color)
+        isVisible = badgeNumber > 0
+        number = badgeNumber
+    }
 }
 
 fun Context?.getFragmentManager(): FragmentManager? {


### PR DESCRIPTION
### Description

This PR fixes the position of badge in bottom navigation bar. The logic which alters the position of the badge has stopped working recently. I didn't find the reason, but I suspect that the version of the material library has be updated and as a result the behavior changed. I was relying on a fact that badges are allocated lazily in `BottomNavigationView`. Now, this is obviously not the case.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Our design | Our app |
| --- | --- |
|<img width="382" alt="Screenshot 2021-01-22 at 15 50 46" src="https://user-images.githubusercontent.com/9600921/105492857-a026a080-5cc9-11eb-9938-0f0e5dcae877.png"> |<img width="380" alt="Screenshot 2021-01-22 at 15 49 40" src="https://user-images.githubusercontent.com/9600921/105492823-913fee00-5cc9-11eb-9be8-7c3028a503e7.png"> |




