### PR TITLE
Fix some typos in our deprecation messages

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -101,7 +101,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribe with ChatEventListener")
+    @Deprecated("Use subscribe with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribe(listener: (event: ChatEvent) -> Unit): Disposable {
         return client.subscribe(filterRelevantEvents(listener))
@@ -112,7 +112,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeFor with ChatEventListener")
+    @Deprecated("Use subscribeFor with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribeFor(
         vararg eventTypes: String,
@@ -129,7 +129,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeFor with ChatEventListener")
+    @Deprecated("Use subscribeFor with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribeFor(
         lifecycleOwner: LifecycleOwner,
@@ -156,7 +156,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeFor with ChatEventListener")
+    @Deprecated("Use subscribeFor with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribeFor(
         vararg eventTypes: Class<out ChatEvent>,
@@ -173,7 +173,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeFor with ChatEventListener")
+    @Deprecated("Use subscribeFor with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribeFor(
         lifecycleOwner: LifecycleOwner,
@@ -200,7 +200,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeForSingle with ChatEventListener")
+    @Deprecated("Use subscribeForSingle with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun subscribeForSingle(
         eventType: String,
@@ -217,7 +217,7 @@ public class ChannelClient internal constructor(
     }
 
     @Suppress("NEWER_VERSION_IN_SINCE_KOTLIN")
-    @Deprecated("User subscribeForSingle with ChatEventListener")
+    @Deprecated("Use subscribeForSingle with ChatEventListener")
     @SinceKotlin("99999.9")
     override fun <T : ChatEvent> subscribeForSingle(
         eventType: Class<T>,


### PR DESCRIPTION
Typo fixes