### PR TITLE
Fix channelId property names in ChannelDeletedEvents

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -30,6 +30,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Renamed `ChannelId` property to `channelId` in both `ChannelDeletedEvent` and `NotificationChannelDeletedEvent`
 
 ### ❌ Removed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -39,7 +39,7 @@ public data class ChannelDeletedEvent(
     @SerializedName("created_at") override val createdAt: Date,
     override val cid: String,
     @SerializedName("channel_type") val channelType: String,
-    @SerializedName("channel_id") val ChannelId: String,
+    @SerializedName("channel_id") val channelId: String,
     val channel: Channel,
     val user: User?,
 ) : CidEvent()
@@ -212,7 +212,7 @@ public data class NotificationChannelDeletedEvent(
     @SerializedName("created_at") override val createdAt: Date,
     override val cid: String,
     @SerializedName("channel_type") val channelType: String,
-    @SerializedName("channel_id") val ChannelId: String,
+    @SerializedName("channel_id") val channelId: String,
     val channel: Channel,
     val user: User?,
 ) : CidEvent()


### PR DESCRIPTION
### Description

Fixes uppercase property names in two events.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
