### PR TITLE
Update parameter type of createAttachmentView

### DIFF
--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
@@ -2,6 +2,7 @@ package io.getstream.chat.docs.java;
 
 import android.content.Context;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.getstream.sdk.chat.adapter.MessageListItem;
 
@@ -442,7 +443,7 @@ public class Messages {
                     @NotNull MessageListItem.MessageItem data,
                     @NotNull MessageListListenerContainer listeners,
                     @NotNull MessageListItemStyle style,
-                    @NotNull View parent
+                    @NotNull ViewGroup parent
             ) {
                 return super.createAttachmentView(data, listeners, style, parent);
             }
@@ -465,7 +466,7 @@ public class Messages {
                     @NotNull MessageListItem.MessageItem data,
                     @NotNull MessageListListenerContainer listeners,
                     @NotNull MessageListItemStyle style,
-                    @NotNull View parent
+                    @NotNull ViewGroup parent
             ) {
                 boolean containsMyAttachments = false;
                 for (Attachment attachment: data.getMessage().getAttachments()) {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Messages.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Messages.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.docs.kotlin
 
 import android.content.Context
 import android.view.View
+import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
@@ -435,11 +436,12 @@ class Messages(
                 data: MessageListItem.MessageItem,
                 listeners: MessageListListenerContainer,
                 style: MessageListItemStyle,
-                parent: View
+                parent: ViewGroup,
             ): View {
                 return super.createAttachmentView(data, listeners, style, parent)
             }
         }
+
         private lateinit var messageListView: MessageListView
 
         fun setAttachmentFactory() {
@@ -453,7 +455,7 @@ class Messages(
                 data: MessageListItem.MessageItem,
                 listeners: MessageListListenerContainer,
                 style: MessageListItemStyle,
-                parent: View,
+                parent: ViewGroup,
             ): View {
                 return if (data.message.attachments.any { it.imageUrl?.contains(MY_URL_ADDRESS) == true }) {
                     // put your custom attachment view creation here

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -852,7 +852,7 @@ public abstract interface class io/getstream/chat/android/ui/message/list/adapte
 
 public class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory {
 	public fun <init> ()V
-	public fun createAttachmentView (Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Lio/getstream/chat/android/ui/message/list/internal/MessageListItemStyle;Landroid/view/View;)Landroid/view/View;
+	public fun createAttachmentView (Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Lio/getstream/chat/android/ui/message/list/internal/MessageListItemStyle;Landroid/view/ViewGroup;)Landroid/view/View;
 	protected final fun createAttachmentsContent (Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Ljava/util/List;Landroid/view/View;)Landroid/view/View;
 	protected final fun createLinkAndAttachmentsContent (Ljava/util/List;Lio/getstream/chat/android/client/models/Attachment;Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Lio/getstream/chat/android/ui/message/list/internal/MessageListItemStyle;Landroid/view/View;)Landroid/view/View;
 	protected final fun createLinkContent (Lio/getstream/chat/android/client/models/Attachment;ZLio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Lio/getstream/chat/android/ui/message/list/internal/MessageListItemStyle;Landroid/view/View;)Landroid/view/View;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory.kt
@@ -42,7 +42,7 @@ public open class AttachmentViewFactory {
         data: MessageListItem.MessageItem,
         listeners: MessageListListenerContainer,
         style: MessageListItemStyle,
-        parent: View,
+        parent: ViewGroup,
     ): View {
         val (links, attachments) = data.message.attachments.partition(Attachment::hasLink)
 


### PR DESCRIPTION
### Description

Changes the parameter from `View` to `ViewGroup` to better represent what it is + match similar APIs like RecyclerView.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
