### PR TITLE
Message item  attributes

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
@@ -21,6 +21,7 @@
         android:layout_height="0dp"
         android:layout_marginHorizontal="0dp"
         android:clipToPadding="false"
+        app:streamUiMessageBackgroundColorMine="@color/red"
         app:layout_constraintBottom_toTopOf="@+id/messageInputView"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/DecoratedBaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/DecoratedBaseMessageItemViewHolder.kt
@@ -4,13 +4,15 @@ import android.view.View
 import androidx.annotation.CallSuper
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal abstract class DecoratedBaseMessageItemViewHolder<T : MessageListItem>(
     itemView: View,
     private val decorators: List<Decorator>,
+    private val style: MessageListItemStyle? = null,
 ) : BaseMessageItemViewHolder<T>(itemView) {
     @CallSuper
     override fun bindData(data: T, diff: MessageListItemPayloadDiff?) {
-        decorators.forEach { it.decorate(this, data) }
+        decorators.forEach { it.decorate(this, data, style) }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/MessageListItemViewHolderFactory.kt
@@ -24,10 +24,13 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFil
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.ThreadSeparatorViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.DecoratorProvider
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 public open class MessageListItemViewHolderFactory {
 
     internal lateinit var decoratorProvider: DecoratorProvider
+
+    internal lateinit var messageItemStyle: MessageListItemStyle
 
     protected lateinit var listenerContainer: MessageListListenerContainer
         private set
@@ -85,7 +88,12 @@ public open class MessageListItemViewHolderFactory {
     protected fun createPlainTextViewHolder(
         parentView: ViewGroup,
     ): BaseMessageItemViewHolder<MessageListItem.MessageItem> {
-        return MessagePlainTextViewHolder(parentView, decoratorProvider.decorators, listenerContainer)
+        return MessagePlainTextViewHolder(
+            parentView,
+            decoratorProvider.decorators,
+            listenerContainer,
+            messageItemStyle
+        )
     }
 
     protected fun createPlainTextWithFileAttachmentsViewHolder(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/MessagePlainTextViewHolder.kt
@@ -10,19 +10,21 @@ import io.getstream.chat.android.ui.messages.adapter.DecoratedBaseMessageItemVie
 import io.getstream.chat.android.ui.messages.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.messages.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.messages.adapter.viewholder.decorator.Decorator
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 import io.getstream.chat.android.ui.utils.LongClickFriendlyLinkMovementMethod
 
 internal class MessagePlainTextViewHolder(
     parent: ViewGroup,
     decorators: List<Decorator>,
     listeners: MessageListListenerContainer,
+    style: MessageListItemStyle?,
     internal val binding: StreamUiItemMessagePlainTextBinding =
         StreamUiItemMessagePlainTextBinding.inflate(
             parent.inflater,
             parent,
             false
         ),
-) : DecoratedBaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
+) : DecoratedBaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators, style) {
 
     init {
         binding.run {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/AvatarDecorator.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal class AvatarDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
@@ -22,6 +23,7 @@ internal class AvatarDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?
     ) {
         setupAvatar(viewHolder.binding.avatarView, data)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BackgroundDecorator.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 import io.getstream.chat.android.ui.utils.extensions.dpToPxPrecise
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 import io.getstream.chat.android.ui.utils.extensions.hasText
@@ -38,8 +39,9 @@ internal class BackgroundDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?,
     ) {
-        setDefaultBackgroundDrawable(viewHolder.binding.messageContainer, data)
+        setDefaultBackgroundDrawable(viewHolder.binding.messageContainer, data, style)
     }
 
     override fun decorateOnlyMediaAttachmentsMessage(
@@ -115,7 +117,11 @@ internal class BackgroundDecorator : BaseDecorator() {
             .apply { setTint(ContextCompat.getColor(attachmentView.context, R.color.stream_ui_literal_transparent)) }
     }
 
-    private fun setDefaultBackgroundDrawable(view: View, data: MessageListItem.MessageItem) {
+    private fun setDefaultBackgroundDrawable(
+        view: View,
+        data: MessageListItem.MessageItem,
+        style: MessageListItemStyle? = null,
+    ) {
         val radius = DEFAULT_CORNER_RADIUS
         val bottomRightCorner = if (data.isMine && data.isBottomPosition()) 0f else radius
         val bottomLeftCorner = if (data.isMine.not() && data.isBottomPosition()) 0f else radius
@@ -126,22 +132,22 @@ internal class BackgroundDecorator : BaseDecorator() {
             val hasLink = data.message.attachments.any(Attachment::hasLink)
             if (data.isMine) {
                 paintStyle = Paint.Style.FILL
-                setTint(
-                    ContextCompat.getColor(
-                        view.context,
-                        if (hasLink) MESSAGE_LINK_BACKGROUND else MESSAGE_CURRENT_USER_BACKGROUND
-                    )
-                )
+
+                val backgroundTintColor = if (hasLink) {
+                    ContextCompat.getColor(view.context, MESSAGE_LINK_BACKGROUND)
+                } else style?.messageColorMine ?: ContextCompat.getColor(view.context, MESSAGE_CURRENT_USER_BACKGROUND)
+
+                setTint(backgroundTintColor)
             } else {
                 paintStyle = Paint.Style.FILL_AND_STROKE
                 setStrokeTint(ContextCompat.getColor(view.context, MESSAGE_OTHER_STROKE_COLOR))
                 strokeWidth = DEFAULT_STROKE_WIDTH
-                setTint(
-                    ContextCompat.getColor(
-                        view.context,
-                        if (hasLink) MESSAGE_LINK_BACKGROUND else MESSAGE_OTHER_USER_BACKGROUND
-                    )
-                )
+
+                val backgroundTintColor = if (hasLink) {
+                    ContextCompat.getColor(view.context, MESSAGE_LINK_BACKGROUND)
+                } else style?.messageColorTheirs ?: ContextCompat.getColor(view.context, MESSAGE_OTHER_USER_BACKGROUND)
+
+                setTint(backgroundTintColor)
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BaseDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/BaseDecorator.kt
@@ -11,18 +11,21 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal abstract class BaseDecorator : Decorator {
+
     final override fun <T : MessageListItem> decorate(
         viewHolder: BaseMessageItemViewHolder<T>,
         data: T,
+        style: MessageListItemStyle?,
     ) {
         if (data !is MessageListItem.MessageItem) {
             return
         }
         when (viewHolder) {
             is MessageDeletedViewHolder -> decorateDeletedMessage(viewHolder, data)
-            is MessagePlainTextViewHolder -> decoratePlainTextMessage(viewHolder, data)
+            is MessagePlainTextViewHolder -> decoratePlainTextMessage(viewHolder, data, style)
             is OnlyMediaAttachmentsViewHolder -> decorateOnlyMediaAttachmentsMessage(viewHolder, data)
             is PlainTextWithMediaAttachmentsViewHolder -> decoratePlainTextWithMediaAttachmentsMessage(
                 viewHolder,
@@ -62,6 +65,7 @@ internal abstract class BaseDecorator : Decorator {
     protected abstract fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?,
     )
 
     protected open fun decorateDeletedMessage(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/Decorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/Decorator.kt
@@ -2,7 +2,13 @@ package io.getstream.chat.android.ui.messages.adapter.viewholder.decorator
 
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.ui.messages.adapter.BaseMessageItemViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal interface Decorator {
-    fun <T : MessageListItem> decorate(viewHolder: BaseMessageItemViewHolder<T>, data: T)
+
+    fun <T : MessageListItem> decorate(
+        viewHolder: BaseMessageItemViewHolder<T>,
+        data: T,
+        style: MessageListItemStyle?,
+    )
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FailedIndicatorDecorator.kt
@@ -11,12 +11,14 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal class FailedIndicatorDecorator : BaseDecorator() {
 
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?
     ) {
         setupFailedIndicator(viewHolder.binding.deliveryFailedIcon, data)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FootnoteDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/FootnoteDecorator.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 import io.getstream.chat.android.ui.utils.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.ui.utils.extensions.getUpdatedAtOrNull
 import io.getstream.chat.android.ui.utils.extensions.isDeleted
@@ -82,14 +83,14 @@ internal class FootnoteDecorator(
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
-    ) =
-        setupFootnote(
-            viewHolder.binding.footnote,
-            viewHolder.binding.root,
-            viewHolder.binding.threadGuideline,
-            viewHolder.binding.messageContainer,
-            data,
-        )
+        style: MessageListItemStyle?,
+    ) = setupFootnote(
+        viewHolder.binding.footnote,
+        viewHolder.binding.root,
+        viewHolder.binding.threadGuideline,
+        viewHolder.binding.messageContainer,
+        data,
+    )
 
     override fun decorateGiphyMessage(
         viewHolder: GiphyViewHolder,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/GapDecorator.kt
@@ -9,6 +9,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal class GapDecorator : BaseDecorator() {
 
@@ -28,6 +29,7 @@ internal class GapDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?,
     ) = setupGapView(viewHolder.binding.gapView, data)
 
     override fun decorateOnlyMediaAttachmentsMessage(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/LinkAttachmentDecorator.kt
@@ -14,6 +14,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 import io.getstream.chat.android.ui.utils.extensions.hasLink
 
 internal class LinkAttachmentDecorator : BaseDecorator() {
@@ -44,6 +45,7 @@ internal class LinkAttachmentDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?
     ) {
         applyMaxPossibleWidth(viewHolder.binding.root, viewHolder.binding.messageContainer, data.message)
         decorate(viewHolder.binding.linkAttachmentView, data.message)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/MaxPossibleWidthDecorator.kt
@@ -9,6 +9,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal class MaxPossibleWidthDecorator : BaseDecorator() {
     override fun decorateOnlyMediaAttachmentsMessage(
@@ -21,6 +22,7 @@ internal class MaxPossibleWidthDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?
     ) {
         applyMaxPossibleWidth(viewHolder.binding.marginStart, viewHolder.binding.marginEnd, data)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -15,6 +15,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachm
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.reactions.view.ViewReactionsView
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 import io.getstream.chat.android.ui.utils.extensions.dpToPx
 import io.getstream.chat.android.ui.utils.extensions.hasSingleReaction
 
@@ -23,6 +24,7 @@ internal class ReactionsDecorator : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?,
     ) {
         with(viewHolder.binding) {
             setupReactionsView(root, messageContainer, reactionsSpace, reactionsView, data)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReplyDecorator.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyFileAttachme
 import io.getstream.chat.android.ui.messages.adapter.viewholder.OnlyMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFileAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
+import io.getstream.chat.android.ui.messages.view.MessageListItemStyle
 
 internal class ReplyDecorator(private val currentUser: User) : BaseDecorator() {
     override fun decoratePlainTextWithFileAttachmentsMessage(
@@ -35,6 +36,7 @@ internal class ReplyDecorator(private val currentUser: User) : BaseDecorator() {
     override fun decoratePlainTextMessage(
         viewHolder: MessagePlainTextViewHolder,
         data: MessageListItem.MessageItem,
+        style: MessageListItemStyle?,
     ) = setupReplyView(viewHolder.binding.replyView, data)
 
     override fun decorateGiphyMessage(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListItemStyle.kt
@@ -1,0 +1,40 @@
+package io.getstream.chat.android.ui.messages.view
+
+import android.content.res.TypedArray
+import androidx.annotation.ColorInt
+import androidx.annotation.StyleableRes
+
+internal class MessageListItemStyle private constructor(
+    val messageColorMine: Int,
+    val messageColorTheirs: Int,
+) {
+
+    internal class Builder(private val attributes: TypedArray? = null) {
+        @ColorInt
+        private var messageColorMine: Int = 0
+
+        @ColorInt
+        private var messageColorTheirs: Int = 0
+
+        fun messageBackgroundColorMine(
+            @StyleableRes messageColorMineStyleableId: Int,
+            @ColorInt defaultValue: Int,
+        ) = apply {
+            messageColorMine = attributes?.getColor(messageColorMineStyleableId, defaultValue) ?: defaultValue
+        }
+
+        fun messageBackgroundColorTheirs(
+            @StyleableRes messageColorTheirsStyleableId: Int = 0,
+            @ColorInt defaultValue: Int,
+        ) = apply {
+            messageColorTheirs = attributes?.getColor(messageColorTheirsStyleableId, defaultValue) ?: defaultValue
+        }
+
+        fun build(): MessageListItemStyle {
+            return MessageListItemStyle(
+                messageColorMine,
+                messageColorTheirs
+            )
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -614,6 +614,8 @@ public class MessageListView : ConstraintLayout {
             dateFormatter = messageDateFormatter,
             isDirectMessage = channel.isDirectMessaging()
         )
+
+        messageListItemViewHolderFactory.messageItemStyle = style.itemStyle
         messageListItemViewHolderFactory.setListenerContainer(this.listenerContainer)
 
         adapter = MessageListItemAdapter(messageListItemViewHolderFactory)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListViewStyle.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.ui.utils.extensions.use
 internal class MessageListViewStyle(context: Context, attrs: AttributeSet?) {
 
     internal val scrollButtonViewStyle: ScrollButtonViewStyle
+    internal val itemStyle: MessageListItemStyle
 
     init {
         context.obtainStyledAttributes(
@@ -17,8 +18,8 @@ internal class MessageListViewStyle(context: Context, attrs: AttributeSet?) {
             R.styleable.MessageListView,
             0,
             0
-        ).use {
-            scrollButtonViewStyle = ScrollButtonViewStyle.Builder(it)
+        ).use { attributes ->
+            scrollButtonViewStyle = ScrollButtonViewStyle.Builder(attributes)
                 .scrollButtonEnabled(
                     R.styleable.MessageListView_streamUiScrollButtonEnabled,
                     true
@@ -43,6 +44,17 @@ internal class MessageListViewStyle(context: Context, attrs: AttributeSet?) {
                     R.styleable.MessageListView_streamUiScrollButtonIcon,
                     context.getDrawableCompat(R.drawable.stream_ui_ic_down)
                 ).build()
+
+            itemStyle = MessageListItemStyle.Builder(attributes)
+                .messageBackgroundColorMine(
+                    R.styleable.MessageListView_streamUiMessageBackgroundColorMine,
+                    context.getColorCompat(R.color.stream_ui_grey_gainsboro)
+                )
+                .messageBackgroundColorTheirs(
+                    R.styleable.MessageListView_streamUiMessageBackgroundColorTheirs,
+                    context.getColorCompat(R.color.stream_ui_white)
+                )
+                .build()
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -266,6 +266,14 @@
         <attr name="streamUiDeleteConfirmationEnabled" format="boolean" />
         <attr name="streamUiDeleteConfirmationTitle" format="string" />
         <attr name="streamUiDeleteConfirmationMessage" format="string" />
+
+        <!-- Message text color -->
+        <attr name="streamUiMessageTextColorMine" format="color" />
+        <attr name="streamUiMessageTextColorTheirs" format="color" />
+
+        <!-- Message background color -->
+        <attr name="streamUiMessageBackgroundColorMine" format="color"/>
+        <attr name="streamUiMessageBackgroundColorTheirs" format="color"/>
     </declare-styleable>
 
     <declare-styleable name="ChannelsView">


### PR DESCRIPTION
### Description

A section of our tutorial covers changing plain text message item background colors, but we can't do that with our UI components.

This is just a POC for unblocking me on that section of the tutorial. This seemed like the most straightforward way. I tried style as a constructor dependency for the decorator, but that didn't work well with `MessageOptionsDecoratorProvider`. Definitely looking for ideas and feedback.

### Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Reviewers added
