### PR TITLE
Fix end margin of unread badge when timestamp is missing

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -5,8 +5,8 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/stream_ui_channel_list_item_height"
     android:background="@drawable/stream_ui_foreground_channel_list"
-    android:backgroundTintMode="src_in"
     android:backgroundTint="@color/stream_ui_white_snow"
+    android:backgroundTintMode="src_in"
     >
 
     <io.getstream.chat.android.ui.avatar.AvatarView
@@ -79,6 +79,7 @@
         android:id="@+id/unread_count_badge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_marginEnd="8dp"
         android:layout_marginBottom="4dp"
         android:background="@drawable/stream_ui_shape_badge_background"
         android:fontFamily="sans-serif-medium"
@@ -88,7 +89,7 @@
         android:textColor="@color/stream_ui_literal_white"
         android:textSize="@dimen/stream_ui_text_small"
         app:layout_constraintBottom_toTopOf="@+id/last_message_time_label"
-        app:layout_constraintEnd_toEndOf="@+id/last_message_time_label"
+        app:layout_constraintEnd_toEndOf="parent"
         tools:text="99"
         />
 


### PR DESCRIPTION

### Description

When the timestamp is hidden in `ChannelListView`, the end constraint of the unread badge got invalid and it fell back to no margin being added. Constrained the badge to the end of the parent instead.

| Before | After |
| --- | --- |
| ![Screenshot_20210215_165242](https://user-images.githubusercontent.com/12054216/107968450-ae0cd000-6fae-11eb-98b5-0e63f63f5a13.png) | ![Screenshot_20210215_165259](https://user-images.githubusercontent.com/12054216/107968447-ac430c80-6fae-11eb-86b2-fc4bfd0f9b8c.png)|

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
