### PR TITLE
[CAS-764] Feature/store all participants of a message

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -40,6 +40,7 @@ It is not possible to remove users from distinct channels anymore.
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed an issue that didn't find the user when obtaining the list of messages
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/Message.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/extensions/Message.kt
@@ -24,7 +24,12 @@ internal fun Message.wasCreatedBeforeOrAt(date: Date?): Boolean {
 }
 
 internal fun Message.users(): List<User> {
-    return latestReactions.mapNotNull(Reaction::user) + user + (replyTo?.users().orEmpty())
+    return latestReactions.mapNotNull(Reaction::user) +
+        user +
+        (replyTo?.users().orEmpty()) +
+        mentionedUsers +
+        ownReactions.mapNotNull(Reaction::user) +
+        threadParticipants
 }
 
 internal fun Message.shouldIncrementUnreadCount(currentUserId: String): Boolean {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
@@ -298,7 +298,6 @@ internal fun randomMessage(
     parentId: String? = randomString(),
     command: String? = randomString(),
     attachments: MutableList<Attachment> = mutableListOf(),
-    mentionedUsersIds: MutableList<String> = mutableListOf(),
     mentionedUsers: MutableList<User> = mutableListOf(),
     replyCount: Int = randomInt(),
     reactionCounts: MutableMap<String, Int> = mutableMapOf(),
@@ -317,7 +316,8 @@ internal fun randomMessage(
     silent: Boolean = randomBoolean(),
     replyTo: Message? = null,
     showInChannel: Boolean = randomBoolean(),
-    shadowed: Boolean = false
+    shadowed: Boolean = false,
+    threadParticipants: List<User> = emptyList()
 ): Message = Message(
     id = id,
     cid = cid,
@@ -326,7 +326,7 @@ internal fun randomMessage(
     parentId = parentId,
     command = command,
     attachments = attachments,
-    mentionedUsersIds = mentionedUsersIds,
+    mentionedUsersIds = mentionedUsers.map(User::id).toMutableList(),
     mentionedUsers = mentionedUsers,
     replyCount = replyCount,
     reactionCounts = reactionCounts,
@@ -345,7 +345,8 @@ internal fun randomMessage(
     silent = silent,
     replyTo = replyTo,
     showInChannel = showInChannel,
-    shadowed = shadowed
+    shadowed = shadowed,
+    threadParticipants = threadParticipants,
 )
 
 internal fun randomChannel(


### PR DESCRIPTION
### Description
Store all participants of a message into our DB

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
