### PR TITLE
[CAS-245] Adding InProgress as status before view type is requested

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -599,16 +599,16 @@ internal class ChannelControllerImpl(
 
         newMessage.user = domainImpl.currentUser
 
+        newMessage.attachments.forEach { attachment ->
+            attachment.uploadId = generateUploadId()
+            attachment.uploadState = Attachment.UploadState.InProgress
+        }
+
         newMessage.type = getMessageType(message)
         newMessage.createdLocallyAt = newMessage.createdAt ?: newMessage.createdLocallyAt ?: Date()
         newMessage.syncStatus = SyncStatus.IN_PROGRESS
         if (!online) {
             newMessage.syncStatus = SyncStatus.SYNC_NEEDED
-        }
-
-        newMessage.attachments.forEach { attachment ->
-            attachment.uploadId = generateUploadId()
-            attachment.uploadState = Attachment.UploadState.InProgress
         }
 
         val attachmentProgressList = newMessage.attachments.map { attachment ->

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessagesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessagesTest.kt
@@ -93,11 +93,7 @@ internal class SendMessagesTest {
             (it.arguments[0] as () -> Call<Message>).invoke().execute()
         }
 
-        val attachments = randomAttachmentsWithFile()
-            .map { attachment ->
-                attachment.apply { this.uploadState = Attachment.UploadState.InProgress }
-            }
-            .toMutableList()
+        val attachments = randomAttachmentsWithFile().toMutableList()
         val files: List<File> = attachments.map { it.upload!! }
 
         mockFileUploadsFailure(files)


### PR DESCRIPTION
[CAS-245](https://stream-io.atlassian.net/browse/CAS-245)

### Description

Fixing crash in the progress attachment. If the `uploadState` for the `attachments` if set after the `getMessageType`, it doesn't become ephemeral and then it can't be canceled. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
-  ~Changelog updated with client-facing changes~
-  ~New code is covered by unit tests~
- ~Comparison screenshots added for visual changes~
- [x] Reviewers added
