### PR TITLE
Fixing toolbar colour for Photos & VIdeos screen

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_media.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_media.xml
@@ -10,7 +10,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/stream_ui_white_snow"
+        android:background="@color/stream_ui_white"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"


### PR DESCRIPTION
### Description

The toolbar in this screen to darker then it should.

| Before | After | 
| --- | --- | 
| ![Screenshot_20210204-093752](https://user-images.githubusercontent.com/10619102/106894274-7f007f80-66cd-11eb-845e-249c2e50c764.png) | ![Screenshot_20210204-093545](https://user-images.githubusercontent.com/10619102/106894294-858ef700-66cd-11eb-86d4-a727753a942b.png) | 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~Changelog updated with client-facing changes~
- ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
