### PR TITLE
[CAS-642] Fix cropped MediaAttachmentDialogFragment

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_media_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_media_attachment.xml
@@ -1,51 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
     >
 
-    <ImageView
-        android:id="@+id/closeButton"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/stream_ui_spacing_medium"
-        android:background="?selectableItemBackgroundBorderless"
-        android:src="@drawable/stream_ui_ic_close"
-        app:layout_constraintBottom_toBottomOf="@id/toolbarGuideline"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        app:tint="@color/stream_ui_black"
-        tools:ignore="ContentDescription"
-        />
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="40dp"
+        >
 
-    <TextView
-        android:id="@+id/title"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/stream_ui_gallery_overview_title"
-        android:textAppearance="@style/StreamUiTextAppearance.HeadlineBold"
-        app:layout_constraintBottom_toBottomOf="@id/toolbarGuideline"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
+        <ImageView
+            android:id="@+id/closeButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="start|center_vertical"
+            android:layout_marginStart="@dimen/stream_ui_spacing_medium"
+            android:background="?selectableItemBackgroundBorderless"
+            android:src="@drawable/stream_ui_ic_close"
+            app:tint="@color/stream_ui_black"
+            tools:ignore="ContentDescription"
+            />
 
-    <androidx.constraintlayout.widget.Guideline
-        android:id="@+id/toolbarGuideline"
-        android:layout_width="0dp"
-        android:layout_height="0dp"
-        android:orientation="horizontal"
-        app:layout_constraintGuide_begin="40dp"
-        />
+        <TextView
+            android:id="@+id/title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/stream_ui_gallery_overview_title"
+            android:textAppearance="@style/StreamUiTextAppearance.HeadlineBold"
+            />
+
+    </FrameLayout>
 
     <io.getstream.chat.android.ui.gallery.overview.MediaAttachmentGridView
         android:id="@+id/mediaAttachmentGridView"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        app:layout_constraintTop_toBottomOf="@id/toolbarGuideline"
         app:streamUiShowUserAvatars="true"
         />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</LinearLayout>


### PR DESCRIPTION
[CAS-642](https://stream-io.atlassian.net/browse/CAS-642)

### Description

Part of the last row of `MediaAttachmentDialogFragment` was cropped. Removing `ConstraintLayout` fixes the issue. Items in the grid are recycled on scroll as expected. 

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
| ![device-2021-02-09-115419](https://user-images.githubusercontent.com/9600921/107340719-22d39c00-6acf-11eb-9bec-776db76d15c0.png)| ![device-2021-02-09-115317](https://user-images.githubusercontent.com/9600921/107340741-2bc46d80-6acf-11eb-8710-b98f98af39d3.png)|
