### PR TITLE
[CAS-672] Push sync service fixes

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.MarkAllReadEvent
 import io.getstream.chat.android.client.extensions.enrichWithCid
 import io.getstream.chat.android.client.logger.ChatLogger
@@ -29,6 +30,7 @@ import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.UserEntity
 import io.getstream.chat.android.client.parser.StreamGson
+import io.getstream.chat.android.client.socket.SocketListener
 import io.getstream.chat.android.client.utils.FilterObject
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -243,15 +245,6 @@ internal class ChatDomainImpl internal constructor(
 
         currentUser = user
 
-        if (backgroundSyncEnabled && !isTestRunner()) {
-            val config = BackgroundSyncConfig(client.config.apiKey, currentUser.id, client.getCurrentToken() ?: "")
-            if (config.isValid()) {
-                syncModule.encryptedBackgroundSyncConfigStore.apply {
-                    put(config)
-                }
-            }
-        }
-
         database = db ?: createDatabase(appContext, user, offlineEnabled)
 
         repos = RepositoryHelper.create(factory = RepositoryFactory(database, user), scope = scope, defaultConfig = defaultConfig)
@@ -310,6 +303,7 @@ internal class ChatDomainImpl internal constructor(
                 }
             }
         }
+        storeBgSyncDataWhenUserConnects()
     }
 
     internal suspend fun updateCurrentUser(me: User) {
@@ -456,6 +450,28 @@ internal class ChatDomainImpl internal constructor(
 
     fun setTotalUnreadCount(newCount: Int) {
         _totalUnreadCount.value = newCount
+    }
+
+    private fun storeBgSyncDataWhenUserConnects() {
+        client.addSocketListener(
+            object : SocketListener() {
+                override fun onConnected(event: ConnectedEvent) {
+                    storeBgSyncData()
+                    client.removeSocketListener(this)
+                }
+            }
+        )
+    }
+
+    private fun storeBgSyncData() {
+        if (backgroundSyncEnabled && !isTestRunner()) {
+            val config = BackgroundSyncConfig(client.config.apiKey, currentUser.id, client.getCurrentToken() ?: "")
+            if (config.isValid()) {
+                syncModule.encryptedBackgroundSyncConfigStore.apply {
+                    put(config)
+                }
+            }
+        }
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/OfflineSyncFirebaseMessagingService.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/OfflineSyncFirebaseMessagingService.kt
@@ -55,6 +55,7 @@ internal class OfflineSyncFirebaseMessagingService : FirebaseMessagingService() 
         GlobalScope.launch(DispatcherProvider.IO) {
             val cid: String = firebaseMessageParser.parse(message).let { "${it.channelType}:${it.channelId}" }
             if (ChatDomain.isInitialized && ChatClient.isInitialized) {
+                logger.logD("Starting the sync")
                 performSync(ChatDomain.instance(), cid, ChatClient.instance(), message)
             } else {
                 val syncConfig = syncModule.encryptedBackgroundSyncConfigStore.get()
@@ -81,9 +82,9 @@ internal class OfflineSyncFirebaseMessagingService : FirebaseMessagingService() 
     ) {
         domain.useCases.replayEventsForActiveChannels(cid).enqueue {
             if (it.isSuccess) {
-                logger.logD("sync success.")
+                logger.logD("Sync success.")
             } else {
-                logger.logD("sync failed")
+                logger.logD("Sync failed.")
             }
             client.onMessageReceived(message)
         }


### PR DESCRIPTION
### Description

~1. Don't connect to the socket when doing bg data sync API call~
_This is not possible at the moment without modifying LLC API client. Added task to allow setting user without opening WS connection https://stream-io.atlassian.net/browse/CAS-681_
2. Fix storing the bg sync data. Previously, data was persisted before the user was set into `ChatClient` resulting in missing userToken value. Now we are waiting for the first event which is emitted after user is connected to WS, we persist sync config and unsubscribe the listener to make sure it's not invoked on every event. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
