### PR TITLE
Creating a default gson instance

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/GsonChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/GsonChatParser.kt
@@ -2,43 +2,14 @@ package io.getstream.chat.android.client.parser
 
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.VisibleForTesting.PRIVATE
-import com.google.gson.ExclusionStrategy
-import com.google.gson.FieldAttributes
 import com.google.gson.Gson
-import com.google.gson.GsonBuilder
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 internal class GsonChatParser : ChatParser {
 
     @VisibleForTesting(otherwise = PRIVATE)
-    val gson: Gson by lazy {
-        GsonBuilder()
-            .registerTypeAdapterFactory(TypeAdapterFactory())
-            .addSerializationExclusionStrategy(
-                object : ExclusionStrategy {
-                    override fun shouldSkipClass(clazz: Class<*>): Boolean {
-                        return false
-                    }
-
-                    override fun shouldSkipField(f: FieldAttributes): Boolean {
-                        return f.getAnnotation(IgnoreSerialisation::class.java) != null
-                    }
-                }
-            )
-            .addDeserializationExclusionStrategy(
-                object : ExclusionStrategy {
-                    override fun shouldSkipClass(clazz: Class<*>): Boolean {
-                        return false
-                    }
-
-                    override fun shouldSkipField(f: FieldAttributes): Boolean {
-                        return f.getAnnotation(IgnoreDeserialisation::class.java) != null
-                    }
-                }
-            )
-            .create()
-    }
+    internal val gson: Gson by lazy { JsonUtils.defaultStreamGson() }
 
     override fun toJson(any: Any): String {
         return gson.toJson(any)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/GsonChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/GsonChatParser.kt
@@ -9,7 +9,7 @@ import retrofit2.converter.gson.GsonConverterFactory
 internal class GsonChatParser : ChatParser {
 
     @VisibleForTesting(otherwise = PRIVATE)
-    internal val gson: Gson by lazy { JsonUtils.defaultStreamGson() }
+    internal val gson: Gson = StreamGson.gson
 
     override fun toJson(any: Any): String {
         return gson.toJson(any)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/JsonUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/JsonUtils.kt
@@ -1,0 +1,39 @@
+package io.getstream.chat.android.client.parser
+
+import com.google.gson.ExclusionStrategy
+import com.google.gson.FieldAttributes
+import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
+@InternalStreamChatApi
+public object JsonUtils {
+
+    public fun defaultStreamGson() : Gson {
+        return GsonBuilder()
+            .registerTypeAdapterFactory(TypeAdapterFactory())
+            .addSerializationExclusionStrategy(
+                object : ExclusionStrategy {
+                    override fun shouldSkipClass(clazz: Class<*>): Boolean {
+                        return false
+                    }
+
+                    override fun shouldSkipField(f: FieldAttributes): Boolean {
+                        return f.getAnnotation(IgnoreSerialisation::class.java) != null
+                    }
+                }
+            )
+            .addDeserializationExclusionStrategy(
+                object : ExclusionStrategy {
+                    override fun shouldSkipClass(clazz: Class<*>): Boolean {
+                        return false
+                    }
+
+                    override fun shouldSkipField(f: FieldAttributes): Boolean {
+                        return f.getAnnotation(IgnoreDeserialisation::class.java) != null
+                    }
+                }
+            )
+            .create()
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/StreamGson.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/StreamGson.kt
@@ -7,10 +7,10 @@ import com.google.gson.GsonBuilder
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 @InternalStreamChatApi
-public object JsonUtils {
+public object StreamGson {
 
-    public fun defaultStreamGson() : Gson {
-        return GsonBuilder()
+    public val gson: Gson by lazy {
+        GsonBuilder()
             .registerTypeAdapterFactory(TypeAdapterFactory())
             .addSerializationExclusionStrategy(
                 object : ExclusionStrategy {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -8,7 +8,6 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.asLiveData
 import androidx.room.Room
-import com.google.gson.Gson
 import io.getstream.chat.android.client.BuildConfig.STREAM_CHAT_VERSION
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
@@ -27,6 +26,7 @@ import io.getstream.chat.android.client.models.Mute
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.parser.JsonUtils
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -72,8 +72,7 @@ private const val MEMBER_LIMIT = 30
 private const val INITIAL_CHANNEL_OFFSET = 0
 private const val CHANNEL_LIMIT = 30
 
-internal val gson = Gson()
-
+internal val gson = JsonUtils.defaultStreamGson()
 /**
  * The Chat Domain exposes livedata objects to make it easier to build your chat UI.
  * It intercepts the various low level events to ensure data stays in sync.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -26,7 +26,7 @@ import io.getstream.chat.android.client.models.Mute
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.client.parser.JsonUtils
+import io.getstream.chat.android.client.parser.StreamGson
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -72,7 +72,7 @@ private const val MEMBER_LIMIT = 30
 private const val INITIAL_CHANNEL_OFFSET = 0
 private const val CHANNEL_LIMIT = 30
 
-internal val gson = JsonUtils.defaultStreamGson()
+internal val gson = StreamGson.gson
 /**
  * The Chat Domain exposes livedata objects to make it easier to build your chat UI.
  * It intercepts the various low level events to ensure data stays in sync.


### PR DESCRIPTION
### Description

This PR creates a default gson instance. As the instace of `gson` of `ChatDomainImpl` doesn't have a exclusion strategy, annotations like `@IgnoreDeserialisation` don't work with this instance. This create problems when setting the update state of an `Attachment` inside a `Message` so it can be upserted with this information. Without the correct exclusing strategy the app breaks with serialization/desarialization expcetion. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- Changelog updated with client-facing changes. **no need**
- New code is covered by unit tests. **no need**
- Comparison screenshots added for visual changes. **no need**
- [x] Reviewers added
