### PR TITLE
Fix NoClassDefFound error when using ChatClient.unbanUser() method

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.client.api.models.SendActionRequest
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.call.map
+import io.getstream.chat.android.client.call.toUnitCall
 import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.clientstate.ClientState
 import io.getstream.chat.android.client.clientstate.ClientStateService
@@ -1072,9 +1073,7 @@ public class ChatClient internal constructor(
         reason = reason,
         timeout = timeout,
         shadow = false
-    ).map {
-        Unit
-    }
+    ).toUnitCall()
 
     @CheckResult
     @Deprecated(
@@ -1090,9 +1089,7 @@ public class ChatClient internal constructor(
         channelType = channelType,
         channelId = channelId,
         shadow = false
-    ).map {
-        Unit
-    }
+    ).toUnitCall()
 
     @CheckResult
     public fun unbanUser(
@@ -1104,9 +1101,7 @@ public class ChatClient internal constructor(
         channelType = channelType,
         channelId = channelId,
         shadow = false
-    ).map {
-        Unit
-    }
+    ).toUnitCall()
 
     @CheckResult
     public fun shadowBanUser(
@@ -1122,9 +1117,7 @@ public class ChatClient internal constructor(
         reason = reason,
         timeout = timeout,
         shadow = true
-    ).map {
-        Unit
-    }
+    ).toUnitCall()
 
     @CheckResult
     public fun removeShadowBan(
@@ -1136,9 +1129,7 @@ public class ChatClient internal constructor(
         channelType = channelType,
         channelId = channelId,
         shadow = true
-    ).map {
-        Unit
-    }
+    ).toUnitCall()
 
     @CheckResult
     public fun queryBannedUsers(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.client.api2.model.response.TranslateMessageRequ
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.call.map
+import io.getstream.chat.android.client.call.toUnitCall
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.extensions.enrichWithCid
@@ -830,8 +831,6 @@ internal class MoshiChatApi(
     override fun warmUp() {
         generalApi.warmUp().enqueue()
     }
-
-    private fun Call<*>.toUnitCall() = map {}
 
     private fun <T : Any> noConnectionIdError(): ErrorCall<T> {
         return ErrorCall(ChatError("setUser is either not called or not finished"))

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -1,11 +1,14 @@
 package io.getstream.chat.android.client
 
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
 import io.getstream.chat.android.client.api.models.AcceptInviteRequest
 import io.getstream.chat.android.client.api.models.ChannelResponse
 import io.getstream.chat.android.client.api.models.CompletableResponse
 import io.getstream.chat.android.client.api.models.EventResponse
 import io.getstream.chat.android.client.api.models.HideChannelRequest
 import io.getstream.chat.android.client.api.models.MarkReadRequest
+import io.getstream.chat.android.client.api.models.MuteChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsResponse
@@ -361,9 +364,16 @@ internal class ChannelsApiCallsTests {
 
     @Test
     fun markReadSuccess() {
-
         val messageId = "message-id"
-        val event = MessageReadEvent(EventType.MESSAGE_READ, Date(), User(), "${mock.channelType}:${mock.channelId}", mock.channelType, mock.channelId, 0)
+        val event = MessageReadEvent(
+            EventType.MESSAGE_READ,
+            Date(),
+            User(),
+            "${mock.channelType}:${mock.channelId}",
+            mock.channelType,
+            mock.channelId,
+            0
+        )
 
         Mockito.`when`(
             mock.retrofitApi.markRead(
@@ -384,7 +394,6 @@ internal class ChannelsApiCallsTests {
 
     @Test
     fun markReadError() {
-
         val messageId = "message-id"
 
         Mockito.`when`(
@@ -489,5 +498,37 @@ internal class ChannelsApiCallsTests {
         val result = client.stopWatching(mock.channelType, mock.channelId).execute()
 
         verifyError(result, mock.serverErrorCode)
+    }
+
+    @Test
+    fun `Given mute channel api call succeeds When muting a channel Should return a result with success`() {
+        whenever(
+            mock.retrofitApi.muteChannel(
+                mock.apiKey,
+                mock.userId,
+                mock.connectionId,
+                MuteChannelRequest("${mock.channelType}:${mock.channelId}")
+            )
+        ) doReturn RetroSuccess(CompletableResponse()).toRetrofitCall()
+
+        val result = client.muteChannel(mock.channelType, mock.channelId).execute()
+
+        verifySuccess(result, Unit)
+    }
+
+    @Test
+    fun `Given unmute channel api call succeeds When unmuting a channel Should return a result with success`() {
+        whenever(
+            mock.retrofitApi.unmuteChannel(
+                mock.apiKey,
+                mock.userId,
+                mock.connectionId,
+                MuteChannelRequest("${mock.channelType}:${mock.channelId}")
+            )
+        ) doReturn RetroSuccess(CompletableResponse()).toRetrofitCall()
+
+        val result = client.unmuteChannel(mock.channelType, mock.channelId).execute()
+
+        verifySuccess(result, Unit)
     }
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
@@ -95,3 +95,6 @@ public fun <T : Any, K : Any> Call<T>.map(mapper: (T) -> K): Call<K> {
 public fun <T : Any, K : Any> Call<T>.zipWith(call: Call<K>): Call<Pair<T, K>> {
     return ZipCall(this, call)
 }
+
+@InternalStreamChatApi
+public fun Call<*>.toUnitCall(): Call<Unit> = map {}


### PR DESCRIPTION
### Description

```
    @Deprecated(
        message = "Use the unbanUser(targetId, channelType, channelId) method instead",
        replaceWith = ReplaceWith("this.unbanUser(targetId, channelType, channelId)")
    )
    public fun unBanUser(
        targetId: String,
        channelType: String,
        channelId: String,
    ): Call<Unit> = api.unbanUser(
        targetId = targetId,
        channelType = channelType,
        channelId = channelId,
        shadow = false
    ).map {
        Unit
    }

    @CheckResult
    public fun unbanUser(
        targetId: String,
        channelType: String,
        channelId: String,
    ): Call<Unit> = api.unbanUser(
        targetId = targetId,
        channelType = channelType,
        channelId = channelId,
        shadow = false
    ).map {
        Unit
    }
```
 
The unit test for `ChatClient.unbanUser()` was not working on my machine (works fine on our CI). Lambdas generated from `map { Unit }` class have different names, but on case-insensitive operating systems like MacOS / Windows one overwrites another. As a result, `NoClassDefFoundError` error is thrown at runtime.


### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [X] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
