### PR TITLE
[CAS-632] Thread footnote fix

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -14,3 +14,5 @@ If reaction is sent with `enforceUnique` set to true, new reaction will replace 
 - Fix updating `Message::ownReactions` and `Message:latestReactions` after sending or deleting reaction - add missing `userId` to `Reaction`
 
 ## stream-chat-android-ui-common
+- Add a new `isThreadMode` flag to the `MessageListItem.MessageItem` class. 
+  It shows is a message item should be shown as part of thread mode in chat.

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -115,14 +115,15 @@ public final class com/getstream/sdk/chat/adapter/MessageListItem$LoadingMoreInd
 }
 
 public final class com/getstream/sdk/chat/adapter/MessageListItem$MessageItem : com/getstream/sdk/chat/adapter/MessageListItem {
-	public fun <init> (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;Z)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/Message;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/util/List;
-	public final fun copy (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;)Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;
-	public static synthetic fun copy$default (Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;ILjava/lang/Object;)Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;
+	public final fun component5 ()Z
+	public final fun copy (Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;Z)Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;
+	public static synthetic fun copy$default (Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/client/models/Message;Ljava/util/List;ZLjava/util/List;ZILjava/lang/Object;)Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMessage ()Lio/getstream/chat/android/client/models/Message;
 	public final fun getMessageReadBy ()Ljava/util/List;
@@ -130,6 +131,7 @@ public final class com/getstream/sdk/chat/adapter/MessageListItem$MessageItem : 
 	public fun hashCode ()I
 	public final fun isMine ()Z
 	public final fun isTheirs ()Z
+	public final fun isThreadMode ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/adapter/MessageListItem.kt
@@ -40,6 +40,7 @@ public sealed class MessageListItem {
         val positions: List<Position> = listOf(),
         val isMine: Boolean = false,
         val messageReadBy: List<ChannelUserRead> = listOf(),
+        val isThreadMode: Boolean = false
     ) : MessageListItem() {
         public val isTheirs: Boolean
             get() = !isMine

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -55,7 +55,7 @@ internal class MessageListItemLiveData(
     private val readsLd: LiveData<List<ChannelUserRead>>,
     private val typingLd: LiveData<List<User>>? = null,
     private val isThread: Boolean = false,
-    private val dateSeparator: ((previous: Message?, current: Message) -> Boolean)? = null
+    private val dateSeparator: ((previous: Message?, current: Message) -> Boolean)? = null,
 ) : MediatorLiveData<MessageListItemWrapper>() {
 
     private var hasNewMessages: Boolean = false
@@ -187,7 +187,14 @@ internal class MessageListItemLiveData(
                 }
             }
 
-            items.add(MessageListItem.MessageItem(message, positions, isMine = message.user.id == currentUser.id))
+            items.add(
+                MessageListItem.MessageItem(
+                    message,
+                    positions,
+                    isMine = message.user.id == currentUser.id,
+                    isThreadMode = isThread,
+                )
+            )
             previousMessage = message
         }
         return items.toList()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -361,7 +361,7 @@ public final class io/getstream/chat/android/ui/messagepreview/MessagePreviewVie
 
 public abstract class io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder : androidx/recyclerview/widget/RecyclerView$ViewHolder {
 	public fun <init> (Landroid/view/View;)V
-	public abstract fun bindData (Lcom/getstream/sdk/chat/adapter/MessageListItem;ZLio/getstream/chat/android/ui/messages/adapter/MessageListItemPayloadDiff;)V
+	public abstract fun bindData (Lcom/getstream/sdk/chat/adapter/MessageListItem;Lio/getstream/chat/android/ui/messages/adapter/MessageListItemPayloadDiff;)V
 	protected final fun getContext ()Landroid/content/Context;
 	protected final fun getData ()Lcom/getstream/sdk/chat/adapter/MessageListItem;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/BaseMessageItemViewHolder.kt
@@ -25,14 +25,14 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
      * Workaround to allow a downcast of the MessageListItem to T
      */
     @Suppress("UNCHECKED_CAST")
-    internal fun bindListItem(messageListItem: MessageListItem, isThread: Boolean, diff: MessageListItemPayloadDiff? = null) {
+    internal fun bindListItem(messageListItem: MessageListItem, diff: MessageListItemPayloadDiff? = null) {
         messageListItem as T
 
         this.data = messageListItem
-        bindData(messageListItem, isThread, diff)
+        bindData(messageListItem, diff)
     }
 
-    public abstract fun bindData(data: T, isThread: Boolean, diff: MessageListItemPayloadDiff?)
+    public abstract fun bindData(data: T, diff: MessageListItemPayloadDiff?)
 
     internal fun unbind() {
         cancelHighlightAnimation()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/DecoratedBaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/DecoratedBaseMessageItemViewHolder.kt
@@ -10,7 +10,7 @@ internal abstract class DecoratedBaseMessageItemViewHolder<T : MessageListItem>(
     private val decorators: List<Decorator>,
 ) : BaseMessageItemViewHolder<T>(itemView) {
     @CallSuper
-    override fun bindData(data: T, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        decorators.forEach { it.decorate(this, data, isThread) }
+    override fun bindData(data: T, diff: MessageListItemPayloadDiff?) {
+        decorators.forEach { it.decorate(this, data) }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemAdapter.kt
@@ -24,7 +24,7 @@ internal class MessageListItemAdapter(
     }
 
     override fun onBindViewHolder(holder: BaseMessageItemViewHolder<out MessageListItem>, position: Int) {
-        holder.bindListItem(getItem(position), isThread, FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF)
+        holder.bindListItem(getItem(position), FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF)
     }
 
     override fun onBindViewHolder(
@@ -42,7 +42,7 @@ internal class MessageListItemAdapter(
                 acc + messageListItemPayloadDiff
             }
 
-        holder.bindListItem(getItem(position), isThread, diff)
+        holder.bindListItem(getItem(position), diff)
     }
 
     override fun onViewRecycled(holder: BaseMessageItemViewHolder<out MessageListItem>) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemDiffCallback.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.ui.messages.adapter
 import androidx.recyclerview.widget.DiffUtil
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.models.UserEntity
 
 internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListItem>() {
     override fun areItemsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean {
@@ -29,12 +30,16 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                     false
                 } else if (oldItem.positions != newItem.positions) {
                     false
-                } else oldItem.messageReadBy.map { it.getUserId() } == newItem.messageReadBy.map { it.getUserId() }
+                } else if (oldItem.messageReadBy.map(UserEntity::getUserId) != newItem.messageReadBy.map(UserEntity::getUserId)) {
+                    false
+                } else oldItem.isThreadMode == newItem.isThreadMode
             }
             is MessageListItem.DateSeparatorItem -> oldItem.date == (newItem as? MessageListItem.DateSeparatorItem)?.date
             is MessageListItem.ThreadSeparatorItem -> oldItem == (newItem as? MessageListItem.ThreadSeparatorItem)
             is MessageListItem.LoadingMoreIndicatorItem -> true
-            is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(User::id)
+            is MessageListItem.TypingItem -> oldItem.users.map(User::id) == ((newItem) as? MessageListItem.TypingItem)?.users?.map(
+                User::id
+            )
         }
 
     override fun getChangePayload(oldItem: MessageListItem, newItem: MessageListItem): Any? {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -129,7 +129,7 @@ public open class MessageListItemViewHolderFactory {
     ): BaseMessageItemViewHolder<MessageListItem> {
         return object :
             BaseMessageItemViewHolder<MessageListItem>(View(parentView.context)) {
-            override fun bindData(data: MessageListItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) = Unit
+            override fun bindData(data: MessageListItem, diff: MessageListItemPayloadDiff?) = Unit
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/DateDividerViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/DateDividerViewHolder.kt
@@ -19,8 +19,8 @@ internal class DateDividerViewHolder(
     ),
 ) : DecoratedBaseMessageItemViewHolder<MessageListItem.DateSeparatorItem>(binding.root, decorators) {
 
-    override fun bindData(data: MessageListItem.DateSeparatorItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.DateSeparatorItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         binding.dateLabel.text =
             DateUtils.getRelativeTimeSpanString(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/GiphyViewHolder.kt
@@ -35,8 +35,8 @@ internal class GiphyViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         data.message.attachments.firstOrNull()?.let(binding.mediaAttachmentView::showAttachment)
         binding.giphyTextLabel.text = trimText(data.message.text)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -55,8 +55,8 @@ internal class MessagePlainTextViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         with(binding) {
             messageText.text = data.message.text

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyFileAttachmentsViewHolder.kt
@@ -52,8 +52,8 @@ internal class OnlyFileAttachmentsViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         binding.fileAttachmentsView.setAttachments(data.message.attachments)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/OnlyMediaAttachmentsViewHolder.kt
@@ -49,8 +49,8 @@ internal class OnlyMediaAttachmentsViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         if (data.message.attachments.isMedia()) {
             binding.mediaAttachmentsGroupView.showAttachments(data.message.attachments)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithFileAttachmentsViewHolder.kt
@@ -66,8 +66,8 @@ internal class PlainTextWithFileAttachmentsViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         binding.messageText.text = data.message.text
         binding.fileAttachmentsView.setAttachments(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/PlainTextWithMediaAttachmentsViewHolder.kt
@@ -62,8 +62,8 @@ internal class PlainTextWithMediaAttachmentsViewHolder(
         }
     }
 
-    override fun bindData(data: MessageListItem.MessageItem, isThread: Boolean, diff: MessageListItemPayloadDiff?) {
-        super.bindData(data, isThread, diff)
+    override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+        super.bindData(data, diff)
 
         binding.messageText.text = data.message.text
         binding.mediaAttachmentsGroupView.showAttachments(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
@@ -22,7 +22,7 @@ internal class ThreadSeparatorViewHolder(
 
     override fun bindData(
         data: MessageListItem.ThreadSeparatorItem,
-        diff: MessageListItemPayloadDiff?
+        diff: MessageListItemPayloadDiff?,
     ) {
         super.bindData(data, diff)
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/ThreadSeparatorViewHolder.kt
@@ -22,10 +22,9 @@ internal class ThreadSeparatorViewHolder(
 
     override fun bindData(
         data: MessageListItem.ThreadSeparatorItem,
-        isThread: Boolean,
         diff: MessageListItemPayloadDiff?
     ) {
-        super.bindData(data, isThread, diff)
+        super.bindData(data, diff)
 
         binding.threadSeparatorLabel.text = context.resources.getQuantityString(
             R.plurals.stream_ui_thread_separator_replies_label,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
@@ -15,15 +15,13 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
@@ -31,7 +29,6 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
@@ -39,7 +36,6 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
@@ -47,12 +43,11 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun setupAvatar(avatarView: AvatarView, data: MessageListItem.MessageItem) {
         if (data.isTheirs && data.isTheirs && data.isBottomPosition()) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
@@ -21,7 +21,7 @@ internal class AvatarDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -25,7 +25,7 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         val bottomRightCorner = if (data.isBottomPosition()) 0f else DEFAULT_CORNER_RADIUS
         val shapeAppearanceModel = ShapeAppearanceModel.builder().setAllCornerSizes(DEFAULT_CORNER_RADIUS)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -25,8 +25,7 @@ internal class BackgroundDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         val bottomRightCorner = if (data.isBottomPosition()) 0f else DEFAULT_CORNER_RADIUS
         val shapeAppearanceModel = ShapeAppearanceModel.builder().setAllCornerSizes(DEFAULT_CORNER_RADIUS)
@@ -39,7 +38,6 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setDefaultBackgroundDrawable(viewHolder.binding.messageContainer, data)
     }
@@ -47,7 +45,6 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.mediaAttachmentsGroupView,
@@ -57,7 +54,6 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.mediaAttachmentsGroupView,
@@ -67,7 +63,6 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.fileAttachmentsView,
@@ -77,14 +72,13 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = decorateAttachmentsAndBackground(
         viewHolder.binding.backgroundView,
         viewHolder.binding.fileAttachmentsView,
         data
     )
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) {
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
         viewHolder.binding.cardView.shapeAppearanceModel = ShapeAppearanceModel.builder()
             .setAllCornerSizes(DEFAULT_CORNER_RADIUS)
             .setBottomRightCornerSize(SMALL_CARD_VIEW_CORNER_RADIUS)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BaseDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BaseDecorator.kt
@@ -16,27 +16,24 @@ internal abstract class BaseDecorator : Decorator {
     final override fun <T : MessageListItem> decorate(
         viewHolder: BaseMessageItemViewHolder<T>,
         data: T,
-        isThread: Boolean,
     ) {
         if (data !is MessageListItem.MessageItem) {
             return
         }
         when (viewHolder) {
-            is MessageDeletedViewHolder -> decorateDeletedMessage(viewHolder, data, isThread)
-            is MessagePlainTextViewHolder -> decoratePlainTextMessage(viewHolder, data, isThread)
-            is OnlyMediaAttachmentsViewHolder -> decorateOnlyMediaAttachmentsMessage(viewHolder, data, isThread)
+            is MessageDeletedViewHolder -> decorateDeletedMessage(viewHolder, data)
+            is MessagePlainTextViewHolder -> decoratePlainTextMessage(viewHolder, data)
+            is OnlyMediaAttachmentsViewHolder -> decorateOnlyMediaAttachmentsMessage(viewHolder, data)
             is PlainTextWithMediaAttachmentsViewHolder -> decoratePlainTextWithMediaAttachmentsMessage(
                 viewHolder,
-                data,
-                isThread
+                data
             )
-            is OnlyFileAttachmentsViewHolder -> decorateOnlyFileAttachmentsMessage(viewHolder, data, isThread)
+            is OnlyFileAttachmentsViewHolder -> decorateOnlyFileAttachmentsMessage(viewHolder, data)
             is PlainTextWithFileAttachmentsViewHolder -> decoratePlainTextWithFileAttachmentsMessage(
                 viewHolder,
-                data,
-                isThread
+                data
             )
-            is GiphyViewHolder -> decorateGiphyMessage(viewHolder, data, isThread)
+            is GiphyViewHolder -> decorateGiphyMessage(viewHolder, data)
             is DateDividerViewHolder -> Unit
             else -> Unit
         }.exhaustive
@@ -45,38 +42,32 @@ internal abstract class BaseDecorator : Decorator {
     protected abstract fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     )
 
     protected abstract fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     )
 
     protected abstract fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     )
 
     protected abstract fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     )
 
     protected abstract fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     )
 
     protected open fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = Unit
 
-    abstract fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean)
+    abstract fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem)
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/Decorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/Decorator.kt
@@ -4,5 +4,5 @@ import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
 
 internal interface Decorator {
-    fun <T : MessageListItem> decorate(viewHolder: BaseMessageItemViewHolder<T>, data: T, isThread: Boolean)
+    fun <T : MessageListItem> decorate(viewHolder: BaseMessageItemViewHolder<T>, data: T)
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
@@ -16,50 +16,44 @@ internal class FailedIndicatorDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun setupFailedIndicator(
         deliveryFailedIcon: ImageView,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
@@ -16,48 +16,49 @@ internal class FailedIndicatorDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
+
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun setupFailedIndicator(
         deliveryFailedIcon: ImageView,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         val isFailed = data.isMine && data.message.syncStatus == SyncStatus.FAILED_PERMANENTLY
         deliveryFailedIcon.isVisible = isFailed

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FootnoteDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FootnoteDecorator.kt
@@ -38,59 +38,50 @@ internal class FootnoteDecorator(
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = setupFootnote(
         viewHolder.binding.footnote,
         viewHolder.binding.root,
         viewHolder.binding.threadGuideline,
         viewHolder.binding.messageContainer,
         data,
-        isThread,
     )
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = setupFootnote(
         viewHolder.binding.footnote,
         viewHolder.binding.root,
         viewHolder.binding.threadGuideline,
         viewHolder.binding.fileAttachmentsView,
         data,
-        isThread,
     )
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = setupFootnote(
         viewHolder.binding.footnote,
         viewHolder.binding.root,
         viewHolder.binding.threadGuideline,
         viewHolder.binding.messageContainer,
         data,
-        isThread,
     )
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) = setupFootnote(
         viewHolder.binding.footnote,
         viewHolder.binding.root,
         viewHolder.binding.threadGuideline,
         viewHolder.binding.mediaAttachmentsGroupView,
         data,
-        isThread,
     )
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) =
         setupFootnote(
             viewHolder.binding.footnote,
@@ -98,13 +89,11 @@ internal class FootnoteDecorator(
             viewHolder.binding.threadGuideline,
             viewHolder.binding.messageContainer,
             data,
-            isThread,
         )
 
     override fun decorateGiphyMessage(
         viewHolder: GiphyViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupSimpleFootnoteWithRootConstraints(
             viewHolder.binding.footnote,
@@ -121,7 +110,6 @@ internal class FootnoteDecorator(
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
         data: MessageListItem.MessageItem,
-        isThread: Boolean,
     ) {
         setupSimpleFootnote(viewHolder.binding.footnote, data)
     }
@@ -132,9 +120,8 @@ internal class FootnoteDecorator(
         threadGuideline: View,
         anchorView: View,
         data: MessageListItem.MessageItem,
-        isThreadMode: Boolean,
     ) {
-        val isSimpleFootnoteMode = data.message.replyCount == 0 || isThreadMode
+        val isSimpleFootnoteMode = data.message.replyCount == 0 || data.isThreadMode
         if (isSimpleFootnoteMode) {
             setupSimpleFootnoteWithRootConstraints(footnoteView, root, anchorView, data)
         } else {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
@@ -22,40 +22,34 @@ internal class GapDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupGapView(viewHolder.binding.gapView, data)
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) =
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) =
         setupGapView(viewHolder.binding.gapView, data)
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
@@ -22,32 +22,32 @@ internal class GapDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) =

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
@@ -15,41 +15,36 @@ import io.getstream.chat.android.ui.utils.extensions.hasLink
 internal class LinkAttachmentDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun decorate(linkAttachmentView: LinkAttachmentView, message: Message) {
         val linkAttachment = message.attachments.firstOrNull { it.hasLink() }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
@@ -15,31 +15,31 @@ import io.getstream.chat.android.ui.utils.extensions.hasLink
 internal class LinkAttachmentDecorator : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
@@ -13,51 +13,45 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMed
 internal class MaxPossibleWidthDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) {
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
@@ -13,42 +13,42 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMed
 internal class MaxPossibleWidthDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -22,7 +22,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, messageContainer, reactionsSpace, reactionsView, data)
@@ -31,7 +31,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -40,7 +40,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -49,7 +49,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -58,7 +58,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -67,7 +67,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
 
     override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
@@ -77,7 +77,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         contentView: View,
         reactionsSpace: View,
         reactionsView: ViewReactionsView,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) {
         if (data.message.latestReactions.isNotEmpty()) {
             reactionsView.isVisible = true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -22,8 +22,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, messageContainer, reactionsSpace, reactionsView, data)
@@ -32,8 +31,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -42,8 +40,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -52,8 +49,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -62,8 +58,7 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, backgroundView, reactionsSpace, reactionsView, data)
@@ -72,11 +67,10 @@ internal class ReactionsDecorator : BaseDecorator() {
 
     override fun decorateDeletedMessage(
         viewHolder: MessageDeletedViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
 
-    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem, isThread: Boolean) = Unit
+    override fun decorateGiphyMessage(viewHolder: GiphyViewHolder, data: MessageListItem.MessageItem) = Unit
 
     private fun setupReactionsView(
         rootConstraintLayout: ConstraintLayout,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
@@ -14,32 +14,32 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMed
 internal class ReplyDecorator(private val currentUser: User) : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateGiphyMessage(
         viewHolder: GiphyViewHolder,
-        data: MessageListItem.MessageItem
+        data: MessageListItem.MessageItem,
     ) = Unit
 
     private fun setupReplyView(replyView: MessageReplyView, data: MessageListItem.MessageItem) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
@@ -14,38 +14,32 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMed
 internal class ReplyDecorator(private val currentUser: User) : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
         viewHolder: PlainTextWithFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateOnlyFileAttachmentsMessage(
         viewHolder: OnlyFileAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decoratePlainTextWithMediaAttachmentsMessage(
         viewHolder: PlainTextWithMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateOnlyMediaAttachmentsMessage(
         viewHolder: OnlyMediaAttachmentsViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateGiphyMessage(
         viewHolder: GiphyViewHolder,
-        data: MessageListItem.MessageItem,
-        isThread: Boolean
+        data: MessageListItem.MessageItem
     ) = Unit
 
     private fun setupReplyView(replyView: MessageReplyView, data: MessageListItem.MessageItem) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
@@ -146,7 +146,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                         FrameLayout.LayoutParams.WRAP_CONTENT
                     )
                 )
-                viewHolder.bindListItem(messageItem, false)
+                viewHolder.bindListItem(messageItem)
             }
     }
 


### PR DESCRIPTION
### Description

Threadfootnote didn't get shown when writing thread reply to the latest message. 
It happens because VH didn't get redrawn since `MessageListItemDiffCallback::areContentsTheSame` returned true. So we need to make messages different when in `ThreadMode` and when in `NormalMode`.  So:
1) Introduce the new field `isThreadMode` to `MessageListItem.MessageItem`
2) Remove from VHs' binding logic the `isThread`flag and use `isThreadMode` from `MessageItem`
3) Add this new flag into comparison logic of `MessageListItemDiffCallback` 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
