### PR TITLE
Remove Jacoco

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,6 @@ buildscript {
         classpath Dependencies.androidGradlePlugin
         classpath Dependencies.kotlinGradlePlugin
         classpath Dependencies.googleServicesPlugin
-        classpath Dependencies.jacoco
         classpath Dependencies.androidMavenGradlePlugin
         classpath Dependencies.androidJunit5GradlePlugin
         classpath Dependencies.gitversionerPlugin

--- a/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/getstream/sdk/chat/Dependencies.kt
@@ -131,7 +131,6 @@ object Dependencies {
     const val googleServicesPlugin = "com.google.gms:google-services:$GOOGLE_SERVICES_VERSION"
     const val gradleVersionsPlugin = "com.github.ben-manes:gradle-versions-plugin:$GRADLE_VERSIONS_PLUGIN"
     const val gson = "com.google.code.gson:gson:$GSON_VERSION"
-    const val jacoco = "com.hiya:jacoco-android:$JACOCO_VERSION"
     const val json = "org.json:json:$JSON_VERSION"
     const val junit4 = "junit:junit:$JUNIT4_VERSION"
     const val junitJupiterApi = "org.junit.jupiter:junit-jupiter-api:$JUNIT5_VERSION"

--- a/stream-chat-android-client/build.gradle
+++ b/stream-chat-android-client/build.gradle
@@ -7,8 +7,6 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: "de.mannodermaus.android-junit5"
-apply plugin: "com.hiya.jacoco-android"
-
 
 ext {
     PUBLISH_GROUP_ID = Configuration.artifactGroup

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -7,8 +7,6 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'com.github.dcendents.android-maven'
 apply plugin: 'de.mannodermaus.android-junit5'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'
-apply plugin: "com.hiya.jacoco-android"
-
 
 ext {
     PUBLISH_GROUP_ID = Configuration.artifactGroup

--- a/stream-chat-android-ui-common/build.gradle
+++ b/stream-chat-android-ui-common/build.gradle
@@ -3,7 +3,6 @@ import com.getstream.sdk.chat.Configuration
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.hiya.jacoco-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'de.mannodermaus.android-junit5'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'

--- a/stream-chat-android-ui-components/build.gradle
+++ b/stream-chat-android-ui-components/build.gradle
@@ -3,7 +3,6 @@ import com.getstream.sdk.chat.Configuration
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.hiya.jacoco-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'kotlin-parcelize'

--- a/stream-chat-android/build.gradle
+++ b/stream-chat-android/build.gradle
@@ -3,7 +3,6 @@ import com.getstream.sdk.chat.Configuration
 
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
-apply plugin: 'com.hiya.jacoco-android'
 apply plugin: 'kotlin-android'
 apply plugin: 'de.mannodermaus.android-junit5'
 apply plugin: 'org.jlleitschuh.gradle.ktlint'


### PR DESCRIPTION
### Description

Jacoco pollutes our test logs with numerous exceptions and shows zero test coverage in `jacoco.exec` files. Decided to remove it completely.

```
 java.lang.instrument.IllegalClassFormatException: Error while instrumenting io/getstream/chat/android/livedata/usecase/SendMessageWithAttachments$DefaultImpls.
        at org.jacoco.agent.rt.internal_f3994fa.CoverageTransformer.transform(CoverageTransformer.java:94)
        at sun.instrument.TransformerManager.transform(TransformerManager.java:188)
        at sun.instrument.InstrumentationImpl.transform(InstrumentationImpl.java:428)
        ...
```

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
