### PR TITLE
Bugfix cas-748 token registration

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -117,6 +117,7 @@ public class ChatClient internal constructor(
                     clientStateService.onConnected(user, connectionId)
                     api.setConnection(user.id, connectionId)
                     lifecycleObserver.observe()
+                    notifications.onSetUser()
                 }
                 is DisconnectedEvent -> {
                     clientStateService.onDisconnected()
@@ -230,7 +231,6 @@ public class ChatClient internal constructor(
         config.isAnonymous = false
         tokenManager.setTokenProvider(tokenProvider)
         warmUp()
-        notifications.onSetUser()
     }
 
     /**


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-748

### Description

Firebase token needs to be registered on the backend after the `ConnectedEvent` is received, after `api::setConnection` is called. Otherwise, the registration call may fail occasionally. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
