### PR TITLE
Fix the spelling of unmute, unban and unflag

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,10 +4,10 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `ChatClient#unMuteChannel(channelType, channelId)`<br/>*client* | 2021.03.15<br/>4.7.1  | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unmuteChannel(channelType, channelId)` method instead |
-| `ChatClient#unBanUser(userId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(userId)` method instead |
-| `ChannelClient#unBanUser(targetId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(targetId)` method instead |
-| `ChannelController#unBanUser(targetId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(targetId)` method instead |
+| `ChatClient#unMuteChannel`<br/>*client* | 2021.03.15<br/>4.7.1  | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unmuteChannel` method instead |
+| `ChatClient#unBanUser`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser` method instead |
+| `ChannelClient#unBanUser`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser` method instead |
+| `ChannelController#unBanUser`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser` method instead |
 | `ChatDomain.Builder` constructors with user params | 2021.02.26<br/>4.7.0 | 2021.05.26 ⌛ | 2021.08.26 ⌛ | Use `ChatDomain.Builder(context, chatClient)` instead |
 | `ChatDomain#disconnect` | 2021.02.25<br/>4.7.0 | 2021.05.25 ⌛ | 2021.08.25 ⌛ | Use just `ChatClient#disconnect` instead |
 | `setUser` (and similar) methods<br/>*client* | 2021.02.03<br/>4.5.3 | 2021.05.03 ⌛ | 2021.08.03 ⌛ | Replaced by `connectUser` style methods that return `Call` objects, see the updated documentation for [Initialization & Users](https://getstream.io/chat/docs/android/init_and_users/?language=kotlin)) |

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,10 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `ChatClient#unMuteChannel(channelType, channelId)`<br/>*client* | 2021.03.15<br/>4.7.1  | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unmuteChannel(channelType, channelId)` method instead |
+| `ChatClient#unBanUser(userId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(userId)` method instead |
+| `ChannelClient#unBanUser(targetId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(targetId)` method instead |
+| `ChannelController#unBanUser(targetId)`<br/>*client* | 2021.03.15<br/>4.7.1 | 2021.04.15 ⌛ | 2021.05.15 ⌛ | Use the `unbanUser(targetId)` method instead |
 | `ChatDomain.Builder` constructors with user params | 2021.02.26<br/>4.7.0 | 2021.05.26 ⌛ | 2021.08.26 ⌛ | Use `ChatDomain.Builder(context, chatClient)` instead |
 | `ChatDomain#disconnect` | 2021.02.25<br/>4.7.0 | 2021.05.25 ⌛ | 2021.08.25 ⌛ | Use just `ChatClient#disconnect` instead |
 | `setUser` (and similar) methods<br/>*client* | 2021.02.03<br/>4.5.3 | 2021.05.03 ⌛ | 2021.08.03 ⌛ | Replaced by `connectUser` style methods that return `Call` objects, see the updated documentation for [Initialization & Users](https://getstream.io/chat/docs/android/init_and_users/?language=kotlin)) |

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -34,10 +34,10 @@ It is not possible to remove users from distinct channels anymore.
 
 ### ⚠️ Changed
 - Renamed `ChannelId` property to `channelId` in both `ChannelDeletedEvent` and `NotificationChannelDeletedEvent`
-- Deprecated `ChatClient::unMuteChannel`, the `ChatClient::unmuteChannel` should be used instead
-- Deprecated `ChatClient::unBanUser`, the `ChatClient::unbanUser` should be used instead
-- Deprecated `ChannelClient::unBanUser`, the `ChannelClient::unbanUser` should be used instead
-- Deprecated `ChannelController::unBanUser`, the `ChannelController::unbanUser` should be used instead
+- Deprecated `ChatClient::unMuteChannel`, the `ChatClient::unmuteChannel` method should be used instead
+- Deprecated `ChatClient::unBanUser`, the `ChatClient::unbanUser` method should be used instead
+- Deprecated `ChannelClient::unBanUser`, the `ChannelClient::unbanUser` method should be used instead
+- Deprecated `ChannelController::unBanUser`, the `ChannelController::unbanUser` method should be used instead
 
 ### ❌ Removed
 

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -30,10 +30,14 @@ It is not possible to remove users from distinct channels anymore.
 ### ⬆️ Improved
 
 ### ✅ Added
-- Added `unFlagMessage(messageId)` and `unFlagUser(userId)` methods to `ChatClient`
+- Added `unflagMessage(messageId)` and `unflagUser(userId)` methods to `ChatClient`
 
 ### ⚠️ Changed
 - Renamed `ChannelId` property to `channelId` in both `ChannelDeletedEvent` and `NotificationChannelDeletedEvent`
+- Deprecated `ChatClient::unMuteChannel`, the `ChatClient::unmuteChannel` should be used instead
+- Deprecated `ChatClient::unBanUser`, the `ChatClient::unbanUser` should be used instead
+- Deprecated `ChannelClient::unBanUser`, the `ChannelClient::unbanUser` should be used instead
+- Deprecated `ChannelController::unBanUser`, the `ChannelController::unbanUser` should be used instead
 
 ### ❌ Removed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -123,9 +123,11 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun subscribeForSingle (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public final fun translate (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
-	public final fun unFlagMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
-	public final fun unFlagUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unMuteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unbanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unflagMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unflagUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun unmuteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unmuteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public final fun unmuteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun unpinMessage (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
@@ -645,6 +647,7 @@ public final class io/getstream/chat/android/client/channel/ChannelClient : io/g
 	public final fun subscribeForSingle (Ljava/lang/String;Lio/getstream/chat/android/client/ChatEventListener;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public fun subscribeForSingle (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public fun unBanUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public fun unbanUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public fun unmute ()Lio/getstream/chat/android/client/call/Call;
 	public fun unmuteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public fun unmuteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
@@ -710,6 +713,7 @@ public abstract interface class io/getstream/chat/android/client/controllers/Cha
 	public abstract fun subscribeForSingle (Ljava/lang/Class;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public abstract fun subscribeForSingle (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public abstract fun unBanUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public abstract fun unbanUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun unmute ()Lio/getstream/chat/android/client/call/Call;
 	public abstract fun unmuteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public abstract fun unmuteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1010,8 +1010,17 @@ public class ChatClient internal constructor(
     }
 
     @CheckResult
+    @Deprecated(
+        message = "Use the unmuteChannel(channelType, channelId) method instead",
+        replaceWith = ReplaceWith("this.unmuteChannel(channelType, channelId)")
+    )
     public fun unMuteChannel(channelType: String, channelId: String): Call<Unit> {
-        return api.unMuteChannel(channelType, channelId)
+        return api.unmuteChannel(channelType, channelId)
+    }
+
+    @CheckResult
+    public fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+        return api.unmuteChannel(channelType, channelId)
     }
 
     @CheckResult
@@ -1035,13 +1044,13 @@ public class ChatClient internal constructor(
     public fun flagUser(userId: String): Call<Flag> = api.flagUser(userId)
 
     @CheckResult
-    public fun unFlagUser(userId: String): Call<Flag> = api.unFlagUser(userId)
+    public fun unflagUser(userId: String): Call<Flag> = api.unflagUser(userId)
 
     @CheckResult
     public fun flagMessage(messageId: String): Call<Flag> = api.flagMessage(messageId)
 
     @CheckResult
-    public fun unFlagMessage(messageId: String): Call<Flag> = api.unFlagMessage(messageId)
+    public fun unflagMessage(messageId: String): Call<Flag> = api.unflagMessage(messageId)
 
     @CheckResult
     public fun translate(messageId: String, language: String): Call<Message> =
@@ -1066,11 +1075,29 @@ public class ChatClient internal constructor(
     }
 
     @CheckResult
+    @Deprecated(
+        message = "Use the unbanUser(targetId, channelType, channelId) method instead",
+        replaceWith = ReplaceWith("this.unbanUser(targetId, channelType, channelId)")
+    )
     public fun unBanUser(
         targetId: String,
         channelType: String,
         channelId: String,
-    ): Call<Unit> = api.unBanUser(
+    ): Call<Unit> = api.unbanUser(
+        targetId = targetId,
+        channelType = channelType,
+        channelId = channelId,
+        shadow = false
+    ).map {
+        Unit
+    }
+
+    @CheckResult
+    public fun unbanUser(
+        targetId: String,
+        channelType: String,
+        channelId: String,
+    ): Call<Unit> = api.unbanUser(
         targetId = targetId,
         channelType = channelType,
         channelId = channelId,
@@ -1102,7 +1129,7 @@ public class ChatClient internal constructor(
         targetId: String,
         channelType: String,
         channelId: String,
-    ): Call<Unit> = api.unBanUser(
+    ): Call<Unit> = api.unbanUser(
         targetId = targetId,
         channelType = channelType,
         channelId = channelId,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -110,7 +110,7 @@ internal interface ChatApi {
     fun muteChannel(channelType: String, channelId: String): Call<Unit>
 
     @CheckResult
-    fun unMuteChannel(channelType: String, channelId: String): Call<Unit>
+    fun unmuteChannel(channelType: String, channelId: String): Call<Unit>
 
     @CheckResult
     fun updateMessage(
@@ -240,13 +240,13 @@ internal interface ChatApi {
     fun flagUser(userId: String): Call<Flag>
 
     @CheckResult
-    fun unFlagUser(userId: String): Call<Flag>
+    fun unflagUser(userId: String): Call<Flag>
 
     @CheckResult
     fun flagMessage(messageId: String): Call<Flag>
 
     @CheckResult
-    fun unFlagMessage(messageId: String): Call<Flag>
+    fun unflagMessage(messageId: String): Call<Flag>
 
     @CheckResult
     fun banUser(
@@ -259,7 +259,7 @@ internal interface ChatApi {
     ): Call<Unit>
 
     @CheckResult
-    fun unBanUser(
+    fun unbanUser(
         targetId: String,
         channelType: String,
         channelId: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -305,8 +305,8 @@ internal class GsonChatApi(
         ).map { Unit }
     }
 
-    override fun unMuteChannel(channelType: String, channelId: String): Call<Unit> {
-        return retrofitApi.unMuteChannel(
+    override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+        return retrofitApi.unmuteChannel(
             apiKey,
             userId,
             connectionId,
@@ -596,7 +596,7 @@ internal class GsonChatApi(
     override fun unmuteUser(
         userId: String,
     ): Call<Unit> {
-        return retrofitApi.unMuteUser(
+        return retrofitApi.unmuteUser(
             apiKey,
             this.userId,
             connectionId,
@@ -608,7 +608,7 @@ internal class GsonChatApi(
         return flag(mutableMapOf("target_user_id" to userId))
     }
 
-    override fun unFlagUser(userId: String): Call<Flag> {
+    override fun unflagUser(userId: String): Call<Flag> {
         return unflag(mutableMapOf("target_user_id" to userId))
     }
 
@@ -616,7 +616,7 @@ internal class GsonChatApi(
         return flag(mutableMapOf("target_message_id" to messageId))
     }
 
-    override fun unFlagMessage(messageId: String): Call<Flag> {
+    override fun unflagMessage(messageId: String): Call<Flag> {
         return unflag(mutableMapOf("target_message_id" to messageId))
     }
 
@@ -630,7 +630,7 @@ internal class GsonChatApi(
     }
 
     private fun unflag(body: MutableMap<String, String>): Call<Flag> {
-        return retrofitApi.unFlag(
+        return retrofitApi.unflag(
             apiKey,
             userId,
             connectionId,
@@ -660,13 +660,13 @@ internal class GsonChatApi(
         ).map { Unit }
     }
 
-    override fun unBanUser(
+    override fun unbanUser(
         targetId: String,
         channelType: String,
         channelId: String,
         shadow: Boolean,
     ): Call<Unit> {
-        return retrofitApi.unBanUser(
+        return retrofitApi.unbanUser(
             apiKey = apiKey,
             connectionId = connectionId,
             targetUserId = targetId,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -65,7 +65,7 @@ internal interface RetrofitApi {
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/unmute/channel")
-    fun unMuteChannel(
+    fun unmuteChannel(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("connection_id") connectionId: String,
@@ -251,7 +251,7 @@ internal interface RetrofitApi {
     ): RetrofitCall<MuteUserResponse>
 
     @POST("/moderation/unmute")
-    fun unMuteUser(
+    fun unmuteUser(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("client_id") connectionId: String,
@@ -267,7 +267,7 @@ internal interface RetrofitApi {
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/unflag")
-    fun unFlag(
+    fun unflag(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("client_id") connectionId: String,
@@ -282,7 +282,7 @@ internal interface RetrofitApi {
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/moderation/ban")
-    fun unBanUser(
+    fun unbanUser(
         @Query("api_key") apiKey: String,
         @Query("client_id") connectionId: String,
         @Query("target_user_id") targetUserId: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
@@ -26,7 +26,7 @@ internal interface ModerationApi {
     ): RetrofitCall<MuteUserResponse>
 
     @POST("/moderation/unmute")
-    fun unMuteUser(
+    fun unmuteUser(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("client_id") connectionId: String,
@@ -42,7 +42,7 @@ internal interface ModerationApi {
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/unmute/channel")
-    fun unMuteChannel(
+    fun unmuteChannel(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("connection_id") connectionId: String,
@@ -58,7 +58,7 @@ internal interface ModerationApi {
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/unflag")
-    fun unFlag(
+    fun unflag(
         @Query("api_key") apiKey: String,
         @Query("user_id") userId: String,
         @Query("client_id") connectionId: String,
@@ -73,7 +73,7 @@ internal interface ModerationApi {
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/moderation/ban")
-    fun unBanUser(
+    fun unbanUser(
         @Query("api_key") apiKey: String,
         @Query("client_id") connectionId: String,
         @Query("target_user_id") targetUserId: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -223,7 +223,7 @@ internal class MoshiChatApi(
     }
 
     override fun unmuteUser(userId: String): Call<Unit> {
-        return moderationApi.unMuteUser(
+        return moderationApi.unmuteUser(
             apiKey = apiKey,
             userId = this.userId,
             connectionId = this.connectionId,
@@ -240,8 +240,8 @@ internal class MoshiChatApi(
         ).toUnitCall()
     }
 
-    override fun unMuteChannel(channelType: String, channelId: String): Call<Unit> {
-        return moderationApi.unMuteChannel(
+    override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+        return moderationApi.unmuteChannel(
             apiKey = apiKey,
             userId = userId,
             connectionId = connectionId,
@@ -346,14 +346,14 @@ internal class MoshiChatApi(
     override fun flagUser(userId: String): Call<Flag> =
         flag(mutableMapOf("target_user_id" to userId))
 
-    override fun unFlagUser(userId: String): Call<Flag> =
-        unFlag(mutableMapOf("target_user_id" to userId))
+    override fun unflagUser(userId: String): Call<Flag> =
+        unflag(mutableMapOf("target_user_id" to userId))
 
     override fun flagMessage(messageId: String): Call<Flag> =
         flag(mutableMapOf("target_message_id" to messageId))
 
-    override fun unFlagMessage(messageId: String): Call<Flag> =
-        unFlag(mutableMapOf("target_message_id" to messageId))
+    override fun unflagMessage(messageId: String): Call<Flag> =
+        unflag(mutableMapOf("target_message_id" to messageId))
 
     private fun flag(body: MutableMap<String, String>): Call<Flag> {
         return moderationApi.flag(
@@ -364,8 +364,8 @@ internal class MoshiChatApi(
         ).map { response -> response.flag.toDomain() }
     }
 
-    private fun unFlag(body: MutableMap<String, String>): Call<Flag> {
-        return moderationApi.unFlag(
+    private fun unflag(body: MutableMap<String, String>): Call<Flag> {
+        return moderationApi.unflag(
             apiKey,
             userId,
             connectionId,
@@ -395,13 +395,13 @@ internal class MoshiChatApi(
         ).toUnitCall()
     }
 
-    override fun unBanUser(
+    override fun unbanUser(
         targetId: String,
         channelType: String,
         channelId: String,
         shadow: Boolean,
     ): Call<Unit> {
-        return moderationApi.unBanUser(
+        return moderationApi.unbanUser(
             apiKey = apiKey,
             connectionId = connectionId,
             targetUserId = targetId,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -363,8 +363,21 @@ public class ChannelClient internal constructor(
     }
 
     @CheckResult
+    @Deprecated(
+        message = "Use the unbanUser(targetId) method instead",
+        replaceWith = ReplaceWith("this.unbanUser(targetId)")
+    )
     override fun unBanUser(targetId: String): Call<Unit> {
-        return client.unBanUser(
+        return client.unbanUser(
+            targetId = targetId,
+            channelType = channelType,
+            channelId = channelId,
+        )
+    }
+
+    @CheckResult
+    override fun unbanUser(targetId: String): Call<Unit> {
+        return client.unbanUser(
             targetId = targetId,
             channelType = channelType,
             channelId = channelId,
@@ -510,7 +523,7 @@ public class ChannelClient internal constructor(
 
     @CheckResult
     override fun unmute(): Call<Unit> {
-        return client.unMuteChannel(channelType, channelId)
+        return client.unmuteChannel(channelType, channelId)
     }
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/controllers/ChannelController.kt
@@ -66,7 +66,14 @@ public interface ChannelController {
     public fun banUser(targetId: String, reason: String?, timeout: Int?): Call<Unit>
 
     @CheckResult
+    @Deprecated(
+        message = "Use the unbanUser(targetId) method instead",
+        replaceWith = ReplaceWith("this.unbanUser(targetId)")
+    )
     public fun unBanUser(targetId: String): Call<Unit>
+
+    @CheckResult
+    public fun unbanUser(targetId: String): Call<Unit>
 
     @CheckResult
     public fun shadowBanUser(targetId: String, reason: String?, timeout: Int?): Call<Unit>

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -62,12 +62,12 @@ internal class UsersApiCallsTests {
     }
 
     @Test
-    fun unBanSuccess() {
+    fun unbanSuccess() {
 
         val targetUserId = "target-id"
 
         Mockito.`when`(
-            mock.retrofitApi.unBanUser(
+            mock.retrofitApi.unbanUser(
                 mock.apiKey,
                 mock.connectionId,
                 targetUserId,
@@ -77,7 +77,7 @@ internal class UsersApiCallsTests {
             )
         ).thenReturn(RetroSuccess(CompletableResponse()).toRetrofitCall())
 
-        val result = client.unBanUser(
+        val result = client.unbanUser(
             targetUserId,
             mock.channelType,
             mock.channelId
@@ -260,12 +260,12 @@ internal class UsersApiCallsTests {
     }
 
     @Test
-    fun unMuteUserSuccess() {
+    fun unmuteUserSuccess() {
 
         val targetUser = User().apply { id = "target-id" }
 
         Mockito.`when`(
-            mock.retrofitApi.unMuteUser(
+            mock.retrofitApi.unmuteUser(
                 mock.apiKey,
                 mock.userId,
                 mock.connectionId,

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Moderation.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Moderation.java
@@ -35,8 +35,8 @@ public class Moderation {
             });
         }
 
-        public void unFlagMessage() {
-            client.unFlagMessage("message-id").enqueue(result -> {
+        public void unflagMessage() {
+            client.unflagMessage("message-id").enqueue(result -> {
                 if (result.isSuccess()) {
                     // Message flag was removed
                     Flag flag = result.data();
@@ -57,8 +57,8 @@ public class Moderation {
             });
         }
 
-        public void unFlagUser() {
-            client.unFlagUser("user-id").enqueue(result -> {
+        public void unflagUser() {
+            client.unflagUser("user-id").enqueue(result -> {
                 if (result.isSuccess()) {
                     // User flag was removed
                     Flag flag = result.data();
@@ -114,7 +114,7 @@ public class Moderation {
         }
 
         public void unbanUser() {
-            channelClient.unBanUser("user-id").enqueue(result -> {
+            channelClient.unbanUser("user-id").enqueue(result -> {
                 if (result.isSuccess()) {
                     // User was unbanned
                 } else {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
@@ -28,8 +28,8 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
             }
         }
 
-        fun unFlagMessage() {
-            client.unFlagMessage("message-id").enqueue { result ->
+        fun unflagMessage() {
+            client.unflagMessage("message-id").enqueue { result ->
                 if (result.isSuccess) {
                     // Message flag was removed
                     val flag: Flag = result.data()
@@ -50,8 +50,8 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
             }
         }
 
-        fun unFlagUser() {
-            client.unFlagUser("user-id").enqueue { result ->
+        fun unflagUser() {
+            client.unflagUser("user-id").enqueue { result ->
                 if (result.isSuccess) {
                     // User flag was removed
                     val flag: Flag = result.data()
@@ -106,7 +106,7 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
         }
 
         fun unbanUser() {
-            channelClient.unBanUser(targetId = "user-id").enqueue { result ->
+            channelClient.unbanUser(targetId = "user-id").enqueue { result ->
                 if (result.isSuccess) {
                     // User was unbanned
                 } else {


### PR DESCRIPTION
### Description

- Renamed `unBanUser` to `unbanUser`
- Renamed `unMuteChannel` to `unmuteChannel`
- Renamed `unFlagMessage` to `unflagMessage`
- Renamed `unFlagUser` to `unflagUser`

Note: `unflagMessage` and `unflagUser` were not added to the deprecations file as these methods have not been release yet.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [X] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
