### PR TITLE
Fix consistency of MessageListView handler names and setters

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -126,7 +126,7 @@ class ChatFragment : Fragment() {
                     }
                 }
             )
-            binding.messageListView.setOnMessageEditHandler {
+            binding.messageListView.setMessageEditHandler {
                 editMessage.postValue(it)
             }
         }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -527,10 +527,13 @@ public final class io/getstream/chat/android/ui/messages/view/MessageListView : 
 	public final fun scrollToMessage (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun setAttachmentClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$AttachmentClickListener;)V
 	public final fun setAttachmentDownloadClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$AttachmentDownloadClickListener;)V
+	public final fun setAttachmentDownloadHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$AttachmentDownloadHandler;)V
 	public final fun setEmptyStateView (Landroid/view/View;)V
 	public final fun setEmptyStateView (Landroid/view/View;Landroid/widget/FrameLayout$LayoutParams;)V
 	public static synthetic fun setEmptyStateView$default (Lio/getstream/chat/android/ui/messages/view/MessageListView;Landroid/view/View;Landroid/widget/FrameLayout$LayoutParams;ILjava/lang/Object;)V
 	public final fun setEndRegionReachedHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$EndRegionReachedHandler;)V
+	public final fun setEnterThreadListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$EnterThreadListener;)V
+	public final fun setGiphySendHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$GiphySendHandler;)V
 	public final fun setLastMessageReadHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$LastMessageReadHandler;)V
 	public final fun setLinkClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$LinkClickListener;)V
 	public final fun setLoadingMore (Z)V
@@ -539,27 +542,24 @@ public final class io/getstream/chat/android/ui/messages/view/MessageListView : 
 	public static synthetic fun setLoadingView$default (Lio/getstream/chat/android/ui/messages/view/MessageListView;Landroid/view/View;Landroid/widget/FrameLayout$LayoutParams;ILjava/lang/Object;)V
 	public final fun setMessageClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageClickListener;)V
 	public final fun setMessageDateFormatter (Lcom/getstream/sdk/chat/utils/DateFormatter;)V
+	public final fun setMessageDeleteHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageDeleteHandler;)V
+	public final fun setMessageEditHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageEditHandler;)V
+	public final fun setMessageFlagHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageFlagHandler;)V
 	public final fun setMessageListItemFilter (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageListItemFilter;)V
 	public final fun setMessageLongClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageLongClickListener;)V
+	public final fun setMessageReactionHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageReactionHandler;)V
+	public final fun setMessageReplyHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageReplyHandler;)V
+	public final fun setMessageRetryHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageRetryHandler;)V
 	public final fun setMessageRetryListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageRetryListener;)V
 	public final fun setMessageViewHolderFactory (Lio/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory;)V
 	public final fun setNewMessagesBehaviour (Lio/getstream/chat/android/ui/messages/view/MessageListView$NewMessagesBehaviour;)V
-	public final fun setOnAttachmentDownloadHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$AttachmentDownloadHandler;)V
-	public final fun setOnBlockUserHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$BlockUserHandler;)V
-	public final fun setOnMessageDeleteHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageDeleteHandler;)V
-	public final fun setOnMessageEditHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageEditHandler;)V
-	public final fun setOnMessageFlagHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageFlagHandler;)V
-	public final fun setOnMessageReactionHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageReactionHandler;)V
-	public final fun setOnMessageRetryHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageRetryHandler;)V
-	public final fun setOnMuteUserHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MuteUserHandler;)V
-	public final fun setOnReplyMessageHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$MessageReplyHandler;)V
-	public final fun setOnSendGiphyHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$SendGiphyHandler;)V
-	public final fun setOnStartThreadHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$StartThreadHandler;)V
-	public final fun setOnStartThreadListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$EnterThreadListener;)V
 	public final fun setReactionViewClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$ReactionViewClickListener;)V
 	public final fun setScrollToBottomButtonEnabled (Z)V
 	public final fun setThreadClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$ThreadClickListener;)V
+	public final fun setThreadStartHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$ThreadStartHandler;)V
+	public final fun setUserBlockHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$UserBlockHandler;)V
 	public final fun setUserClickListener (Lio/getstream/chat/android/ui/messages/view/MessageListView$UserClickListener;)V
+	public final fun setUserMuteHandler (Lio/getstream/chat/android/ui/messages/view/MessageListView$UserMuteHandler;)V
 	public final fun showEmptyStateView ()V
 	public final fun showLoadingView ()V
 }
@@ -576,16 +576,16 @@ public abstract interface class io/getstream/chat/android/ui/messages/view/Messa
 	public abstract fun onAttachmentDownload (Lio/getstream/chat/android/client/models/Attachment;)V
 }
 
-public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$BlockUserHandler {
-	public abstract fun onUserBlock (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;)V
-}
-
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$EndRegionReachedHandler {
 	public abstract fun onEndRegionReached ()V
 }
 
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$EnterThreadListener {
 	public abstract fun onThreadEntered (Lio/getstream/chat/android/client/models/Message;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$GiphySendHandler {
+	public abstract fun onSendGiphy (Lio/getstream/chat/android/client/models/Message;Lcom/getstream/sdk/chat/enums/GiphyAction;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$GiphySendListener {
@@ -640,10 +640,6 @@ public abstract interface class io/getstream/chat/android/ui/messages/view/Messa
 	public abstract fun onRetryMessage (Lio/getstream/chat/android/client/models/Message;)V
 }
 
-public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$MuteUserHandler {
-	public abstract fun onUserMute (Lio/getstream/chat/android/client/models/User;)V
-}
-
 public final class io/getstream/chat/android/ui/messages/view/MessageListView$NewMessagesBehaviour : java/lang/Enum {
 	public static final field COUNT_UPDATE Lio/getstream/chat/android/ui/messages/view/MessageListView$NewMessagesBehaviour;
 	public static final field Companion Lio/getstream/chat/android/ui/messages/view/MessageListView$NewMessagesBehaviour$Companion;
@@ -656,20 +652,24 @@ public abstract interface class io/getstream/chat/android/ui/messages/view/Messa
 	public abstract fun onReactionViewClick (Lio/getstream/chat/android/client/models/Message;)V
 }
 
-public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$SendGiphyHandler {
-	public abstract fun onSendGiphy (Lio/getstream/chat/android/client/models/Message;Lcom/getstream/sdk/chat/enums/GiphyAction;)V
-}
-
-public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$StartThreadHandler {
-	public abstract fun onStartThread (Lio/getstream/chat/android/client/models/Message;)V
-}
-
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$ThreadClickListener {
 	public abstract fun onThreadClick (Lio/getstream/chat/android/client/models/Message;)V
 }
 
+public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$ThreadStartHandler {
+	public abstract fun onStartThread (Lio/getstream/chat/android/client/models/Message;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$UserBlockHandler {
+	public abstract fun onUserBlock (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;)V
+}
+
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$UserClickListener {
 	public abstract fun onUserClick (Lio/getstream/chat/android/client/models/User;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$UserMuteHandler {
+	public abstract fun onUserMute (Lio/getstream/chat/android/client/models/User;)V
 }
 
 public final class io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewModelBinding.kt
@@ -28,20 +28,20 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
     }
     view.setEndRegionReachedHandler { onEvent(EndRegionReached) }
     view.setLastMessageReadHandler { onEvent(LastMessageRead) }
-    view.setOnMessageDeleteHandler { onEvent(DeleteMessage(it)) }
-    view.setOnStartThreadHandler { onEvent(ThreadModeEntered(it)) }
-    view.setOnMessageFlagHandler { onEvent(FlagMessage(it)) }
-    view.setOnSendGiphyHandler { message, giphyAction ->
+    view.setMessageDeleteHandler { onEvent(DeleteMessage(it)) }
+    view.setThreadStartHandler { onEvent(ThreadModeEntered(it)) }
+    view.setMessageFlagHandler { onEvent(FlagMessage(it)) }
+    view.setGiphySendHandler { message, giphyAction ->
         onEvent(GiphyActionSelected(message, giphyAction))
     }
-    view.setOnMessageRetryHandler { onEvent(RetryMessage(it)) }
-    view.setOnMessageReactionHandler { message, reactionType ->
+    view.setMessageRetryHandler { onEvent(RetryMessage(it)) }
+    view.setMessageReactionHandler { message, reactionType ->
         onEvent(MessageReaction(message, reactionType, enforceUnique = true))
     }
-    view.setOnMuteUserHandler { onEvent(MuteUser(it)) }
-    view.setOnBlockUserHandler { user, cid -> onEvent(BlockUser(user, cid)) }
-    view.setOnReplyMessageHandler { cid, message -> onEvent(ReplyMessage(cid, message)) }
-    view.setOnAttachmentDownloadHandler { attachment -> onEvent(AttachmentDownload(attachment)) }
+    view.setUserMuteHandler { onEvent(MuteUser(it)) }
+    view.setUserBlockHandler { user, cid -> onEvent(BlockUser(user, cid)) }
+    view.setMessageReplyHandler { cid, message -> onEvent(ReplyMessage(cid, message)) }
+    view.setAttachmentDownloadHandler { attachment -> onEvent(AttachmentDownload(attachment)) }
 
     state.observe(lifecycleOwner) { state ->
         when (state) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/MessageOptionsDialogFragment.kt
@@ -252,12 +252,12 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     }
 
     internal class MessageOptionsHandlers(
-        val threadReplyHandler: MessageListView.StartThreadHandler,
+        val threadReplyHandler: MessageListView.ThreadStartHandler,
         val retryHandler: MessageListView.MessageRetryHandler,
         val editClickHandler: MessageListView.MessageEditHandler,
         val flagClickHandler: MessageListView.MessageFlagHandler,
-        val muteClickHandler: MessageListView.MuteUserHandler,
-        val blockClickHandler: MessageListView.BlockUserHandler,
+        val muteClickHandler: MessageListView.UserMuteHandler,
+        val blockClickHandler: MessageListView.UserBlockHandler,
         val deleteClickHandler: MessageListView.MessageDeleteHandler,
         val replyClickHandler: MessageListView.MessageReplyHandler,
     ) : Serializable


### PR DESCRIPTION

### Description

Minor API cleanup: removes "On" prefixes from listener names, unifies order of words in the handler names to `NounVerbHandler`.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
