### PR TITLE
[CAS-631] Decrease GoToBottom button visibility threshold

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListScrollHelper.kt
@@ -148,6 +148,6 @@ internal class MessageListScrollHelper(
 
     private companion object {
         private const val HIGHLIGHT_MESSAGE_DELAY = 100L
-        private const val SCROLL_BUTTON_VISIBILITY_THRESHOLD = 30
+        private const val SCROLL_BUTTON_VISIBILITY_THRESHOLD = 8
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-631

### Description

Agreed to show scroll to bottom button when we scroll 8 messages up (~1 screen on average)

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
