### PR TITLE
Update Events docs snippets

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -230,7 +230,7 @@ public class ChannelClient internal constructor(
         eventType: Class<T>,
         listener: ChatEventListener<T>,
     ): Disposable {
-        return subscribeForSingle(eventType, listener = filterRelevantEvents(listener))
+        return client.subscribeForSingle(eventType, listener = filterRelevantEvents(listener))
     }
 
     private fun <T : ChatEvent> filterRelevantEvents(

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Events.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Events.java
@@ -7,7 +7,6 @@ import io.getstream.chat.android.client.events.ConnectedEvent;
 import io.getstream.chat.android.client.events.ConnectingEvent;
 import io.getstream.chat.android.client.events.DisconnectedEvent;
 import io.getstream.chat.android.client.events.NewMessageEvent;
-import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent;
 import io.getstream.chat.android.client.events.UserPresenceChangedEvent;
 import io.getstream.chat.android.client.models.Message;
 import io.getstream.chat.android.client.utils.observable.Disposable;
@@ -20,7 +19,6 @@ public class Events {
      * @see <a href="https://getstream.io/chat/docs/event_object/?language=java">Event Object</a>
      */
     class EventObject {
-
     }
 
     /**
@@ -29,12 +27,13 @@ public class Events {
     class ListeningForEvents {
 
         public void listenSpecificChannelEvents() {
+            ChannelClient channelClient = client.channel("messaging", "general");
+
             // Subscribe for new message events
-            Disposable disposable = client.subscribeForSingle(
-                    NewMessageEvent.class,
-                    (NewMessageEvent event) -> {
-                        // To get the message
-                        Message message = event.getMessage();
+            Disposable disposable = channelClient.subscribeFor(
+                    new Class[]{NewMessageEvent.class},
+                    (ChatEvent event) -> {
+                        Message message = ((NewMessageEvent) event).getMessage();
                     }
             );
 
@@ -44,8 +43,8 @@ public class Events {
 
         public void listenAllChannelEvents() {
             Disposable disposable = client.subscribe((ChatEvent event) -> {
+                // Check for specific event types
                 if (event instanceof NewMessageEvent) {
-                    // To get the message
                     Message message = ((NewMessageEvent) event).getMessage();
                 }
             });
@@ -103,34 +102,6 @@ public class Events {
                 /* ... */
             });
             disposable.dispose();
-        }
-    }
-
-    /**
-     * @see <a href="https://getstream.io/chat/docs/event_typing/?language=java">Typing Events</a>
-     */
-    class TypingEvents {
-        public void sendTypingEvent() {
-            // Sends a typing.start event if it's been more than 3000 ms since the last event
-            channelClient.keystroke().enqueue();
-
-            // Sends an event typing.stop to all channel participants
-            channelClient.stopTyping().enqueue();
-        }
-    }
-
-    /**
-     * @see <a href="https://getstream.io/chat/docs/notification_events/?language=java">Typing Events</a>
-     */
-    class NotificationEvents {
-        public void notificationEvents() {
-            // An example of how listen event when a user is added to a channel
-            channelClient.subscribeFor(
-                    new Class[]{NotificationAddedToChannelEvent.class},
-                    addedToChannelEvent -> {
-                        // Handle event
-                    }
-            );
         }
     }
 }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Events.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Events.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.ConnectingEvent
 import io.getstream.chat.android.client.events.DisconnectedEvent
 import io.getstream.chat.android.client.events.NewMessageEvent
-import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
 import io.getstream.chat.android.client.events.UserPresenceChangedEvent
 import io.getstream.chat.android.client.subscribeFor
 import io.getstream.chat.android.client.subscribeForSingle
@@ -26,12 +25,12 @@ class Events(val client: ChatClient, val channelClient: ChannelClient) {
      */
     inner class ListeningForEvents {
         fun listenSpecificChannelEvents() {
+            val channelClient = client.channel("messaging", "general")
+
             // Subscribe for new message events
-            val disposable: Disposable = channelClient
-                .subscribeFor<NewMessageEvent> { newMessageEvent ->
-                    // To get the message
-                    val message = newMessageEvent.message
-                }
+            val disposable: Disposable = channelClient.subscribeFor<NewMessageEvent> { newMessageEvent ->
+                val message = newMessageEvent.message
+            }
 
             // Dispose when you want to stop receiving events
             disposable.dispose()
@@ -40,8 +39,8 @@ class Events(val client: ChatClient, val channelClient: ChannelClient) {
         fun listenAllChannelEvents() {
             val disposable: Disposable = channelClient.subscribe { event: ChatEvent ->
                 when (event) {
+                    // Check for specific event types
                     is NewMessageEvent -> {
-                        // To get the message
                         val message = event.message
                     }
                 }
@@ -75,7 +74,7 @@ class Events(val client: ChatClient, val channelClient: ChannelClient) {
             client.subscribeFor(
                 ConnectedEvent::class,
                 ConnectingEvent::class,
-                DisconnectedEvent::class
+                DisconnectedEvent::class,
             ) { event ->
                 when (event) {
                     is ConnectedEvent -> {
@@ -97,31 +96,6 @@ class Events(val client: ChatClient, val channelClient: ChannelClient) {
         fun stopListeningEvents() {
             val disposable: Disposable = client.subscribe { /* ... */ }
             disposable.dispose()
-        }
-    }
-
-    /**
-     * @see <a href="https://getstream.io/chat/docs/event_typing/?language=kotlin">Typing Events</a>
-     */
-    inner class TypingEvents {
-        fun sendTypingEvents() {
-            // Sends a typing.start event if it's been more than 3000 ms since the last event
-            channelClient.keystroke().enqueue()
-
-            // Sends an event typing.stop to all channel participants
-            channelClient.stopTyping().enqueue()
-        }
-    }
-
-    /**
-     * @see <a href="https://getstream.io/chat/docs/notification_events/?language=kotlin">Typing Events</a>
-     */
-    inner class NotificationEvents {
-        fun notificationEvents() {
-            // An example of how listen event when a user is added to a channel
-            channelClient.subscribeFor<NotificationAddedToChannelEvent> { notificationEvent ->
-                // Handle event
-            }
         }
     }
 }


### PR DESCRIPTION
### Description

Minor updates to the Events docs + a surprise bugfix for a `ChannelClient#subscribeForSingle` method which was recursively calling itself in an infinite loop instead of calling into `ChatClient`.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Reviewers added
