### PR TITLE
Align reaction type names with other sdks

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -349,8 +349,7 @@ public class MessageListViewModel @JvmOverloads constructor(
             type = reactionType
             score = 1
         }
-        val currentUserId = ChatDomain.instance().currentUser.id
-        if (message.latestReactions.any { it.type == reactionType && it.user?.id == currentUserId }) {
+        if (message.ownReactions.any { it.type == reactionType }) {
             domain.useCases.deleteReaction(cid, reaction).enqueue()
         } else {
             domain.useCases.sendReaction(cid, reaction, enforceUnique = enforceUnique).enqueue()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -942,8 +942,11 @@ public final class io/getstream/chat/android/ui/utils/extensions/MemberKt {
 public final class io/getstream/chat/android/ui/utils/extensions/MessageKt {
 	public static final fun getCreatedAtOrNull (Lio/getstream/chat/android/client/models/Message;)Ljava/util/Date;
 	public static final fun getCreatedAtOrThrow (Lio/getstream/chat/android/client/models/Message;)Ljava/util/Date;
+	public static final fun getSupportedLatestReactions (Lio/getstream/chat/android/client/models/Message;)Ljava/util/List;
+	public static final fun getSupportedReactionCounts (Lio/getstream/chat/android/client/models/Message;)Ljava/util/Map;
 	public static final fun getUpdatedAtOrNull (Lio/getstream/chat/android/client/models/Message;)Ljava/util/Date;
 	public static final fun hasNoAttachments (Lio/getstream/chat/android/client/models/Message;)Z
+	public static final fun hasReactions (Lio/getstream/chat/android/client/models/Message;)Z
 	public static final fun hasSingleReaction (Lio/getstream/chat/android/client/models/Message;)Z
 	public static final fun hasText (Lio/getstream/chat/android/client/models/Message;)Z
 	public static final fun isDeleted (Lio/getstream/chat/android/client/models/Message;)Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/adapter/viewholder/decorator/ReactionsDecorator.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithFil
 import io.getstream.chat.android.ui.messages.adapter.viewholder.PlainTextWithMediaAttachmentsViewHolder
 import io.getstream.chat.android.ui.messages.reactions.view.ViewReactionsView
 import io.getstream.chat.android.ui.utils.extensions.dpToPx
+import io.getstream.chat.android.ui.utils.extensions.hasReactions
 import io.getstream.chat.android.ui.utils.extensions.hasSingleReaction
 
 internal class ReactionsDecorator : BaseDecorator() {
@@ -82,7 +83,7 @@ internal class ReactionsDecorator : BaseDecorator() {
         reactionsView: ViewReactionsView,
         data: MessageListItem.MessageItem,
     ) {
-        if (data.message.latestReactions.isNotEmpty()) {
+        if (data.message.hasReactions()) {
             reactionsView.isVisible = true
             reactionsSpace.isVisible = true
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/user/UserReactionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/user/UserReactionsView.kt
@@ -11,6 +11,7 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiUserReactionsViewBinding
 import io.getstream.chat.android.ui.utils.UiUtils
+import io.getstream.chat.android.ui.utils.extensions.supportedLatestReactions
 
 @InternalStreamChatApi
 public class UserReactionsView : FrameLayout {
@@ -35,7 +36,7 @@ public class UserReactionsView : FrameLayout {
     }
 
     private fun bindTitle(message: Message) {
-        val reactionCount = message.latestReactions.size
+        val reactionCount = message.supportedLatestReactions.size
         binding.messageMembersTextView.text = context.resources.getQuantityString(
             R.plurals.stream_ui_user_reactions_title,
             reactionCount,
@@ -44,7 +45,7 @@ public class UserReactionsView : FrameLayout {
     }
 
     private fun bindReactionList(message: Message, currentUser: User) {
-        val userReactionItems = message.latestReactions.mapNotNull {
+        val userReactionItems = message.supportedLatestReactions.mapNotNull {
             val user = it.user
             val iconDrawableRes = UiUtils.getReactionIcon(it.type)
             if (user != null && iconDrawableRes != null) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/view/ViewReactionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/messages/reactions/view/ViewReactionsView.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.ui.messages.reactions.ReactionItem
 import io.getstream.chat.android.ui.messages.reactions.ReactionsAdapter
 import io.getstream.chat.android.ui.utils.UiUtils
 import io.getstream.chat.android.ui.utils.extensions.hasSingleReaction
+import io.getstream.chat.android.ui.utils.extensions.supportedReactionCounts
 
 @InternalStreamChatApi
 public class ViewReactionsView : RecyclerView {
@@ -81,7 +82,7 @@ public class ViewReactionsView : RecyclerView {
     }
 
     private fun createReactionItems(message: Message): List<ReactionItem> {
-        return message.reactionCounts.keys
+        return message.supportedReactionCounts.keys
             .mapNotNull { type ->
                 UiUtils.getReactionIcon(type)?.let {
                     ReactionItem(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/UiUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/UiUtils.kt
@@ -8,6 +8,8 @@ public object UiUtils {
 
     private val reactionTypes: Map<String, Int> = ReactionType.values()
         .associate { it.type to it.iconRes }
+    private val supportedReactionTypes = ReactionType.values()
+        .map { it.type }
 
     private val mimeTypesToIconResMap: Map<String, Int> = mapOf(
         ModelType.attach_mime_pdf to R.drawable.stream_ui_ic_file_pdf,
@@ -48,6 +50,10 @@ public object UiUtils {
     internal fun getReactionIcon(type: String): Int? {
         return reactionTypes[type]
     }
+
+    internal fun isReactionTypeSupported(type: String): Boolean {
+        return supportedReactionTypes.contains(type)
+    }
 }
 
 public enum class ReactionType(
@@ -55,8 +61,8 @@ public enum class ReactionType(
     @DrawableRes public val iconRes: Int,
 ) {
     LOVE("love", R.drawable.stream_ui_ic_reaction_love),
-    THUMBS_UP("thumbs_up", R.drawable.stream_ui_ic_reaction_thumbs_up),
-    THUMBS_DOWN("thumbs_down", R.drawable.stream_ui_ic_reaction_thumbs_down),
-    LOL("lol", R.drawable.stream_ui_ic_reaction_lol),
-    WUT("wut", R.drawable.stream_ui_ic_reaction_wut);
+    THUMBS_UP("like", R.drawable.stream_ui_ic_reaction_thumbs_up),
+    THUMBS_DOWN("sad", R.drawable.stream_ui_ic_reaction_thumbs_down),
+    LOL("haha", R.drawable.stream_ui_ic_reaction_lol),
+    WUT("wow", R.drawable.stream_ui_ic_reaction_wut);
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
@@ -2,9 +2,11 @@ package io.getstream.chat.android.ui.utils.extensions
 
 import android.content.Context
 import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.utils.ModelType
+import io.getstream.chat.android.ui.utils.UiUtils
 import java.util.Date
 
 internal fun Message.getSenderDisplayName(context: Context, isDirectMessaging: Boolean = false): String? =
@@ -42,8 +44,30 @@ public fun Message.getCreatedAtOrThrow(): Date = checkNotNull(getCreatedAtOrNull
 }
 
 public fun Message.hasSingleReaction(): Boolean {
-    return reactionCounts.size == 1
+    return supportedReactionCounts.size == 1
 }
+
+public fun Message.hasReactions(): Boolean {
+    return supportedReactionCounts.isNotEmpty()
+}
+
+public val Message.supportedLatestReactions: List<Reaction>
+    get() {
+        return if (latestReactions.isEmpty()) {
+            latestReactions
+        } else {
+            latestReactions.filter { UiUtils.isReactionTypeSupported(it.type) }
+        }
+    }
+
+public val Message.supportedReactionCounts: Map<String, Int>
+    get() {
+        return if (reactionCounts.isEmpty()) {
+            reactionCounts
+        } else {
+            reactionCounts.filterKeys { UiUtils.isReactionTypeSupported(it) }
+        }
+    }
 
 public fun Message.isReply(): Boolean = replyTo != null
 


### PR DESCRIPTION
### Description

According to https://getstream.slack.com/archives/G01DU3XSWM7/p1609507461260100 it was agreed that reaction type names should be aligned across all platforms, and the names are:
```
{
    Icon: LoveReaction,
    type: 'love',
  },
  {
    Icon: ThumbsUpReaction,
    type: 'like',
  },
  {
    Icon: ThumbsDownReaction,
    type: 'sad',
  },
  {
    Icon: LOLReaction,
    type: 'haha',
  },
  {
    Icon: WutReaction,
    type: 'wow',
  },
```
Also, some extra effort to filter out unsupported reactions, to prevent such corner cases as on the screenshots below (mixed supported/unsupported reactions, reaction bubble offset was calculated incorrectly):

| Before | After |
| --- | --- |
| ![device-2021-02-09-191725](https://user-images.githubusercontent.com/9600921/107394052-7fa17780-6b0c-11eb-8670-3ed907398510.png) | ![device-2021-02-09-191346](https://user-images.githubusercontent.com/9600921/107394065-83cd9500-6b0c-11eb-8954-3da17f498e40.png) |


### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added
