### PR TITLE
[CAS-711] Add attributes for configuring text style and icon tint in message actions view

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,9 @@
 ## Common changes for all artifacts
 
 ## stream-chat-android
+- Add `streamMessageActionButtonsTextSize`, `streamMessageActionButtonsTextColor`, `streamMessageActionButtonsTextFont`,
+ `streamMessageActionButtonsTextFontAssets`, `streamMessageActionButtonsTextStyle`, `streamMessageActionButtonsIconTint`
+ attributes to `MessageListView`
 
 ## stream-chat-android-client
 - Introduce ChatClient::setUserWithoutConnecting function

--- a/stream-chat-android/api/stream-chat-android.api
+++ b/stream-chat-android/api/stream-chat-android.api
@@ -493,6 +493,8 @@ public final class com/getstream/sdk/chat/view/MessageListViewStyle {
 	public final fun getEditMessageActionEnabled ()Z
 	public final fun getFlagMessageActionEnabled ()Z
 	public final fun getMessageActionButtonsBackground ()Landroid/graphics/drawable/Drawable;
+	public final fun getMessageActionButtonsIconTint ()Landroid/content/res/ColorStateList;
+	public final fun getMessageActionButtonsTextStyle ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public final fun getMessageBackgroundColor (Z)I
 	public final fun getMessageBorderColor (Z)I
 	public final fun getMessageBorderWidth (Z)I

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListViewStyle.kt
@@ -1,6 +1,7 @@
 package com.getstream.sdk.chat.view
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Color
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
@@ -82,6 +83,8 @@ public class MessageListViewStyle(c: Context, attrs: AttributeSet?) {
 
     // MessageMoreActionDialog
     public val messageActionButtonsBackground: Drawable?
+    public val messageActionButtonsIconTint: ColorStateList?
+    public val messageActionButtonsTextStyle: TextStyle
     public val startThreadMessageActionEnabled: Boolean
     public val copyMessageActionEnabled: Boolean
     public val flagMessageActionEnabled: Boolean
@@ -564,6 +567,26 @@ public class MessageListViewStyle(c: Context, attrs: AttributeSet?) {
         isMessageDateShow = a.getBoolean(R.styleable.MessageListView_streamMessageDateShow, true)
 
         messageActionButtonsBackground = a.getDrawable(R.styleable.MessageListView_streamMessageActionButtonsBackground)
+        messageActionButtonsIconTint =
+            a.getColorStateList(R.styleable.MessageListView_streamMessageActionButtonsIconTint)
+            ?: ContextCompat.getColorStateList(c, R.color.stream_black_54)
+        messageActionButtonsTextStyle = TextStyle.Builder(a)
+            .size(
+                R.styleable.MessageListView_streamMessageActionButtonsTextSize,
+                res.getDimensionPixelSize(
+                    R.dimen.stream_message_action_buttons_text_size
+                )
+            )
+            .color(
+                R.styleable.MessageListView_streamMessageActionButtonsTextColor,
+                ContextCompat.getColor(c, R.color.stream_black_54)
+            )
+            .font(
+                R.styleable.MessageListView_streamMessageActionButtonsTextFontAssets,
+                R.styleable.MessageListView_streamMessageActionButtonsTextFont
+            )
+            .style(R.styleable.MessageListView_streamMessageActionButtonsTextStyle, Typeface.NORMAL)
+            .build()
 
         startThreadMessageActionEnabled = a.getBoolean(
             R.styleable.MessageListView_streamStartThreadMessageActionEnabled,

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/dialog/MessageMoreActionDialog.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/dialog/MessageMoreActionDialog.kt
@@ -31,7 +31,7 @@ public class MessageMoreActionDialog(
     private val onMessageEditHandler: (message: Message) -> Unit,
     private val onMessageDeleteHandler: (message: Message) -> Unit,
     private val onStartThreadHandler: (message: Message) -> Unit,
-    private val onMessageFlagHandler: (message: Message) -> Unit
+    private val onMessageFlagHandler: (message: Message) -> Unit,
 ) : Dialog(context, R.style.DialogTheme) {
 
     init {
@@ -50,7 +50,11 @@ public class MessageMoreActionDialog(
     }
 
     private fun setupMessageActions() {
-        val binding = StreamDialogMessageMoreactionBinding.inflate(context.inflater)
+        val binding = StreamDialogMessageMoreactionBinding.inflate(context.inflater).also {
+            applyButtonsTextStyle(it)
+            applyButtonsIconTint(it)
+        }
+
         style.messageActionButtonsBackground?.let { actionButtonsBackground ->
             binding.messageActionButtons.background = actionButtonsBackground
         }
@@ -115,6 +119,30 @@ public class MessageMoreActionDialog(
                     clipboard.setPrimaryClip(clip)
                     dismiss()
                 }
+            }
+        }
+    }
+
+    private fun applyButtonsTextStyle(binding: StreamDialogMessageMoreactionBinding) {
+        style.messageActionButtonsTextStyle.let { textStyle ->
+            binding.apply {
+                textStyle.apply(startThreadButtonTextView)
+                textStyle.apply(copyMessageButtonTextView)
+                textStyle.apply(flagMessageButtonTextView)
+                textStyle.apply(editMessageButtonTextView)
+                textStyle.apply(deleteMessageButtonTextView)
+            }
+        }
+    }
+
+    private fun applyButtonsIconTint(binding: StreamDialogMessageMoreactionBinding) {
+        style.messageActionButtonsIconTint.let { tint ->
+            binding.apply {
+                startThreadButtonImageView.imageTintList = tint
+                copyMessageButtonImageView.imageTintList = tint
+                flagMessageButtonImageView.imageTintList = tint
+                editMessageButtonImageView.imageTintList = tint
+                deleteMessageButtonImageView.imageTintList = tint
             }
         }
     }

--- a/stream-chat-android/src/main/res/layout/stream_dialog_message_moreaction.xml
+++ b/stream-chat-android/src/main/res/layout/stream_dialog_message_moreaction.xml
@@ -53,6 +53,7 @@
             >
 
             <ImageView
+                android:id="@+id/startThreadButtonImageView"
                 android:layout_width="22dp"
                 android:layout_height="22dp"
                 android:src="@drawable/stream_ic_reply"
@@ -64,12 +65,13 @@
                 />
 
             <TextView
-                style="@style/text"
+                android:id="@+id/startThreadButtonTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="@string/stream_more_action_start_thread"
-                android:textColor="#8A000000"
+                android:textColor="@color/stream_black_54"
+                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -84,6 +86,7 @@
             >
 
             <ImageView
+                android:id="@+id/copyMessageButtonImageView"
                 android:layout_width="22dp"
                 android:layout_height="22dp"
                 android:src="@drawable/stream_ic_copy"
@@ -95,12 +98,13 @@
                 />
 
             <TextView
-                style="@style/text"
+                android:id="@+id/copyMessageButtonTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="@string/stream_more_action_copy"
-                android:textColor="#8A000000"
+                android:textColor="@color/stream_black_54"
+                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -115,6 +119,7 @@
             >
 
             <ImageView
+                android:id="@+id/flagMessageButtonImageView"
                 android:layout_width="22dp"
                 android:layout_height="22dp"
                 android:src="@drawable/stream_ic_flag"
@@ -126,12 +131,13 @@
                 />
 
             <TextView
-                style="@style/text"
+                android:id="@+id/flagMessageButtonTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="@string/stream_more_action_flag"
-                android:textColor="#8A000000"
+                android:textColor="@color/stream_black_54"
+                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -146,6 +152,7 @@
             >
 
             <ImageView
+                android:id="@+id/editMessageButtonImageView"
                 android:layout_width="22dp"
                 android:layout_height="22dp"
                 android:src="@drawable/stream_ic_edit"
@@ -157,12 +164,13 @@
                 />
 
             <TextView
-                style="@style/text"
+                android:id="@+id/editMessageButtonTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="@string/stream_more_action_edit"
-                android:textColor="#8A000000"
+                android:textColor="@color/stream_black_54"
+                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -177,6 +185,7 @@
             >
 
             <ImageView
+                android:id="@+id/deleteMessageButtonImageView"
                 android:layout_width="22dp"
                 android:layout_height="22dp"
                 android:src="@drawable/stream_ic_delete"
@@ -188,12 +197,13 @@
                 />
 
             <TextView
-                style="@style/text"
+                android:id="@+id/deleteMessageButtonTextView"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="@string/stream_more_action_delete"
-                android:textColor="#8A000000"
+                android:textColor="@color/stream_black_54"
+                android:textSize="15sp"
                 />
         </LinearLayout>
     </LinearLayout>

--- a/stream-chat-android/src/main/res/layout/stream_dialog_message_moreaction.xml
+++ b/stream-chat-android/src/main/res/layout/stream_dialog_message_moreaction.xml
@@ -66,12 +66,10 @@
 
             <TextView
                 android:id="@+id/startThreadButtonTextView"
+                style="@style/StreamMessageActionButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
                 android:text="@string/stream_more_action_start_thread"
-                android:textColor="@color/stream_black_54"
-                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -99,12 +97,10 @@
 
             <TextView
                 android:id="@+id/copyMessageButtonTextView"
+                style="@style/StreamMessageActionButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
                 android:text="@string/stream_more_action_copy"
-                android:textColor="@color/stream_black_54"
-                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -132,12 +128,10 @@
 
             <TextView
                 android:id="@+id/flagMessageButtonTextView"
+                style="@style/StreamMessageActionButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
                 android:text="@string/stream_more_action_flag"
-                android:textColor="@color/stream_black_54"
-                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -165,12 +159,10 @@
 
             <TextView
                 android:id="@+id/editMessageButtonTextView"
+                style="@style/StreamMessageActionButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
                 android:text="@string/stream_more_action_edit"
-                android:textColor="@color/stream_black_54"
-                android:textSize="15sp"
                 />
         </LinearLayout>
 
@@ -198,12 +190,10 @@
 
             <TextView
                 android:id="@+id/deleteMessageButtonTextView"
+                style="@style/StreamMessageActionButtonText"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
                 android:text="@string/stream_more_action_delete"
-                android:textColor="@color/stream_black_54"
-                android:textSize="15sp"
                 />
         </LinearLayout>
     </LinearLayout>

--- a/stream-chat-android/src/main/res/values/attrs.xml
+++ b/stream-chat-android/src/main/res/values/attrs.xml
@@ -393,6 +393,16 @@
 
         <!-- MessageMoreActionDialog -->
         <attr name="streamMessageActionButtonsBackground" format="reference" />
+        <attr name="streamMessageActionButtonsTextSize" format="dimension|reference" />
+        <attr name="streamMessageActionButtonsTextColor" format="color|reference" />
+        <attr name="streamMessageActionButtonsTextFont" format="reference" />
+        <attr name="streamMessageActionButtonsTextFontAssets" format="string" />
+        <attr name="streamMessageActionButtonsTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+        <attr name="streamMessageActionButtonsIconTint" format="color|reference" />
         <attr name="streamStartThreadMessageActionEnabled" format="boolean" />
         <attr name="streamCopyMessageActionEnabled" format="boolean" />
         <attr name="streamFlagMessageActionEnabled" format="boolean" />
@@ -403,7 +413,7 @@
     <!--ChannelHeaderView-->
     <declare-styleable name="ChannelHeaderView">
         <!--AvatarGroupView-->
-        <attr name="streamChannelHeaderAvatarShow" format="boolean"/>
+        <attr name="streamChannelHeaderAvatarShow" format="boolean" />
         <attr name="streamAvatarWidth" />
         <attr name="streamAvatarHeight" />
         <attr name="streamAvatarBorderWidth" />

--- a/stream-chat-android/src/main/res/values/colors.xml
+++ b/stream-chat-android/src/main/res/values/colors.xml
@@ -7,6 +7,7 @@
     <color name="stream_gray">#ebebeb</color>
     <color name="stream_gray_light">#e8e8e8</color>
     <color name="stream_white">#FFFFFF</color>
+    <color name="stream_black_54">#8A000000</color>
 
     <!--Channel Item-->
     <color name="stream_channel_item_text_color">@color/stream_black</color>

--- a/stream-chat-android/src/main/res/values/dimens.xml
+++ b/stream-chat-android/src/main/res/values/dimens.xml
@@ -84,6 +84,7 @@
     <dimen name="stream_reaction_margin">8dp</dimen>
 
     <dimen name="stream_message_date_margin_start">5dp</dimen>
+    <dimen name="stream_message_action_buttons_text_size">15sp</dimen>
     <!--Attachment Item-->
     <dimen name="stream_attach_image_height">200dp</dimen>
     <dimen name="stream_attach_file_height">50dp</dimen>

--- a/stream-chat-android/src/main/res/values/styles.xml
+++ b/stream-chat-android/src/main/res/values/styles.xml
@@ -40,6 +40,12 @@
         <item name="android:textColor">@color/stream_black</item>
     </style>
 
+    <style name="StreamMessageActionButtonText">
+        <item name="android:textSize">15sp</item>
+        <item name="android:textColor">@color/stream_black_54</item>
+        <item name="android:gravity">center_vertical</item>
+    </style>
+
     <style name="text_single_line">
         <item name="android:textSize">15sp</item>
         <item name="android:textColor">@color/stream_black</item>


### PR DESCRIPTION
Add attributes that allow configuring  action buttons text style and icon tint in message action view
| Before | After |
| --- | --- |
<img width="321" alt="Screenshot 2021-02-16 at 15 44 48" src="https://user-images.githubusercontent.com/17440581/108080472-32735780-7070-11eb-8bef-251c3c1081e4.png">|<img width="321" alt="Screenshot 2021-02-16 at 15 45 38" src="https://user-images.githubusercontent.com/17440581/108080482-343d1b00-7070-11eb-9b2c-844366ea2696.png">|

closes #1406 
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
