### PR TITLE
Make sync notification not pop up over the app

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/PushMessageSyncHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/PushMessageSyncHandler.kt
@@ -138,13 +138,16 @@ public class PushMessageSyncHandler(private val service: Service) {
     private fun createSyncNotificationChannel() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
             NotificationChannel(CHANNEL_ID, CHANNEL_NAME, NotificationManager.IMPORTANCE_HIGH).run {
+                this.importance = NotificationManager.IMPORTANCE_LOW
                 service.getSystemService(NotificationManager::class.java).createNotificationChannel(this)
             }
         }
     }
 
     private fun initDomain(user: User, client: ChatClient): ChatDomain {
-        return ChatDomain.Builder(service, client, user).build()
+        return ChatDomain.Builder(service, client).build().apply {
+            currentUser = user
+        }
     }
 
     private fun initClient(


### PR DESCRIPTION
Fixes #1498

### Description

1. Set foreground sync service notification channel importance to `NotificationManager.IMPORTANCE_LOW`. This prevents the notification from popping over the app which is currently opened.
2. Stop using deprecated `ChatDomain.Builder` constructor
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
