### PR TITLE
Introduce BaseMessageListHeaderViewModel::resetThread to make it consistent with thread handling in MessageInputViewModel

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add `streamMessageActionButtonsTextSize`, `streamMessageActionButtonsTextColor`, `streamMessageActionButtonsTextFont`,
  `streamMessageActionButtonsTextFontAssets`, `streamMessageActionButtonsTextStyle`, `streamMessageActionButtonsIconTint`
  attributes to `MessageListView`
+- Add `ChannelHeaderViewModel::resetThread` method and make `ChannelHeaderViewModel::setActiveThread` message parameter non-nullable
 
 ## stream-chat-android-client
 - Introduce ChatClient::setUserWithoutConnecting function

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
@@ -53,7 +53,11 @@ public abstract class BaseMessageListHeaderViewModel constructor(
         }
     }
 
-    public fun setActiveThread(message: Message?) {
+    public fun setActiveThread(message: Message) {
         _activeThread.postValue(message)
+    }
+
+    public fun resetThread() {
+        _activeThread.postValue(null)
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -119,7 +119,7 @@ class ChatFragment : Fragment() {
                         messageInputViewModel.setActiveThread(it.parentMessage)
                     }
                     is MessageListViewModel.Mode.Normal -> {
-                        headerViewModel.setActiveThread(null)
+                        headerViewModel.resetThread()
                         messageInputViewModel.resetThread()
                     }
                 }


### PR DESCRIPTION
Introduce `BaseMessageListHeaderViewModel::resetThread`method to match thread handling in MessageInputView. Make `BaseMessageListHeaderViewModel::setActiveThread` message parameter non-nullable

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
