### PR TITLE
[CAS-700] Fix - online status propagation

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -475,8 +475,8 @@ internal class EventHandlerImpl(
                         ?.contains(event.user.id) == true
                 }
                 .forEach { channelController ->
-                channelController.handleEvent(userPresenceChanged)
-            }
+                    channelController.handleEvent(userPresenceChanged)
+                }
         }
 
         // only afterwards forward to the queryRepo since it borrows some data from the channel

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -215,9 +215,6 @@ internal class EventHandlerImpl(
                     event.totalUnreadCount?.let { domainImpl.setTotalUnreadCount(it) }
                     batch.addMessageData(event.cid, event.message, isNewMessage = true)
                 }
-                is UserPresenceChangedEvent -> {
-                    batch.addUser(event.user)
-                }
                 is MessageDeletedEvent -> {
                     event.message.enrichWithCid(event.cid)
                     event.message.enrichWithOwnReactions(batch, event.user)
@@ -409,6 +406,7 @@ internal class EventHandlerImpl(
                 is UserDeletedEvent,
                 is UserStartWatchingEvent,
                 is UserStopWatchingEvent,
+                is UserPresenceChangedEvent,
                 -> Unit
             }.exhaustive
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -1271,9 +1271,7 @@ internal class ChannelControllerImpl(
     }
 
     fun upsertMembers(members: List<Member>) {
-        val oldMembers = _members.value + members.associateBy { it.user.id }
-
-        _members.value += oldMembers
+        _members.value = _members.value + members.associateBy { it.user.id }
     }
 
     fun upsertMember(member: Member) = upsertMembers(listOf(member))

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -1206,7 +1206,7 @@ internal class ChannelControllerImpl(
         // members and watchers have users
         val members = _members.value
         val watchers = _watchers.value
-        val member = members[userId]
+        val member = members[userId]?.copy()
         val watcher = watchers[userId]
         if (member != null) {
             member.user = user
@@ -1271,7 +1271,9 @@ internal class ChannelControllerImpl(
     }
 
     fun upsertMembers(members: List<Member>) {
-        _members.value = _members.value + members.associateBy { it.user.id }
+        val oldMembers = _members.value + members.associateBy { it.user.id }
+
+        _members.value += oldMembers
     }
 
     fun upsertMember(member: Member) = upsertMembers(listOf(member))

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -29,6 +29,7 @@ class ChatInitializer(private val context: Context) {
             .build()
 
         val domain = ChatDomain.Builder(client, user, context)
+            .userPresenceEnabled()
             .offlineEnabled()
             .build()
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/User.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/User.kt
@@ -11,7 +11,7 @@ public fun User.getLastSeenText(context: Context): String {
         return context.getString(R.string.stream_ui_message_list_header_online)
     }
 
-    (lastActive ?: createdAt)?.let { date ->
+    (updatedAt ?: lastActive ?: createdAt)?.let { date ->
         return context.getString(
             R.string.stream_ui_message_list_header_last_seen,
             DateUtils.getRelativeTimeSpanString(date.time).toString()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -9,10 +9,8 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.livedata.ChatDomain
-import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.common.extensions.getCreatedAtOrThrow
-import io.getstream.chat.android.ui.common.extensions.getLastSeenText
 import io.getstream.chat.android.ui.common.extensions.isDeleted
 import io.getstream.chat.android.ui.common.extensions.isEphemeral
 import io.getstream.chat.android.ui.common.extensions.isFailed

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -46,37 +46,6 @@ internal fun Channel.diff(other: Channel): ChannelListPayloadDiff =
         unreadCountChanged = unreadCount != other.unreadCount,
     )
 
-internal fun Channel.getOnlineStateSubtitle(context: Context): String {
-    val users = getUsers()
-    if (users.isEmpty()) return String.EMPTY
-
-    if (users.size == 1) {
-        return users.first().getLastSeenText(context)
-    }
-
-    return getGroupSubtitle(context)
-}
-
-internal fun Channel.getGroupSubtitle(context: Context): String {
-    val allUsers = members.map { it.user }
-    val onlineUsers = allUsers.count { it.online }
-    val groupMembers = context.resources.getQuantityString(
-        R.plurals.stream_ui_message_list_header_group_member_count,
-        allUsers.size,
-        allUsers.size
-    )
-
-    return if (onlineUsers > 0) {
-        context.getString(
-            R.string.stream_ui_message_list_header_group_member_count_with_online,
-            groupMembers,
-            onlineUsers
-        )
-    } else {
-        groupMembers
-    }
-}
-
 internal fun Channel.isMessageRead(message: Message): Boolean {
     val currentUser = ChatDomain.instance().currentUser
     return read.filter { it.user.id != currentUser.id }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
@@ -23,6 +23,7 @@ public fun MessageListHeaderViewModel.bindView(view: MessageListHeaderView, life
         view.setTitle(it.getDisplayName(view.context))
         view.setAvatar(it)
     }
+
     online.observe(lifecycle) { isOnline ->
         if (isOnline) {
             view.showOnlineStateSubtitle()
@@ -30,6 +31,7 @@ public fun MessageListHeaderViewModel.bindView(view: MessageListHeaderView, life
             view.showSearchingForNetworkLabel()
         }
     }
+
     typingUsers.observe(lifecycle, view::showTypingStateLabel)
 
     activeThread.observe(lifecycle) { message ->
@@ -49,11 +51,11 @@ private fun getOnlineStateSubtitle(context: Context, members: List<Member>): Str
     val users = members.map { member -> member.user }.filterCurrentUser()
     if (users.isEmpty()) return String.EMPTY
 
-    if (users.size == 1) {
-        return users.first().getLastSeenText(context)
+    return if (users.size == 1) {
+         users.first().getLastSeenText(context)
+    } else {
+        getGroupSubtitle(context, members)
     }
-
-    return getGroupSubtitle(context, members)
 }
 
 private fun List<User>.filterCurrentUser(): List<User> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
@@ -52,7 +52,7 @@ private fun getOnlineStateSubtitle(context: Context, members: List<Member>): Str
     if (users.isEmpty()) return String.EMPTY
 
     return if (users.size == 1) {
-         users.first().getLastSeenText(context)
+        users.first().getLastSeenText(context)
     } else {
         getGroupSubtitle(context, members)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewBinding.kt
@@ -2,9 +2,15 @@
 
 package io.getstream.chat.android.ui.message.list.header.viewmodel
 
+import android.content.Context
 import androidx.lifecycle.LifecycleOwner
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.getDisplayName
-import io.getstream.chat.android.ui.common.extensions.internal.getOnlineStateSubtitle
+import io.getstream.chat.android.ui.common.extensions.getLastSeenText
+import io.getstream.chat.android.ui.common.extensions.internal.EMPTY
 import io.getstream.chat.android.ui.message.list.header.MessageListHeaderView
 
 /**
@@ -15,7 +21,6 @@ import io.getstream.chat.android.ui.message.list.header.MessageListHeaderView
 public fun MessageListHeaderViewModel.bindView(view: MessageListHeaderView, lifecycle: LifecycleOwner) {
     channelState.observe(lifecycle) {
         view.setTitle(it.getDisplayName(view.context))
-        view.setOnlineStateSubtitle(it.getOnlineStateSubtitle(view.context))
         view.setAvatar(it)
     }
     online.observe(lifecycle) { isOnline ->
@@ -33,5 +38,49 @@ public fun MessageListHeaderViewModel.bindView(view: MessageListHeaderView, life
         } else {
             view.setNormalMode()
         }
+    }
+
+    members.observe(lifecycle) { memberList ->
+        view.setOnlineStateSubtitle(getOnlineStateSubtitle(view.context, memberList))
+    }
+}
+
+private fun getOnlineStateSubtitle(context: Context, members: List<Member>): String {
+    val users = members.map { member -> member.user }.filterCurrentUser()
+    if (users.isEmpty()) return String.EMPTY
+
+    if (users.size == 1) {
+        return users.first().getLastSeenText(context)
+    }
+
+    return getGroupSubtitle(context, members)
+}
+
+private fun List<User>.filterCurrentUser(): List<User> {
+    return if (ChatDomain.isInitialized) {
+        val currentUser = ChatDomain.instance().currentUser
+        filter { it.id != currentUser.id }
+    } else {
+        this
+    }
+}
+
+private fun getGroupSubtitle(context: Context, members: List<Member>): String {
+    val allUsers = members.map { it.user }
+    val onlineUsers = allUsers.count { it.online }
+    val groupMembers = context.resources.getQuantityString(
+        R.plurals.stream_ui_message_list_header_group_member_count,
+        allUsers.size,
+        allUsers.size
+    )
+
+    return if (onlineUsers > 0) {
+        context.getString(
+            R.string.stream_ui_message_list_header_group_member_count_with_online,
+            groupMembers,
+            onlineUsers
+        )
+    } else {
+        groupMembers
     }
 }


### PR DESCRIPTION
[CAS-700](https://stream-io.atlassian.net/browse/CAS-700)

### Description

This PR propagates online/offline status of the user in our Message List Header View. This PR doesn't fix the online/offline status in the whole app, more PRs will come to fix the other screens.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/109827134-3c718a80-7c1a-11eb-8dec-50e37890dd51.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/109827287-5a3eef80-7c1a-11eb-98c7-ef994c6047b0.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

_It is hard to see... but take a look at the subtitle of the channel_

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes.
- [x] Reviewers added
