### PR TITLE
Make activeThread LiveData immutable

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
@@ -18,13 +18,13 @@ public abstract class BaseMessageListHeaderViewModel constructor(
     private val chatDomain: ChatDomain,
 ) : ViewModel() {
 
-    private var _activeThread = MutableLiveData<Message?>()
+    private val _activeThread = MutableLiveData<Message?>()
     private val _members = MediatorLiveData<List<Member>>()
     private val _channelState = MediatorLiveData<Channel>()
     private val _anyOtherUsersOnline = MediatorLiveData<Boolean>()
     private val _typingUsers = MediatorLiveData<List<User>>()
 
-    public var activeThread: LiveData<Message?> = _activeThread
+    public val activeThread: LiveData<Message?> = _activeThread
     public val members: LiveData<List<Member>> = _members
     public val channelState: LiveData<Channel> = _channelState
     public val anyOtherUsersOnline: LiveData<Boolean> = _anyOtherUsersOnline


### PR DESCRIPTION
activeThread LiveData should be immutable, otherwise calling `messageListHeaderViewModel.setActiveThread()` from Java shows following error:
_Ambiguous method call. Both
setActiveThread
(LiveData<Message>)
in BaseMessageListHeaderViewModel and
setActiveThread
(Message)
in BaseMessageListHeaderViewModel match_

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
