### PR TITLE
Use channel separator attribute in ChannelListViewStyle

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
+- Fix `streamChannelsItemSeparatorDrawable` attribute not being parsed
 
 ## stream-chat-android-client
 - Fix `ConcurrentModificationException` on our `NetworkStateProvider`

--- a/stream-chat-android/api/stream-chat-android.api
+++ b/stream-chat-android/api/stream-chat-android.api
@@ -594,6 +594,7 @@ public final class com/getstream/sdk/chat/view/channels/ChannelListViewStyle {
 	public final fun getChannelTitleText ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public final fun getChannelTitleUnreadText ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public final fun getChannelWithoutNameText ()Ljava/lang/String;
+	public final fun getItemSeparatorDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getLastMessage ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public final fun getLastMessageDateText ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public final fun getLastMessageDateUnreadText ()Lcom/getstream/sdk/chat/style/TextStyle;

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelViewHolderFactory.java
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/ChannelViewHolderFactory.java
@@ -1,10 +1,13 @@
 package com.getstream.sdk.chat.adapter;
 
 
+import android.graphics.drawable.Drawable;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.ImageView;
 
+import com.getstream.sdk.chat.R;
 import com.getstream.sdk.chat.view.channels.ChannelListViewStyle;
 
 import io.getstream.chat.android.client.models.Channel;
@@ -32,10 +35,17 @@ public class ChannelViewHolderFactory {
         // inflate the layout specified in the style
         View v = LayoutInflater.from(parent.getContext()).inflate(style.getChannelPreviewLayout(), parent, false);
 
+        ImageView separator = v.findViewById(R.id.iv_separator);
+        if (separator != null) {
+            final Drawable itemSeparatorDrawable = style.getItemSeparatorDrawable();
+            if (itemSeparatorDrawable != null) {
+                separator.setImageDrawable(itemSeparatorDrawable);
+            }
+        }
+
         // configure the viewholder
         ChannelListItemViewHolder holder = new ChannelListItemViewHolder(v);
         configureHolder(holder, adapter);
-        // return..
 
         return holder;
     }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelListViewStyle.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelListViewStyle.kt
@@ -3,6 +3,7 @@ package com.getstream.sdk.chat.view.channels
 import android.content.Context
 import android.graphics.Color
 import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import androidx.annotation.ColorRes
 import androidx.annotation.LayoutRes
@@ -13,6 +14,7 @@ import com.getstream.sdk.chat.view.ReadStateStyle
 import com.getstream.sdk.chat.view.messages.AvatarStyle
 
 public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
+
     @LayoutRes
     public val channelPreviewLayout: Int
     public val channelTitleText: TextStyle
@@ -23,6 +25,8 @@ public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
     public val lastMessageDateUnreadText: TextStyle
     public var avatarStyle: AvatarStyle
     public val readStateStyle: ReadStateStyle
+    public val itemSeparatorDrawable: Drawable?
+
     private val resources = context.resources
 
     private var channelWithoutNameText = ""
@@ -77,7 +81,8 @@ public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
             style(R.styleable.ChannelListView_streamChannelTitleUnreadTextStyle, Typeface.BOLD)
         }.build()
 
-        attributes.getString(R.styleable.ChannelListView_streamChannelWithOutNameTitleText)?.let { channelWithoutNameText = it }
+        attributes.getString(R.styleable.ChannelListView_streamChannelWithOutNameTitleText)
+            ?.let { channelWithoutNameText = it }
 
         lastMessage = TextStyle.Builder(attributes).apply {
             size(
@@ -207,5 +212,14 @@ public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
 
             recycle()
         }
+
+        val parentAttrs = context.obtainStyledAttributes(
+            attrs,
+            R.styleable.ChannelsView,
+            0,
+            0
+        )
+        itemSeparatorDrawable = parentAttrs.getDrawable(R.styleable.ChannelsView_streamChannelsItemSeparatorDrawable)
+        parentAttrs.recycle()
     }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelsView.kt
@@ -39,8 +39,8 @@ public class ChannelsView @JvmOverloads constructor(
     }
 
     private fun parseAttrs(attrs: AttributeSet?) {
-        context.obtainStyledAttributes(attrs, R.styleable.ChannelsView, 0, 0).use {
-            it.getText(R.styleable.ChannelsView_streamChannelsEmptyStateLabelText)?.let { emptyStateText ->
+        context.obtainStyledAttributes(attrs, R.styleable.ChannelsView, 0, 0).use { attrs ->
+            attrs.getText(R.styleable.ChannelsView_streamChannelsEmptyStateLabelText)?.let { emptyStateText ->
                 emptyStateView.apply {
                     if (this is TextView) {
                         text = emptyStateText

--- a/stream-chat-android/src/main/res/drawable/stream_ic_channel_divider.xml
+++ b/stream-chat-android/src/main/res/drawable/stream_ic_channel_divider.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <size android:height="1dp" />
+    <solid android:color="@color/stream_gray" />
+</shape>

--- a/stream-chat-android/src/main/res/layout/stream_item_channel.xml
+++ b/stream-chat-android/src/main/res/layout/stream_item_channel.xml
@@ -13,7 +13,7 @@
         android:layout_marginStart="12dp"
         android:layout_marginTop="12dp"
         android:layout_marginBottom="12dp"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/iv_separator"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         />
@@ -82,8 +82,8 @@
     <ImageView
         android:id="@+id/iv_separator"
         android:layout_width="match_parent"
-        android:layout_height="1dp"
-        android:background="@color/stream_gray"
+        android:layout_height="wrap_content"
+        android:src="@drawable/stream_ic_channel_divider"
         app:layout_constraintBottom_toBottomOf="parent"
         />
 


### PR DESCRIPTION
Bugfix for #1371 

### Description

Parses the attribute into `ChannelListViewStyle`, and then overrides the default divider drawable with the custom value if it's present.

| No attr | Custom attr - Stream logo |
| --- | --- |
| ![Screenshot_20210210_115713](https://user-images.githubusercontent.com/12054216/107501641-f899e100-6b97-11eb-8c7a-07ed72e9872f.png) | ![Screenshot_20210210_115644](https://user-images.githubusercontent.com/12054216/107501651-fafc3b00-6b97-11eb-8cb0-7ff33241bd30.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
