### PR TITLE
[CAS-700] Fix - Propagating online status in chat info

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
@@ -42,7 +42,7 @@ class ChatInfoViewModel(
                     _state.value = _state.value!!.copy(canDeleteChannel = canDeleteChannel)
 
                     _state.addSource(channelController.members) { memberList ->
-                        //Updates only if the user state is already set
+                        // Updates only if the user state is already set
                         memberList.find { member -> member.user.id == _state.value?.member?.user?.id }?.let { member ->
                             _state.value = _state.value?.copy(member = member)
                         }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
@@ -37,8 +37,16 @@ class ChatInfoViewModel(
             viewModelScope.launch {
                 val channelControllerResult = chatDomain.useCases.getChannelController(cid).await()
                 if (channelControllerResult.isSuccess) {
-                    val canDeleteChannel = channelControllerResult.data().members.value.isCurrentUserOwnerOrAdmin()
+                    val channelController = channelControllerResult.data()
+                    val canDeleteChannel = channelController.members.value.isCurrentUserOwnerOrAdmin()
                     _state.value = _state.value!!.copy(canDeleteChannel = canDeleteChannel)
+
+                    _state.addSource(channelController.members) { memberList ->
+                        //Updates only if the user state is already set
+                        memberList.find { member -> member.user.id == _state.value?.member?.user?.id }?.let { member ->
+                            _state.value = _state.value?.copy(member = member)
+                        }
+                    }
                 }
                 // Currently, we don't receive any event when channel member is banned/shadow banned, so
                 // we need to get member data from the server


### PR DESCRIPTION
[CAS-700](https://stream-io.atlassian.net/browse/CAS-700)

### Description

This PR creates the propagation of the online/offline status in the chat info screen.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/109856915-d2b4a900-7c38-11eb-9ecb-c9a8f5f52f7e.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/109856962-e06a2e80-7c38-11eb-9871-3386edafd1b4.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes -> In a minute.
- [x] Reviewers added
