### PR TITLE
[CAS-552] Channel entity isolation

### DIFF
--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -235,6 +235,7 @@ public final class io/getstream/chat/android/livedata/dao/ChannelDao_Impl : io/g
 	public fun select (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun select (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectSyncNeeded (Lio/getstream/chat/android/client/utils/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun setDeletedAt (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/chat/android/livedata/dao/MessageDao_Impl {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDatabase.kt
@@ -44,7 +44,7 @@ import io.getstream.chat.android.livedata.entity.UserEntity
         CommandInnerEntity::class,
         SyncStateEntity::class
     ],
-    version = 36,
+    version = 37,
     exportSchema = false
 )
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -253,7 +253,7 @@ internal class ChatDomainImpl internal constructor(
 
         database = db ?: createDatabase(appContext, user, offlineEnabled)
 
-        repos = RepositoryHelper(RepositoryFactory(database, client, user), scope)
+        repos = RepositoryHelper(RepositoryFactory(database, user), scope)
 
         // load channel configs from Room into memory
         initJob = scope.async {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.livedata.controller.ChannelControllerImpl
 import io.getstream.chat.android.livedata.controller.QueryChannelsControllerImpl
+import io.getstream.chat.android.livedata.entity.ChannelEntity
 import io.getstream.chat.android.livedata.extensions.applyPagination
 import io.getstream.chat.android.livedata.extensions.isPermanent
 import io.getstream.chat.android.livedata.extensions.users
@@ -680,10 +681,14 @@ internal class ChatDomainImpl internal constructor(
     internal suspend fun retryFailedEntities() {
         delay(1000)
         // retry channels, messages and reactions in that order..
-        val channelEntities = repos.channels.retryChannels()
+        val channels = retryChannels()
         val messages = retryMessages()
         val reactions = retryReactions()
-        logger.logI("Retried ${channelEntities.size} channel entities, ${messages.size} messages and ${reactions.size} reaction entities")
+        logger.logI("Retried ${channels.size} channel entities, ${messages.size} messages and ${reactions.size} reaction entities")
+    }
+
+    private suspend fun retryChannels(): List<ChannelEntity> {
+        return repos.channels.retryChannels()
     }
 
     @VisibleForTesting

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -689,7 +689,8 @@ internal class ChatDomainImpl internal constructor(
         logger.logI("Retried ${channels.size} channel entities, ${messages.size} messages and ${reactions.size} reaction entities")
     }
 
-    private suspend fun retryChannels(): List<Channel> {
+    @VisibleForTesting
+    internal suspend fun retryChannels(): List<Channel> {
         return repos.selectChannelsSyncNeeded().onEach { channel ->
             val result = client.createChannel(
                 channel.type,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -423,7 +423,7 @@ internal class EventHandlerImpl(
                 }
                 is ChannelDeletedEvent -> {
                     domainImpl.repos.messages.deleteChannelMessagesBefore(event.cid, event.createdAt)
-                    domainImpl.repos.channels.select(event.cid)?.let {
+                    domainImpl.repos.selectChannelWithoutMessages(event.cid)?.let {
                         domainImpl.repos.channels.insert(it.apply { deletedAt = event.createdAt })
                     }
                 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -423,9 +423,7 @@ internal class EventHandlerImpl(
                 }
                 is ChannelDeletedEvent -> {
                     domainImpl.repos.messages.deleteChannelMessagesBefore(event.cid, event.createdAt)
-                    domainImpl.repos.selectChannelWithoutMessages(event.cid)?.let {
-                        domainImpl.repos.channels.insert(it.apply { deletedAt = event.createdAt })
-                    }
+                    domainImpl.repos.updateChannelByDeletedDate(event.cid, event.createdAt)
                 }
             }
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -631,14 +631,7 @@ internal class ChannelControllerImpl(
 
         // we insert early to ensure we don't lose messages
         domainImpl.repos.messages.insert(newMessage)
-
-        // TODO make updateLastMessageMethod
-        /*val channelStateEntity = domainImpl.repos.channels.select(newMessage.cid).
-        channelStateEntity?.let {
-            // update channel lastMessage at and lastMessageAt
-            it.updateLastMessage(messageEntity)
-            domainImpl.repos.channels.insert(it)
-        }*/
+        domainImpl.repos.updateLastMessageForChannel(newMessage.cid, newMessage)
 
         return if (online) {
             // upload attachments

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -355,12 +355,11 @@ internal class ChannelControllerImpl(
         setHidden(true)
         val result = channelClient.hide(clearHistory).execute()
         if (result.isSuccess) {
-            val channelEntity = domainImpl.repos.channels.select(cid)
-            channelEntity?.let {
+            domainImpl.repos.selectChannelWithoutMessages(cid)?.let {
                 it.hidden = true
                 if (clearHistory) {
                     val now = Date()
-                    it.hideMessagesBefore = now
+                    it.hiddenMessagesBefore = now
                     hideMessagesBefore = now
                     removeMessagesBefore(now)
                     domainImpl.repos.messages.deleteChannelMessagesBefore(cid, now)
@@ -375,8 +374,7 @@ internal class ChannelControllerImpl(
         setHidden(false)
         val result = channelClient.show().execute()
         if (result.isSuccess) {
-            val channelEntity = domainImpl.repos.channels.select(cid)
-            channelEntity?.let {
+            domainImpl.repos.selectChannelWithoutMessages(cid)?.let {
                 it.hidden = false
                 domainImpl.repos.channels.insert(it)
             }
@@ -634,12 +632,13 @@ internal class ChannelControllerImpl(
         // we insert early to ensure we don't lose messages
         domainImpl.repos.messages.insert(newMessage)
 
-        val channelStateEntity = domainImpl.repos.channels.select(newMessage.cid)
+        // TODO make updateLastMessageMethod
+        /*val channelStateEntity = domainImpl.repos.channels.select(newMessage.cid).
         channelStateEntity?.let {
             // update channel lastMessage at and lastMessageAt
             it.updateLastMessage(messageEntity)
             domainImpl.repos.channels.insert(it)
-        }
+        }*/
 
         return if (online) {
             // upload attachments

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/dao/ChannelDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/dao/ChannelDao.kt
@@ -6,6 +6,7 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.entity.ChannelEntity
+import java.util.Date
 
 @Dao
 internal interface ChannelDao {
@@ -35,4 +36,7 @@ internal interface ChannelDao {
 
     @Query("DELETE from stream_chat_channel_state WHERE cid = :cid")
     suspend fun delete(cid: String)
+
+    @Query("UPDATE stream_chat_channel_state SET deletedAt = :deletedAt WHERE cid = :cid")
+    suspend fun setDeletedAt(cid: String, deletedAt: Date)
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -64,17 +64,4 @@ internal data class ChannelEntity(
 
     /** if the channel has been synced to the servers */
     var syncStatus: SyncStatus = SyncStatus.COMPLETED,
-) {
-    /** updates last message and lastMessageAt on this channel entity */
-    internal fun updateLastMessage(messageEntity: MessageEntity) {
-        val createdAt = messageEntity.messageInnerEntity.createdAt ?: messageEntity.messageInnerEntity.createdLocallyAt
-        val messageEntityCreatedAt = checkNotNull(createdAt) { "created at cant be null, be sure to set message.createdAt" }
-
-        val updateNeeded = messageEntity.messageInnerEntity.id == lastMessageId
-        val newLastMessage = lastMessageAt == null || messageEntityCreatedAt.after(lastMessageAt)
-        if (newLastMessage || updateNeeded) {
-            lastMessageAt = messageEntityCreatedAt
-            lastMessageId = messageEntity.messageInnerEntity.id
-        }
-    }
-}
+)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntity.kt
@@ -7,7 +7,7 @@ import io.getstream.chat.android.client.utils.SyncStatus
 import java.util.Date
 
 /**
- * ChannelStateEntity stores both the channel information as well as references
+ * ChannelEntity stores both the channel information as well as references
  * to all of the channel's state
  *
  * note that we don't store channel watchers or watcher_count.
@@ -18,50 +18,35 @@ import java.util.Date
  */
 @Entity(tableName = "stream_chat_channel_state", indices = [Index(value = ["syncStatus"])])
 internal data class ChannelEntity(
-    var type: String,
-    var channelId: String,
-    val cooldown: Int = 0,
-    @PrimaryKey
-    var cid: String = "%s:%s".format(type, channelId),
-
+    val type: String,
+    val channelId: String,
+    val cooldown: Int,
     /** created by user id */
-    var createdByUserId: String,
-
+    val createdByUserId: String,
     /** if the channel is frozen or not (new messages wont be allowed) */
-    var frozen: Boolean = false,
-
+    val frozen: Boolean,
     /** if the channel is hidden (new messages will cause to reappear) */
-    var hidden: Boolean? = null,
-
+    val hidden: Boolean?,
     /** hide messages before this date */
-    var hideMessagesBefore: Date? = null,
-
+    val hideMessagesBefore: Date?,
     /** till when the channel is muted */
-    var mutedTill: Date? = null,
-
-    /** list of the channel members, can be regular members, moderators or admins */
-    var members: MutableMap<String, MemberEntity> = mutableMapOf(),
-
+    val members: Map<String, MemberEntity>,
     /** list of how far each user has read */
-    var reads: MutableMap<String, ChannelUserReadEntity> = mutableMapOf(),
-
+    val reads: Map<String, ChannelUserReadEntity>,
     /** denormalize the last message date so we can sort on it */
-    var lastMessageAt: Date? = null,
-
-    var lastMessageId: String? = null,
-
+    val lastMessageAt: Date?,
+    val lastMessageId: String?,
     /** when the channel was created */
-    var createdAt: Date? = null,
-
+    val createdAt: Date?,
     /** when the channel was updated */
-    var updatedAt: Date? = null,
-
+    val updatedAt: Date?,
     /** when the channel was deleted */
-    var deletedAt: Date? = null,
-
+    val deletedAt: Date?,
     /** all the custom data provided for this channel */
-    var extraData: MutableMap<String, Any> = mutableMapOf(),
-
+    val extraData: Map<String, Any>,
     /** if the channel has been synced to the servers */
-    var syncStatus: SyncStatus = SyncStatus.COMPLETED,
-)
+    val syncStatus: SyncStatus,
+) {
+    @PrimaryKey
+    var cid: String = "%s:%s".format(type, channelId)
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntityPair.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/entity/ChannelEntityPair.kt
@@ -1,5 +1,0 @@
-package io.getstream.chat.android.livedata.entity
-
-import io.getstream.chat.android.client.models.Channel
-
-internal data class ChannelEntityPair(var channel: Channel, var entity: ChannelEntity)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -51,7 +51,7 @@ internal class ChannelRepository(
         getUser: suspend (userId: String) -> User,
         getMessage: suspend (messageId: String) -> Message?,
     ): List<Channel> {
-        val cachedChannels: MutableList<Channel> = channelCIDs.mapNotNullTo(mutableListOf()) { channelCache.get(it) }
+        val cachedChannels: MutableList<Channel> = channelCIDs.mapNotNullTo(mutableListOf(), channelCache::get)
         val missingChannelIds = channelCIDs.filter { channelCache.get(it) == null }
         val dbChannels = channelDao.select(missingChannelIds).map { it.toModel(getUser, getMessage) }.toMutableList()
         updateCache(dbChannels)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.livedata.repository
 
 import androidx.collection.LruCache
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
@@ -11,13 +10,11 @@ import io.getstream.chat.android.livedata.repository.mapper.toEntity
 import io.getstream.chat.android.livedata.repository.mapper.toModel
 
 internal class ChannelRepository(
-    var channelDao: ChannelDao,
-    var cacheSize: Int = 100,
-    var currentUser: User,
-    var client: ChatClient,
+    private val channelDao: ChannelDao,
+    cacheSize: Int = 100,
 ) {
-    // the channel cache is simple, just keeps the last 100 users in memory
-    var channelCache = LruCache<String, ChannelEntity>(cacheSize)
+    // the channel cache is simple, just keeps the last several users in memory
+    private val channelCache = LruCache<String, ChannelEntity>(cacheSize)
 
     suspend fun insert(channelEntity: ChannelEntity) {
         insert(listOf(channelEntity))

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -67,6 +67,7 @@ internal class ChannelRepository(
     }
 
     internal suspend fun setDeletedAt(cid: String, deletedAt: Date) {
+        channelCache.remove(cid)
         channelDao.setDeletedAt(cid, deletedAt)
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.dao.ChannelDao
 import io.getstream.chat.android.livedata.repository.mapper.toEntity
 import io.getstream.chat.android.livedata.repository.mapper.toModel
+import java.util.Date
 
 internal class ChannelRepository(
     private val channelDao: ChannelDao,
@@ -63,5 +64,9 @@ internal class ChannelRepository(
         getMessage: suspend (messageId: String) -> Message?,
     ): List<Channel> {
         return channelDao.selectSyncNeeded().map { it.toModel(getUser, getMessage) }
+    }
+
+    internal suspend fun setDeletedAt(cid: String, deletedAt: Date) {
+        channelDao.setDeletedAt(cid, deletedAt)
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -3,16 +3,18 @@ package io.getstream.chat.android.livedata.repository
 import androidx.collection.LruCache
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.dao.ChannelDao
 import io.getstream.chat.android.livedata.entity.ChannelEntity
 import io.getstream.chat.android.livedata.repository.mapper.toEntity
+import io.getstream.chat.android.livedata.repository.mapper.toModel
 
 internal class ChannelRepository(
     var channelDao: ChannelDao,
     var cacheSize: Int = 100,
     var currentUser: User,
-    var client: ChatClient
+    var client: ChatClient,
 ) {
     // the channel cache is simple, just keeps the last 100 users in memory
     var channelCache = LruCache<String, ChannelEntity>(cacheSize)
@@ -59,7 +61,10 @@ internal class ChannelRepository(
         return dbChannels
     }
 
-    suspend fun selectSyncNeeded(): List<ChannelEntity> {
-        return channelDao.selectSyncNeeded()
+    internal suspend fun selectSyncNeeded(
+        getUser: suspend (userId: String) -> User,
+        getMessage: suspend (messageId: String) -> Message?,
+    ): List<Channel> {
+        return channelDao.selectSyncNeeded().map { it.toModel(getUser, getMessage) }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/ChannelRepository.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.dao.ChannelDao
-import io.getstream.chat.android.livedata.entity.ChannelEntity
 import io.getstream.chat.android.livedata.repository.mapper.toEntity
 import io.getstream.chat.android.livedata.repository.mapper.toModel
 
@@ -14,26 +13,23 @@ internal class ChannelRepository(
     cacheSize: Int = 100,
 ) {
     // the channel cache is simple, just keeps the last several users in memory
-    private val channelCache = LruCache<String, ChannelEntity>(cacheSize)
+    private val channelCache = LruCache<String, Channel>(cacheSize)
 
-    suspend fun insert(channelEntity: ChannelEntity) {
-        insert(listOf(channelEntity))
+    suspend fun insert(channel: Channel) {
+        updateCache(listOf(channel))
+        channelDao.insert(channel.toEntity())
     }
 
-    private fun updateCache(channelEntities: List<ChannelEntity>) {
-        for (channelEntity in channelEntities) {
-            channelCache.put(channelEntity.cid, channelEntity)
+    private fun updateCache(channels: Collection<Channel>) {
+        for (channel in channels) {
+            channelCache.put(channel.cid, channel)
         }
     }
 
     suspend fun insertChannels(channels: Collection<Channel>) {
-        insert(channels.map(Channel::toEntity))
-    }
-
-    private suspend fun insert(channelEntities: List<ChannelEntity>) {
-        if (channelEntities.isEmpty()) return
-        channelDao.insertMany(channelEntities)
-        updateCache(channelEntities)
+        if (channels.isEmpty()) return
+        updateCache(channels)
+        channelDao.insertMany(channels.map(Channel::toEntity))
     }
 
     suspend fun delete(cid: String) {
@@ -41,18 +37,22 @@ internal class ChannelRepository(
         channelDao.delete(cid)
     }
 
-    suspend fun select(cid: String): ChannelEntity? {
-        return select(listOf(cid)).getOrElse(0) { null }
+    suspend fun select(
+        cid: String,
+        getUser: suspend (userId: String) -> User,
+        getMessage: suspend (messageId: String) -> Message?,
+    ): Channel? {
+        return select(listOf(cid), getUser, getMessage).getOrNull(0)
     }
 
-    suspend fun select(channelCIDs: List<String>): List<ChannelEntity> {
-        val cachedChannels: MutableList<ChannelEntity> = mutableListOf()
-        for (cid in channelCIDs) {
-            val channelEntity = channelCache.get(cid)
-            channelEntity?.let { cachedChannels.add(it) }
-        }
+    suspend fun select(
+        channelCIDs: List<String>,
+        getUser: suspend (userId: String) -> User,
+        getMessage: suspend (messageId: String) -> Message?,
+    ): List<Channel> {
+        val cachedChannels: MutableList<Channel> = channelCIDs.mapNotNullTo(mutableListOf()) { channelCache.get(it) }
         val missingChannelIds = channelCIDs.filter { channelCache.get(it) == null }
-        val dbChannels = channelDao.select(missingChannelIds).toMutableList()
+        val dbChannels = channelDao.select(missingChannelIds).map { it.toModel(getUser, getMessage) }.toMutableList()
         updateCache(dbChannels)
         dbChannels.addAll(cachedChannels)
         return dbChannels

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryFactory.kt
@@ -1,18 +1,15 @@
 package io.getstream.chat.android.livedata.repository
 
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDatabase
 
 internal class RepositoryFactory(
     private val database: ChatDatabase,
-    private val client: ChatClient,
-    private val currentUser: User
+    private val currentUser: User,
 ) {
     fun createUserRepository(): UserRepository = UserRepository(database.userDao(), currentUser, 100)
     fun createChannelConfigRepository(): ChannelConfigRepository = ChannelConfigRepository(database.channelConfigDao())
-    fun createChannelRepository(): ChannelRepository =
-        ChannelRepository(database.channelStateDao(), 100, currentUser, client)
+    fun createChannelRepository(): ChannelRepository = ChannelRepository(database.channelStateDao(), 100)
 
     fun createQueryChannelsRepository(): QueryChannelsRepository = QueryChannelsRepository(database.queryChannelsQDao())
     fun createMessageRepository(): MessageRepository = MessageRepository(database.messageDao(), 100)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
@@ -50,7 +50,7 @@ internal class RepositoryHelper(
 
         // convert the channels
         return channelEntities.map { entity ->
-            entity.toModel(::selectUser) { messages.select(it, ::selectUser) }.apply {
+            entity.toModel(::selectUser, ::selectMessage).apply {
                 config = configsRepository.select(type)?.config ?: defaultConfig
                 messages = messagesMap[cid] ?: messages
             }
@@ -130,6 +130,10 @@ internal class RepositoryHelper(
     suspend fun removeChannel(cid: String) {
         channels.delete(cid)
     }
+
+    suspend fun selectChannelsSyncNeeded(): List<Channel> = channels.selectSyncNeeded(::selectUser, ::selectMessage)
+
+    private suspend fun selectMessage(messageId: String): Message? = messages.select(messageId, ::selectUser)
 
     private suspend fun selectUser(userId: String): User =
         userRepository.select(userId) ?: error("User with the userId: `$userId` has not been found")

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
@@ -55,7 +55,7 @@ internal class RepositoryHelper(
     private fun Channel.enrichChannel(messageMap: Map<String, List<Message>>, defaultConfig: Config) {
         config = configsRepository.select(type)?.config ?: defaultConfig
         messages = if (messageMap.containsKey(cid)) {
-            val fullList = (messageMap[cid] ?: error("")) + messages
+            val fullList = (messageMap[cid] ?: error("Messages must be in the map")) + messages
             fullList.distinct()
         } else {
             messages

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
@@ -98,6 +98,10 @@ internal class RepositoryHelper(
         configsRepository.clearCache()
     }
 
+    internal suspend fun updateChannelByDeletedDate(cid: String, deletedAt: Date) {
+        channels.setDeletedAt(cid, deletedAt)
+    }
+
     internal suspend fun selectMessageSyncNeeded(): List<Message> {
         return messages.selectSyncNeeded(::selectUser)
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/RepositoryHelper.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.extensions.lastMessage
 import io.getstream.chat.android.livedata.extensions.users
 import io.getstream.chat.android.livedata.model.ChannelConfig
-import io.getstream.chat.android.livedata.repository.mapper.toModel
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.livedata.request.isRequestingMoreThanLastMessage
 import kotlinx.coroutines.CoroutineScope
@@ -52,7 +51,8 @@ internal class RepositoryHelper(
         return channels.onEach { it.enrichChannel(messagesMap, defaultConfig) }
     }
 
-    private fun Channel.enrichChannel(messageMap: Map<String, List<Message>>, defaultConfig: Config) {
+    @VisibleForTesting
+    internal fun Channel.enrichChannel(messageMap: Map<String, List<Message>>, defaultConfig: Config) {
         config = configsRepository.select(type)?.config ?: defaultConfig
         messages = if (messageMap.containsKey(cid)) {
             val fullList = (messageMap[cid] ?: error("Messages must be in the map")) + messages

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/mapper/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/mapper/ChannelMapper.kt
@@ -50,7 +50,7 @@ internal suspend fun ChannelEntity.toModel(
     createdAt = createdAt,
     updatedAt = updatedAt,
     deletedAt = deletedAt,
-    extraData = extraData,
+    extraData = extraData.toMutableMap(),
     lastMessageAt = lastMessageAt,
     syncStatus = syncStatus,
     hidden = hidden,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainEventDomainImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainEventDomainImplTest.kt
@@ -56,7 +56,7 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
     @Test
     fun `when you are added to a channel it should be stored in room`() = runBlocking {
         chatDomainImpl.eventHandler.handleEvent(data.notificationAddedToChannel2Event)
-        val channel = chatDomainImpl.repos.channels.select(data.notificationAddedToChannel2Event.channel.cid)
+        val channel = chatDomainImpl.repos.selectChannelWithoutMessages(data.notificationAddedToChannel2Event.channel.cid)
         Truth.assertThat(channel).isNotNull()
     }
 
@@ -91,7 +91,7 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
             chatDomainImpl.eventHandler.handleEvent(data.channelDeletedEvent)
             val message =
                 chatDomainImpl.repos.messages.select(data.newMessageEvent.message.id) { data.userMap[it]!! }
-            val channel = chatDomainImpl.repos.channels.select(data.channel1.cid)
+            val channel = chatDomainImpl.repos.selectChannelWithoutMessages(data.channel1.cid)
             Truth.assertThat(message).isNull()
             Truth.assertThat(channel!!.deletedAt).isEqualTo(data.channelDeletedEvent.createdAt)
             val channelController = chatDomainImpl.channel(data.channel1)
@@ -131,10 +131,10 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
         chatDomainImpl.eventHandler.handleEvent(data.readEvent)
         // check channel level read info
         val cid = data.readEvent.cid
-        val channel = chatDomainImpl.repos.channels.select(cid)
-        Truth.assertThat(channel!!.reads.size).isEqualTo(1)
-        val read = channel.reads.values.first()
-        Truth.assertThat(read.userId).isEqualTo(data.readEvent.user.id)
+        val channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)
+        Truth.assertThat(channel!!.read.size).isEqualTo(1)
+        val read = channel.read.first()
+        Truth.assertThat(read.user.id).isEqualTo(data.readEvent.user.id)
     }
 
     @Test
@@ -171,7 +171,7 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
         chatDomainImpl.eventHandler.handleEvent(data.channelUpdatedEvent)
         // check channel level read info
         val cid = data.channelUpdatedEvent.cid
-        val channel = chatDomainImpl.repos.channels.select(cid)!!
+        val channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)!!
         Truth.assertThat(channel.extraData["color"]).isEqualTo("green")
     }
 
@@ -182,10 +182,10 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
         chatDomainImpl.eventHandler.handleEvent(data.memberAddedToChannelEvent)
         val cid = data.memberAddedToChannelEvent.cid
         // verify that user 2 is now part of the members
-        var channel = chatDomainImpl.repos.channels.select(cid)!!
+        var channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)!!
         Truth.assertThat(channel.members.size).isEqualTo(2)
         chatDomainImpl.eventHandler.handleEvent(data.memberRemovedFromChannel)
-        channel = chatDomainImpl.repos.channels.select(cid)!!
+        channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)!!
         Truth.assertThat(channel.members.size).isEqualTo(1)
     }
 
@@ -196,11 +196,11 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
         chatDomainImpl.eventHandler.handleEvent(data.memberAddedToChannelEvent)
         val cid = data.memberAddedToChannelEvent.cid
         // verify that user 2 is now part of the members
-        var channel = chatDomainImpl.repos.channels.select(cid)!!
+        var channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)!!
         Truth.assertThat(channel.members.size).isEqualTo(2)
         // remove user 1
         chatDomainImpl.eventHandler.handleEvent(data.notificationRemovedFromChannel)
-        channel = chatDomainImpl.repos.channels.select(cid)!!
+        channel = chatDomainImpl.repos.selectChannelWithoutMessages(cid)!!
         Truth.assertThat(channel.members.size).isEqualTo(1)
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ExampleBaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ExampleBaseDomainTest2.kt
@@ -9,7 +9,7 @@ import org.junit.runner.RunWith
 internal class ExampleBaseDomainTest2 : BaseDomainTest2() {
     @Test
     fun `test that room testing setup is configured correctly`(): Unit = runBlocking {
-        chatDomainImpl.repos.channels.select(listOf(data.channel1.cid))
+        chatDomainImpl.repos.selectChannelWithoutMessages(data.channel1.cid)
         queryControllerImpl.query(10)
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
@@ -15,9 +15,6 @@ import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.entity.AttachmentEntity
-import io.getstream.chat.android.livedata.entity.ChannelEntity
-import io.getstream.chat.android.livedata.entity.ChannelUserReadEntity
-import io.getstream.chat.android.livedata.entity.MemberEntity
 import io.getstream.chat.android.livedata.entity.MessageEntity
 import io.getstream.chat.android.livedata.entity.MessageInnerEntity
 import io.getstream.chat.android.livedata.entity.ReactionEntity
@@ -183,46 +180,6 @@ internal fun randomChannel(
     team = team,
     hidden = hidden,
     hiddenMessagesBefore = hiddenMessagesBefore
-)
-
-internal fun randomChannelEntity(
-    type: String = randomString(),
-    channelId: String = randomString(),
-    cooldown: Int = randomInt(),
-    cid: String = randomCID(),
-    createdByUserId: String = randomString(),
-    frozen: Boolean = randomBoolean(),
-    hidden: Boolean? = randomBoolean(),
-    hideMessagesBefore: Date? = randomDate(),
-    mutedTill: Date? = randomDate(),
-    members: MutableMap<String, MemberEntity> = mutableMapOf(),
-    reads: MutableMap<String, ChannelUserReadEntity> = mutableMapOf(),
-    lastMessageAt: Date? = randomDate(),
-    lastMessageId: String? = randomString(),
-    createdAt: Date? = randomDate(),
-    updatedAt: Date? = randomDate(),
-    deletedAt: Date? = randomDate(),
-    extraData: MutableMap<String, Any> = mutableMapOf(),
-    syncStatus: SyncStatus = SyncStatus.COMPLETED,
-): ChannelEntity = ChannelEntity(
-    type = type,
-    channelId = channelId,
-    cooldown = cooldown,
-    cid = cid,
-    createdByUserId = createdByUserId,
-    frozen = frozen,
-    hidden = hidden,
-    hideMessagesBefore = hideMessagesBefore,
-    mutedTill = mutedTill,
-    members = members,
-    reads = reads,
-    lastMessageAt = lastMessageAt,
-    lastMessageId = lastMessageId,
-    createdAt = createdAt,
-    updatedAt = updatedAt,
-    deletedAt = deletedAt,
-    extraData = extraData,
-    syncStatus = syncStatus,
 )
 
 internal fun randomMessageEntity(

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplInsertDomainTest.kt
@@ -77,7 +77,7 @@ internal class ChannelControllerImplInsertDomainTest : BaseConnectedIntegrationT
         val message1 = data.createMessage()
         channelControllerImpl.sendMessage(message1)
         // get the message and channel state both live and offline versions
-        val roomChannel = chatDomainImpl.repos.channels.select(message1.cid)
+        val roomChannel = chatDomainImpl.repos.selectChannelWithoutMessages(message1.cid)
         val liveChannel = channelControllerImpl.toChannel()
         var roomMessages = chatDomainImpl.repos.messages.selectMessagesForChannel(
             message1.cid,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/ChannelRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/ChannelRepositoryTest.kt
@@ -3,20 +3,19 @@ package io.getstream.chat.android.livedata.repository
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import io.getstream.chat.android.livedata.BaseDomainTest2
-import io.getstream.chat.android.livedata.repository.mapper.toModel
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 internal class ChannelRepositoryTest : BaseDomainTest2() {
-    val repo by lazy { chatDomainImpl.repos.channels }
+    private val repo by lazy { helper.channels }
+    private val helper by lazy { chatDomainImpl.repos }
 
     @Test
     fun `inserting a channel and reading it should be equal`() = runBlocking {
         repo.insertChannels(listOf(data.channel1))
-        val entity = repo.select(data.channel1.cid)
-        val channel = entity!!.toModel(getUser = { data.userMap[it]!! }, getMessage = { null })
+        val channel = helper.selectChannelWithoutMessages(data.channel1.cid)!!
         channel.config = data.channel1.config
         channel.watchers = data.channel1.watchers
         channel.watcherCount = data.channel1.watcherCount
@@ -28,7 +27,7 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
     fun `deleting a channel should work`() = runBlocking {
         repo.insertChannels(listOf(data.channel1))
         repo.delete(data.channel1.cid)
-        val entity = repo.select(data.channel1.cid)
+        val entity = helper.selectChannelWithoutMessages(data.channel1.cid)
 
         Truth.assertThat(entity).isNull()
     }
@@ -36,8 +35,7 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
     @Test
     fun `updating a channel should work as intended`() = runBlocking {
         repo.insertChannels(listOf(data.channel1, data.channel1Updated))
-        val entity = repo.select(data.channel1.cid)
-        val channel = entity!!.toModel(getUser = { data.userMap[it]!! }, getMessage = { null })
+        val channel = helper.selectChannelWithoutMessages(data.channel1.cid)!!
 
         // ignore these 4 fields
         channel.config = data.channel1.config

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/ChannelRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/ChannelRepositoryTest.kt
@@ -2,16 +2,9 @@ package io.getstream.chat.android.livedata.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
-import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.doReturn
-import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.BaseDomainTest2
 import io.getstream.chat.android.livedata.repository.mapper.toModel
-import io.getstream.chat.android.test.TestCall
 import kotlinx.coroutines.runBlocking
-import org.amshove.kluent.When
-import org.amshove.kluent.calling
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -52,25 +45,5 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
         channel.watchers = data.channel1Updated.watchers
         channel.watcherCount = data.channel1Updated.watcherCount
         Truth.assertThat(channel).isEqualTo(data.channel1Updated)
-    }
-
-    @Test
-    fun `sync needed is used for our offline to online recovery flow`() = runBlocking {
-        data.channel1.syncStatus = SyncStatus.SYNC_NEEDED
-        data.channel2.syncStatus = SyncStatus.COMPLETED
-
-        repo.insertChannels(listOf(data.channel1, data.channel2))
-
-        var channels = repo.selectSyncNeeded()
-        Truth.assertThat(channels.size).isEqualTo(1)
-        Truth.assertThat(channels.first().syncStatus).isEqualTo(SyncStatus.SYNC_NEEDED)
-
-        When calling clientMock.createChannel(any(), any(), any(), any()) doReturn TestCall(Result(data.channel1))
-        channels = repo.retryChannels()
-        Truth.assertThat(channels.size).isEqualTo(1)
-        Truth.assertThat(channels.first().syncStatus).isEqualTo(SyncStatus.COMPLETED)
-
-        channels = repo.selectSyncNeeded()
-        Truth.assertThat(channels.size).isEqualTo(0)
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
@@ -6,8 +6,10 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Config
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.model.ChannelConfig
 import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
@@ -172,4 +174,31 @@ internal class RepositoryHelperTests {
                 }
             ) was called
         }
+
+    @Test
+    fun `When enrich channel If there is channel config in repo Should update channel by config from repo`() {
+        sut.run {
+            val channel = randomChannel(type = "channelType")
+            val defaultConfig = Config(name = "default")
+            val config = Config(name = "forChannel")
+            When calling configs.select("channelType") doReturn ChannelConfig("channelType", config)
+
+            channel.enrichChannel(emptyMap(), defaultConfig)
+
+            channel.config `should be equal to` config
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there is not channel config in repo Should update channel by default config`() {
+        sut.run {
+            val channel = randomChannel(type = "channelType")
+            val defaultConfig = Config(name = "default")
+            When calling configs.select("channelType") doReturn null
+
+            channel.enrichChannel(emptyMap(), defaultConfig)
+
+            channel.config `should be equal to` defaultConfig
+        }
+    }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/RepositoryHelperTests.kt
@@ -201,4 +201,57 @@ internal class RepositoryHelperTests {
             channel.config `should be equal to` defaultConfig
         }
     }
+
+    @Test
+    fun `When enrich channel If there are messages for channel in the map And channel messages are empty Should update channel with these messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val channel = randomChannel(cid = "cid1")
+            val messageMap = mapOf("cid1" to listOf(message1, message2))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 2
+            channelMessages[0] `should be equal to` message1
+            channelMessages[1] `should be equal to` message2
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there are messages for channel in the map And channel messages are not empty Should update channel with distinct set of messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val message3 = randomMessage()
+            val channel = randomChannel(cid = "cid1", messages = listOf(message1, message3))
+            val messageMap = mapOf("cid1" to listOf(message1, message2))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 3
+            channelMessages[0] `should be equal to` message1
+            channelMessages[1] `should be equal to` message2
+            channelMessages[2] `should be equal to` message3
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there are no messages for channel in the map Should not update channel messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val message3 = randomMessage()
+            val channel = randomChannel(cid = "cid1", messages = listOf(message1))
+            val messageMap = mapOf("cid2" to listOf(message2, message3))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 1
+            channelMessages[0] `should be equal to` message1
+        }
+    }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/BaseRepositoryHelperTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/BaseRepositoryHelperTest.kt
@@ -1,0 +1,55 @@
+package io.getstream.chat.android.livedata.repository.helper
+
+import androidx.annotation.CallSuper
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.getstream.chat.android.livedata.repository.ChannelConfigRepository
+import io.getstream.chat.android.livedata.repository.ChannelRepository
+import io.getstream.chat.android.livedata.repository.MessageRepository
+import io.getstream.chat.android.livedata.repository.QueryChannelsRepository
+import io.getstream.chat.android.livedata.repository.ReactionRepository
+import io.getstream.chat.android.livedata.repository.RepositoryFactory
+import io.getstream.chat.android.livedata.repository.RepositoryHelper
+import io.getstream.chat.android.livedata.repository.SyncStateRepository
+import io.getstream.chat.android.livedata.repository.UserRepository
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.jupiter.api.BeforeEach
+
+@ExperimentalCoroutinesApi
+internal open class BaseRepositoryHelperTest {
+
+    protected lateinit var users: UserRepository
+    protected lateinit var configs: ChannelConfigRepository
+    protected lateinit var channels: ChannelRepository
+    protected lateinit var queryChannels: QueryChannelsRepository
+    protected lateinit var messages: MessageRepository
+    protected lateinit var reactions: ReactionRepository
+    protected lateinit var syncState: SyncStateRepository
+
+    protected val scope = TestCoroutineScope()
+
+    protected lateinit var sut: RepositoryHelper
+
+    @CallSuper
+    @BeforeEach
+    fun setUp() {
+        users = mock()
+        configs = mock()
+        channels = mock()
+        queryChannels = mock()
+        messages = mock()
+        reactions = mock()
+        syncState = mock()
+        val factory: RepositoryFactory = mock {
+            on { createUserRepository() } doReturn users
+            on { createChannelConfigRepository() } doReturn configs
+            on { createChannelRepository() } doReturn channels
+            on { createQueryChannelsRepository() } doReturn queryChannels
+            on { createMessageRepository() } doReturn messages
+            on { createReactionRepository() } doReturn reactions
+            on { createSyncStateRepository() } doReturn syncState
+        }
+        sut = RepositoryHelper(factory, scope)
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
@@ -13,19 +13,9 @@ import io.getstream.chat.android.livedata.model.ChannelConfig
 import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
-import io.getstream.chat.android.livedata.repository.ChannelConfigRepository
-import io.getstream.chat.android.livedata.repository.ChannelRepository
-import io.getstream.chat.android.livedata.repository.MessageRepository
-import io.getstream.chat.android.livedata.repository.QueryChannelsRepository
-import io.getstream.chat.android.livedata.repository.ReactionRepository
-import io.getstream.chat.android.livedata.repository.RepositoryFactory
-import io.getstream.chat.android.livedata.repository.RepositoryHelper
-import io.getstream.chat.android.livedata.repository.SyncStateRepository
-import io.getstream.chat.android.livedata.repository.UserRepository
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.test.positiveRandomInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.Verify
 import org.amshove.kluent.When
@@ -37,44 +27,10 @@ import org.amshove.kluent.on
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.that
 import org.amshove.kluent.was
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
-internal class RepositoryHelperTests {
-
-    private lateinit var users: UserRepository
-    private lateinit var configs: ChannelConfigRepository
-    private lateinit var channels: ChannelRepository
-    private lateinit var queryChannels: QueryChannelsRepository
-    private lateinit var messages: MessageRepository
-    private lateinit var reactions: ReactionRepository
-    private lateinit var syncState: SyncStateRepository
-
-    private val scope = TestCoroutineScope()
-
-    private lateinit var sut: RepositoryHelper
-
-    @BeforeEach
-    fun setUp() {
-        users = mock()
-        configs = mock()
-        channels = mock()
-        queryChannels = mock()
-        messages = mock()
-        reactions = mock()
-        syncState = mock()
-        val factory: RepositoryFactory = mock {
-            on { createUserRepository() } doReturn users
-            on { createChannelConfigRepository() } doReturn configs
-            on { createChannelRepository() } doReturn channels
-            on { createQueryChannelsRepository() } doReturn queryChannels
-            on { createMessageRepository() } doReturn messages
-            on { createReactionRepository() } doReturn reactions
-            on { createSyncStateRepository() } doReturn syncState
-        }
-        sut = RepositoryHelper(factory, scope)
-    }
+internal class RepositoryHelperTests : BaseRepositoryHelperTest() {
 
     @Test
     fun `Given request less than last message When select channels Should return channels from DB with empty messages`() =

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
@@ -6,10 +6,8 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
-import io.getstream.chat.android.client.models.Config
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.livedata.model.ChannelConfig
 import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
@@ -139,84 +137,4 @@ internal class RepositoryHelperTests : BaseRepositoryHelperTest() {
                 }
             ) was called
         }
-
-    @Test
-    fun `When enrich channel If there is channel config in repo Should update channel by config from repo`() {
-        sut.run {
-            val channel = randomChannel(type = "channelType")
-            val defaultConfig = Config(name = "default")
-            val config = Config(name = "forChannel")
-            When calling configs.select("channelType") doReturn ChannelConfig("channelType", config)
-
-            channel.enrichChannel(emptyMap(), defaultConfig)
-
-            channel.config `should be equal to` config
-        }
-    }
-
-    @Test
-    fun `When enrich channel If there is not channel config in repo Should update channel by default config`() {
-        sut.run {
-            val channel = randomChannel(type = "channelType")
-            val defaultConfig = Config(name = "default")
-            When calling configs.select("channelType") doReturn null
-
-            channel.enrichChannel(emptyMap(), defaultConfig)
-
-            channel.config `should be equal to` defaultConfig
-        }
-    }
-
-    @Test
-    fun `When enrich channel If there are messages for channel in the map And channel messages are empty Should update channel with these messages`() {
-        sut.run {
-            val message1 = randomMessage()
-            val message2 = randomMessage()
-            val channel = randomChannel(cid = "cid1")
-            val messageMap = mapOf("cid1" to listOf(message1, message2))
-
-            channel.enrichChannel(messageMap, Config())
-
-            val channelMessages = channel.messages
-            channelMessages.size `should be equal to` 2
-            channelMessages[0] `should be equal to` message1
-            channelMessages[1] `should be equal to` message2
-        }
-    }
-
-    @Test
-    fun `When enrich channel If there are messages for channel in the map And channel messages are not empty Should update channel with distinct set of messages`() {
-        sut.run {
-            val message1 = randomMessage()
-            val message2 = randomMessage()
-            val message3 = randomMessage()
-            val channel = randomChannel(cid = "cid1", messages = listOf(message1, message3))
-            val messageMap = mapOf("cid1" to listOf(message1, message2))
-
-            channel.enrichChannel(messageMap, Config())
-
-            val channelMessages = channel.messages
-            channelMessages.size `should be equal to` 3
-            channelMessages[0] `should be equal to` message1
-            channelMessages[1] `should be equal to` message2
-            channelMessages[2] `should be equal to` message3
-        }
-    }
-
-    @Test
-    fun `When enrich channel If there are no messages for channel in the map Should not update channel messages`() {
-        sut.run {
-            val message1 = randomMessage()
-            val message2 = randomMessage()
-            val message3 = randomMessage()
-            val channel = randomChannel(cid = "cid1", messages = listOf(message1))
-            val messageMap = mapOf("cid2" to listOf(message2, message3))
-
-            channel.enrichChannel(messageMap, Config())
-
-            val channelMessages = channel.messages
-            channelMessages.size `should be equal to` 1
-            channelMessages[0] `should be equal to` message1
-        }
-    }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/RepositoryHelperTests.kt
@@ -1,4 +1,4 @@
-package io.getstream.chat.android.livedata.repository
+package io.getstream.chat.android.livedata.repository.helper
 
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -13,6 +13,15 @@ import io.getstream.chat.android.livedata.model.ChannelConfig
 import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
+import io.getstream.chat.android.livedata.repository.ChannelConfigRepository
+import io.getstream.chat.android.livedata.repository.ChannelRepository
+import io.getstream.chat.android.livedata.repository.MessageRepository
+import io.getstream.chat.android.livedata.repository.QueryChannelsRepository
+import io.getstream.chat.android.livedata.repository.ReactionRepository
+import io.getstream.chat.android.livedata.repository.RepositoryFactory
+import io.getstream.chat.android.livedata.repository.RepositoryHelper
+import io.getstream.chat.android.livedata.repository.SyncStateRepository
+import io.getstream.chat.android.livedata.repository.UserRepository
 import io.getstream.chat.android.livedata.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.test.positiveRandomInt
 import kotlinx.coroutines.ExperimentalCoroutinesApi

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenEnrichChannel.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenEnrichChannel.kt
@@ -1,0 +1,96 @@
+package io.getstream.chat.android.livedata.repository.helper
+
+import com.nhaarman.mockitokotlin2.doReturn
+import io.getstream.chat.android.client.models.Config
+import io.getstream.chat.android.livedata.model.ChannelConfig
+import io.getstream.chat.android.livedata.randomChannel
+import io.getstream.chat.android.livedata.randomMessage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import org.amshove.kluent.When
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.calling
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
+
+    @Test
+    fun `When enrich channel If there is channel config in repo Should update channel by config from repo`() {
+        sut.run {
+            val channel = randomChannel(type = "channelType")
+            val defaultConfig = Config(name = "default")
+            val config = Config(name = "forChannel")
+            When calling configs.select("channelType") doReturn ChannelConfig("channelType", config)
+
+            channel.enrichChannel(emptyMap(), defaultConfig)
+
+            channel.config `should be equal to` config
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there is not channel config in repo Should update channel by default config`() {
+        sut.run {
+            val channel = randomChannel(type = "channelType")
+            val defaultConfig = Config(name = "default")
+            When calling configs.select("channelType") doReturn null
+
+            channel.enrichChannel(emptyMap(), defaultConfig)
+
+            channel.config `should be equal to` defaultConfig
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there are messages for channel in the map And channel messages are empty Should update channel with these messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val channel = randomChannel(cid = "cid1")
+            val messageMap = mapOf("cid1" to listOf(message1, message2))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 2
+            channelMessages[0] `should be equal to` message1
+            channelMessages[1] `should be equal to` message2
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there are messages for channel in the map And channel messages are not empty Should update channel with distinct set of messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val message3 = randomMessage()
+            val channel = randomChannel(cid = "cid1", messages = listOf(message1, message3))
+            val messageMap = mapOf("cid1" to listOf(message1, message2))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 3
+            channelMessages[0] `should be equal to` message1
+            channelMessages[1] `should be equal to` message2
+            channelMessages[2] `should be equal to` message3
+        }
+    }
+
+    @Test
+    fun `When enrich channel If there are no messages for channel in the map Should not update channel messages`() {
+        sut.run {
+            val message1 = randomMessage()
+            val message2 = randomMessage()
+            val message3 = randomMessage()
+            val channel = randomChannel(cid = "cid1", messages = listOf(message1))
+            val messageMap = mapOf("cid2" to listOf(message2, message3))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 1
+            channelMessages[0] `should be equal to` message1
+        }
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenEnrichChannel.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenEnrichChannel.kt
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test
 internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
 
     @Test
-    fun `When enrich channel If there is channel config in repo Should update channel by config from repo`() {
+    fun `Given a channel config in repo Should update channel by config from repo`() {
         sut.run {
             val channel = randomChannel(type = "channelType")
             val defaultConfig = Config(name = "default")
@@ -29,7 +29,7 @@ internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
     }
 
     @Test
-    fun `When enrich channel If there is not channel config in repo Should update channel by default config`() {
+    fun `Given no channel config in repo Should update channel by default config`() {
         sut.run {
             val channel = randomChannel(type = "channelType")
             val defaultConfig = Config(name = "default")
@@ -42,7 +42,7 @@ internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
     }
 
     @Test
-    fun `When enrich channel If there are messages for channel in the map And channel messages are empty Should update channel with these messages`() {
+    fun `Given messages for channel in the map And channel messages are empty Should update channel with these messages`() {
         sut.run {
             val message1 = randomMessage()
             val message2 = randomMessage()
@@ -59,7 +59,7 @@ internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
     }
 
     @Test
-    fun `When enrich channel If there are messages for channel in the map And channel messages are not empty Should update channel with distinct set of messages`() {
+    fun `Given messages for channel in the map And channel messages are not empty Should update channel with distinct set of messages`() {
         sut.run {
             val message1 = randomMessage()
             val message2 = randomMessage()
@@ -78,7 +78,7 @@ internal class WhenEnrichChannel : BaseRepositoryHelperTest() {
     }
 
     @Test
-    fun `When enrich channel If there are no messages for channel in the map Should not update channel messages`() {
+    fun `Given no messages for channel in the map Should not update channel messages`() {
         sut.run {
             val message1 = randomMessage()
             val message2 = randomMessage()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenUpdateLastMessage.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenUpdateLastMessage.kt
@@ -1,0 +1,27 @@
+package io.getstream.chat.android.livedata.repository.helper
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import io.getstream.chat.android.livedata.randomMessage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.VerifyNotCalled
+import org.amshove.kluent.When
+import org.amshove.kluent.any
+import org.amshove.kluent.calling
+import org.amshove.kluent.on
+import org.amshove.kluent.that
+import org.junit.jupiter.api.Test
+
+@ExperimentalCoroutinesApi
+internal class WhenUpdateLastMessage : BaseRepositoryHelperTest() {
+
+    @Test
+    fun `Given no channel in DB Should not do insert`() = runBlockingTest {
+        When calling channels.select(eq("cid"), any(), any()) doReturn null
+
+        sut.updateLastMessageForChannel("cid", randomMessage())
+
+        VerifyNotCalled on channels that channels.insert(any())
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenUpdateLastMessage.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/repository/helper/WhenUpdateLastMessage.kt
@@ -1,17 +1,25 @@
 package io.getstream.chat.android.livedata.repository.helper
 
+import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
+import io.getstream.chat.android.livedata.extensions.lastMessage
+import io.getstream.chat.android.livedata.randomChannel
 import io.getstream.chat.android.livedata.randomMessage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
+import org.amshove.kluent.Verify
 import org.amshove.kluent.VerifyNotCalled
 import org.amshove.kluent.When
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.any
+import org.amshove.kluent.called
 import org.amshove.kluent.calling
 import org.amshove.kluent.on
 import org.amshove.kluent.that
+import org.amshove.kluent.was
 import org.junit.jupiter.api.Test
+import java.util.Date
 
 @ExperimentalCoroutinesApi
 internal class WhenUpdateLastMessage : BaseRepositoryHelperTest() {
@@ -21,6 +29,62 @@ internal class WhenUpdateLastMessage : BaseRepositoryHelperTest() {
         When calling channels.select(eq("cid"), any(), any()) doReturn null
 
         sut.updateLastMessageForChannel("cid", randomMessage())
+
+        VerifyNotCalled on channels that channels.insert(any())
+    }
+
+    @Test
+    fun `Given channel without messages in DB Should insert channel with updated last message`() = runBlockingTest {
+        val channel = randomChannel(messages = emptyList())
+        val lastMessage = randomMessage(createdAt = Date())
+        When calling channels.select(eq("cid"), any(), any()) doReturn channel
+
+        sut.updateLastMessageForChannel("cid", lastMessage)
+
+        channel.lastMessageAt `should be equal to` lastMessage.createdAt
+        channel.lastMessage `should be equal to` lastMessage
+        Verify on channels that channels.insert(eq(channel)) was called
+    }
+
+    @Test
+    fun `Given channel without lastMessageAt in DB Should insert channel with updated last message at`() = runBlockingTest {
+        val channel = randomChannel(messages = listOf(randomMessage()), lastMessageAt = null)
+        val lastMessage = randomMessage(createdAt = Date())
+        When calling channels.select(eq("cid"), any(), any()) doReturn channel
+
+        sut.updateLastMessageForChannel("cid", lastMessage)
+
+        channel.lastMessageAt `should be equal to` lastMessage.createdAt
+        channel.lastMessage `should be equal to` lastMessage
+        Verify on channels that channels.insert(argThat { lastMessageAt == lastMessage.createdAt }) was called
+    }
+
+    @Test
+    fun `Given channel with outdated lastMessage in DB Should insert channel with updated last message`() = runBlockingTest {
+        val before = Date(1000)
+        val after = Date(2000)
+        val outdatedMessage = randomMessage(id = "messageId1", createdAt = before)
+        val newLastMessage = randomMessage(id = "messageId2", createdAt = after)
+        val channel = randomChannel(messages = listOf(outdatedMessage), lastMessageAt = before)
+        When calling channels.select(eq("cid"), any(), any()) doReturn channel
+
+        sut.updateLastMessageForChannel("cid", newLastMessage)
+
+        channel.lastMessageAt `should be equal to` newLastMessage.createdAt
+        channel.lastMessage `should be equal to` newLastMessage
+        Verify on channels that channels.insert(argThat { lastMessageAt == after }) was called
+    }
+
+    @Test
+    fun `Given channel with actual lastMessage in DB Should not insert any channel`() = runBlockingTest {
+        val before = Date(1000)
+        val after = Date(2000)
+        val outdatedMessage = randomMessage(id = "messageId1", createdAt = before)
+        val newLastMessage = randomMessage(id = "messageId2", createdAt = after)
+        val channel = randomChannel(messages = listOf(newLastMessage), lastMessageAt = after)
+        When calling channels.select(eq("cid"), any(), any()) doReturn channel
+
+        sut.updateLastMessageForChannel("cid", outdatedMessage)
 
         VerifyNotCalled on channels that channels.insert(any())
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/HideChannelImplTest.kt
@@ -5,7 +5,6 @@ import com.google.common.truth.Truth
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
 import io.getstream.chat.android.livedata.controller.QueryChannelsSpec
-import io.getstream.chat.android.livedata.repository.mapper.toEntity
 import io.getstream.chat.android.livedata.request.QueryChannelsPaginationRequest
 import io.getstream.chat.android.test.getOrAwaitValue
 import kotlinx.coroutines.runBlocking
@@ -18,9 +17,9 @@ internal class HideChannelImplTest : BaseConnectedIntegrationTest() {
 
     @Test
     fun loadHidden() = runBlocking {
-        val channelEntity = data.channel1.toEntity()
-        channelEntity.hidden = true
-        chatDomainImpl.repos.channels.insert(channelEntity)
+        val channel = data.channel1
+        channel.hidden = true
+        chatDomainImpl.repos.channels.insert(channel)
         // setup the channel controller
         val channelController = chatDomain.useCases.watchChannel(data.channel1.cid, 0).execute().data()
         val channelControllerImpl = chatDomainImpl.channel(data.channel1.cid)
@@ -32,9 +31,9 @@ internal class HideChannelImplTest : BaseConnectedIntegrationTest() {
     @Test
     fun loadHiddenQueryChannels() = runBlocking {
         // insert the channel and queryChannelsResult
-        val channelEntity = data.channel1.toEntity()
-        channelEntity.hidden = true
-        chatDomainImpl.repos.channels.insert(channelEntity)
+        val channel = data.channel1
+        channel.hidden = true
+        chatDomainImpl.repos.channels.insert(channel)
         val query = QueryChannelsSpec(data.filter1, QuerySort(), listOf(data.channel1.cid))
         chatDomainImpl.repos.queryChannels.insert(query)
 
@@ -43,8 +42,8 @@ internal class HideChannelImplTest : BaseConnectedIntegrationTest() {
         val channels = queryChannelsControllerImpl.runQueryOffline(QueryChannelsPaginationRequest(QuerySort(), 0, 30, 10, 0))
 
         // verify we have 1 channel in the result list and that it's hidden
-        val channel = channels?.firstOrNull { it.cid == data.channel1.cid }
-        Truth.assertThat(channel?.hidden).isTrue()
+        val localChannel = channels?.firstOrNull { it.cid == data.channel1.cid }
+        Truth.assertThat(localChannel?.hidden).isTrue()
     }
 
     @Test


### PR DESCRIPTION
### Description

**Goal:** "Isolate ChannelEntity usage in ChannelDao/ChannelRepository only"

**What done:**
1) Remove usage ChannelEntity from business logic
2) Rewrite ChannelRepository methods in order to use only models
3) Move logic from ChannelEntity to RepositoryHelper
4) Add update methods to DAO 
5) Refactor ChannelEntity structure. Remove unused field `mutedTill`
6) Add several tests to cover new logic in RepositoryHelper

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
