### PR TITLE
[CAS-795] Enable/disable mentions

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -80,6 +80,7 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 ### ✅ Added
 - Added possibility to configure delete message option visibility using `streamUiDeleteMessageEnabled` attribute, and `MessageListView::setDeleteMessageEnabled` method
 - Add `streamUiEditMessageEnabled` attribute to `MessageListView` and `MessageListView::setEditMessageEnabled` method to enable/disable the message editing feature
+- Add `streamUiMentionsEnabled` attribute to `MessageInputView` and `MessageInputView::setMentionsEnabled` method to enable/disable mentions
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -533,6 +533,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setInputMode (Lio/getstream/chat/android/ui/message/input/MessageInputView$InputMode;)V
 	public final fun setMaxMessageLength (I)V
 	public final fun setMembers (Ljava/util/List;)V
+	public final fun setMentionsEnabled (Z)V
 	public final fun setOnSendButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnMessageSendButtonClickListener;)V
 	public final fun setSendMessageHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$MessageSendHandler;)V
 	public final fun setSuggestionListView (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -45,6 +45,7 @@ public class MessageInputView : ConstraintLayout {
     private var sendMessageHandler: MessageSendHandler = EMPTY_MESSAGE_SEND_HANDLER
     private var suggestionListController: SuggestionListController? = null
     private var isSendButtonEnabled: Boolean = true
+    private var mentionsEnabled: Boolean = true
 
     private var onSendButtonClickListener: OnMessageSendButtonClickListener? = null
     private var typingListener: TypingListener? = null
@@ -143,6 +144,16 @@ public class MessageInputView : ConstraintLayout {
         refreshControlsState()
     }
 
+    /**
+     * Enables or disables the handling of mentions in the message input view.
+     *
+     * @param enabled True if handling of mentions in the message input view is enabled, false otherwise.
+     */
+    public fun setMentionsEnabled(enabled: Boolean) {
+        this.mentionsEnabled = enabled
+        suggestionListController?.mentionsEnabled = mentionsEnabled
+    }
+
     public fun setSuggestionListView(suggestionListView: SuggestionListView) {
         suggestionListView.setOnSuggestionClickListener(
             object : SuggestionListView.OnSuggestionClickListener {
@@ -157,6 +168,8 @@ public class MessageInputView : ConstraintLayout {
         )
         suggestionListController = SuggestionListController(suggestionListView) {
             binding.commandsButton.isSelected = false
+        }.also {
+            it.mentionsEnabled = mentionsEnabled
         }
         refreshControlsState()
     }
@@ -177,6 +190,7 @@ public class MessageInputView : ConstraintLayout {
         configSendAlsoToChannelCheckbox()
         configSendButtonListener()
         binding.dismissInputMode.setOnClickListener { dismissInputMode(inputMode) }
+        setMentionsEnabled(style.mentionsEnabled)
     }
 
     private fun dismissInputMode(inputMode: InputMode) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputViewStyle.kt
@@ -24,6 +24,7 @@ internal class MessageInputViewStyle(context: Context, attrs: AttributeSet?) {
     val sendButtonEnabledIcon: Drawable?
     val sendButtonDisabledIcon: Drawable?
     val showSendAlsoToChannelCheckbox: Boolean
+    val mentionsEnabled: Boolean
 
     init {
         context.obtainStyledAttributes(
@@ -146,6 +147,10 @@ internal class MessageInputViewStyle(context: Context, attrs: AttributeSet?) {
 
             showSendAlsoToChannelCheckbox = a.getBoolean(
                 R.styleable.MessageInputView_streamUiShowSendAlsoToChannelCheckbox,
+                true
+            )
+            mentionsEnabled = a.getBoolean(
+                R.styleable.MessageInputView_streamUiMentionsEnabled,
                 true
             )
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
@@ -9,7 +9,7 @@ import java.util.regex.Pattern
 
 internal class SuggestionListController(
     private val suggestionListView: SuggestionListView,
-    private val dismissListener: SuggestionListDismissListener
+    private val dismissListener: SuggestionListDismissListener,
 ) {
     var users: List<User> = emptyList()
         set(value) {
@@ -21,13 +21,19 @@ internal class SuggestionListController(
             field = value
             showSuggestions(messageText)
         }
+    var mentionsEnabled: Boolean = true
+
     private var messageText: String = String.EMPTY
 
     fun showSuggestions(messageText: String) {
         this.messageText = messageText
         when {
-            messageText.isCommandMessage() -> suggestionListView.showSuggestionList(messageText.getCommandSuggestions())
-            messageText.isMentionMessage() -> suggestionListView.showSuggestionList(messageText.getMentionSuggestions())
+            messageText.isCommandMessage() -> {
+                suggestionListView.showSuggestionList(messageText.getCommandSuggestions())
+            }
+            mentionsEnabled && messageText.isMentionMessage() -> {
+                suggestionListView.showSuggestionList(messageText.getMentionSuggestions())
+            }
             else -> hideSuggestionList()
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
@@ -33,6 +33,9 @@
 
         <!-- "Also send to channel" CheckBox -->
         <attr name="streamUiShowSendAlsoToChannelCheckbox" format="boolean" />
+
+        <!-- Mentions -->
+        <attr name="streamUiMentionsEnabled" format="boolean" />
     </declare-styleable>
 
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-795

### Description

With our UI, disabling mentions means only disabling mention suggestions. User will still be able to type `@someuser` from his/her keyboard and send such message with a mention.

- Added `streamUiMentionsEnabled` attribute to `MessageInputView`
- Added `MessageInputView::setMentionsEnabled` method

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
