### PR TITLE
[CAS-785] Add unflag message and unflag user methods

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -30,6 +30,7 @@ It is not possible to remove users from distinct channels anymore.
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `unFlagMessage(messageId)` and `unFlagUser(userId)` methods to `ChatClient`
 
 ### ⚠️ Changed
 - Renamed `ChannelId` property to `channelId` in both `ChannelDeletedEvent` and `NotificationChannelDeletedEvent`

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -123,6 +123,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun subscribeForSingle (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public final fun translate (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unFlagMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unFlagUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unMuteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unmuteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public final fun unmuteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1035,7 +1035,13 @@ public class ChatClient internal constructor(
     public fun flagUser(userId: String): Call<Flag> = api.flagUser(userId)
 
     @CheckResult
+    public fun unFlagUser(userId: String): Call<Flag> = api.unFlagUser(userId)
+
+    @CheckResult
     public fun flagMessage(messageId: String): Call<Flag> = api.flagMessage(messageId)
+
+    @CheckResult
+    public fun unFlagMessage(messageId: String): Call<Flag> = api.unFlagMessage(messageId)
 
     @CheckResult
     public fun translate(messageId: String, language: String): Call<Message> =
@@ -1127,7 +1133,8 @@ public class ChatClient internal constructor(
         return runCatching {
             when (clientStateService.state) {
                 is ClientState.User.Pending,
-                is ClientState.User.Authorized -> if (tokenManager.hasToken()) tokenManager.getToken() else null
+                is ClientState.User.Authorized,
+                -> if (tokenManager.hasToken()) tokenManager.getToken() else null
                 else -> null
             }
         }.getOrNull()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -240,7 +240,13 @@ internal interface ChatApi {
     fun flagUser(userId: String): Call<Flag>
 
     @CheckResult
+    fun unFlagUser(userId: String): Call<Flag>
+
+    @CheckResult
     fun flagMessage(messageId: String): Call<Flag>
+
+    @CheckResult
+    fun unFlagMessage(messageId: String): Call<Flag>
 
     @CheckResult
     fun banUser(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -604,14 +604,33 @@ internal class GsonChatApi(
         ).map { Unit }
     }
 
-    override fun flagUser(userId: String): Call<Flag> =
-        flag(mutableMapOf("target_user_id" to userId))
+    override fun flagUser(userId: String): Call<Flag> {
+        return flag(mutableMapOf("target_user_id" to userId))
+    }
 
-    override fun flagMessage(messageId: String): Call<Flag> =
-        flag(mutableMapOf("target_message_id" to messageId))
+    override fun unFlagUser(userId: String): Call<Flag> {
+        return unflag(mutableMapOf("target_user_id" to userId))
+    }
+
+    override fun flagMessage(messageId: String): Call<Flag> {
+        return flag(mutableMapOf("target_message_id" to messageId))
+    }
+
+    override fun unFlagMessage(messageId: String): Call<Flag> {
+        return unflag(mutableMapOf("target_message_id" to messageId))
+    }
 
     private fun flag(body: MutableMap<String, String>): Call<Flag> {
         return retrofitApi.flag(
+            apiKey,
+            userId,
+            connectionId,
+            body
+        ).map { it.flag }
+    }
+
+    private fun unflag(body: MutableMap<String, String>): Call<Flag> {
+        return retrofitApi.unFlag(
             apiKey,
             userId,
             connectionId,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -266,6 +266,14 @@ internal interface RetrofitApi {
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
+    @POST("/moderation/unflag")
+    fun unFlag(
+        @Query("api_key") apiKey: String,
+        @Query("user_id") userId: String,
+        @Query("client_id") connectionId: String,
+        @Body body: Map<String, String>
+    ): RetrofitCall<FlagResponse>
+
     @POST("/moderation/ban")
     fun banUser(
         @Query("api_key") apiKey: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
@@ -57,6 +57,14 @@ internal interface ModerationApi {
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
+    @POST("/moderation/unflag")
+    fun unFlag(
+        @Query("api_key") apiKey: String,
+        @Query("user_id") userId: String,
+        @Query("client_id") connectionId: String,
+        @Body body: Map<String, String>
+    ): RetrofitCall<FlagResponse>
+
     @POST("/moderation/ban")
     fun banUser(
         @Query("api_key") apiKey: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -346,11 +346,26 @@ internal class MoshiChatApi(
     override fun flagUser(userId: String): Call<Flag> =
         flag(mutableMapOf("target_user_id" to userId))
 
+    override fun unFlagUser(userId: String): Call<Flag> =
+        unFlag(mutableMapOf("target_user_id" to userId))
+
     override fun flagMessage(messageId: String): Call<Flag> =
         flag(mutableMapOf("target_message_id" to messageId))
 
+    override fun unFlagMessage(messageId: String): Call<Flag> =
+        unFlag(mutableMapOf("target_message_id" to messageId))
+
     private fun flag(body: MutableMap<String, String>): Call<Flag> {
         return moderationApi.flag(
+            apiKey,
+            userId,
+            connectionId,
+            body
+        ).map { response -> response.flag.toDomain() }
+    }
+
+    private fun unFlag(body: MutableMap<String, String>): Call<Flag> {
+        return moderationApi.unFlag(
             apiKey,
             userId,
             connectionId,

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Moderation.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Moderation.java
@@ -35,10 +35,32 @@ public class Moderation {
             });
         }
 
+        public void unFlagMessage() {
+            client.unFlagMessage("message-id").enqueue(result -> {
+                if (result.isSuccess()) {
+                    // Message flag was removed
+                    Flag flag = result.data();
+                } else {
+                    // Handle result.error()
+                }
+            });
+        }
+
         public void flagUser() {
             client.flagUser("user-id").enqueue(result -> {
                 if (result.isSuccess()) {
                     // User was flagged
+                    Flag flag = result.data();
+                } else {
+                    // Handle result.error()
+                }
+            });
+        }
+
+        public void unFlagUser() {
+            client.unFlagUser("user-id").enqueue(result -> {
+                if (result.isSuccess()) {
+                    // User flag was removed
                     Flag flag = result.data();
                 } else {
                     // Handle result.error()

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
@@ -28,10 +28,32 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
             }
         }
 
+        fun unFlagMessage() {
+            client.unFlagMessage("message-id").enqueue { result ->
+                if (result.isSuccess) {
+                    // Message flag was removed
+                    val flag: Flag = result.data()
+                } else {
+                    // Handle result.error()
+                }
+            }
+        }
+
         fun flagUser() {
             client.flagUser("user-id").enqueue { result ->
                 if (result.isSuccess) {
                     // User was flagged
+                    val flag: Flag = result.data()
+                } else {
+                    // Handle result.error()
+                }
+            }
+        }
+
+        fun unFlagUser() {
+            client.unFlagUser("user-id").enqueue { result ->
+                if (result.isSuccess) {
+                    // User flag was removed
                     val flag: Flag = result.data()
                 } else {
                     // Handle result.error()


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-785

### Description

Added `unFlagMessage(messageId)` and `unFlagUser(userId)` methods to `ChatClient`.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [X] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
