### PR TITLE
[CAS-576] Fix incorrect dimensions of messages with links

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/LinkAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/view/LinkAttachmentView.kt
@@ -2,53 +2,66 @@ package io.getstream.chat.android.ui.messages.adapter.view
 
 import android.content.Context
 import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.images.StreamImageLoader.ImageTransformation.RoundedCorners
 import com.getstream.sdk.chat.images.load
+import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiLinkAttachmentsViewBinding
 import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
 
 internal class LinkAttachmentView : FrameLayout {
+    private val binding: StreamUiLinkAttachmentsViewBinding = StreamUiLinkAttachmentsViewBinding
+        .inflate(context.inflater, this, true)
+    private var previewUrl: String? = null
+
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
 
-    private val binding: StreamUiLinkAttachmentsViewBinding =
-        StreamUiLinkAttachmentsViewBinding.inflate(LayoutInflater.from(context), this, true)
-    private var previewUrl: String? = null
-
     fun showLinkAttachment(attachment: Attachment) {
         previewUrl = attachment.ogUrl
-        attachment.title?.let { title ->
-            binding.titleTextView.apply {
-                isVisible = true
-                text = title
-            }
+
+        val title = attachment.title
+        if (title != null) {
+            binding.titleTextView.isVisible = true
+            binding.titleTextView.text = title
+        } else {
+            binding.titleTextView.isVisible = false
         }
 
-        attachment.text?.let { description ->
-            binding.descriptionTextView.apply {
-                isVisible = true
-                text = description
-            }
+        val description = attachment.text
+        if (description != null) {
+            binding.descriptionTextView.isVisible = true
+            binding.descriptionTextView.text = description
+        } else {
+            binding.descriptionTextView.isVisible = false
         }
-        attachment.authorName?.let { label ->
+
+        val label = attachment.authorName
+        if (label != null) {
             binding.labelContainer.isVisible = true
             binding.labelTextView.text = label.capitalize()
+        } else {
+            binding.labelContainer.isVisible = false
         }
 
-        binding.linkPreviewImageView.load(
-            data = attachment.thumbUrl ?: attachment.imageUrl,
-            placeholderResId = R.drawable.stream_ui_picture_placeholder,
-            onStart = { binding.progressBar.isVisible = true },
-            onComplete = { binding.progressBar.isVisible = false },
-            transformation = RoundedCorners(LINK_PREVIEW_CORNER_RADIUS),
-        )
+        val previewUrl = attachment.thumbUrl ?: attachment.imageUrl
+        if (previewUrl != null) {
+            binding.linkPreviewImageView.load(
+                data = previewUrl,
+                placeholderResId = R.drawable.stream_ui_picture_placeholder,
+                onStart = { binding.progressBar.isVisible = true },
+                onComplete = { binding.progressBar.isVisible = false },
+                transformation = RoundedCorners(LINK_PREVIEW_CORNER_RADIUS),
+            )
+        } else {
+            binding.linkPreviewImageView.isVisible = false
+            binding.progressBar.isVisible = false
+        }
     }
 
     fun setLinkPreviewClickListener(linkPreviewClickListener: LinkPreviewClickListener) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
@@ -1,7 +1,11 @@
 package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
+import android.view.View
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.adapter.MessageListItem
+import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.messages.adapter.view.LinkAttachmentView
 import io.getstream.chat.android.ui.messages.adapter.viewholder.GiphyViewHolder
@@ -41,6 +45,7 @@ internal class LinkAttachmentDecorator : BaseDecorator() {
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
     ) {
+        applyMaxPossibleWidth(viewHolder.binding.root, viewHolder.binding.messageContainer, data.message)
         decorate(viewHolder.binding.linkAttachmentView, data.message)
     }
 
@@ -53,6 +58,22 @@ internal class LinkAttachmentDecorator : BaseDecorator() {
             linkAttachmentView.showLinkAttachment(linkAttachment)
         } else {
             linkAttachmentView.isVisible = false
+        }
+    }
+
+    private fun applyMaxPossibleWidth(root: ConstraintLayout, messageContainer: View, message: Message) {
+        val hasLink = message.attachments.any { it.hasLink() }
+        val layoutWidth = messageContainer.layoutParams.width
+        if (hasLink && layoutWidth == ConstraintSet.WRAP_CONTENT) {
+            root.updateConstraints {
+                constrainWidth(messageContainer.id, ConstraintSet.MATCH_CONSTRAINT)
+                constrainDefaultWidth(messageContainer.id, ConstraintSet.MATCH_CONSTRAINT_SPREAD)
+            }
+        } else if (!hasLink && layoutWidth == ConstraintSet.MATCH_CONSTRAINT) {
+            root.updateConstraints {
+                constrainWidth(messageContainer.id, ConstraintSet.WRAP_CONTENT)
+                constrainDefaultWidth(messageContainer.id, ConstraintSet.MATCH_CONSTRAINT_WRAP)
+            }
         }
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-576

### Description

Added enough room for the messages with links to render properly.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

<img src="https://user-images.githubusercontent.com/9600921/105908822-bc16a300-6037-11eb-9a18-c2ab730cd7e9.png" width="30%"> <img src="https://user-images.githubusercontent.com/9600921/105908827-bde06680-6037-11eb-913e-c7f975dd0a8c.png" width="30%"> <img src="https://user-images.githubusercontent.com/9600921/105908832-bf119380-6037-11eb-8163-bad1efe3a734.png" width="30%">


