### PR TITLE
[CAS-695] Navigation from notification

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragment.kt
@@ -76,6 +76,9 @@ class HomeFragment : Fragment() {
                 val channelId = it.getStringExtra(EXTRA_CHANNEL_ID)
                 val cid = "$channelType:$channelId"
                 val messageId = it.getStringExtra(EXTRA_MESSAGE_ID)
+
+                requireActivity().intent = null
+
                 findNavController().navigateSafely(HomeFragmentDirections.actionOpenChat(cid, messageId))
             }
         }


### PR DESCRIPTION
[CAS-695](https://stream-io.atlassian.net/browse/CAS-695)

### Description

Clearing the intent after the navigation happened. 

It is necessary to clear this intent otherwise the app always go back to the chat when trying to navigate back. The intent is still there and it keeps sending the user back to the chat. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
