### PR TITLE
Fix adding date separators

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -16,3 +16,5 @@ If reaction is sent with `enforceUnique` set to true, new reaction will replace 
 ## stream-chat-android-ui-common
 - Add a new `isThreadMode` flag to the `MessageListItem.MessageItem` class. 
   It shows is a message item should be shown as part of thread mode in chat.
+- Add possibility to set `DateSeparatorHandler` via `MessageListViewModel::setDateSeparatorHandler`
+  and `MessageListViewModel::setThreadDateSeparatorHandler` which determines when to add date separator between messages

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -2108,6 +2108,12 @@ public final class com/getstream/sdk/chat/viewmodel/messages/MessageListViewMode
 	public final fun getState ()Landroidx/lifecycle/LiveData;
 	public final fun getTargetMessage ()Landroidx/lifecycle/LiveData;
 	public final fun onEvent (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel$Event;)V
+	public final fun setDateSeparatorHandler (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel$DateSeparatorHandler;)V
+	public final fun setThreadDateSeparatorHandler (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel$DateSeparatorHandler;)V
+}
+
+public abstract interface class com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel$DateSeparatorHandler {
+	public abstract fun shouldAddDateSeparator (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/Message;)Z
 }
 
 public abstract class com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel$Event {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -55,7 +55,7 @@ internal class MessageListItemLiveData(
     private val readsLd: LiveData<List<ChannelUserRead>>,
     private val typingLd: LiveData<List<User>>? = null,
     private val isThread: Boolean = false,
-    private val dateSeparator: ((previous: Message?, current: Message) -> Boolean)? = null,
+    private val dateSeparatorHandler: MessageListViewModel.DateSeparatorHandler? = null,
 ) : MediatorLiveData<MessageListItemWrapper>() {
 
     private var hasNewMessages: Boolean = false
@@ -166,10 +166,16 @@ internal class MessageListItemLiveData(
                 )
             }
 
+            // date separator
+            val shouldAddDateSeparator = dateSeparatorHandler?.shouldAddDateSeparator(previousMessage, message) ?: false
+            if (shouldAddDateSeparator) {
+                items.add(MessageListItem.DateSeparatorItem(message.getCreatedAtOrThrow()))
+            }
+
             // determine the position (top, middle, bottom)
             val user = message.user
             val positions = mutableListOf<MessageListItem.Position>()
-            if (previousMessage == null || previousMessage.user != user) {
+            if (previousMessage == null || previousMessage.user != user || shouldAddDateSeparator) {
                 positions.add(MessageListItem.Position.TOP)
             }
             if (nextMessage == null || nextMessage.user != user) {
@@ -178,12 +184,6 @@ internal class MessageListItemLiveData(
             if (previousMessage != null && nextMessage != null) {
                 if (previousMessage.user == user && nextMessage.user == user) {
                     positions.add(MessageListItem.Position.MIDDLE)
-                }
-            }
-            // date separators
-            dateSeparator?.let {
-                if (it(previousMessage, message)) {
-                    items.add(MessageListItem.DateSeparatorItem(message.getCreatedAtOrThrow()))
                 }
             }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -59,6 +59,24 @@ public class MessageListViewModel @JvmOverloads constructor(
     public val state: LiveData<State> = stateMerger
     public val currentUser: User = domain.currentUser
 
+    private var dateSeparatorHandler: DateSeparatorHandler? =
+        DateSeparatorHandler { previousMessage: Message?, message: Message ->
+            if (previousMessage == null) {
+                true
+            } else {
+                (message.getCreatedAtOrThrow().time - previousMessage.getCreatedAtOrThrow().time) > (1000 * 60 * 60 * 4)
+            }
+        }
+
+    private var threadDateSeparatorHandler: DateSeparatorHandler? =
+        DateSeparatorHandler { previousMessage: Message?, message: Message ->
+            if (previousMessage == null) {
+                false
+            } else {
+                (message.getCreatedAtOrThrow().time - previousMessage.getCreatedAtOrThrow().time) > (1000 * 60 * 60 * 4)
+            }
+        }
+
     init {
         stateMerger.addSource(MutableLiveData(State.Loading)) { stateMerger.value = it }
 
@@ -74,7 +92,7 @@ public class MessageListViewModel @JvmOverloads constructor(
                     channelController.reads,
                     typingIds,
                     false,
-                    ::dateSeparator
+                    dateSeparatorHandler,
                 )
                 _reads.addSource(channelController.reads) { _reads.value = it }
                 _loadMoreLiveData.addSource(channelController.loadingOlderMessages) { _loadMoreLiveData.value = it }
@@ -84,7 +102,8 @@ public class MessageListViewModel @JvmOverloads constructor(
                         addSource(channelController.messagesState) { messageState ->
                             when (messageState) {
                                 is ChannelController.MessagesState.NoQueryActive,
-                                is ChannelController.MessagesState.Loading -> value = State.Loading
+                                is ChannelController.MessagesState.Loading,
+                                -> value = State.Loading
                                 is ChannelController.MessagesState.OfflineNoResults ->
                                     value = State.Result(MessageListItemWrapper())
                                 is ChannelController.MessagesState.Result -> {
@@ -113,22 +132,6 @@ public class MessageListViewModel @JvmOverloads constructor(
         }
     }
 
-    private fun dateSeparator(previous: Message?, message: Message): Boolean {
-        return if (previous == null) {
-            true
-        } else {
-            (message.getCreatedAtOrThrow().time - previous.getCreatedAtOrThrow().time) > (1000 * 60 * 60 * 4)
-        }
-    }
-
-    private fun threadDateSeparator(previous: Message?, message: Message): Boolean {
-        return if (previous == null) {
-            false
-        } else {
-            (message.getCreatedAtOrThrow().time - previous.getCreatedAtOrThrow().time) > (1000 * 60 * 60 * 4)
-        }
-    }
-
     private fun setThreadMessages(threadMessages: LiveData<List<Message>>) {
         threadListData = MessageListItemLiveData(
             currentUser,
@@ -136,7 +139,7 @@ public class MessageListViewModel @JvmOverloads constructor(
             reads,
             null,
             true,
-            ::threadDateSeparator
+            threadDateSeparatorHandler,
         )
         threadListData?.let { tld ->
             messageListData?.let { mld ->
@@ -208,6 +211,26 @@ public class MessageListViewModel @JvmOverloads constructor(
                 domain.useCases.downloadAttachment.invoke(event.attachment).enqueue()
             }
         }.exhaustive
+    }
+
+    /**
+     * Sets the date separator handler which determines when to add date separators.
+     * By default, a date separator will be added if the difference between two messages' dates is greater than 4h.
+     *
+     * @param dateSeparatorHandler The handler to use. If null, [messageListData] won't contain date separators.
+     */
+    public fun setDateSeparatorHandler(dateSeparatorHandler: DateSeparatorHandler?) {
+        this.dateSeparatorHandler = dateSeparatorHandler
+    }
+
+    /**
+     * Sets thread date separator handler which determines when to add date separators inside the thread.
+     * @see setDateSeparatorHandler
+     *
+     * @param threadDateSeparatorHandler The handler to use. If null, [messageListData] won't contain date separators.
+     */
+    public fun setThreadDateSeparatorHandler(threadDateSeparatorHandler: DateSeparatorHandler?) {
+        this.threadDateSeparatorHandler = threadDateSeparatorHandler
     }
 
     private fun onGiphyActionSelected(event: Event.GiphyActionSelected) {
@@ -316,6 +339,10 @@ public class MessageListViewModel @JvmOverloads constructor(
     public sealed class Mode {
         public data class Thread(val parentMessage: Message) : Mode()
         public object Normal : Mode()
+    }
+
+    public fun interface DateSeparatorHandler {
+        public fun shouldAddDateSeparator(previousMessage: Message?, message: Message): Boolean
     }
 
     internal companion object {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -13,6 +13,8 @@ import com.getstream.sdk.chat.viewmodel.ChannelHeaderViewModel
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import com.getstream.sdk.chat.viewmodel.factory.ChannelViewModelFactory
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import com.getstream.sdk.chat.viewmodel.messages.getCreatedAtOrThrow
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.utils.EventObserver
 import io.getstream.chat.android.ui.messages.header.bindView
 import io.getstream.chat.android.ui.messages.view.bindView
@@ -20,6 +22,7 @@ import io.getstream.chat.android.ui.textinput.bindView
 import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.databinding.FragmentChatBinding
 import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
+import java.util.Calendar
 
 class ChatFragment : Fragment() {
 
@@ -133,8 +136,25 @@ class ChatFragment : Fragment() {
     }
 
     private fun initMessagesViewModel() {
+        val calendar = Calendar.getInstance()
         messageListViewModel
-            .apply { bindView(binding.messageListView, viewLifecycleOwner) } // TODO replace with new design message list
+            .apply {
+                setDateSeparatorHandler { previousMessage, message ->
+                    if (previousMessage == null) {
+                        true
+                    } else {
+                        shouldShowDateSeparator(calendar, previousMessage, message)
+                    }
+                }
+                setThreadDateSeparatorHandler { previousMessage, message ->
+                    if (previousMessage == null) {
+                        false
+                    } else {
+                        shouldShowDateSeparator(calendar, previousMessage, message)
+                    }
+                }
+            }
+            .apply { bindView(binding.messageListView, viewLifecycleOwner) }
             .apply {
                 state.observe(
                     viewLifecycleOwner,
@@ -145,5 +165,17 @@ class ChatFragment : Fragment() {
                     }
                 )
             }
+    }
+
+    private fun shouldShowDateSeparator(calendar: Calendar, previousMessage: Message, message: Message): Boolean {
+        val (previousYear, previousDayOfYear) = calendar.run {
+            time = previousMessage.getCreatedAtOrThrow()
+            get(Calendar.YEAR) to get(Calendar.DAY_OF_YEAR)
+        }
+        val (year, dayOfYear) = calendar.run {
+            time = message.getCreatedAtOrThrow()
+            get(Calendar.YEAR) to get(Calendar.DAY_OF_YEAR)
+        }
+        return previousYear != year || previousDayOfYear != dayOfYear
     }
 }


### PR DESCRIPTION
| Before | After |
| --- | --- |
|<img width="326" alt="Screenshot 2021-01-25 at 14 21 48" src="https://user-images.githubusercontent.com/17440581/105711477-e32a8300-5f18-11eb-8940-7f23f862b526.png">|<img width="326" alt="Screenshot 2021-01-25 at 14 20 34" src="https://user-images.githubusercontent.com/17440581/105711472-e1f95600-5f18-11eb-9e21-bfbf1ecf07c7.png">|

1. Add possibility to configure when to add date separator through `DateSeparatorHandler`. We should reconsider the way we are passing it to `MessageListItemLiveData` because it won't work fine if the handler will be set after presenting results to the user. Maybe we should add an extra rerender?
2. Add missing TOP position to Message which has `DateSeparator` above

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
