### PR TITLE
Small fix for channel title in shared channels

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/chat_info_shared_groups_item.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/chat_info_shared_groups_item.xml
@@ -19,7 +19,7 @@
 
     <TextView
         android:id="@+id/nameTextView"
-        android:layout_width="wrap_content"
+        android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
         android:ellipsize="end"
@@ -28,9 +28,9 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@id/membersCountTextView"
         app:layout_constraintHorizontal_chainStyle="spread_inside"
-        app:layout_constraintStart_toEndOf="@+id/avatarView"
+        app:layout_constraintStart_toEndOf="@id/avatarView"
         app:layout_constraintTop_toTopOf="parent"
-        tools:text="Gebruiker, Usuario, Benutzer"
+        tools:text="Gebruiker, Usuario, Benutzer, User, Gebruiker, Usuario, Benutzer, User"
         />
 
     <TextView


### PR DESCRIPTION
### Description

A small fix for the title in the shared groups list item. 

| Before | After |  
| --- | --- |  
| ![Screenshot_20210219-155116](https://user-images.githubusercontent.com/10619102/108549257-a78e9900-72cb-11eb-9473-9b5c9b4dc5fa.png) | ![Screenshot_20210219-155539](https://user-images.githubusercontent.com/10619102/108549274-aeb5a700-72cb-11eb-801e-58994c2dec48.png) | 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
