### PR TITLE
Hiding edit message for theirs

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/message/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/options/message/MessageOptionsView.kt
@@ -52,6 +52,7 @@ public class MessageOptionsView : FrameLayout {
         binding.flagTV.configureListItem(configuration.flagIcon, iconsTint)
         binding.muteTV.configureListItem(configuration.muteIcon, iconsTint)
         binding.blockTV.configureListItem(configuration.blockIcon, iconsTint)
+        binding.editTV.isVisible = false
         binding.deleteTV.isVisible = false
     }
 


### PR DESCRIPTION
### Description

Making edit message gone when the message is not mine. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
-  ~Changelog updated with client-facing changes~
-  ~New code is covered by unit tests~
- [ ] Comparison screenshots added for visual changes (The edit message is not there anymore, that's it =P)
- [x] Reviewers added
