### PR TITLE
Do not show logs by default

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1260,7 +1260,7 @@ public class ChatClient internal constructor(
         private var cdnUrl: String = baseUrl
         private var baseTimeout = 10000L
         private var cdnTimeout = 10000L
-        private var logLevel = ChatLogLevel.ALL
+        private var logLevel = ChatLogLevel.NOTHING
         private var warmUp: Boolean = true
         private var loggerHandler: ChatLoggerHandler? = null
         private var notificationsHandler: ChatNotificationHandler =

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/Chat.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/Chat.kt
@@ -55,7 +55,7 @@ public interface Chat {
         public var markdown: ChatMarkdown = ChatMarkdownImpl(context)
         public var offlineEnabled: Boolean = false
         public var notificationHandler: ChatNotificationHandler = ChatNotificationHandler(context)
-        public var chatLogLevel: ChatLogLevel = ChatLogLevel.ALL
+        public var chatLogLevel: ChatLogLevel = ChatLogLevel.NOTHING
         public var chatLoggerHandler: ChatLoggerHandler? = null
         public var fileUploader: FileUploader? = null
 


### PR DESCRIPTION
### Description

The following `val client = ChatClient.Builder(apiKey, context).build()` creates a logger internally with `ChatLogLevel.ALL` level. Changing the default log level to `ChatLogLevel.NOTHING`

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
