### PR TITLE
[CAS-749] Adding replyTo message inside MessageUpdatedEvent handling

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -1106,7 +1106,10 @@ internal class ChannelControllerImpl(
                 setHidden(false)
             }
             is MessageUpdatedEvent -> {
-                upsertEventMessage(event.message)
+                event.message.apply {
+                    replyTo = _messages.value[replyMessageId]
+                }.let(::upsertEventMessage)
+
                 setHidden(false)
             }
             is MessageDeletedEvent -> {


### PR DESCRIPTION
[CAS-749](https://stream-io.atlassian.net/browse/CAS-749)

### Description

Adding `replyTo` using `replyMessageId` when handling `MessageUpdatedEvent` inside `ChannelControllerImpl`. This avoid that the reply message redraws itself in a wrong way inside a thread.

Before

https://user-images.githubusercontent.com/10619102/109515412-cd632d00-7a85-11eb-832f-5c2757ce78b7.mov

After

https://user-images.githubusercontent.com/10619102/109515196-955bea00-7a85-11eb-9479-0fc1387118cd.mov

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
