### PR TITLE
Fix typing indicator in dark mode

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_typing_indicator_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_typing_indicator_view.xml
@@ -4,8 +4,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:alpha="0.9"
-    android:background="@color/stream_ui_white_snow"
     android:gravity="center_vertical"
     android:orientation="horizontal"
     android:paddingHorizontal="8dp"
@@ -17,8 +15,8 @@
         android:layout_height="18dp"
         app:lottie_autoPlay="true"
         app:lottie_loop="true"
-        app:lottie_speed="4"
         app:lottie_rawRes="@raw/stream_ui_typing_dots"
+        app:lottie_speed="4"
         />
 
     <TextView


### PR DESCRIPTION
### Description

Removed unnecessary background from typing indicator view

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

| Before | After |
| --- | --- |
| ![device-2021-02-11-150821](https://user-images.githubusercontent.com/9600921/107634856-40456900-6c7b-11eb-8a1c-fc7887d67ae1.png) | ![device-2021-02-11-150739](https://user-images.githubusercontent.com/9600921/107634874-45a2b380-6c7b-11eb-81c3-77a1c39106f5.png)|
