### PR TITLE
Fix sendImage being a no-op

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,13 +1,13 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
--. `ChatUtils::devToken` is not accesible anymore, it has been moved to `ChatClient::devToken`
+-. `ChatUtils::devToken` is not accessible anymore, it has been moved to `ChatClient::devToken`
 
 ## stream-chat-android-client
 - Add support for typing events in threads:
     - Add `parentId` to `TypingStartEvent` and `TypingStopEvent`
     - Add `parentId` to ``ChannelClient::keystroke` and `ChannelClient::stopTyping`
-- `ChatClient::sendFile` is merged into one variation with `ProgressCallback` as an optional parameter. Now the method returns `Call<String>`, the option with asyonchronous call with no return is removed. 
+- `ChatClient::sendFile` and `ChatClient::sendImage` each now have just one definition with `ProgressCallback` as an optional parameter. These methods both return `Call<String>`, allowing for sync/async execution, and error handling. The old overloads that were asynchronous and returned no value/error have been removed.
 - `FileUploader::sendFile` and `FileUploader::sendImages` variations with `ProgressCallback` are no longer async with no return type. Now they are synchronous with `String?` as return type
 
 ## stream-chat-android-offline

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -84,8 +84,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public static synthetic fun sendEvent$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun sendFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
-	public final fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/chat/android/client/call/Call;
-	public final fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)V
+	public final fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun sendImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendMessage (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendReaction (Lio/getstream/chat/android/client/models/Reaction;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendReaction (Lio/getstream/chat/android/client/models/Reaction;Z)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -214,13 +214,14 @@ public class ChatClient internal constructor(
         return api.sendFile(channelType, channelId, file, callback)
     }
 
+    @CheckResult
     public fun sendImage(
         channelType: String,
         channelId: String,
         file: File,
-        callback: ProgressCallback,
-    ) {
-        api.sendImage(channelType, channelId, file, callback)
+        callback: ProgressCallback? = null,
+    ): Call<String> {
+        return api.sendImage(channelType, channelId, file, callback)
     }
 
     @CheckResult
@@ -234,15 +235,6 @@ public class ChatClient internal constructor(
         members: List<Member> = emptyList(),
     ): Call<List<Member>> {
         return api.queryMembers(channelType, channelId, offset, limit, filter, sort, members)
-    }
-
-    @CheckResult
-    public fun sendImage(
-        channelType: String,
-        channelId: String,
-        file: File,
-    ): Call<String> {
-        return api.sendImage(channelType, channelId, file)
     }
 
     @CheckResult
@@ -1137,7 +1129,8 @@ public class ChatClient internal constructor(
         require(userId.isNotEmpty()) { "User id must not be empty" }
         val header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" //  {"alg": "HS256", "typ": "JWT"}
         val devSignature = "devtoken"
-        val payload: String = Base64.encodeToString("{\"user_id\":\"$userId\"}".toByteArray(StandardCharsets.UTF_8), Base64.NO_WRAP)
+        val payload: String =
+            Base64.encodeToString("{\"user_id\":\"$userId\"}".toByteArray(StandardCharsets.UTF_8), Base64.NO_WRAP)
         return "$header.$payload.$devSignature"
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessagesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessagesTest.kt
@@ -138,12 +138,13 @@ internal class SendMessagesTest {
                 eq(channelController.channelType),
                 eq(channelController.channelId),
                 same(file),
-                anyOrNull()
+                anyOrNull(),
             ) doReturn TestCall(result)
             When calling chatClient.sendImage(
                 eq(channelController.channelType),
                 eq(channelController.channelId),
-                same(file)
+                same(file),
+                anyOrNull(),
             ) doReturn TestCall(result)
         }
     }
@@ -155,12 +156,13 @@ internal class SendMessagesTest {
                 eq(channelController.channelType),
                 eq(channelController.channelId),
                 same(file),
-                anyOrNull()
+                anyOrNull(),
             ) doReturn TestCall(result)
             When calling chatClient.sendImage(
                 eq(channelController.channelType),
                 eq(channelController.channelId),
-                same(file)
+                same(file),
+                anyOrNull(),
             ) doReturn TestCall(result)
         }
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/SendMessageWithFilesTest.kt
@@ -45,12 +45,13 @@ internal class SendMessageWithFilesTest : BaseDomainTest2() {
                 eq(channelControllerImpl.channelType),
                 eq(channelControllerImpl.channelId),
                 same(file),
-                anyOrNull()
+                anyOrNull(),
             ) doReturn TestCall(result)
             When calling clientMock.sendImage(
                 eq(channelControllerImpl.channelType),
                 eq(channelControllerImpl.channelId),
-                same(file)
+                same(file),
+                anyOrNull(),
             ) doReturn TestCall(result)
         }
     }
@@ -62,12 +63,13 @@ internal class SendMessageWithFilesTest : BaseDomainTest2() {
                 eq(channelControllerImpl.channelType),
                 eq(channelControllerImpl.channelId),
                 same(file),
-                anyOrNull()
+                anyOrNull(),
             ) doReturn TestCall(result)
             When calling clientMock.sendImage(
                 eq(channelControllerImpl.channelType),
                 eq(channelControllerImpl.channelId),
-                same(file)
+                same(file),
+                anyOrNull(),
             ) doReturn TestCall(result)
         }
     }


### PR DESCRIPTION
### Description

We removed methods that silently and asynchronously (no result or error handling possible) uploaded files and images in https://github.com/GetStream/stream-chat-android/pull/1265

We left out a `sendImage` method in `ChatClient`, which was now calling into a `ChatApi` method that returned a `Call`, essentially making it a no-op. This PR removes that method (merging it with the proper one that also itself returns a `Call`), and updates the changelog to reflect this.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
