### PR TITLE
Fix streamLastMessageDateUnreadTextColor not being used

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
+- Fix `streamLastMessageDateUnreadTextColor` attribute not being used in ChannelListView
 
 ## stream-chat-android-client
 - Fix `ConcurrentModificationException` on our `NetworkStateProvider`

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelListViewStyle.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/channels/ChannelListViewStyle.kt
@@ -77,7 +77,8 @@ public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
             style(R.styleable.ChannelListView_streamChannelTitleUnreadTextStyle, Typeface.BOLD)
         }.build()
 
-        attributes.getString(R.styleable.ChannelListView_streamChannelWithOutNameTitleText)?.let { channelWithoutNameText = it }
+        attributes.getString(R.styleable.ChannelListView_streamChannelWithOutNameTitleText)
+            ?.let { channelWithoutNameText = it }
 
         lastMessage = TextStyle.Builder(attributes).apply {
             size(
@@ -133,7 +134,7 @@ public class ChannelListViewStyle(context: Context, attrs: AttributeSet?) {
                 resources.getDimensionPixelSize(R.dimen.stream_channel_item_message_date)
             )
             color(
-                R.styleable.ChannelListView_streamLastMessageDateTextColor,
+                R.styleable.ChannelListView_streamLastMessageDateUnreadTextColor,
                 ContextCompat.getColor(context, R.color.stream_channel_item_text_color)
             )
             font(


### PR DESCRIPTION
Bugfix for #1370 

### Description

Uses the `streamLastMessageDateUnreadTextColor` for colouring unread message dates instead of the regular attribute's value.

| Before | After |
| --- | --- |
|![Screenshot_20210210_121639](https://user-images.githubusercontent.com/12054216/107503622-77901900-6b9a-11eb-8628-c9ddf680f5ea.png) | ![Screenshot_20210210_121610](https://user-images.githubusercontent.com/12054216/107503615-765eec00-6b9a-11eb-8fd0-22528f8781a4.png) |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
