### PR TITLE
Add kotlin source folder to sources jar configuration

### DIFF
--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -9,6 +9,7 @@ task androidSourcesJar(type: Jar) {
         from android.sourceSets.main.kotlin.srcDirs
     } else {
         from sourceSets.main.java.srcDirs
+        from sourceSets.main.kotlin.srcDirs
     }
 }
 

--- a/scripts/publish-mavencentral.gradle
+++ b/scripts/publish-mavencentral.gradle
@@ -6,6 +6,7 @@ task androidSourcesJar(type: Jar) {
     archiveClassifier.set('sources')
     if (project.plugins.findPlugin("com.android.library")) {
         from android.sourceSets.main.java.srcDirs
+        from android.sourceSets.main.kotlin.srcDirs
     } else {
         from sourceSets.main.java.srcDirs
     }


### PR DESCRIPTION

### Description

Some of our modules (`ui-common`, `ui-components`) use `src/main/kotlin` instead of `src/main/java`, and for these, we've been shipping empty `sources.jar` artifacts so far, because only the `src/main/java` folder's contents were included in those. This PR fixes that.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Reviewers added
