### PR TITLE
Fix name of MediaAttachmentGridView styleable

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/overview/MediaAttachmentGridView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/overview/MediaAttachmentGridView.kt
@@ -64,8 +64,8 @@ public class MediaAttachmentGridView : FrameLayout {
     }
 
     private fun init(context: Context, attrs: AttributeSet?) {
-        context.obtainStyledAttributes(attrs, R.styleable.StreamUiMediaAttachmentGritView).use {
-            showUserAvatars = it.getBoolean(R.styleable.StreamUiMediaAttachmentGritView_streamUiShowUserAvatars, false)
+        context.obtainStyledAttributes(attrs, R.styleable.MediaAttachmentGridView).use {
+            showUserAvatars = it.getBoolean(R.styleable.MediaAttachmentGridView_streamUiShowUserAvatars, false)
         }
 
         binding.mediaRecyclerView.apply {

--- a/stream-chat-android-ui-components/src/main/res/values/attrs.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs.xml
@@ -277,7 +277,7 @@
         <attr name="streamUiEllipsize" format="boolean" />
     </declare-styleable>
 
-    <declare-styleable name="StreamUiMediaAttachmentGritView">
+    <declare-styleable name="MediaAttachmentGridView">
         <attr name="streamUiShowUserAvatars" format="boolean" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION

### Description

Fix name of styleable to match name of custom view

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
