### PR TITLE
[CAS-726] Fix channel item background on API 21

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_base_channel_list_item.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_base_channel_list_item.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!-- Used by stream_ui_foreground_channel_list.xml -->
-<shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="rectangle"
-    android:tint="@color/stream_ui_white_snow"
-    />

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_foreground_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_foreground_channel_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ripple xmlns:android="http://schemas.android.com/apk/res/android"
-    android:color="?colorControlHighlight"
-    >
-    <item android:drawable="@drawable/stream_ui_base_channel_list_item" />
-</ripple>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@color/stream_ui_white_snow" />
+    <item android:drawable="?attr/selectableItemBackground" />
+</layer-list>
+

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -5,8 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="@dimen/stream_ui_channel_list_item_height"
     android:background="@drawable/stream_ui_foreground_channel_list"
-    android:backgroundTint="@color/stream_ui_white_snow"
-    android:backgroundTintMode="src_in"
     >
 
     <io.getstream.chat.android.ui.avatar.AvatarView


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-726

### Description

Fix transparent channel item background on API 21

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

API 21 / API 22 / API 29
https://user-images.githubusercontent.com/9600921/108197703-cc4c0a80-712b-11eb-8e49-5b4880e2d187.mov

