### PR TITLE
[CAS-751] Fix refreshing channel list after removing member

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -36,6 +36,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed refreshing channel list after removing member
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImpl.kt
@@ -338,7 +338,13 @@ internal class QueryChannelsControllerImpl(
         val existingChannelMap = _channels.value.toMutableMap()
 
         newChannels.forEach { channel ->
-            existingChannelMap[channel.cid] = channel
+            if (channel.members.any { member -> member.getUserId() == domainImpl.currentUser.id }) {
+                existingChannelMap[channel.cid] = channel
+            } else {
+                domainImpl.scope.launch {
+                    removeChannel(channel.cid)
+                }
+            }
         }
         _channels.value = existingChannelMap
     }


### PR DESCRIPTION
Fixes #1473 

### Description
`QueryChannelsControllerImpl::refreshChannels` wasn't checking if the current user is still a member of the channel. 
I've added an additional check to ensure that we skip channels to which the current user doesn't belong to.


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
