### PR TITLE
Add CheckResult annotations

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client
 
 import android.content.Context
+import androidx.annotation.CheckResult
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
 import androidx.lifecycle.LifecycleOwner
@@ -92,8 +93,8 @@ public class ChatClient internal constructor(
         }
     )
 
-    public val disconnectListeners: MutableList<(User?) -> Unit> = mutableListOf<(User?) -> Unit>()
-    public val preSetUserListeners: MutableList<(User) -> Unit> = mutableListOf<(User) -> Unit>()
+    public val disconnectListeners: MutableList<(User?) -> Unit> = mutableListOf()
+    public val preSetUserListeners: MutableList<(User) -> Unit> = mutableListOf()
 
     init {
         eventsObservable.subscribe { event ->
@@ -195,6 +196,7 @@ public class ChatClient internal constructor(
         }
     }
 
+    @CheckResult
     public fun getGuestToken(userId: String, userName: String): Call<GuestUser> {
         return api.getGuestUser(userId, userName)
     }
@@ -217,6 +219,7 @@ public class ChatClient internal constructor(
         api.sendImage(channelType, channelId, file, callback)
     }
 
+    @CheckResult
     public fun sendFile(
         channelType: String,
         channelId: String,
@@ -225,6 +228,7 @@ public class ChatClient internal constructor(
         return api.sendFile(channelType, channelId, file)
     }
 
+    @CheckResult
     public fun queryMembers(
         channelType: String,
         channelId: String,
@@ -237,6 +241,7 @@ public class ChatClient internal constructor(
         return api.queryMembers(channelType, channelId, offset, limit, filter, sort, members)
     }
 
+    @CheckResult
     public fun sendImage(
         channelType: String,
         channelId: String,
@@ -245,15 +250,18 @@ public class ChatClient internal constructor(
         return api.sendImage(channelType, channelId, file)
     }
 
+    @CheckResult
     public fun deleteFile(channelType: String, channelId: String, url: String): Call<Unit> {
         return api.deleteFile(channelType, channelId, url)
     }
 
+    @CheckResult
     public fun deleteImage(channelType: String, channelId: String, url: String): Call<Unit> {
         return api.deleteImage(channelType, channelId, url)
     }
 
     //region Reactions
+    @CheckResult
     public fun getReactions(
         messageId: String,
         offset: Int,
@@ -262,15 +270,18 @@ public class ChatClient internal constructor(
         return api.getReactions(messageId, offset, limit)
     }
 
+    @CheckResult
     @JvmOverloads
     public fun sendReaction(messageId: String, reactionType: String, enforceUnique: Boolean = false): Call<Reaction> {
         return api.sendReaction(messageId, reactionType, enforceUnique)
     }
 
+    @CheckResult
     public fun deleteReaction(messageId: String, reactionType: String): Call<Message> {
         return api.deleteReaction(messageId, reactionType)
     }
 
+    @CheckResult
     @JvmOverloads
     public fun sendReaction(reaction: Reaction, enforceUnique: Boolean = false): Call<Reaction> {
         return api.sendReaction(reaction, enforceUnique)
@@ -287,7 +298,8 @@ public class ChatClient internal constructor(
         when (val state = clientStateService.state) {
             is ClientState.Anonymous -> socket.connectAnonymously()
             is ClientState.User -> socket.connect(state.user)
-            is ClientState.Idle -> { }
+            is ClientState.Idle -> {
+            }
         }.exhaustive
     }
 
@@ -447,22 +459,27 @@ public class ChatClient internal constructor(
 
     //region: api calls
 
+    @CheckResult
     public fun getDevices(): Call<List<Device>> {
         return api.getDevices()
     }
 
+    @CheckResult
     public fun deleteDevice(deviceId: String): Call<Unit> {
         return api.deleteDevice(deviceId)
     }
 
+    @CheckResult
     public fun addDevice(deviceId: String): Call<Unit> {
         return api.addDevice(deviceId)
     }
 
+    @CheckResult
     public fun searchMessages(request: SearchMessagesRequest): Call<List<Message>> {
         return api.searchMessages(request)
     }
 
+    @CheckResult
     public fun getFileAttachments(
         channelType: String,
         channelId: String,
@@ -471,6 +488,7 @@ public class ChatClient internal constructor(
     ): Call<List<Attachment>> =
         getAttachments(channelType, channelId, offset, limit, ATTACHMENT_TYPE_FILE)
 
+    @CheckResult
     public fun getImageAttachments(
         channelType: String,
         channelId: String,
@@ -479,6 +497,7 @@ public class ChatClient internal constructor(
     ): Call<List<Attachment>> =
         getAttachments(channelType, channelId, offset, limit, ATTACHMENT_TYPE_IMAGE)
 
+    @CheckResult
     private fun getAttachments(
         channelType: String,
         channelId: String,
@@ -500,6 +519,7 @@ public class ChatClient internal constructor(
      * @param limit max limit messages to be fetched
      * @param type The desired type attachment
      */
+    @CheckResult
     public fun getMessagesWithAttachments(
         channelType: String,
         channelId: String,
@@ -512,10 +532,12 @@ public class ChatClient internal constructor(
         return searchMessages(SearchMessagesRequest(offset, limit, channelFilter, messageFilter))
     }
 
+    @CheckResult
     public fun getReplies(messageId: String, limit: Int): Call<List<Message>> {
         return api.getReplies(messageId, limit)
     }
 
+    @CheckResult
     public fun getRepliesMore(
         messageId: String,
         firstId: String,
@@ -524,18 +546,22 @@ public class ChatClient internal constructor(
         return api.getRepliesMore(messageId, firstId, limit)
     }
 
+    @CheckResult
     public fun sendAction(request: SendActionRequest): Call<Message> {
         return api.sendAction(request)
     }
 
+    @CheckResult
     public fun deleteMessage(messageId: String): Call<Message> {
         return api.deleteMessage(messageId)
     }
 
+    @CheckResult
     public fun getMessage(messageId: String): Call<Message> {
         return api.getMessage(messageId)
     }
 
+    @CheckResult
     public fun sendMessage(
         channelType: String,
         channelId: String,
@@ -544,12 +570,14 @@ public class ChatClient internal constructor(
         return api.sendMessage(channelType, channelId, message)
     }
 
+    @CheckResult
     public fun updateMessage(
         message: Message,
     ): Call<Message> {
         return api.updateMessage(message)
     }
 
+    @CheckResult
     public fun pinMessage(message: Message, expirationDate: Date?): Call<Message> {
         return updateMessage(
             message.apply {
@@ -559,6 +587,7 @@ public class ChatClient internal constructor(
         )
     }
 
+    @CheckResult
     public fun pinMessage(message: Message, timeout: Int): Call<Message> {
         val calendar = Calendar.getInstance().apply {
             add(Calendar.SECOND, timeout)
@@ -571,6 +600,7 @@ public class ChatClient internal constructor(
         )
     }
 
+    @CheckResult
     public fun unpinMessage(message: Message): Call<Message> {
         return updateMessage(
             message.apply {
@@ -579,6 +609,7 @@ public class ChatClient internal constructor(
         )
     }
 
+    @CheckResult
     public fun queryChannel(
         channelType: String,
         channelId: String,
@@ -587,14 +618,17 @@ public class ChatClient internal constructor(
         return queryChannelsPostponeHelper.queryChannel(channelType, channelId, request)
     }
 
+    @CheckResult
     public fun queryChannels(request: QueryChannelsRequest): Call<List<Channel>> {
         return queryChannelsPostponeHelper.queryChannels(request)
     }
 
+    @CheckResult
     public fun deleteChannel(channelType: String, channelId: String): Call<Channel> {
         return api.deleteChannel(channelType, channelId)
     }
 
+    @CheckResult
     public fun markMessageRead(
         channelType: String,
         channelId: String,
@@ -603,10 +637,12 @@ public class ChatClient internal constructor(
         return api.markRead(channelType, channelId, messageId)
     }
 
+    @CheckResult
     public fun showChannel(channelType: String, channelId: String): Call<Unit> {
         return api.showChannel(channelType, channelId)
     }
 
+    @CheckResult
     public fun hideChannel(
         channelType: String,
         channelId: String,
@@ -615,10 +651,12 @@ public class ChatClient internal constructor(
         return api.hideChannel(channelType, channelId, clearHistory)
     }
 
+    @CheckResult
     public fun stopWatching(channelType: String, channelId: String): Call<Unit> {
         return api.stopWatching(channelType, channelId)
     }
 
+    @CheckResult
     public fun updateChannel(
         channelType: String,
         channelId: String,
@@ -631,6 +669,7 @@ public class ChatClient internal constructor(
             UpdateChannelRequest(channelExtraData, updateMessage)
         )
 
+    @CheckResult
     public fun enableSlowMode(
         channelType: String,
         channelId: String,
@@ -638,16 +677,19 @@ public class ChatClient internal constructor(
     ): Call<Channel> =
         api.enableSlowMode(channelType, channelId, cooldownTimeInSeconds)
 
+    @CheckResult
     public fun disableSlowMode(
         channelType: String,
         channelId: String,
     ): Call<Channel> =
         api.disableSlowMode(channelType, channelId)
 
+    @CheckResult
     public fun rejectInvite(channelType: String, channelId: String): Call<Channel> {
         return api.rejectInvite(channelType, channelId)
     }
 
+    @CheckResult
     public fun sendEvent(
         eventType: String,
         channelType: String,
@@ -659,6 +701,7 @@ public class ChatClient internal constructor(
 
     public fun getVersion(): String = VERSION_PREFIX + BuildConfig.STREAM_CHAT_VERSION
 
+    @CheckResult
     public fun acceptInvite(
         channelType: String,
         channelId: String,
@@ -667,26 +710,32 @@ public class ChatClient internal constructor(
         return api.acceptInvite(channelType, channelId, message)
     }
 
+    @CheckResult
     public fun markAllRead(): Call<Unit> {
         return api.markAllRead()
     }
 
+    @CheckResult
     public fun markRead(channelType: String, channelId: String): Call<Unit> {
         return api.markRead(channelType, channelId)
     }
 
+    @CheckResult
     public fun updateUsers(users: List<User>): Call<List<User>> {
         return api.updateUsers(users)
     }
 
+    @CheckResult
     public fun updateUser(user: User): Call<User> {
         return updateUsers(listOf(user)).map { it.first() }
     }
 
+    @CheckResult
     public fun queryUsers(query: QueryUsersRequest): Call<List<User>> {
         return api.queryUsers(query)
     }
 
+    @CheckResult
     public fun addMembers(
         channelType: String,
         channelId: String,
@@ -699,6 +748,7 @@ public class ChatClient internal constructor(
         )
     }
 
+    @CheckResult
     public fun removeMembers(
         channelType: String,
         channelId: String,
@@ -709,35 +759,46 @@ public class ChatClient internal constructor(
         members
     )
 
+    @CheckResult
     public fun muteUser(userId: String): Call<Mute> = api.muteUser(userId)
 
+    @CheckResult
     public fun muteChannel(channelType: String, channelId: String): Call<Unit> {
         return api.muteChannel(channelType, channelId)
     }
 
+    @CheckResult
     public fun unMuteChannel(channelType: String, channelId: String): Call<Unit> {
         return api.unMuteChannel(channelType, channelId)
     }
 
+    @CheckResult
     public fun unmuteUser(userId: String): Call<Unit> = api.unmuteUser(userId)
 
+    @CheckResult
     public fun unmuteCurrentUser(): Call<Unit> = api.unmuteCurrentUser()
 
+    @CheckResult
     public fun muteCurrentUser(): Call<Mute> = api.muteCurrentUser()
 
+    @CheckResult
     @Deprecated(
         message = "We are going to replace with flagUser()",
         replaceWith = ReplaceWith("this.flagUser(userId)")
     )
     public fun flag(userId: String): Call<Flag> = flagUser(userId)
 
+    @CheckResult
     public fun flagUser(userId: String): Call<Flag> = api.flagUser(userId)
 
+    @CheckResult
     public fun flagMessage(messageId: String): Call<Flag> = api.flagMessage(messageId)
 
+    @CheckResult
     public fun translate(messageId: String, language: String): Call<Message> =
         api.translate(messageId, language)
 
+    @CheckResult
     public fun banUser(
         targetId: String,
         channelType: String,
@@ -755,6 +816,7 @@ public class ChatClient internal constructor(
         Unit
     }
 
+    @CheckResult
     public fun unBanUser(
         targetId: String,
         channelType: String,
@@ -768,6 +830,7 @@ public class ChatClient internal constructor(
         Unit
     }
 
+    @CheckResult
     public fun shadowBanUser(
         targetId: String,
         channelType: String,
@@ -785,6 +848,7 @@ public class ChatClient internal constructor(
         Unit
     }
 
+    @CheckResult
     public fun removeShadowBan(
         targetId: String,
         channelType: String,
@@ -848,6 +912,7 @@ public class ChatClient internal constructor(
         return channel(type, id)
     }
 
+    @CheckResult
     public fun createChannel(
         channelType: String,
         channelId: String,
@@ -855,6 +920,7 @@ public class ChatClient internal constructor(
     ): Call<Channel> =
         createChannel(channelType, channelId, emptyList(), extraData)
 
+    @CheckResult
     public fun createChannel(
         channelType: String,
         channelId: String,
@@ -862,9 +928,11 @@ public class ChatClient internal constructor(
     ): Call<Channel> =
         createChannel(channelType, channelId, members, emptyMap())
 
+    @CheckResult
     public fun createChannel(channelType: String, members: List<String>): Call<Channel> =
         createChannel(channelType, "", members, emptyMap())
 
+    @CheckResult
     public fun createChannel(
         channelType: String,
         members: List<String>,
@@ -872,6 +940,7 @@ public class ChatClient internal constructor(
     ): Call<Channel> =
         createChannel(channelType, "", members, extraData)
 
+    @CheckResult
     public fun createChannel(
         channelType: String,
         channelId: String,
@@ -884,6 +953,7 @@ public class ChatClient internal constructor(
             QueryChannelRequest().withData(extraData + mapOf(ModelFields.MEMBERS to members))
         )
 
+    @CheckResult
     public fun getSyncHistory(
         channelsIds: List<String>,
         lastSyncAt: Date,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.client.channel
 
+import androidx.annotation.CheckResult
 import androidx.lifecycle.LifecycleOwner
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
@@ -84,10 +85,12 @@ public class ChannelClient internal constructor(
 
     override val cid: String = "$channelType:$channelId"
 
+    @CheckResult
     override fun create(members: List<String>, extraData: Map<String, Any>): Call<Channel> {
         return client.createChannel(channelType, channelId, members, extraData)
     }
 
+    @CheckResult
     override fun create(extraData: Map<String, Any>): Call<Channel> {
         return client.createChannel(channelType, channelId, emptyList())
     }
@@ -216,48 +219,59 @@ public class ChannelClient internal constructor(
             is ConnectingEvent,
             is DisconnectedEvent,
             is ErrorEvent,
-            is MarkAllReadEvent -> false
+            is MarkAllReadEvent,
+            -> false
         }
     }
 
+    @CheckResult
     override fun query(request: QueryChannelRequest): Call<Channel> {
         return client.queryChannel(channelType, channelId, request)
     }
 
+    @CheckResult
     override fun watch(request: WatchChannelRequest): Call<Channel> {
         return client.queryChannel(channelType, channelId, request)
     }
 
+    @CheckResult
     override fun watch(data: Map<String, Any>): Call<Channel> {
         val request = WatchChannelRequest()
         request.data.putAll(data)
         return watch(request)
     }
 
+    @CheckResult
     override fun watch(): Call<Channel> {
         return client.queryChannel(channelType, channelId, WatchChannelRequest())
     }
 
+    @CheckResult
     override fun stopWatching(): Call<Unit> {
         return client.stopWatching(channelType, channelId)
     }
 
+    @CheckResult
     override fun getMessage(messageId: String): Call<Message> {
         return client.getMessage(messageId)
     }
 
+    @CheckResult
     override fun updateMessage(message: Message): Call<Message> {
         return client.updateMessage(message)
     }
 
+    @CheckResult
     override fun deleteMessage(messageId: String): Call<Message> {
         return client.deleteMessage(messageId)
     }
 
+    @CheckResult
     override fun sendMessage(message: Message): Call<Message> {
         return client.sendMessage(channelType, channelId, message)
     }
 
+    @CheckResult
     override fun banUser(targetId: String, reason: String?, timeout: Int?): Call<Unit> {
         return client.banUser(
             targetId = targetId,
@@ -268,6 +282,7 @@ public class ChannelClient internal constructor(
         )
     }
 
+    @CheckResult
     override fun unBanUser(targetId: String, reason: String?, timeout: Int?): Call<Unit> {
         return client.unBanUser(
             targetId = targetId,
@@ -276,6 +291,7 @@ public class ChannelClient internal constructor(
         )
     }
 
+    @CheckResult
     override fun shadowBanUser(targetId: String, reason: String?, timeout: Int?): Call<Unit> {
         return client.shadowBanUser(
             targetId = targetId,
@@ -286,6 +302,7 @@ public class ChannelClient internal constructor(
         )
     }
 
+    @CheckResult
     override fun removeShadowBan(targetId: String): Call<Unit> {
         return client.removeShadowBan(
             targetId = targetId,
@@ -294,58 +311,72 @@ public class ChannelClient internal constructor(
         )
     }
 
+    @CheckResult
     override fun markMessageRead(messageId: String): Call<Unit> {
         return client.markMessageRead(channelType, channelId, messageId)
     }
 
+    @CheckResult
     override fun markRead(): Call<Unit> {
         return client.markRead(channelType, channelId)
     }
 
+    @CheckResult
     override fun delete(): Call<Channel> {
         return client.deleteChannel(channelType, channelId)
     }
 
+    @CheckResult
     override fun show(): Call<Unit> {
         return client.showChannel(channelType, channelId)
     }
 
+    @CheckResult
     override fun hide(clearHistory: Boolean): Call<Unit> {
         return client.hideChannel(channelType, channelId, clearHistory)
     }
 
+    @CheckResult
     override fun sendFile(file: File): Call<String> {
         return client.sendFile(channelType, channelId, file)
     }
 
+    @CheckResult
     override fun sendImage(file: File): Call<String> {
         return client.sendImage(channelType, channelId, file)
     }
 
+    @CheckResult
     override fun sendFile(file: File, callback: ProgressCallback): Call<String> {
         return client.sendFile(channelType, channelId, file)
     }
 
+    @CheckResult
     override fun sendImage(file: File, callback: ProgressCallback): Call<String> {
         return client.sendImage(channelType, channelId, file)
     }
 
+    @CheckResult
     override fun sendReaction(reaction: Reaction, enforceUnique: Boolean): Call<Reaction> {
         return client.sendReaction(reaction, enforceUnique)
     }
 
+    @CheckResult
     override fun sendAction(request: SendActionRequest): Call<Message> {
         return client.sendAction(request)
     }
 
+    @CheckResult
     override fun deleteReaction(messageId: String, reactionType: String): Call<Message> {
         return client.deleteReaction(messageId, reactionType)
     }
 
+    @CheckResult
     override fun getReactions(messageId: String, offset: Int, limit: Int): Call<List<Reaction>> {
         return client.getReactions(messageId, offset, limit)
     }
 
+    @CheckResult
     override fun getReactions(
         messageId: String,
         firstReactionId: String,
@@ -354,64 +385,80 @@ public class ChannelClient internal constructor(
         return client.getRepliesMore(messageId, firstReactionId, limit)
     }
 
+    @CheckResult
     override fun update(message: Message?, extraData: Map<String, Any>): Call<Channel> {
         return client.updateChannel(channelType, channelId, message, extraData)
     }
 
+    @CheckResult
     override fun enableSlowMode(cooldownTimeInSeconds: Int): Call<Channel> =
         client.enableSlowMode(channelType, channelId, cooldownTimeInSeconds)
 
+    @CheckResult
     override fun disableSlowMode(): Call<Channel> =
         client.disableSlowMode(channelType, channelId)
 
+    @CheckResult
     override fun addMembers(vararg userIds: String): Call<Channel> {
         return client.addMembers(channelType, channelId, userIds.toList())
     }
 
+    @CheckResult
     override fun removeMembers(vararg userIds: String): Call<Channel> {
         return client.removeMembers(channelType, channelId, userIds.toList())
     }
 
+    @CheckResult
     override fun acceptInvite(message: String?): Call<Channel> {
         return client.acceptInvite(channelType, channelId, message)
     }
 
+    @CheckResult
     override fun rejectInvite(): Call<Channel> {
         return client.rejectInvite(channelType, channelId)
     }
 
+    @CheckResult
     override fun muteCurrentUser(): Call<Mute> {
         return client.muteCurrentUser()
     }
 
+    @CheckResult
     override fun mute(): Call<Unit> {
         return client.muteChannel(channelType, channelId)
     }
 
+    @CheckResult
     override fun unmute(): Call<Unit> {
         return client.unMuteChannel(channelType, channelId)
     }
 
+    @CheckResult
     override fun muteUser(userId: String): Call<Mute> {
         return client.muteUser(userId)
     }
 
+    @CheckResult
     override fun unmuteUser(userId: String): Call<Unit> {
         return client.unmuteUser(userId)
     }
 
+    @CheckResult
     override fun unmuteCurrentUser(): Call<Unit> {
         return client.unmuteCurrentUser()
     }
 
+    @CheckResult
     override fun keystroke(): Call<ChatEvent> {
         return client.sendEvent(EventType.TYPING_START, channelType, channelId)
     }
 
+    @CheckResult
     override fun stopTyping(): Call<ChatEvent> {
         return client.sendEvent(EventType.TYPING_STOP, channelType, channelId)
     }
 
+    @CheckResult
     override fun queryMembers(
         offset: Int,
         limit: Int,
@@ -422,22 +469,28 @@ public class ChannelClient internal constructor(
         return client.queryMembers(channelType, channelId, offset, limit, filter, sort, members)
     }
 
+    @CheckResult
     public fun getFileAttachments(offset: Int, limit: Int): Call<List<Attachment>> =
         client.getFileAttachments(channelType, channelId, offset, limit)
 
+    @CheckResult
     public fun getImageAttachments(offset: Int, limit: Int): Call<List<Attachment>> =
         client.getImageAttachments(channelType, channelId, offset, limit)
 
+    @CheckResult
     public fun getMessagesWithAttachments(offset: Int, limit: Int, type: String): Call<List<Message>> =
         client.getMessagesWithAttachments(channelType, channelId, offset, limit, type)
 
+    @CheckResult
     public fun pinMessage(message: Message, expirationDate: Date?): Call<Message> {
         return client.pinMessage(message, expirationDate)
     }
 
+    @CheckResult
     public fun pinMessage(message: Message, timeout: Int): Call<Message> {
         return client.pinMessage(message, timeout)
     }
 
+    @CheckResult
     public fun unpinMessage(message: Message): Call<Message> = client.unpinMessage(message)
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.client.controllers
 
+import androidx.annotation.CheckResult
 import androidx.lifecycle.LifecycleOwner
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QuerySort
@@ -28,33 +29,88 @@ public interface ChannelController {
     public val channelId: String
     public val cid: String
 
+    @CheckResult
     public fun create(extraData: Map<String, Any> = emptyMap()): Call<Channel>
+
+    @CheckResult
     public fun create(members: List<String>, extraData: Map<String, Any> = emptyMap()): Call<Channel>
+
+    @CheckResult
     public fun query(request: QueryChannelRequest): Call<Channel>
+
+    @CheckResult
     public fun watch(request: WatchChannelRequest): Call<Channel>
+
+    @CheckResult
     public fun watch(): Call<Channel>
+
+    @CheckResult
     public fun stopWatching(): Call<Unit>
+
+    @CheckResult
     public fun sendMessage(message: Message): Call<Message>
+
+    @CheckResult
     public fun updateMessage(message: Message): Call<Message>
+
+    @CheckResult
     public fun deleteMessage(messageId: String): Call<Message>
+
+    @CheckResult
     public fun getMessage(messageId: String): Call<Message>
+
+    @CheckResult
     public fun banUser(targetId: String, reason: String?, timeout: Int?): Call<Unit>
+
+    @CheckResult
     public fun unBanUser(targetId: String, reason: String?, timeout: Int?): Call<Unit>
+
+    @CheckResult
     public fun shadowBanUser(targetId: String, reason: String?, timeout: Int?): Call<Unit>
+
+    @CheckResult
     public fun removeShadowBan(targetId: String): Call<Unit>
+
+    @CheckResult
     public fun markMessageRead(messageId: String): Call<Unit>
+
+    @CheckResult
     public fun markRead(): Call<Unit>
+
+    @CheckResult
     public fun delete(): Call<Channel>
+
+    @CheckResult
     public fun show(): Call<Unit>
+
+    @CheckResult
     public fun hide(clearHistory: Boolean = false): Call<Unit>
+
+    @CheckResult
     public fun sendFile(file: File): Call<String>
+
+    @CheckResult
     public fun sendImage(file: File): Call<String>
+
+    @CheckResult
     public fun sendFile(file: File, callback: ProgressCallback): Call<String>
+
+    @CheckResult
     public fun sendImage(file: File, callback: ProgressCallback): Call<String>
+
+    @CheckResult
     public fun sendReaction(reaction: Reaction, enforceUnique: Boolean = false): Call<Reaction>
+
+    @CheckResult
     public fun sendAction(request: SendActionRequest): Call<Message>
+
+    @CheckResult
     public fun deleteReaction(messageId: String, reactionType: String): Call<Message>
+
+    @CheckResult
     public fun getReactions(messageId: String, offset: Int, limit: Int): Call<List<Reaction>>
+
+    @CheckResult
     public fun getReactions(messageId: String, firstReactionId: String, limit: Int): Call<List<Message>>
 
     @Deprecated(
@@ -114,22 +170,55 @@ public interface ChannelController {
         listener: (event: T) -> Unit
     ): Disposable
 
+    @CheckResult
     public fun update(message: Message? = null, extraData: Map<String, Any> = emptyMap()): Call<Channel>
+
+    @CheckResult
     public fun enableSlowMode(cooldownTimeInSeconds: Int): Call<Channel>
+
+    @CheckResult
     public fun disableSlowMode(): Call<Channel>
+
+    @CheckResult
     public fun addMembers(vararg userIds: String): Call<Channel>
+
+    @CheckResult
     public fun removeMembers(vararg userIds: String): Call<Channel>
+
+    @CheckResult
     public fun acceptInvite(message: String?): Call<Channel>
+
+    @CheckResult
     public fun rejectInvite(): Call<Channel>
+
+    @CheckResult
     public fun mute(): Call<Unit>
+
+    @CheckResult
     public fun unmute(): Call<Unit>
+
+    @CheckResult
     public fun muteCurrentUser(): Call<Mute>
+
+    @CheckResult
     public fun muteUser(userId: String): Call<Mute>
+
+    @CheckResult
     public fun unmuteUser(userId: String): Call<Unit>
+
+    @CheckResult
     public fun unmuteCurrentUser(): Call<Unit>
+
+    @CheckResult
     public fun watch(data: Map<String, Any>): Call<Channel>
+
+    @CheckResult
     public fun stopTyping(): Call<ChatEvent>
+
+    @CheckResult
     public fun keystroke(): Call<ChatEvent>
+
+    @CheckResult
     public fun queryMembers(
         offset: Int,
         limit: Int,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/CancelMessage.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/CancelMessage.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -13,6 +14,7 @@ public interface CancelMessage {
      * @param message the message to send
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(message: Message): Call<Boolean>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/CreateChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/CreateChannelImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Channel
@@ -12,6 +13,7 @@ public interface CreateChannel {
      *
      * @param channel the channel object
      */
+    @CheckResult
     public operator fun invoke(channel: Channel): Call<Channel>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteChannel.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteChannel.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -10,6 +11,7 @@ public interface DeleteChannel {
      *
      * @param cid: the full channel id i. e. messaging:123
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteMessageImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteMessageImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -12,6 +13,7 @@ public interface DeleteMessage {
      * @param message the message to mark as deleted
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(message: Message): Call<Message>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteReactionImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DeleteReactionImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -14,6 +15,7 @@ public interface DeleteReaction {
      * @param reaction the reaction to mark as deleted
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(cid: String, reaction: Reaction): Call<Message>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/DownloadAttachment.kt
@@ -4,6 +4,7 @@ import android.app.DownloadManager
 import android.content.Context
 import android.net.Uri
 import android.os.Environment
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.errors.ChatError
@@ -11,7 +12,6 @@ import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomainImpl
-import java.lang.Exception
 
 @InternalStreamChatApi
 public interface DownloadAttachment {
@@ -20,6 +20,7 @@ public interface DownloadAttachment {
      *
      * @param attachment the attachment to download
      */
+    @CheckResult
     public operator fun invoke(attachment: Attachment): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/EditMessageImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/EditMessageImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -13,6 +14,7 @@ public interface EditMessage {
      * @param message the message to edit
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(message: Message): Call<Message>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetChannelControllerImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.utils.Result
@@ -15,6 +16,7 @@ public interface GetChannelController {
      *
      * @see io.getstream.chat.android.livedata.controller.ChannelController
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<ChannelController>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetThreadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetThreadImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.utils.Result
@@ -16,6 +17,7 @@ public interface GetThread {
      *
      * @see io.getstream.chat.android.livedata.controller.ThreadController
      */
+    @CheckResult
     public operator fun invoke(cid: String, parentId: String): Call<ThreadController>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetTotalUnreadCountImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetTotalUnreadCountImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import androidx.lifecycle.LiveData
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
@@ -15,6 +16,7 @@ public interface GetTotalUnreadCount {
      * @see io.getstream.chat.android.livedata.usecase.GetUnreadChannelCount
      * @see io.getstream.chat.android.livedata.controller.ChannelController.unreadCount
      */
+    @CheckResult
     public operator fun invoke(): Call<LiveData<Int>>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetUnreadChannelCountImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/GetUnreadChannelCountImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import androidx.lifecycle.LiveData
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
@@ -15,6 +16,7 @@ public interface GetUnreadChannelCount {
      * @see io.getstream.chat.android.livedata.usecase.GetTotalUnreadCount
      * @see io.getstream.chat.android.livedata.controller.ChannelController.unreadCount
      */
+    @CheckResult
     public operator fun invoke(): Call<LiveData<Int>>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/HideChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/HideChannelImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -14,6 +15,7 @@ public interface HideChannel {
      *
      * @see <a href="https://getstream.io/chat/docs/channel_delete/?language=kotlin">Hiding a channel</a>
      */
+    @CheckResult
     public operator fun invoke(cid: String, keepHistory: Boolean): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/KeystrokeImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/KeystrokeImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -14,6 +15,7 @@ public interface Keystroke {
      *
      * @return True when a typing event was sent, false if it wasn't sent
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Boolean>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LeaveChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LeaveChannelImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -10,6 +11,7 @@ public interface LeaveChannel {
      *
      * @param cid: the full channel id i. e. messaging:123
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadMessageByIdImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadMessageByIdImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -15,16 +16,22 @@ public interface LoadMessageById {
      * @param olderMessagesOffset: how many new messages to load before the requested message
      * @param newerMessagesOffset: how many new messages to load after the requested message
      */
+    @CheckResult
     public operator fun invoke(
         cid: String,
         messageId: String,
         olderMessagesOffset: Int = 0,
-        newerMessagesOffset: Int = 0
+        newerMessagesOffset: Int = 0,
     ): Call<Message>
 }
 
 internal class LoadMessageByIdImpl(private val domainImpl: ChatDomainImpl) : LoadMessageById {
-    override operator fun invoke(cid: String, messageId: String, olderMessagesOffset: Int, newerMessagesOffset: Int): Call<Message> {
+    override operator fun invoke(
+        cid: String,
+        messageId: String,
+        olderMessagesOffset: Int,
+        newerMessagesOffset: Int,
+    ): Call<Message> {
         validateCid(cid)
 
         val channelController = domainImpl.channel(cid)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadNewerMessagesImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Channel
@@ -13,6 +14,7 @@ public interface LoadNewerMessages {
      * @param cid: the full channel id i. e. messaging:123
      * @param messageLimit: how many new messages to load
      */
+    @CheckResult
     public operator fun invoke(cid: String, messageLimit: Int): Call<Channel>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadOlderMessagesImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/LoadOlderMessagesImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Channel
@@ -13,6 +14,7 @@ public interface LoadOlderMessages {
      * @param cid: the full channel id i. e. messaging:123
      * @param messageLimit: how many new messages to load
      */
+    @CheckResult
     public operator fun invoke(cid: String, messageLimit: Int): Call<Channel>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkAllReadImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.utils.Result
@@ -9,6 +10,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 
 public interface MarkAllRead {
+    @CheckResult
     public operator fun invoke(): Call<Boolean>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkReadImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/MarkReadImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.utils.Result
@@ -15,6 +16,7 @@ public interface MarkRead {
      * @return True if the mark read event was sent. False if there was no need to mark read
      *         (i. e. the messages are already marked as read).
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Boolean>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
@@ -25,11 +26,22 @@ public interface QueryChannels {
      * @see io.getstream.chat.android.client.api.models.QuerySort
      * @see <a href="https://getstream.io/chat/docs/query_channels/?language=kotlin">Filter syntax</a>
      */
-    public operator fun invoke(filter: FilterObject, sort: QuerySort<Channel>, limit: Int = 30, messageLimit: Int = 1): Call<QueryChannelsController>
+    @CheckResult
+    public operator fun invoke(
+        filter: FilterObject,
+        sort: QuerySort<Channel>,
+        limit: Int = 30,
+        messageLimit: Int = 1,
+    ): Call<QueryChannelsController>
 }
 
 internal class QueryChannelsImpl(private val domainImpl: ChatDomainImpl) : QueryChannels {
-    override operator fun invoke(filter: FilterObject, sort: QuerySort<Channel>, limit: Int, messageLimit: Int): Call<QueryChannelsController> {
+    override operator fun invoke(
+        filter: FilterObject,
+        sort: QuerySort<Channel>,
+        limit: Int,
+        messageLimit: Int,
+    ): Call<QueryChannelsController> {
         val queryChannelsControllerImpl = domainImpl.queryChannels(filter, sort)
         return CoroutineCall(domainImpl.scope) {
             if (limit > 0) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsLoadMoreImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/QueryChannelsLoadMoreImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
@@ -18,11 +19,22 @@ public interface QueryChannelsLoadMore {
      * @see io.getstream.chat.android.client.api.models.QuerySort
      * @see <a href="https://getstream.io/chat/docs/query_channels/?language=kotlin">Filter syntax</a>
      */
-    public operator fun invoke(filter: FilterObject, sort: QuerySort<Channel>, limit: Int = 30, messageLimit: Int = 10): Call<List<Channel>>
+    @CheckResult
+    public operator fun invoke(
+        filter: FilterObject,
+        sort: QuerySort<Channel>,
+        limit: Int = 30,
+        messageLimit: Int = 10,
+    ): Call<List<Channel>>
 }
 
 internal class QueryChannelsLoadMoreImpl(private val domainImpl: ChatDomainImpl) : QueryChannelsLoadMore {
-    override operator fun invoke(filter: FilterObject, sort: QuerySort<Channel>, limit: Int, messageLimit: Int): Call<List<Channel>> {
+    override operator fun invoke(
+        filter: FilterObject,
+        sort: QuerySort<Channel>,
+        limit: Int,
+        messageLimit: Int,
+    ): Call<List<Channel>> {
         return CoroutineCall(domainImpl.scope) {
             val queryChannelsController = domainImpl.queryChannels(filter, sort)
             queryChannelsController.loadMore(limit, messageLimit)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ReplayEventsForActiveChannelsImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ReplayEventsForActiveChannelsImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.events.ChatEvent
@@ -14,10 +15,13 @@ public interface ReplayEventsForActiveChannels {
      *
      * @param cid: the full channel id i. e. messaging:123
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<List<ChatEvent>>
 }
 
-internal class ReplayEventsForActiveChannelsImpl(private val domainImpl: ChatDomainImpl) : ReplayEventsForActiveChannels {
+internal class ReplayEventsForActiveChannelsImpl(
+    private val domainImpl: ChatDomainImpl,
+) : ReplayEventsForActiveChannels {
     override operator fun invoke(cid: String): Call<List<ChatEvent>> {
         validateCid(cid)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendGiphyImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendGiphyImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -14,6 +15,7 @@ public interface SendGiphy {
      * @param message the message to send
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(message: Message): Call<Message>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Attachment
@@ -17,6 +18,7 @@ public interface SendMessage {
      * @param message the message to send
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(
         message: Message,
     ): Call<Message> = invoke(message, null)
@@ -27,6 +29,7 @@ public interface SendMessage {
      * @param message the message to send
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(
         message: Message,
         attachmentTransformer: ((at: Attachment, file: File) -> Attachment)?,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageWithAttachmentsImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendMessageWithAttachmentsImpl.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.livedata.usecase
 
 import android.webkit.MimeTypeMap
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.extensions.enrichWithCid
@@ -18,11 +19,12 @@ public interface SendMessageWithAttachments {
         message = "Use sendMessage() and attachment.upload instead of this useCase",
         level = DeprecationLevel.WARNING
     )
+    @CheckResult
     public operator fun invoke(
         cid: String,
         message: Message,
         files: List<File>,
-        attachmentTransformer: Attachment.(file: File) -> Unit = { }
+        attachmentTransformer: Attachment.(file: File) -> Unit = { },
     ): Call<Message>
 }
 
@@ -32,7 +34,7 @@ internal class SendMessageWithAttachmentsImpl(private val domainImpl: ChatDomain
         cid: String,
         message: Message,
         files: List<File>,
-        attachmentTransformer: Attachment.(file: File) -> Unit
+        attachmentTransformer: Attachment.(file: File) -> Unit,
     ): Call<Message> {
         validateCid(cid)
 
@@ -52,7 +54,7 @@ internal class SendMessageWithAttachmentsImpl(private val domainImpl: ChatDomain
     private suspend fun uploadFiles(
         channelControllerImpl: ChannelControllerImpl,
         files: List<File>,
-        attachmentTransformer: Attachment.(file: File) -> Unit
+        attachmentTransformer: Attachment.(file: File) -> Unit,
     ): Result<List<Attachment>> =
         files.fold(Result(emptyList())) { acc, file ->
             if (acc.isError) {
@@ -69,7 +71,7 @@ internal class SendMessageWithAttachmentsImpl(private val domainImpl: ChatDomain
 
     private suspend fun uploadFile(
         channelControllerImpl: ChannelControllerImpl,
-        file: File
+        file: File,
     ): Result<Attachment> =
         MimeTypeMap.getSingleton().getMimeTypeFromExtension(file.extension).let { mimetype ->
             val pathResult = when (mimetype.isImageMimetype()) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendReactionImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SendReactionImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Reaction
@@ -15,6 +16,7 @@ public interface SendReaction {
      * @param enforceUnique if set to true, new reaction will replace all reactions the user has on this message
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(cid: String, reaction: Reaction, enforceUnique: Boolean = false): Call<Reaction>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SetMessageForReply.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/SetMessageForReply.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -14,6 +15,7 @@ public interface SetMessageForReply {
      * @param cid CID of the channel where reply state is being set.
      * @param message The message we want reply to. The null value means dismiss reply state.
      */
+    @CheckResult
     public operator fun invoke(cid: String, message: Message?): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ShowChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ShowChannelImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -13,6 +14,7 @@ public interface ShowChannel {
      *
      * @see <a href="https://getstream.io/chat/docs/channel_delete/?language=kotlin">Hiding a channel</a>
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Unit>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ShuffleGiphyImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ShuffleGiphyImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -14,6 +15,7 @@ public interface ShuffleGiphy {
      * @param message the message to send
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
+    @CheckResult
     public operator fun invoke(message: Message): Call<Message>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/StopTypingImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/StopTypingImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.livedata.ChatDomainImpl
@@ -13,6 +14,7 @@ public interface StopTyping {
      *
      * @return True when a typing event was sent, false if it wasn't sent.
      */
+    @CheckResult
     public operator fun invoke(cid: String): Call<Boolean>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ThreadLoadMoreImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/ThreadLoadMoreImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.models.Message
@@ -14,6 +15,7 @@ public interface ThreadLoadMore {
      * @param parentId: the parentId of the thread
      * @param messageLimit: how many new messages to load
      */
+    @CheckResult
     public operator fun invoke(cid: String, parentId: String, messageLimit: Int): Call<List<Message>>
 }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/WatchChannelImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/usecase/WatchChannelImpl.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.livedata.usecase
 
+import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.utils.Result
@@ -17,6 +18,7 @@ public interface WatchChannel {
      *
      * @see io.getstream.chat.android.livedata.controller.ChannelController
      */
+    @CheckResult
     public operator fun invoke(cid: String, messageLimit: Int): Call<ChannelController>
 }
 
@@ -26,7 +28,7 @@ internal class WatchChannelImpl(private val domainImpl: ChatDomainImpl) : WatchC
 
         val channelController = domainImpl.channel(cid)
 
-        if (messageLimit> 0) {
+        if (messageLimit > 0) {
             domainImpl.scope.launch {
                 channelController.watch(messageLimit)
             }


### PR DESCRIPTION
### Description

Add [`@CheckResult`](https://developer.android.com/reference/androidx/annotation/CheckResult) annotation to all `Call`-returning API, as not using the `Call` returned is a bug.

![image](https://user-images.githubusercontent.com/12054216/105495635-b24e1200-5cbc-11eb-855a-31dadc9efe9c.png)

We could also create a more specific Lint check ourselves that shows nicely worded errors when clients don't run a `Call` in any of the available ways, but this is way less effort for now (and probably more reliable).

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
