### PR TITLE
Fixing toolbar colour for shared groups

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_groups.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat_info_shared_groups.xml
@@ -9,7 +9,7 @@
         android:id="@+id/toolbar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="@color/white"
+        android:background="@color/stream_ui_white"
         android:elevation="4dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"


### PR DESCRIPTION
### Description

Fixing the toolbar colour for Shared Groups.

| Before | After | 
| --- | --- | 
| ![Screenshot_20210204-095528](https://user-images.githubusercontent.com/10619102/106895648-41045b00-66cf-11eb-804a-56d57f762a6f.png) | ![Screenshot_20210204-095406](https://user-images.githubusercontent.com/10619102/106895681-4792d280-66cf-11eb-8015-3174ff1c4774.png) | 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~changelog updated with client-facing changes~
- ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
