### PR TITLE
[CAS-582] Refactor - Moving message helper to constructor

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -97,6 +97,7 @@ internal class ChannelControllerImpl(
     override val channelId: String,
     val client: ChatClient,
     val domainImpl: ChatDomainImpl,
+    private val messageHelper: MessageHelper = MessageHelper(),
 ) : ChannelController {
     private val editJobs = mutableMapOf<String, Job>()
 
@@ -234,7 +235,6 @@ internal class ChannelControllerImpl(
 
     private val threadControllerMap: ConcurrentHashMap<String, ThreadControllerImpl> =
         ConcurrentHashMap()
-    private val messageHelper = MessageHelper()
 
     fun getThread(threadId: String): ThreadControllerImpl = threadControllerMap.getOrPut(threadId) {
         ThreadControllerImpl(threadId, this, client, domainImpl)


### PR DESCRIPTION
[CAS-582](https://stream-io.atlassian.net/browse/CAS-582)

### Description

MessageHelper should not be constructor inside the constructor of `ChannelControllerImpl`, it binds both logic together and makes impossible to unit tests one class without the other. It makes tests for message update impossible to mock. 
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
