### PR TITLE
Fix user search on the "Create Channel" screen

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/header/AddChannelHeaderView.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/header/AddChannelHeaderView.kt
@@ -60,6 +60,9 @@ class AddChannelHeaderView : FrameLayout, AddChannelHeader {
             }
             isVisible = members.isNotEmpty()
         }
+        if (query.isNotEmpty()) {
+            binding.inputEditText.setText("")
+        }
     }
 
     override fun showInput() {

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/add_channel_header_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/add_channel_header_view.xml
@@ -27,6 +27,7 @@
         android:layout_height="wrap_content"
         android:layout_marginHorizontal="16dp"
         android:layout_marginBottom="4dp"
+        android:visibility="gone"
         app:layout_constraintBottom_toTopOf="@id/bottomBarrier"
         app:layout_constraintEnd_toStartOf="@id/addMemberButton"
         app:layout_constraintStart_toEndOf="@id/addMemberTextView"


### PR DESCRIPTION
### Description

This PR fixes the following issues on "Create Channel" screen:
- "Type a name" label top padding when the screen is just opened
- After we type a user name and click on a user in the results list, `EditText` should be cleared so that next user input starts with an empty search term. Also, after user has beed selected, the list should show all available users (and not only users matching the old search term).

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/109504258-69a02a80-7aac-11eb-8f15-d6918aa69f2a.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/109504281-6f960b80-7aac-11eb-9567-67f1f9fd3b8b.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>
