### PR TITLE
Fix/send message starting with slash

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/MessageExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/MessageExtensions.kt
@@ -3,6 +3,6 @@ package io.getstream.chat.android.client.extensions
 import io.getstream.chat.android.client.models.Message
 
 public fun Message.enrichWithCid(cid: String): Message = apply {
+    replyTo?.enrichWithCid(cid)
     this.cid = cid
-    replyTo?.cid = cid
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -693,7 +693,7 @@ internal class ChannelControllerImpl(
     private suspend fun handleSendAttachmentSuccess(result: Result<Message>): Result<Message> {
         val processedMessage: Message = result.data()
         processedMessage.apply {
-            enrichWithCid(cid)
+            enrichWithCid(this@ChannelControllerImpl.cid)
             syncStatus = SyncStatus.COMPLETED
             domainImpl.repos.insertMessage(this)
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -86,6 +86,7 @@ import java.util.Calendar
 import java.util.Date
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
+import java.util.regex.Pattern
 import kotlin.collections.set
 import kotlin.math.max
 
@@ -725,7 +726,7 @@ internal class ChannelControllerImpl(
             attachment.uploadState is Attachment.UploadState.InProgress
         }
 
-        return if (message.text.startsWith("/") || (hasAttachments && hasAttachmentsToUpload)) {
+        return if (COMMAND_PATTERN.matcher(message.text).find() || (hasAttachments && hasAttachmentsToUpload)) {
             "ephemeral"
         } else {
             "regular"
@@ -1529,5 +1530,6 @@ internal class ChannelControllerImpl(
         private const val TYPE_IMAGE = "image"
         private const val TYPE_VIDEO = "video"
         private const val TYPE_FILE = "file"
+        private val COMMAND_PATTERN = Pattern.compile("^/[a-z]*$")
     }
 }


### PR DESCRIPTION
### Description
`cid` used to store the message on DB was empty, and it is not allowed.
We need to use the `cid` from our `channelController` instead of the one from `message` because backend doesn't sent it.
Fixes #1351 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
