### PR TITLE
[CAS-786] Video support to attachment activity

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -60,6 +60,7 @@ It is not possible to remove users from distinct channels anymore.
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Add video support for AttachmentActivity
 
 ### ✅ Added
 
@@ -73,6 +74,7 @@ It is not possible to remove users from distinct channels anymore.
 - Now replied messages are shown correctly with the replied part in message options
 
 ### ⬆️ Improved
+- Add support of non-image attachment types to the default attachment click listener.
 
 ### ✅ Added
 

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -60,7 +60,7 @@ It is not possible to remove users from distinct channels anymore.
 ### 🐞 Fixed
 
 ### ⬆️ Improved
-- Add video support for AttachmentActivity
+- Show AttachmentMediaActivity for video attachments
 
 ### ✅ Added
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
@@ -28,7 +28,8 @@ public open class AttachmentDestination(
         var type: String? = attachment.type
 
         when (attachment.type) {
-            ModelType.attach_file -> {
+            ModelType.attach_file,
+            ModelType.attach_video -> {
                 loadFile(attachment)
                 return
             }
@@ -48,7 +49,6 @@ public open class AttachmentDestination(
                     }
                 }
             }
-            ModelType.attach_video -> url = attachment.assetUrl
             ModelType.attach_giphy -> url = attachment.thumbUrl
             ModelType.attach_product -> url = attachment.url
         }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
@@ -1,5 +1,6 @@
 package com.getstream.sdk.chat.view.activity
 
+import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -7,8 +8,10 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.ImageView
+import android.widget.MediaController
 import android.widget.ProgressBar
 import android.widget.Toast
+import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.ChatUI
@@ -25,6 +28,7 @@ public class AttachmentActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private lateinit var iv_image: ImageView
     private lateinit var progressBar: ProgressBar
+    private lateinit var videoView: VideoView
 
     private val logger = get("AttachmentActivity")
 
@@ -38,6 +42,7 @@ public class AttachmentActivity : AppCompatActivity() {
         webView = findViewById(R.id.webView)
         iv_image = findViewById(R.id.iv_image)
         progressBar = findViewById(R.id.progressBar)
+        videoView = findViewById(R.id.videoView)
 
         configUIs()
 
@@ -54,6 +59,7 @@ public class AttachmentActivity : AppCompatActivity() {
     private fun configUIs() {
         iv_image.isVisible = false
         webView.isVisible = false
+        videoView.isVisible = false
 
         // WebView
         webView.apply {
@@ -69,11 +75,29 @@ public class AttachmentActivity : AppCompatActivity() {
     }
 
     private fun showAttachment(type: String, url: String) {
-        if (type == ModelType.attach_giphy) {
-            showGiphy(url)
-        } else {
-            loadUrlToWeb(url)
+        when (type) {
+            ModelType.attach_giphy -> showGiphy(url)
+            ModelType.attach_video -> showVideo(url)
+            else -> loadUrlToWeb(url)
         }
+    }
+
+    private fun showVideo(url: String) {
+        iv_image.isVisible = false
+        webView.isVisible = false
+        progressBar.isVisible = false
+        videoView.isVisible = true
+
+        val uri = Uri.parse(url)
+        val mc = MediaController(this).apply {
+            setAnchorView(videoView)
+            setMediaPlayer(videoView)
+        }
+
+        videoView.setMediaController(mc)
+        videoView.setVideoURI(uri)
+        videoView.requestFocus()
+        videoView.start()
     }
 
     /**
@@ -85,6 +109,7 @@ public class AttachmentActivity : AppCompatActivity() {
         iv_image.isVisible = false
         webView.isVisible = true
         progressBar.isVisible = true
+        videoView.isVisible = false
 
         webView.loadUrl(urlSigner.signFileUrl(url))
     }
@@ -101,6 +126,7 @@ public class AttachmentActivity : AppCompatActivity() {
         }
         iv_image.isVisible = true
         webView.isVisible = false
+        videoView.isVisible = false
 
         iv_image.load(
             data = urlSigner.signImageUrl(url),

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
@@ -1,6 +1,5 @@
 package com.getstream.sdk.chat.view.activity
 
-import android.net.Uri
 import android.os.Bundle
 import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
@@ -8,10 +7,8 @@ import android.webkit.WebSettings
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.ImageView
-import android.widget.MediaController
 import android.widget.ProgressBar
 import android.widget.Toast
-import android.widget.VideoView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.isVisible
 import com.getstream.sdk.chat.ChatUI
@@ -28,7 +25,6 @@ public class AttachmentActivity : AppCompatActivity() {
     private lateinit var webView: WebView
     private lateinit var iv_image: ImageView
     private lateinit var progressBar: ProgressBar
-    private lateinit var videoView: VideoView
 
     private val logger = ChatLogger.get("AttachmentActivity")
 
@@ -42,7 +38,6 @@ public class AttachmentActivity : AppCompatActivity() {
         webView = findViewById(R.id.webView)
         iv_image = findViewById(R.id.iv_image)
         progressBar = findViewById(R.id.progressBar)
-        videoView = findViewById(R.id.videoView)
 
         configUIs()
 
@@ -59,7 +54,6 @@ public class AttachmentActivity : AppCompatActivity() {
     private fun configUIs() {
         iv_image.isVisible = false
         webView.isVisible = false
-        videoView.isVisible = false
 
         // WebView
         webView.apply {
@@ -77,31 +71,7 @@ public class AttachmentActivity : AppCompatActivity() {
     private fun showAttachment(type: String, url: String) {
         when (type) {
             ModelType.attach_giphy -> showGiphy(url)
-            ModelType.attach_video -> showVideo(url)
             else -> loadUrlToWeb(url)
-        }
-    }
-
-    private fun showVideo(url: String) {
-        iv_image.isVisible = false
-        webView.isVisible = false
-        progressBar.isVisible = true
-        videoView.isVisible = true
-
-        try {
-            val mc = MediaController(this).apply {
-                setAnchorView(videoView)
-                setMediaPlayer(videoView)
-            }
-            videoView.run {
-                setMediaController(mc)
-                setVideoURI(Uri.parse(url))
-                setOnPreparedListener { progressBar.isVisible = false }
-                requestFocus()
-                start()
-            }
-        } catch (e: Exception) {
-            logger.logE("Exception during playing video\n$e")
         }
     }
 
@@ -114,7 +84,6 @@ public class AttachmentActivity : AppCompatActivity() {
         iv_image.isVisible = false
         webView.isVisible = true
         progressBar.isVisible = true
-        videoView.isVisible = false
 
         webView.loadUrl(urlSigner.signFileUrl(url))
     }
@@ -131,7 +100,6 @@ public class AttachmentActivity : AppCompatActivity() {
         }
         iv_image.isVisible = true
         webView.isVisible = false
-        videoView.isVisible = false
 
         iv_image.load(
             data = urlSigner.signImageUrl(url),

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/view/activity/AttachmentActivity.kt
@@ -18,7 +18,7 @@ import com.getstream.sdk.chat.ChatUI
 import com.getstream.sdk.chat.UrlSigner
 import com.getstream.sdk.chat.images.load
 import com.getstream.sdk.chat.model.ModelType
-import io.getstream.chat.android.client.logger.ChatLogger.Companion.get
+import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.ui.common.R
 
 /**
@@ -30,7 +30,7 @@ public class AttachmentActivity : AppCompatActivity() {
     private lateinit var progressBar: ProgressBar
     private lateinit var videoView: VideoView
 
-    private val logger = get("AttachmentActivity")
+    private val logger = ChatLogger.get("AttachmentActivity")
 
     private val urlSigner: UrlSigner
         get() = ChatUI.instance().urlSigner
@@ -85,19 +85,24 @@ public class AttachmentActivity : AppCompatActivity() {
     private fun showVideo(url: String) {
         iv_image.isVisible = false
         webView.isVisible = false
-        progressBar.isVisible = false
+        progressBar.isVisible = true
         videoView.isVisible = true
 
-        val uri = Uri.parse(url)
-        val mc = MediaController(this).apply {
-            setAnchorView(videoView)
-            setMediaPlayer(videoView)
+        try {
+            val mc = MediaController(this).apply {
+                setAnchorView(videoView)
+                setMediaPlayer(videoView)
+            }
+            videoView.run {
+                setMediaController(mc)
+                setVideoURI(Uri.parse(url))
+                setOnPreparedListener { progressBar.isVisible = false }
+                requestFocus()
+                start()
+            }
+        } catch (e: Exception) {
+            logger.logE("Exception during playing video\n$e")
         }
-
-        videoView.setMediaController(mc)
-        videoView.setVideoURI(uri)
-        videoView.requestFocus()
-        videoView.start()
     }
 
     /**

--- a/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment.xml
+++ b/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment.xml
@@ -29,16 +29,6 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
-    <VideoView
-        android:id="@+id/videoView"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
-        />
-
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_width="wrap_content"

--- a/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment.xml
+++ b/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment.xml
@@ -29,6 +29,16 @@
         app:layout_constraintTop_toTopOf="parent"
         />
 
+    <VideoView
+        android:id="@+id/videoView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
     <ProgressBar
         android:id="@+id/progressBar"
         android:layout_width="wrap_content"


### PR DESCRIPTION
### Description

Support of all attachment types. Previously we supported only images with gallery preview. 

1) Change default attachment click listener
2) Show `AttachmentMediaActivity` for video files. Fix logic in AttachmentDestination


https://user-images.githubusercontent.com/11807573/111455910-a871e980-8716-11eb-8f13-82761edb1589.mov



### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
