### PR TITLE
[CAS-733] Fix `CaptureMediaContract` chooser on Android API 21

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -15,3 +15,4 @@
 - Introduce `PushMessageSyncHandler` class
 
 ## stream-chat-android-ui-common
+- Fix `CaptureMediaContract` chooser on Android API 21

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/CaptureMediaContract.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/CaptureMediaContract.kt
@@ -34,11 +34,13 @@ public class CaptureMediaContract : ActivityResultContract<Unit, File>() {
                 videoFile = it
                 createIntentList(context, MediaStore.ACTION_VIDEO_CAPTURE, it)
             }
-        return Intent.createChooser(Intent(), context.getString(R.string.stream_input_camera_title))
+        val intents = takePictureIntents + recordVideoIntents
+        val initialIntent = intents.lastOrNull() ?: Intent()
+        return Intent.createChooser(initialIntent, context.getString(R.string.stream_input_camera_title))
             .apply {
                 putExtra(
                     Intent.EXTRA_INITIAL_INTENTS,
-                    (takePictureIntents + recordVideoIntents).toTypedArray()
+                    (intents - initialIntent).toTypedArray()
                 )
             }
     }


### PR DESCRIPTION
### Description
Fix `CaptureMediaContract` chooser on Android API 21
IntentChooser doesn't show anything on Android API 21 if there isn't any intent matching with the intent that is passing to the `createChooser()` method.
To fix it I am getting one intent from the list of valid intent that we already created, and the rest are added to the extras. 
The last Intent is the one chosen because the method `Intent.createChooser()` add the one that receives by param as the last one of the list


<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/4047514/108378255-2076ed80-7205-11eb-8515-7c31798c90b5.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/4047514/108378115-02a98880-7205-11eb-9eae-0c6e0ac8865f.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
