### PR TITLE
Discussion - Avoid default color MessageListView

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
@@ -24,6 +24,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messagesHeaderView"
+        android:background="@color/stream_ui_accent_blue"
         />
 
     <io.getstream.chat.android.ui.suggestion.list.SuggestionListView

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_view.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:animateLayoutChanges="true"
-    android:background="@color/stream_ui_white_snow"
     >
 
     <androidx.recyclerview.widget.RecyclerView


### PR DESCRIPTION
This branch shows that we can avoid a default color for the XML of MessageListView and then it is much easier to configure the background from the container view. 

Colour changed: 

![Screenshot_20210317-205648](https://user-images.githubusercontent.com/10619102/111553647-95d1d180-8763-11eb-9cbb-814f6fb110b0.png)


I'm **not** defending that we use this blue =P

