### PR TITLE
Make initJob nullable instead of lateinit

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -212,7 +212,7 @@ internal class ChatDomainImpl internal constructor(
 
     internal lateinit var repos: RepositoryFacade
     private val syncStateFlow: MutableStateFlow<SyncState?> = MutableStateFlow(null)
-    internal lateinit var initJob: Deferred<SyncState?>
+    internal var initJob: Deferred<SyncState?>? = null
 
     /** The retry policy for retrying failed requests */
     override var retryPolicy: RetryPolicy = DefaultRetryPolicy()
@@ -586,7 +586,7 @@ internal class ChatDomainImpl internal constructor(
      */
     suspend fun replayEventsForActiveChannels(cid: String? = null): Result<List<ChatEvent>> {
         // wait for the active channel info to load
-        initJob.join()
+        initJob?.join()
         // make a list of all channel ids
         val cids = activeChannelMapImpl.keys().toList().toMutableList()
         cid?.let {
@@ -628,7 +628,7 @@ internal class ChatDomainImpl internal constructor(
      */
     suspend fun connectionRecovered(recoverAll: Boolean = false) {
         // 0 ensure load is complete
-        initJob.join()
+        initJob?.join()
 
         // 1 update the results for queries that are actively being shown right now
         val updatedChannelIds = mutableSetOf<String>()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/RecoveryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/RecoveryTest.kt
@@ -41,7 +41,7 @@ internal class ConnectedRecoveryTest : BaseDomainTest2() {
     fun `Active channels should be stored in sync state`(): Unit = runBlocking {
         val cid = "messaging:myspecialchannel"
         chatDomainImpl.channel(cid)
-        chatDomainImpl.initJob.await()
+        chatDomainImpl.initJob?.await()
         val syncState1 = chatDomainImpl.storeSyncState()
         val syncState2 = chatDomainImpl.repos.selectSyncState(data.user1.id)
         Truth.assertThat(syncState2!!.activeChannelIds).contains(cid)


### PR DESCRIPTION
Fixes #1497

### Description

`ChatDomainImpl.initJob` property was wrongly declared as `lateinit var`. This was causing `UnitializedProperty` crashes. 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
