### PR TITLE
Fix sending messages with shadow ban

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -150,7 +150,7 @@ internal class ChannelControllerImpl(
             messageMap.values
                 .asSequence()
                 .filter { it.parentId == null || it.showInChannel }
-                .filter { !it.shadowed }
+                .filter { it.user.id == domainImpl.currentUser.id || !it.shadowed }
                 .filter { hideMessagesBefore == null || it.wasCreatedAfter(hideMessagesBefore) }
                 .sortedBy { it.createdAt ?: it.createdLocallyAt }
                 .toList()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -24,7 +24,7 @@ internal fun Channel.getLastMessage(): Message? =
         .filter { it.createdAt != null || it.createdLocallyAt != null }
         .filter { it.deletedAt == null }
         .filter { !it.silent }
-        .filter { !it.shadowed }
+        .filter { it.user.isCurrentUser() || !it.shadowed }
         .filter { it.type == ModelType.message_regular }
         .maxByOrNull { it.getCreatedAtOrThrow() }
 


### PR DESCRIPTION
### Description

Shadow banned uses are unable to observe their sent messages. When shadow banned user tries to send a message, it disappears as soon as it is delivered to the server.

According to the docs
```
Shadow Ban
Users can be shadow banned from an app entirely or from a channel. When a user is shadow banned, it will still be allowed to post messages, but any message sent during, will have shadowed: true field. However, this will be invisible from the author of the message.
```

Therefore modified some conditions so that:
- Shadow banned users are able see their sent messages on the chat screen
- Shadow banned users are able to observe their last sent message on the channel list screen
Other users still:
- Don't see messages from shadow banned users on the chat screen
- Don't see last sent message from a shadow banned user on the channel list screen

After this PR is merged, will unban Carter from the "General" channel, as such feature might look like something is broken for those who evaluate our sample app.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
