### PR TITLE
Message list filter

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -664,7 +664,7 @@ public abstract interface class io/getstream/chat/android/ui/messages/view/Messa
 }
 
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$MessageListItemFilter {
-	public abstract fun filter (Ljava/util/List;)Ljava/util/List;
+	public abstract fun predicate (Lcom/getstream/sdk/chat/adapter/MessageListItem;)Z
 }
 
 public abstract interface class io/getstream/chat/android/ui/messages/view/MessageListView$MessageLongClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/HiddenMessageListItemFilter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/HiddenMessageListItemFilter.kt
@@ -14,10 +14,7 @@ internal object HiddenMessageListItemFilter : MessageListView.MessageListItemFil
         item is MessageListItem.MessageItem && item.message.isGiphyEphemeral() && item.isTheirs
     }
 
-    override fun filter(messageListItems: List<MessageListItem>): List<MessageListItem> {
-        return messageListItems.asSequence()
-            .filterNot(theirDeletedMessagePredicate)
-            .filterNot(theirGiphyEphemeralMessagePredicate)
-            .toList()
+    override fun predicate(item: MessageListItem): Boolean {
+        return theirDeletedMessagePredicate.invoke(item).and(theirGiphyEphemeralMessagePredicate.invoke(item))
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/view/MessageListView.kt
@@ -669,7 +669,7 @@ public class MessageListView : ConstraintLayout {
 
     private fun handleNewWrapper(listItem: MessageListItemWrapper) {
         CoroutineScope(DispatcherProvider.IO).launch {
-            val filteredList = messageListItemFilter.filter(listItem.items)
+            val filteredList = listItem.items.filter(messageListItemFilter::predicate)
             withContext(DispatcherProvider.Main) {
                 buffer.hold()
 
@@ -969,7 +969,7 @@ public class MessageListView : ConstraintLayout {
      * Filter functional object that can filter MessageListItem before applying them to MessageListView.
      */
     public fun interface MessageListItemFilter {
-        public fun filter(messageListItems: List<MessageListItem>): List<MessageListItem>
+        public fun predicate(item: MessageListItem): Boolean
     }
 
     public enum class NewMessagesBehaviour(internal val value: Int) {


### PR DESCRIPTION
[CAS-658](https://stream-io.atlassian.net/browse/CAS-658)

### Description

Suggestion for the `MessageListItemFilter`. A predicate looks better than a method with `(MessageList) -> MessageList`, where any transformation can be applied in the list. 
It also simplies the use, instead of:

```
messageListView.setMessageListItemFilter { messageList ->
    messageList.filter { messageListItem ->
        // Filter logic here
        true
    }
}
```
We can have:

```
messageListView.setMessageListItemFilter { messageItem ->
     // Boolean logic here
    true
}
```
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~Changelog updated with client-facing changes~
- ~New code is covered by unit tests~
- ~Comparison screenshots added for visual changes~
- [x] Reviewers added
