### PR TITLE
Do not keep previous mode in ReplyMode

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -897,13 +897,11 @@ public final class io/getstream/chat/android/ui/textinput/MessageInputFieldView$
 }
 
 public final class io/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode : io/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode {
-	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/Message;
-	public final fun component2 ()Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode;
-	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode;)Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode;ILjava/lang/Object;)Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;
+	public final fun copy (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;Lio/getstream/chat/android/client/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode$ReplyMessageMode;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getPreviousMode ()Lio/getstream/chat/android/ui/textinput/MessageInputFieldView$Mode;
 	public final fun getRepliedMessage ()Lio/getstream/chat/android/client/models/Message;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/textinput/MessageInputFieldView.kt
@@ -152,13 +152,12 @@ public class MessageInputFieldView : FrameLayout {
     }
 
     public fun onReply(replyMessage: Message) {
-        mode = Mode.ReplyMessageMode(replyMessage, mode)
+        mode = Mode.ReplyMessageMode(replyMessage)
     }
 
     public fun onReplyDismissed() {
-        val currentMode = mode
-        if (currentMode is Mode.ReplyMessageMode) {
-            mode = currentMode.previousMode
+        if (mode is Mode.ReplyMessageMode) {
+            mode = Mode.MessageMode
         }
     }
 
@@ -301,6 +300,6 @@ public class MessageInputFieldView : FrameLayout {
         public data class CommandMode(val command: Command) : Mode()
         public data class FileAttachmentMode(val attachments: List<AttachmentMetaData>) : Mode()
         public data class MediaAttachmentMode(val attachments: List<AttachmentMetaData>) : Mode()
-        public data class ReplyMessageMode(val repliedMessage: Message, val previousMode: Mode) : Mode()
+        public data class ReplyMessageMode(val repliedMessage: Message) : Mode()
     }
 }


### PR DESCRIPTION
### Description

Fix bug:
When replied the second time and send or dismiss reply then you saw reply mode from the first time

Before:

https://user-images.githubusercontent.com/11807573/105827442-4ae8d880-5fc2-11eb-9371-d4a4ebfd5291.mov

After:

https://user-images.githubusercontent.com/11807573/105827483-589e5e00-5fc2-11eb-93a6-c7fc2593e875.mov



### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
