### PR TITLE
[CAS-796] Enable/disable the message editing feature

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -75,6 +75,7 @@ It is not possible to remove users from distinct channels anymore.
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `streamUiEditMessageEnabled` attribute to `MessageListView` and `MessageListView::setEditMessageEnabled` method to enable/disable the message editing feature
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -633,6 +633,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListView : a
 	public final fun setAttachmentViewFactory (Lio/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory;)V
 	public final fun setConfirmDeleteMessageHandler (Lio/getstream/chat/android/ui/message/list/MessageListView$ConfirmDeleteMessageHandler;)V
 	public final fun setDownloadOptionHandler (Lio/getstream/chat/android/ui/gallery/AttachmentGalleryActivity$AttachmentDownloadOptionHandler;)V
+	public final fun setEditMessageEnabled (Z)V
 	public final fun setEmptyStateView (Landroid/view/View;)V
 	public final fun setEmptyStateView (Landroid/view/View;Landroid/widget/FrameLayout$LayoutParams;)V
 	public static synthetic fun setEmptyStateView$default (Lio/getstream/chat/android/ui/message/list/MessageListView;Landroid/view/View;Landroid/widget/FrameLayout$LayoutParams;ILjava/lang/Object;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -512,12 +512,15 @@ public class MessageListView : ConstraintLayout {
         val deleteConfirmationEnabled =
             tArray.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)
 
+        val editMessageEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiEditMessageEnabled, true)
+
         messageOptionsConfiguration = MessageOptionsView.Configuration(
             iconsTint = iconsTint,
             replyIcon = replyIcon,
             threadReplyIcon = threadReplyIcon,
             retryIcon = retryIcon,
             copyIcon = copyIcon,
+            editMessageEnabled = editMessageEnabled,
             editIcon = editIcon,
             flagIcon = flagIcon,
             muteIcon = muteIcon,
@@ -654,6 +657,15 @@ public class MessageListView : ConstraintLayout {
         scrollHelper.scrollToBottomButtonEnabled = scrollToBottomButtonEnabled
     }
 
+    /**
+     * Enables or disables the message editing feature.
+     *
+     * @param enabled True if editing a message is enabled, false otherwise.
+     */
+    public fun setEditMessageEnabled(enabled: Boolean) {
+        updateMessageOptionsConfiguration { copy(editMessageEnabled = enabled) }
+    }
+
     public fun setMessageViewHolderFactory(messageListItemViewHolderFactory: MessageListItemViewHolderFactory) {
         check(::adapter.isInitialized.not()) { "Adapter was already initialized, please set MessageViewHolderFactory first" }
         this.messageListItemViewHolderFactory = messageListItemViewHolderFactory
@@ -698,6 +710,15 @@ public class MessageListView : ConstraintLayout {
                 }
             }
         }
+    }
+
+    private fun updateMessageOptionsConfiguration(
+        reducer: MessageOptionsView.Configuration.() -> MessageOptionsView.Configuration,
+    ) {
+        check(::messageOptionsConfiguration.isInitialized.not()) {
+            "Message options configurations needs to be initialized first"
+        }
+        messageOptionsConfiguration = reducer(messageOptionsConfiguration)
     }
 
     //region Listener setters

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -728,7 +728,7 @@ public class MessageListView : ConstraintLayout {
         reducer: MessageOptionsView.Configuration.() -> MessageOptionsView.Configuration,
     ) {
         check(::messageOptionsConfiguration.isInitialized) {
-            "Message options configurations needs to be initialized first"
+            "Message options configuration needs to be initialized first"
         }
         messageOptionsConfiguration = reducer(messageOptionsConfiguration)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -715,7 +715,7 @@ public class MessageListView : ConstraintLayout {
     private fun updateMessageOptionsConfiguration(
         reducer: MessageOptionsView.Configuration.() -> MessageOptionsView.Configuration,
     ) {
-        check(::messageOptionsConfiguration.isInitialized.not()) {
+        check(::messageOptionsConfiguration.isInitialized) {
             "Message options configurations needs to be initialized first"
         }
         messageOptionsConfiguration = reducer(messageOptionsConfiguration)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -87,13 +87,24 @@ internal class MessageOptionsView : FrameLayout {
 
         configureCopyMessage(iconsTint, configuration)
 
-        binding.editTV.configureListItem(configuration.editIcon, iconsTint)
+        configureEditMessage(configuration)
         binding.flagTV.isVisible = false
         binding.muteTV.isVisible = false
         binding.blockTV.isVisible = false
         binding.deleteTV.run {
             configureListItem(configuration.deleteIcon, iconsTint)
             setTextColor(ContextCompat.getColor(context, R.color.stream_ui_accent_red))
+        }
+    }
+
+    private fun configureEditMessage(configuration: Configuration) {
+        binding.editTV.apply {
+            if (configuration.editMessageEnabled) {
+                isVisible = true
+                configureListItem(configuration.editIcon, configuration.iconsTint)
+            } else {
+                isVisible = false
+            }
         }
     }
 
@@ -113,6 +124,7 @@ internal class MessageOptionsView : FrameLayout {
         val threadEnabled: Boolean = true,
         val retryIcon: Int,
         val copyIcon: Int,
+        val editMessageEnabled: Boolean,
         val editIcon: Int,
         val flagIcon: Int,
         val muteIcon: Int,

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -27,6 +27,7 @@
         <attr name="streamUiMessageOptionIconColor" format="color" />
         <attr name="streamUiCopyMessageActionEnabled" format="color" />
         <attr name="streamUiDeleteConfirmationEnabled" format="boolean" />
+        <attr name="streamUiEditMessageEnabled" format="boolean" />
 
         <!-- Message text color -->
         <attr name="streamUiMessageTextColorMine" format="color" />


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-796

### Description

- Added `streamUiEditMessageEnabled` attribute to `MessageListView` and `MessageListView::setEditMessageEnabled` method to enable/disable the message editing feature.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
