### PR TITLE
Fix duplicate reactions

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/ClientExtensions.kt
@@ -18,89 +18,6 @@ internal fun Channel.users(): List<User> = members.map(Member::user) +
     createdBy +
     messages.flatMap { it.users() }
 
-private fun Message.clearOwnReactions(userId: String) {
-    // remove own reactions from latest reactions
-    latestReactions.removeAll { reaction -> reaction.userId == userId }
-
-    // update counts
-    ownReactions.groupBy { it.type }.forEach { (type, reactions) ->
-        // update the count
-        val newCount = reactionCounts.getOrElse(type) { 0 } - reactions.size
-        if (newCount <= 0) {
-            reactionCounts.remove(type)
-        } else {
-            reactionCounts[type] = newCount
-        }
-
-        // update the score
-        val newScore = reactionScores.getOrElse(type) { 0 } - reactions.sumBy { it.score }
-        if (newScore <= 0) {
-            reactionScores.remove(type)
-        } else {
-            reactionScores[type] = newScore
-        }
-    }
-    // clear own reactions
-    ownReactions.clear()
-}
-
-internal fun Message.addReaction(reaction: Reaction, isMine: Boolean, enforceUnique: Boolean = false) {
-
-    // add to own reactions
-    if (isMine) {
-        if (enforceUnique) {
-            clearOwnReactions(reaction.userId)
-        }
-        this.ownReactions.add(reaction)
-    }
-
-    // add to latest reactions
-    this.latestReactions.add(reaction)
-
-    // update the count
-    val currentCount = this.reactionCounts.getOrElse(reaction.type) { 0 }
-    // copy the object so livedata's diffutils can notice a change
-    this.reactionCounts = this.reactionCounts.toMutableMap()
-    this.reactionCounts[reaction.type] = currentCount + 1
-    // update the score
-    val currentScore = this.reactionScores.getOrElse(reaction.type) { 0 }
-    this.reactionScores = this.reactionScores.toMutableMap()
-    this.reactionScores[reaction.type] = currentScore + reaction.score
-}
-
-internal fun Message.removeReaction(reaction: Reaction, updateCounts: Boolean) {
-
-    val countBeforeFilter = ownReactions.size + latestReactions.size
-    ownReactions =
-        ownReactions.filterNot { it.type == reaction.type && it.userId == reaction.userId }
-            .toMutableList()
-    latestReactions =
-        latestReactions.filterNot { it.type == reaction.type && it.userId == reaction.userId }
-            .toMutableList()
-    val countAfterFilter = ownReactions.size + latestReactions.size
-
-    if (updateCounts) {
-        val shouldDecrement =
-            countBeforeFilter > countAfterFilter || this.latestReactions.size >= 15
-        if (shouldDecrement) {
-            this.reactionCounts = this.reactionCounts.toMutableMap()
-            val currentCount = this.reactionCounts.getOrElse(reaction.type) { 1 }
-            val newCount = currentCount - 1
-            this.reactionCounts[reaction.type] = newCount
-            if (newCount <= 0) {
-                reactionCounts.remove(reaction.type)
-            }
-            this.reactionScores = this.reactionScores.toMutableMap()
-            val currentScore = this.reactionScores.getOrElse(reaction.type) { 1 }
-            val newScore = currentScore - reaction.score
-            this.reactionScores[reaction.type] = newScore
-            if (newScore <= 0) {
-                reactionScores.remove(reaction.type)
-            }
-        }
-    }
-}
-
 internal val Channel.lastMessage: Message?
     get() = messages.lastOrNull()
 
@@ -138,7 +55,6 @@ internal fun Channel.updateReads(newRead: ChannelUserRead) {
 
 private const val HTTP_TOO_MANY_REQUESTS = 429
 private const val HTTP_TIMEOUT = 408
-private const val NETWORK_NOT_AVAILABLE = -1
 
 /**
  * Returns true if an error is a permanent failure instead of a temporary one (broken network, 500, rate limit etc.)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/MessageReactionExtensions.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/MessageReactionExtensions.kt
@@ -1,0 +1,82 @@
+package io.getstream.chat.android.livedata.extensions
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Reaction
+
+internal fun Message.addMyReaction(reaction: Reaction, enforceUnique: Boolean = false) {
+    updateReactions {
+        if (enforceUnique) {
+            clearOwnReactions(reaction.userId)
+        }
+        latestReactions.add(reaction)
+        ownReactions.add(reaction)
+        reactionCounts[reaction.type] = reactionCounts.getOrElse(reaction.type) { 0 } + 1
+        reactionScores[reaction.type] = reactionScores.getOrElse(reaction.type) { 0 } + reaction.score
+    }
+}
+
+internal fun Message.removeMyReaction(reaction: Reaction) {
+    updateReactions {
+        latestReactions.removeAll { it.type == reaction.type && it.userId == reaction.userId }
+        val removed = ownReactions.removeAll { it.type == reaction.type && it.userId == reaction.userId }
+
+        if (removed) {
+            val newCount = reactionCounts.getOrElse(reaction.type) { 1 } - 1
+            if (newCount > 0) {
+                reactionCounts[reaction.type] = newCount
+            } else {
+                reactionCounts.remove(reaction.type)
+            }
+
+            val newScore = reactionScores.getOrElse(reaction.type) { 1 } - reaction.score
+            if (newScore > 0) {
+                reactionScores[reaction.type] = newScore
+            } else {
+                reactionScores.remove(reaction.type)
+            }
+        }
+    }
+}
+
+private fun ReactionData.clearOwnReactions(userId: String) {
+    latestReactions.removeAll { it.userId == userId }
+
+    ownReactions.groupBy { it.type }.forEach { (type, reactions) ->
+        val newCount = reactionCounts.getOrElse(type) { 0 } - reactions.size
+        if (newCount > 0) {
+            reactionCounts[type] = newCount
+        } else {
+            reactionCounts.remove(type)
+        }
+
+        val newScore = reactionScores.getOrElse(type) { 0 } - reactions.sumBy { it.score }
+        if (newScore > 0) {
+            reactionScores[type] = newScore
+        } else {
+            reactionScores.remove(type)
+        }
+    }
+    ownReactions.clear()
+}
+
+private inline fun Message.updateReactions(actions: ReactionData.() -> Unit) {
+    // copy objects so that diff utils can notice the change
+    val reactionData = ReactionData(
+        reactionCounts.toMutableMap(),
+        reactionScores.toMutableMap(),
+        latestReactions.toMutableList(),
+        ownReactions.toMutableList(),
+    )
+    reactionData.actions()
+    reactionCounts = reactionData.reactionCounts
+    reactionScores = reactionData.reactionScores
+    latestReactions = reactionData.latestReactions
+    ownReactions = reactionData.ownReactions
+}
+
+private data class ReactionData(
+    val reactionCounts: MutableMap<String, Int>,
+    val reactionScores: MutableMap<String, Int>,
+    val latestReactions: MutableList<Reaction>,
+    val ownReactions: MutableList<Reaction>,
+)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/TestDataHelper.kt
@@ -194,12 +194,24 @@ internal class TestDataHelper {
         cid = channel1.cid; text = "im update now"; id = "message-1"; user =
             user1; createdAt = calendar(2020, 1, 1)
     }
-    val reactionMessage = Message().apply {
-        text = "im update now"; id = "message-1"; user = user1
+    val reactionMessage1 = Message().apply {
+        text = "im update now"
+        id = "message-1"
+        user = user1
         cid = channel1.cid
         reactionScores = mutableMapOf("like" to 10)
-        reactionCounts = mutableMapOf("like" to 1); ownReactions =
-            mutableListOf(reaction1); latestReactions = mutableListOf(reaction1)
+        reactionCounts = mutableMapOf("like" to 1)
+        ownReactions = mutableListOf(reaction1)
+        latestReactions = mutableListOf(reaction1)
+    }
+
+    val reactionMessage2 = Message().apply {
+        text = "im update now"; id = "message-1"; user = user1
+        cid = channel1.cid
+        reactionScores = mutableMapOf("like" to 11)
+        reactionCounts = mutableMapOf("like" to 2)
+        ownReactions = mutableListOf(reaction2)
+        latestReactions = mutableListOf(reaction2, reaction1)
     }
     val message2Older = Message().apply {
         text = "message2"; id = "message-2"; user = user1; createdAt =
@@ -222,8 +234,8 @@ internal class TestDataHelper {
 
     val messageUpdatedEvent = MessageUpdatedEvent(EventType.MESSAGE_UPDATED, Date(), user1, channel1.cid, channel1.type, channel1.id, message1Updated, null)
     val userStartWatchingEvent = UserStartWatchingEvent(EventType.USER_WATCHING_START, Date(), channel1.cid, 1, channel1.type, channel1.id, user1)
-    val reactionEvent = ReactionNewEvent(EventType.REACTION_NEW, Date(), user1, channel1.cid, channel1.type, channel1.id, reactionMessage, reaction1)
-    val reactionEvent2 = ReactionNewEvent(EventType.REACTION_NEW, Date(), user2, channel1.cid, channel1.type, channel1.id, reactionMessage, reaction2)
+    val reactionEvent = ReactionNewEvent(EventType.REACTION_NEW, Date(), user1, channel1.cid, channel1.type, channel1.id, reactionMessage1, reaction1)
+    val reactionEvent2 = ReactionNewEvent(EventType.REACTION_NEW, Date(), user2, channel1.cid, channel1.type, channel1.id, reactionMessage2, reaction2)
 
     val channelUpdatedEvent = ChannelUpdatedEvent(EventType.CHANNEL_UPDATED, Date(), channel1Updated.cid, channel1Updated.type, channel1Updated.id, null, channel1Updated)
     val channelUpdatedEvent2 = ChannelUpdatedEvent(EventType.CHANNEL_UPDATED, Date(), channel5.cid, channel5.type, channel5.id, null, channel5)

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -296,6 +296,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         val reaction = Reaction().apply {
             messageId = message.id
             type = reactionType
+            score = 1
         }
         val currentUserId = ChatDomain.instance().currentUser.id
         if (message.latestReactions.any { it.type == reactionType && it.user?.id == currentUserId }) {


### PR DESCRIPTION
### Description

Motivation:
- `Message.addReaction` in `ClientExtensions` is flawed. For instance, user sends a reaction and `addReaction` method is invoked. In a moment, we receive `reaction.created` event and invoke this method for the second time. As a result, `ownReacitons` contains duplicate entries and counters don't show correct values. Basically this method should "upsert" reactions, which makes its implementation more complex.
- When reaction is sent to the server with `enforce_unique=true` flag, we receive `reaction.updated` event. However, the `enforce_unique=true` flag is not present in the event. Therefore, it is impossible to choose the right strategy to modify reactions of existing message (whether to remove other user reactions or not).

Prerequisites:
According to Mia and Ferhat, messages coming from `reaction.updated`, `reaction.created` and `reaction.deleted` events are fully enriched. It is more reliable to to update the whole message than reactions of a particular message with all the counters.

What's done:
- Renamed `addReaction` and `removeReaction` to `addMyReaction` and `removeMyReaction`. Did a small refactoring of these methods.
- `reaction.updated`, `reaction.created` and `reaction.deleted` now trigger full message update (just like `message.updated` event, excluding the logic of updating the last message)
- Reaction is sent to the server and saved locally with `score=1`, which is the default score the server will return with an event
- `ownReactions` from other user events (e.g. MessageUpdatedEvent) contain information about other user reactions. Had to use proper `ownReactions` of current user from corresponding message fetched from database
- Dropped some code in `ChannelControllerImplReactionsTest`. Sorry for that :)
- Didn't touch diff utils as the current implementation with `reactionCounts` and `reactionScores` seems to cover all possible cases


### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
