### PR TITLE
Fix MessageListView attr parsing

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed some rare crashes when `MessageListView` was created without any attribute info present
 
 ### ⬆️ Improved
 - Updated PhotoView to version 2.3.0

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -363,7 +363,6 @@ public class MessageListView : ConstraintLayout {
     }
 
     public constructor(context: Context, attrs: AttributeSet?) : super(context, attrs) {
-        parseAttr(context, attrs)
         init(context, attrs)
     }
 
@@ -372,11 +371,12 @@ public class MessageListView : ConstraintLayout {
         attrs,
         defStyle
     ) {
-        parseAttr(context, attrs)
         init(context, attrs)
     }
 
     private fun init(context: Context, attr: AttributeSet?) {
+        messageListViewStyle = MessageListViewStyle(context, attr)
+
         binding = StreamUiMessageListViewBinding.inflate(context.inflater, this, true)
 
         initRecyclerView()
@@ -421,10 +421,6 @@ public class MessageListView : ConstraintLayout {
         ) {
             lastMessageReadHandler.onLastMessageRead()
         }
-    }
-
-    private fun parseAttr(context: Context, attrs: AttributeSet?) {
-        messageListViewStyle = MessageListViewStyle(context, attrs)
     }
 
     private fun configureAttributes(attributeSet: AttributeSet) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -384,9 +384,7 @@ public class MessageListView : ConstraintLayout {
         initLoadingView()
         initEmptyStateView()
 
-        if (attr != null) {
-            configureAttributes(attr)
-        }
+        configureAttributes(attr)
 
         buffer.subscribe(::handleNewWrapper)
         buffer.active()
@@ -423,7 +421,7 @@ public class MessageListView : ConstraintLayout {
         }
     }
 
-    private fun configureAttributes(attributeSet: AttributeSet) {
+    private fun configureAttributes(attributeSet: AttributeSet?) {
         val tArray = context
             .obtainStyledAttributes(attributeSet, R.styleable.MessageListView)
 


### PR DESCRIPTION
### Description

If `MessageListView` is created with a plain constructor call passing in just a `Context`, i.e. `MessageListView(context)`, we skipped running some of its initialization code parsing attributes. With this code skipped, multiple `lateinit` variables remain uninitialized (`style`, `loadMoreListener`), leading to crashes during usage.

These changes make it so that attribute parsing always runs (no matter now the instance is created), falling back to default if needed.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
