### PR TITLE
Fix colors and positions on ChatInfo screen

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoItem.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoItem.kt
@@ -28,7 +28,7 @@ sealed class ChatInfoItem {
         abstract val textResId: Int
 
         @get:ColorRes
-        open val tintResId: Int = R.color.grey
+        open val tintResId: Int = R.color.stream_ui_grey
 
         @get:ColorRes
         open val textColorResId: Int = R.color.stream_ui_black

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/header/MessagesHeaderView.kt
@@ -11,6 +11,7 @@ import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
 import androidx.core.view.forEach
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.style.TextStyle
 import io.getstream.chat.android.client.models.Channel
@@ -360,7 +361,7 @@ public class MessagesHeaderView : ConstraintLayout {
         val showAvatar =
             attrs.getBoolean(R.styleable.MessagesHeaderView_streamUiMessagesHeaderShowUserAvatar, true)
         binding.avatar.apply {
-            isVisible = showAvatar
+            isInvisible = !showAvatar
             isClickable = showAvatar
         }
     }


### PR DESCRIPTION
- Change icons tint color on *ChatInfo screens
- Fix title position in MessagesHeaderView when avatar is hidden

| Before | After |
| --- | --- |
|<img width="321" alt="Screenshot 2021-01-29 at 14 44 29" src="https://user-images.githubusercontent.com/17440581/106283849-ba6cfb00-6242-11eb-9ffc-2b2c624bf86c.png">|<img width="329" alt="Screenshot 2021-01-29 at 14 56 45" src="https://user-images.githubusercontent.com/17440581/106283856-bb9e2800-6242-11eb-82dd-fc15b3264274.png">|


### Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Reviewers added
