### PR TITLE
Fix showing GIFs

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
@@ -49,7 +49,7 @@ public open class AttachmentDestination(
                 }
             }
             ModelType.attach_video -> url = attachment.assetUrl
-            ModelType.attach_giphy -> url = attachment.assetUrl
+            ModelType.attach_giphy -> url = attachment.thumbUrl
             ModelType.attach_product -> url = attachment.url
         }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
@@ -33,12 +33,19 @@ public open class AttachmentDestination(
                 return
             }
             ModelType.attach_image -> {
-                if (attachment.ogUrl != null) {
-                    url = attachment.ogUrl
-                    type = ModelType.attach_link
-                } else {
-                    showImageViewer(message, attachment)
-                    return
+                when {
+                    attachment.ogUrl != null -> {
+                        url = attachment.ogUrl
+                        type = ModelType.attach_link
+                    }
+                    attachment.isGif() -> {
+                        url = attachment.imageUrl
+                        type = ModelType.attach_giphy
+                    }
+                    else -> {
+                        showImageViewer(message, attachment)
+                        return
+                    }
                 }
             }
             ModelType.attach_video -> url = attachment.assetUrl
@@ -97,7 +104,7 @@ public open class AttachmentDestination(
 
     protected open fun showImageViewer(
         message: Message,
-        attachment: Attachment
+        attachment: Attachment,
     ) {
         val imageUrls: List<String> = message.attachments
             .filter { it.type == ModelType.attach_image && !it.imageUrl.isNullOrEmpty() }
@@ -116,4 +123,6 @@ public open class AttachmentDestination(
             )
             .show()
     }
+
+    private fun Attachment.isGif() = mimeType?.contains("gif") ?: false
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/roundedImageView/PorterImageView.java
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/roundedImageView/PorterImageView.java
@@ -103,10 +103,11 @@ public abstract class PorterImageView extends AppCompatImageView {
         if (!isInEditMode()) {
             int saveCount = canvas.saveLayer(0.0f, 0.0f, getWidth(), getHeight(), null, Canvas.ALL_SAVE_FLAG);
             try {
-                if (invalidated) {
+                boolean invalidatedCopy = invalidated;
+                if (invalidatedCopy) {
                     Drawable drawable = getDrawable();
                     if (drawable != null) {
-                        invalidated = false;
+                        invalidatedCopy = false;
                         Matrix imageMatrix = getImageMatrix();
                         if (imageMatrix == null) {// && mPaddingTop == 0 && mPaddingLeft == 0) {
                             drawable.draw(drawableCanvas);
@@ -126,7 +127,7 @@ public abstract class PorterImageView extends AppCompatImageView {
                     }
                 }
 
-                if (!invalidated) {
+                if (!invalidatedCopy) {
                     drawablePaint.setXfermode(null);
                     canvas.drawBitmap(drawableBitmap, 0.0f, 0.0f, drawablePaint);
                 }


### PR DESCRIPTION
GIFs weren't appropriately rendered because `PorterImageView` usage. It turned out that `PorterImageView` renders drawable only if the view needs to be [invalidated](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/roundedImageView/PorterImageView.java#L129) (based on `invalidate` flag). The flag is changed to [false](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/roundedImageView/PorterImageView.java#L109) when drawable to render is non-null, but the main problem is that the flag can be changed during `onDraw` method invocation (that happens every time when [invalidate](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/roundedImageView/PorterImageView.java#L70) method is called) :(
The problem was resolved by introducing `invalidate` flag local copy, but this is rather a workaround and we should think about replacing`PorterImageView`.
PR also fixes displaying GIFs after clicking on attachment:
1. It turned out that Giphy attachment contains only `thumbURL`
2. We don't support animated images inside `ImageViewer`

| Before | After |
| --- | --- |
|<img width="325" alt="Screenshot 2021-02-03 at 17 02 46" src="https://user-images.githubusercontent.com/17440581/106773926-e2dd6680-6641-11eb-9b1b-4fc94fb484eb.png">|https://user-images.githubusercontent.com/17440581/106773905-de18b280-6641-11eb-9328-3eea1ab53d9d.mp4|

closes #1315 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
