### PR TITLE
fix cut reactions for specific sdk & dpi

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/internal/ReactionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/internal/ReactionsAdapter.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.ui.message.list.reactions.internal
 
+import android.os.Build
 import android.view.ViewGroup
 import androidx.annotation.Px
 import androidx.core.view.updateLayoutParams
@@ -36,8 +37,11 @@ internal class ReactionsAdapter(
         private lateinit var reactionItem: ReactionItem
 
         init {
+            val isLollipop = Build.VERSION.SDK_INT <= Build.VERSION_CODES.LOLLIPOP_MR1
+            val isProblemDensity = context.resources.displayMetrics.densityDpi == 560
+            val additionalWidth = if (isLollipop && isProblemDensity) 10 else 0
             binding.root.updateLayoutParams<ViewGroup.MarginLayoutParams> {
-                width = itemSize
+                width = itemSize + additionalWidth
                 height = itemSize
             }
             binding.root.setOnClickListener {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-724

### Description

There's a strange issue where "their" reactions get clipped on Lollipop (21 & 22) at screen densities of at least 560dpi.
Some questions you might have:

> Why does this happen? 

I'm not really sure. 21 is the lowest SDK version we support, and 22 is the highest SDK version at which I can reproduce it. It also happens that you can't use a layout inspector for SDK < 23 :(. 560dpi is the highest density I can emulate, and the only density at which I can reproduce the issue. I can only assume it's some backwards compatibility bug / edge case. It's also possible that it's an emulator-only issue.

> How did you fix it?

I... just added 10 pixels to the image width if we're within the problem version & density

> Why 10 px?

Because values of 1 - 9 do nothing :\

> Did you try manipulating the layout?

Oh yes.

> Do we really want to address this edge case?

If it were up to me, I'd let it age out of our supported SDK window.


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
