### PR TITLE
Increase touchable area on the button to remove an attachment

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `ChannelHeaderViewModel::resetThread` method and make `ChannelHeaderViewModel::setActiveThread` message parameter non-nullable
 - Fix ReadIndicator state
 - Use proper color values on Dialog Theme
+- Increase touchable area on the button to remove an attachment
 
 ## stream-chat-android-client
 - Introduce ChatClient::setUserWithoutConnecting function

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/FileAttachmentSelectedAdapter.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/adapter/FileAttachmentSelectedAdapter.kt
@@ -35,12 +35,12 @@ internal class FileAttachmentSelectedAdapter(
         binding.tvFileTitle.text = attachment.title
         binding.ivLargeFileMark.visibility = View.INVISIBLE
         binding.ivSelectMark.isVisible = false
-        binding.tvClose.visibility = View.INVISIBLE
+        binding.ivClose.visibility = View.INVISIBLE
         binding.progressBar.isVisible = false
         binding.tvFileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.size)
         if (!localAttach) return
-        binding.tvClose.isVisible = true
-        binding.tvClose.setOnClickListener { cancelListener(attachment) }
+        binding.ivClose.isVisible = true
+        binding.ivClose.setOnClickListener { cancelListener(attachment) }
     }
 
     fun setAttachments(attachments: List<AttachmentMetaData>) {

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/AttachmentsController.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/AttachmentsController.kt
@@ -71,10 +71,11 @@ internal class AttachmentsController(
     @VisibleForTesting
     internal fun cancelAttachment(
         attachment: AttachmentMetaData,
-        messageInputType: MessageInputType?
+        messageInputType: MessageInputType?,
+        isMediaAttachment: Boolean,
     ) {
         selectedAttachments = selectedAttachments - attachment
-        removeAttachmentFromAdapters(attachment)
+        removeAttachmentFromAdapters(attachment, isMediaAttachment)
         rootController.configSendButtonEnableState()
         if (selectedAttachments.isEmpty() && MessageInputType.EDIT_MESSAGE == messageInputType) {
             configAttachmentButtonVisible(true)
@@ -101,8 +102,8 @@ internal class AttachmentsController(
         fillTotalMediaAttachmentsView(messageInputType)
     }
 
-    private fun removeAttachmentFromAdapters(attachment: AttachmentMetaData) {
-        if (isMediaAttachment(attachment)) {
+    private fun removeAttachmentFromAdapters(attachment: AttachmentMetaData, isMediaAttachment: Boolean) {
+        if (isMediaAttachment) {
             selectedMediaAttachmentAdapter.removeAttachment(attachment)
             totalMediaAttachmentAdapter.unselectAttachment(attachment)
         } else {
@@ -127,7 +128,7 @@ internal class AttachmentsController(
         selectedAttachments = selectedAttachments.filter(isMediaAttachment).toSet()
         selectedMediaAttachmentAdapter.setAttachments(selectedAttachments.toList())
         selectedMediaAttachmentAdapter.cancelListener =
-            { attachment -> cancelAttachment(attachment, messageInputType) }
+            { attachment -> cancelAttachment(attachment, messageInputType, true) }
         view.showSelectedMediaAttachments(selectedMediaAttachmentAdapter)
         selectedFileAttachmentAdapter.clear()
     }
@@ -135,7 +136,7 @@ internal class AttachmentsController(
     private fun setSelectedFileAttachmentAdapter() {
         selectedAttachments = selectedAttachments.filter(isFileAttachment).toSet()
         selectedFileAttachmentAdapter.cancelListener =
-            { attachment -> cancelAttachment(attachment, null) }
+            { attachment -> cancelAttachment(attachment, null, false) }
         view.showSelectedFileAttachments(selectedFileAttachmentAdapter)
         selectedMediaAttachmentAdapter.clear()
     }
@@ -154,7 +155,7 @@ internal class AttachmentsController(
     ) {
         attachment.isSelected = false
         selectedAttachments = selectedAttachments - attachment
-        removeAttachmentFromAdapters(attachment)
+        removeAttachmentFromAdapters(attachment, true)
         rootController.configSendButtonEnableState()
         if (selectedAttachments.isEmpty() && MessageInputType.EDIT_MESSAGE == messageInputType) {
             configAttachmentButtonVisible(true)

--- a/stream-chat-android/src/main/res/layout/stream_item_attach_file.xml
+++ b/stream-chat-android/src/main/res/layout/stream_item_attach_file.xml
@@ -47,24 +47,28 @@
         app:layout_constraintTop_toBottomOf="@+id/tv_file_title"
         />
 
-    <TextView
-        android:id="@+id/tv_close"
+    <ImageView
+        android:id="@+id/iv_close"
         style="@style/text"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginEnd="10dp"
-        android:background="@drawable/stream_attach_close"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:paddingEnd="10dp"
+        android:paddingStart="10dp"
+        android:src="@drawable/stream_attach_close"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         />
 
     <ImageView
         android:id="@+id/iv_large_file_mark"
-        android:layout_width="20dp"
-        android:layout_height="20dp"
-        android:layout_marginTop="5dp"
-        android:layout_marginEnd="10dp"
+        android:layout_width="40dp"
+        android:layout_height="40dp"
+        android:paddingTop="10dp"
+        android:paddingBottom="10dp"
+        android:paddingEnd="10dp"
+        android:paddingStart="10dp"
         android:src="@drawable/stream_ic_file_size_error"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="parent"

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/view/messageinput/attachments/WhenCancelAttachmentTests.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/view/messageinput/attachments/WhenCancelAttachmentTests.kt
@@ -25,7 +25,7 @@ internal class WhenCancelAttachmentTests : BaseAttachmentsControllerTests() {
             .givenMediaSelectedAttachment(attachment)
             .please()
 
-        sut.cancelAttachment(attachment, mock())
+        sut.cancelAttachment(attachment, mock(), false)
 
         sut.selectedAttachments.contains(attachment) shouldBeEqualTo false
     }
@@ -39,7 +39,7 @@ internal class WhenCancelAttachmentTests : BaseAttachmentsControllerTests() {
             .givenMediaSelectedAttachment(attachment)
             .please()
 
-        sut.cancelAttachment(attachment, mock())
+        sut.cancelAttachment(attachment, mock(), true)
 
         verify(selectedMediaAttachmentAdapter).removeAttachment(attachment)
     }
@@ -53,7 +53,7 @@ internal class WhenCancelAttachmentTests : BaseAttachmentsControllerTests() {
             .givenMediaSelectedAttachment(attachment)
             .please()
 
-        sut.cancelAttachment(attachment, mock())
+        sut.cancelAttachment(attachment, mock(), true)
 
         verify(totalMediaAttachmentAdapter).unselectAttachment(attachment)
     }
@@ -67,7 +67,7 @@ internal class WhenCancelAttachmentTests : BaseAttachmentsControllerTests() {
             .please()
         reset(selectedFileAttachmentAdapter)
 
-        sut.cancelAttachment(attachment, mock())
+        sut.cancelAttachment(attachment, mock(), false)
 
         verify(selectedFileAttachmentAdapter).setAttachments(argThat { !contains(attachment) })
     }


### PR DESCRIPTION
### Description
Increase touchable area on the button to remove an attachment
Fixes #1450 

Update logic to remove attachments that depended on the type of files, instead on the adapter where it was added.

| Before | After |
| --- | --- |
| ![device-2021-02-22-133230](https://user-images.githubusercontent.com/4047514/108713981-3d6b3380-7519-11eb-8079-ec682fd04955.png) | ![device-2021-02-22-135646](https://user-images.githubusercontent.com/4047514/108714001-46f49b80-7519-11eb-95fb-7c933f31f32a.png)  |

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
