### PR TITLE
[CAS-725] Fix `MoreCountLabel` color for dark theme

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_media_attachment_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_media_attachment_view.xml
@@ -60,7 +60,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:textAppearance="@style/TextAppearance.MaterialComponents.Headline5"
-            android:textColor="@color/stream_ui_white"
+            android:textColor="@color/stream_ui_literal_white"
             android:textSize="26sp"
             tools:text="+9"
             />


### PR DESCRIPTION
### Description
Fix `MoreCountLabel` color for dark theme
![photo_2021-02-17_11-22-36](https://user-images.githubusercontent.com/4047514/108190602-74ed7080-7112-11eb-993e-468e81ca3098.jpg)


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
