### PR TITLE
[CAS-747] Update REST client to the latest backend specs

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.client.api.models.toDomain
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.call.map
+import io.getstream.chat.android.client.call.toUnitCall
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.extensions.enrichWithCid
@@ -171,25 +172,33 @@ internal class GsonChatApi(
 
     override fun addDevice(firebaseToken: String): Call<Unit> {
         return retrofitApi.addDevices(
-            apiKey,
-            userId,
-            connectionId,
-            AddDeviceRequest(firebaseToken)
-        ).map { Unit }
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = AddDeviceRequest(firebaseToken)
+        ).toUnitCall()
     }
 
     override fun deleteDevice(firebaseToken: String): Call<Unit> {
-        return retrofitApi.deleteDevice(firebaseToken, apiKey, userId, connectionId)
-            .map { Unit }
+        return retrofitApi.deleteDevice(
+            deviceId = firebaseToken,
+            apiKey = apiKey,
+            connectionId = connectionId
+        ).toUnitCall()
     }
 
     override fun getDevices(): Call<List<Device>> {
-        return retrofitApi.getDevices(apiKey, userId, connectionId)
-            .map { it.devices }
+        return retrofitApi.getDevices(
+            apiKey = apiKey,
+            connectionId = connectionId
+        ).map { it.devices }
     }
 
     override fun searchMessages(request: SearchMessagesRequest): Call<List<Message>> {
-        return retrofitApi.searchMessages(apiKey, connectionId, request)
+        return retrofitApi.searchMessages(
+            apiKey = apiKey,
+            connectionId = connectionId,
+            payload = request
+        )
             .map {
                 it.results.map { resp ->
                     resp.message.apply {
@@ -206,22 +215,20 @@ internal class GsonChatApi(
         limit: Int,
     ): Call<List<Message>> {
         return retrofitApi.getRepliesMore(
-            messageId,
-            apiKey,
-            userId,
-            connectionId,
-            limit,
-            firstId
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            limit = limit,
+            firstId = firstId
         ).map { it.messages }
     }
 
     override fun getReplies(messageId: String, limit: Int): Call<List<Message>> {
         return retrofitApi.getReplies(
-            messageId,
-            apiKey,
-            userId,
-            connectionId,
-            limit
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            limit = limit
         ).map { it.messages }
     }
 
@@ -231,56 +238,55 @@ internal class GsonChatApi(
         limit: Int,
     ): Call<List<Reaction>> {
         return retrofitApi.getReactions(
-            messageId,
-            apiKey,
-            connectionId,
-            offset,
-            limit
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            offset = offset,
+            limit = limit
         ).map { it.reactions }
     }
 
     override fun sendReaction(reaction: Reaction, enforceUnique: Boolean): Call<Reaction> {
         return retrofitApi.sendReaction(
-            reaction.messageId,
-            apiKey,
-            userId,
-            connectionId,
-            ReactionRequest(reaction, enforceUnique)
+            messageId = reaction.messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = ReactionRequest(reaction, enforceUnique)
         ).map { it.reaction }
     }
 
     override fun deleteReaction(messageId: String, reactionType: String): Call<Message> {
         return retrofitApi.deleteReaction(
-            messageId,
-            reactionType,
-            apiKey,
-            userId,
-            connectionId
+            messageId = messageId,
+            reactionType = reactionType,
+            apiKey = apiKey,
+            connectionId = connectionId
         ).map { it.message }
     }
 
     override fun deleteMessage(messageId: String): Call<Message> {
         return retrofitApi.deleteMessage(
-            messageId,
-            apiKey,
-            userId,
-            connectionId
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId
         ).map { it.message }
     }
 
     override fun sendAction(request: SendActionRequest): Call<Message> {
         return retrofitApi.sendAction(
-            request.messageId,
-            apiKey,
-            userId,
-            connectionId,
-            request
+            messageId = request.messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = request
         ).map { it.message }
     }
 
     override fun getMessage(messageId: String): Call<Message> {
-        return retrofitApi.getMessage(messageId, apiKey, userId, connectionId)
-            .map { it.message }
+        return retrofitApi.getMessage(
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId
+        ).map { it.message }
     }
 
     override fun sendMessage(
@@ -288,46 +294,41 @@ internal class GsonChatApi(
         channelId: String,
         message: Message,
     ): Call<Message> {
-
         verifyMessageId(message)
 
         return retrofitApi.sendMessage(
-            channelType,
-            channelId,
-            apiKey,
-            userId,
-            connectionId,
-            MessageRequest(message)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            message = MessageRequest(message)
         ).map { it.message }
     }
 
     override fun muteChannel(channelType: String, channelId: String): Call<Unit> {
         return retrofitApi.muteChannel(
-            apiKey,
-            userId,
-            connectionId,
-            MuteChannelRequest("$channelType:$channelId")
-        ).map { Unit }
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = MuteChannelRequest("$channelType:$channelId")
+        ).toUnitCall()
     }
 
     override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
         return retrofitApi.unmuteChannel(
-            apiKey,
-            userId,
-            connectionId,
-            MuteChannelRequest("$channelType:$channelId")
-        ).map { Unit }
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = MuteChannelRequest("$channelType:$channelId")
+        ).toUnitCall()
     }
 
     override fun updateMessage(
         message: Message,
     ): Call<Message> {
         return retrofitApi.updateMessage(
-            message.id,
-            apiKey,
-            userId,
-            connectionId,
-            MessageRequest(message)
+            messageId = message.id,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            message = MessageRequest(message)
         ).map { it.message }
     }
 
@@ -336,36 +337,33 @@ internal class GsonChatApi(
         channelId: String,
     ): Call<Unit> {
         return retrofitApi.stopWatching(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            emptyMap()
-        ).map { Unit }
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = emptyMap()
+        ).toUnitCall()
     }
 
     override fun queryChannels(query: QueryChannelsRequest): Call<List<Channel>> {
-
         if (connectionId.isEmpty()) return noConnectionIdError()
 
         return retrofitApi.queryChannels(
-            apiKey,
-            userId,
-            connectionId,
-            query
+            apiKey = apiKey,
+            connectionId = connectionId,
+            payload = query
         ).map {
             flattenChannels(it.channels)
         }
     }
 
     override fun updateUsers(users: List<User>): Call<List<User>> {
-
         val map = users.associateBy({ it.id }, { user -> user })
 
         return retrofitApi.updateUsers(
-            apiKey,
-            connectionId,
-            UpdateUsersRequest(map)
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = UpdateUsersRequest(map)
         )
             .map { response ->
                 response.users.flatMap {
@@ -381,20 +379,18 @@ internal class GsonChatApi(
     ): Call<Channel> {
         return if (channelId.isEmpty()) {
             retrofitApi.queryChannel(
-                channelType,
-                apiKey,
-                userId,
-                connectionId,
-                query
+                channelType = channelType,
+                apiKey = apiKey,
+                connectionId = connectionId,
+                request = query
             )
         } else {
             retrofitApi.queryChannel(
-                channelType,
-                channelId,
-                apiKey,
-                userId,
-                connectionId,
-                query
+                channelType = channelType,
+                channelId = channelId,
+                apiKey = apiKey,
+                connectionId = connectionId,
+                request = query
             )
         }.map(::flattenChannel)
     }
@@ -406,11 +402,11 @@ internal class GsonChatApi(
         updateMessage: Message?,
     ): Call<Channel> {
         return retrofitApi.updateChannel(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            UpdateChannelRequest(extraData, updateMessage)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = UpdateChannelRequest(extraData, updateMessage)
         ).map { flattenChannel(it) }
     }
 
@@ -418,12 +414,24 @@ internal class GsonChatApi(
         channelType: String,
         channelId: String,
         cooldownTimeInSeconds: Int,
-    ): Call<Channel> = updateCooldown(channelType, channelId, cooldownTimeInSeconds)
+    ): Call<Channel> {
+        return updateCooldown(
+            channelType = channelType,
+            channelId = channelId,
+            cooldownTimeInSeconds = cooldownTimeInSeconds
+        )
+    }
 
     override fun disableSlowMode(
         channelType: String,
         channelId: String,
-    ): Call<Channel> = updateCooldown(channelType, channelId, 0)
+    ): Call<Channel> {
+        return updateCooldown(
+            channelType = channelType,
+            channelId = channelId,
+            cooldownTimeInSeconds = 0
+        )
+    }
 
     private fun updateCooldown(
         channelType: String,
@@ -431,11 +439,11 @@ internal class GsonChatApi(
         cooldownTimeInSeconds: Int,
     ): Call<Channel> =
         retrofitApi.updateCooldown(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            UpdateCooldownRequest(cooldownTimeInSeconds)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = UpdateCooldownRequest(cooldownTimeInSeconds)
         ).map { flattenChannel(it) }
 
     override fun markRead(
@@ -444,18 +452,22 @@ internal class GsonChatApi(
         messageId: String,
     ): Call<Unit> {
         return retrofitApi.markRead(
-            channelType,
-            channelId,
-            apiKey,
-            userId,
-            connectionId,
-            MarkReadRequest(messageId)
-        ).map { Unit }
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = MarkReadRequest(messageId)
+        ).toUnitCall()
     }
 
     override fun showChannel(channelType: String, channelId: String): Call<Unit> {
-        return retrofitApi.showChannel(channelType, channelId, apiKey, connectionId, emptyMap())
-            .map { Unit }
+        return retrofitApi.showChannel(
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = emptyMap()
+        ).toUnitCall()
     }
 
     override fun hideChannel(
@@ -464,21 +476,21 @@ internal class GsonChatApi(
         clearHistory: Boolean,
     ): Call<Unit> {
         return retrofitApi.hideChannel(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            HideChannelRequest(clearHistory)
-        ).map { Unit }
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = HideChannelRequest(clearHistory)
+        ).toUnitCall()
     }
 
     override fun rejectInvite(channelType: String, channelId: String): Call<Channel> {
         return retrofitApi.rejectInvite(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            RejectInviteRequest()
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = RejectInviteRequest()
         ).map { flattenChannel(it) }
     }
 
@@ -496,11 +508,11 @@ internal class GsonChatApi(
         message: String?,
     ): Call<Channel> {
         return retrofitApi.acceptInvite(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            AcceptInviteRequest(
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = AcceptInviteRequest(
                 User().apply { id = userId },
                 AcceptInviteRequest.AcceptInviteMessage(message)
             )
@@ -508,30 +520,33 @@ internal class GsonChatApi(
     }
 
     override fun deleteChannel(channelType: String, channelId: String): Call<Channel> {
-        return retrofitApi.deleteChannel(channelType, channelId, apiKey, connectionId)
-            .map { flattenChannel(it) }
+        return retrofitApi.deleteChannel(
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId
+        ).map { flattenChannel(it) }
     }
 
     override fun markAllRead(): Call<Unit> {
         return retrofitApi.markAllRead(
-            apiKey,
-            userId,
-            connectionId
-        ).map { Unit }
+            apiKey = apiKey,
+            connectionId = connectionId
+        ).toUnitCall()
     }
 
     override fun getGuestUser(userId: String, userName: String): Call<GuestUser> {
-        return retrofitAnonymousApi.getGuestUser(apiKey, GuestUserRequest(userId, userName))
-            .map {
-                GuestUser(it.user, it.accessToken)
-            }
+        return retrofitAnonymousApi.getGuestUser(
+            apiKey = apiKey,
+            body = GuestUserRequest(userId, userName)
+        ).map { GuestUser(it.user, it.accessToken) }
     }
 
     override fun queryUsers(queryUsers: QueryUsersRequest): Call<List<User>> {
         return retrofitApi.queryUsers(
-            apiKey,
-            connectionId,
-            queryUsers
+            apiKey = apiKey,
+            connectionId = connectionId,
+            payload = queryUsers
         ).map { it.users }
     }
 
@@ -541,11 +556,11 @@ internal class GsonChatApi(
         members: List<String>,
     ): Call<Channel> {
         return retrofitApi.addMembers(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            AddMembersRequest(members)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = AddMembersRequest(members)
         ).map { flattenChannel(it) }
     }
 
@@ -555,11 +570,11 @@ internal class GsonChatApi(
         members: List<String>,
     ): Call<Channel> {
         return retrofitApi.removeMembers(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            RemoveMembersRequest(members)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = RemoveMembersRequest(members)
         ).map { flattenChannel(it) }
     }
 
@@ -573,9 +588,9 @@ internal class GsonChatApi(
         members: List<Member>,
     ): Call<List<Member>> {
         return retrofitApi.queryMembers(
-            apiKey,
-            connectionId,
-            QueryMembersRequest(
+            apiKey = apiKey,
+            connectionId = connectionId,
+            payload = QueryMembersRequest(
                 channelType,
                 channelId,
                 filter,
@@ -591,10 +606,9 @@ internal class GsonChatApi(
         userId: String,
     ): Call<Mute> {
         return retrofitApi.muteUser(
-            apiKey,
-            this.userId,
-            connectionId,
-            MuteUserRequest(userId, this.userId)
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = MuteUserRequest(userId, this.userId)
         ).map { it.mute }
     }
 
@@ -602,11 +616,10 @@ internal class GsonChatApi(
         userId: String,
     ): Call<Unit> {
         return retrofitApi.unmuteUser(
-            apiKey,
-            this.userId,
-            connectionId,
-            MuteUserRequest(userId, this.userId)
-        ).map { Unit }
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = MuteUserRequest(userId, this.userId)
+        ).toUnitCall()
     }
 
     override fun flagUser(userId: String): Call<Flag> {
@@ -627,19 +640,17 @@ internal class GsonChatApi(
 
     private fun flag(body: MutableMap<String, String>): Call<Flag> {
         return retrofitApi.flag(
-            apiKey,
-            userId,
-            connectionId,
-            body
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = body
         ).map { it.flag }
     }
 
     private fun unflag(body: MutableMap<String, String>): Call<Flag> {
         return retrofitApi.unflag(
-            apiKey,
-            userId,
-            connectionId,
-            body
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = body
         ).map { it.flag }
     }
 
@@ -662,7 +673,7 @@ internal class GsonChatApi(
                 channelId = channelId,
                 shadow = shadow,
             )
-        ).map { Unit }
+        ).toUnitCall()
     }
 
     override fun unbanUser(
@@ -678,7 +689,7 @@ internal class GsonChatApi(
             channelId = channelId,
             channelType = channelType,
             shadow = shadow,
-        ).map { Unit }
+        ).toUnitCall()
     }
 
     override fun queryBannedUsers(
@@ -694,7 +705,6 @@ internal class GsonChatApi(
         return retrofitApi.queryBannedUsers(
             apiKey = apiKey,
             connectionId = connectionId,
-            userId = userId,
             payload = QueryBannedUsersRequest(
                 filter = filter,
                 sort = sort.toDto(),
@@ -719,31 +729,28 @@ internal class GsonChatApi(
         map.putAll(extraData)
 
         return retrofitApi.sendEvent(
-            channelType,
-            channelId,
-            apiKey,
-            userId,
-            connectionId,
-            SendEventRequest(map)
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = SendEventRequest(map)
         ).map { it.event }
     }
 
     override fun translate(messageId: String, language: String): Call<Message> {
         return retrofitApi.translate(
-            messageId,
-            apiKey,
-            userId,
-            connectionId,
-            TranslateMessageRequest(language)
+            messageId = messageId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            request = TranslateMessageRequest(language)
         ).map { it.message }
     }
 
     override fun getSyncHistory(channelIds: List<String>, lastSyncAt: Date): Call<List<ChatEvent>> {
         return retrofitApi.getSyncHistory(
-            GetSyncHistory(channelIds, lastSyncAt),
-            apiKey,
-            userId,
-            connectionId
+            body = GetSyncHistory(channelIds, lastSyncAt),
+            apiKey = apiKey,
+            connectionId = connectionId
         ).map { it.events }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/QueryParams.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/QueryParams.kt
@@ -1,0 +1,6 @@
+package io.getstream.chat.android.client.api
+
+internal object QueryParams {
+    internal const val API_KEY = "api_key"
+    internal const val CONNECTION_ID = "connection_id"
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitAnonymousApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitAnonymousApi.kt
@@ -12,7 +12,7 @@ internal interface RetrofitAnonymousApi {
 
     @POST("/guest")
     fun getGuestUser(
-        @Query("api_key") apiKey: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
         @Body body: GuestUserRequest
     ): RetrofitCall<TokenResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -60,25 +60,22 @@ internal interface RetrofitApi {
 
     @POST("/moderation/mute/channel")
     fun muteChannel(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteChannelRequest
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/unmute/channel")
     fun unmuteChannel(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteChannelRequest
     ): RetrofitCall<CompletableResponse>
 
     @GET("/channels")
     fun queryChannels(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryChannelsRequest
     ): RetrofitCall<QueryChannelsResponse>
 
@@ -86,18 +83,16 @@ internal interface RetrofitApi {
     fun queryChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: QueryChannelRequest
     ): RetrofitCall<ChannelResponse>
 
     @POST("/channels/{type}/query")
     fun queryChannel(
         @Path("type") channelType: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: QueryChannelRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -105,8 +100,8 @@ internal interface RetrofitApi {
     fun updateChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateChannelRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -114,8 +109,8 @@ internal interface RetrofitApi {
     fun updateCooldown(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateCooldownRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -123,8 +118,8 @@ internal interface RetrofitApi {
     fun deleteChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<ChannelResponse>
 
     @POST("/channels/{type}/{id}/stop-watching")
@@ -132,8 +127,8 @@ internal interface RetrofitApi {
     fun stopWatching(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<Any, Any>
     ): RetrofitCall<CompletableResponse>
 
@@ -141,8 +136,8 @@ internal interface RetrofitApi {
     fun acceptInvite(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: AcceptInviteRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -150,8 +145,8 @@ internal interface RetrofitApi {
     fun rejectInvite(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: RejectInviteRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -159,8 +154,8 @@ internal interface RetrofitApi {
     fun hideChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: HideChannelRequest
     ): RetrofitCall<CompletableResponse>
 
@@ -169,8 +164,8 @@ internal interface RetrofitApi {
     fun showChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<Any, Any>
     ): RetrofitCall<CompletableResponse>
 
@@ -178,26 +173,23 @@ internal interface RetrofitApi {
     fun markRead(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: MarkReadRequest
     ): RetrofitCall<EventResponse>
 
     @POST("/channels/read")
     fun markAllRead(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<CompletableResponse>
 
     @POST("/channels/{type}/{id}/event")
     fun sendEvent(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: SendEventRequest
     ): RetrofitCall<EventResponse>
 
@@ -207,15 +199,15 @@ internal interface RetrofitApi {
 
     @POST("/users")
     fun updateUsers(
-        @Query("api_key") apiKey: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateUsersRequest
     ): RetrofitCall<UpdateUsersResponse>
 
     @GET("/users")
     fun queryUsers(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryUsersRequest
     ): RetrofitCall<QueryUserListResponse>
 
@@ -223,8 +215,8 @@ internal interface RetrofitApi {
     fun addMembers(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: AddMembersRequest
     ): RetrofitCall<ChannelResponse>
 
@@ -232,61 +224,57 @@ internal interface RetrofitApi {
     fun removeMembers(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: RemoveMembersRequest
     ): RetrofitCall<ChannelResponse>
 
     @GET("/members")
     fun queryMembers(
-        @Query("api_key") apiKey: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryMembersRequest
     ): RetrofitCall<QueryMembersResponse>
 
     @POST("/moderation/mute")
     fun muteUser(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteUserRequest
     ): RetrofitCall<MuteUserResponse>
 
     @POST("/moderation/unmute")
     fun unmuteUser(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteUserRequest
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/flag")
     fun flag(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/unflag")
     fun unflag(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/ban")
     fun banUser(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: BanUserRequest
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/moderation/ban")
     fun unbanUser(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("target_user_id") targetUserId: String,
         @Query("type") channelType: String,
         @Query("id") channelId: String,
@@ -295,9 +283,8 @@ internal interface RetrofitApi {
 
     @GET("/query_banned_users")
     fun queryBannedUsers(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryBannedUsersRequest,
     ): RetrofitCall<QueryBannedUsersResponse>
 
@@ -310,9 +297,8 @@ internal interface RetrofitApi {
     fun sendMessage(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body message: MessageRequest
     ): RetrofitCall<MessageResponse>
 
@@ -320,43 +306,38 @@ internal interface RetrofitApi {
     @JvmSuppressWildcards // See issue: https://github.com/square/retrofit/issues/3275
     fun updateMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body message: MessageRequest
     ): RetrofitCall<MessageResponse>
 
     @GET("/messages/{id}")
     fun getMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<MessageResponse>
 
     @POST("/messages/{id}/action")
     fun sendAction(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: SendActionRequest
     ): RetrofitCall<MessageResponse>
 
     @DELETE("/messages/{id}")
     fun deleteMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<MessageResponse>
 
     @POST("/messages/{id}/reaction")
     fun sendReaction(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: ReactionRequest
     ): RetrofitCall<ReactionResponse>
 
@@ -364,16 +345,15 @@ internal interface RetrofitApi {
     fun deleteReaction(
         @Path("id") messageId: String,
         @Path("type") reactionType: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<MessageResponse>
 
     @GET("/messages/{id}/reactions")
     fun getReactions(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("offset") offset: Int,
         @Query("limit") limit: Int
     ): RetrofitCall<GetReactionsResponse>
@@ -381,18 +361,16 @@ internal interface RetrofitApi {
     @GET("/messages/{parent_id}/replies")
     fun getReplies(
         @Path("parent_id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("limit") limit: Int
     ): RetrofitCall<GetRepliesResponse>
 
     @GET("/messages/{parent_id}/replies")
     fun getRepliesMore(
         @Path("parent_id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("limit") limit: Int,
         @Query("id_lt") firstId: String
     ): RetrofitCall<GetRepliesResponse>
@@ -403,8 +381,8 @@ internal interface RetrofitApi {
 
     @GET("/search")
     fun searchMessages(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: SearchMessagesRequest
     ): RetrofitCall<SearchMessagesResponse>
 
@@ -413,25 +391,22 @@ internal interface RetrofitApi {
     // region Device
     @GET("/devices")
     fun getDevices(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<GetDevicesResponse>
 
     @POST("devices")
     fun addDevices(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: AddDeviceRequest
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/devices")
     fun deleteDevice(
         @Query("id") deviceId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<CompletableResponse>
 
     // endregion
@@ -439,18 +414,16 @@ internal interface RetrofitApi {
     @POST("/messages/{messageId}/translate")
     fun translate(
         @Path("messageId") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: TranslateMessageRequest
     ): RetrofitCall<MessageResponse>
 
     @POST("/sync")
     fun getSyncHistory(
         @Body body: GetSyncHistory,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<GetSyncHistoryResponse>
 
     @OPTIONS("/connect")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
@@ -19,9 +19,8 @@ internal interface RetrofitCdnApi {
         @Path("type") channelType: String,
         @Path("id") channelId: String,
         @Part file: MultipartBody.Part,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<UploadFileResponse>
 
     @Multipart
@@ -30,17 +29,16 @@ internal interface RetrofitCdnApi {
         @Path("type") channelType: String,
         @Path("id") channelId: String,
         @Part file: MultipartBody.Part,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String
     ): RetrofitCall<UploadFileResponse>
 
     @DELETE("/channels/{type}/{id}/file")
     fun deleteFile(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("url") url: String
     ): RetrofitCall<CompletableResponse>
 
@@ -48,8 +46,8 @@ internal interface RetrofitCdnApi {
     fun deleteImage(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("url") url: String
     ): RetrofitCall<CompletableResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ChannelApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ChannelApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
@@ -30,34 +31,31 @@ internal interface ChannelApi {
 
     @GET("/channels")
     fun queryChannels(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryChannelsRequest,
     ): RetrofitCall<QueryChannelsResponse>
 
     @POST("/channels/{type}/query")
     fun queryChannel(
         @Path("type") channelType: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: QueryChannelRequest,
     ): RetrofitCall<ChannelResponse>
 
     @POST("/channels/read")
     fun markAllRead(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<CompletableResponse>
 
     @POST("/channels/{type}/{id}")
     fun updateChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateChannelRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -65,8 +63,8 @@ internal interface ChannelApi {
     fun updateCooldown(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateCooldownRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -74,16 +72,16 @@ internal interface ChannelApi {
     fun deleteChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<ChannelResponse>
 
     @POST("/channels/{type}/{id}")
     fun acceptInvite(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: AcceptInviteRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -91,8 +89,8 @@ internal interface ChannelApi {
     fun rejectInvite(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: RejectInviteRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -100,8 +98,8 @@ internal interface ChannelApi {
     fun addMembers(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: AddMembersRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -109,8 +107,8 @@ internal interface ChannelApi {
     fun removeMembers(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: RemoveMembersRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -118,9 +116,8 @@ internal interface ChannelApi {
     fun sendEvent(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: SendEventRequest,
     ): RetrofitCall<EventResponse>
 
@@ -128,8 +125,8 @@ internal interface ChannelApi {
     fun hideChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: HideChannelRequest,
     ): RetrofitCall<CompletableResponse>
 
@@ -137,9 +134,8 @@ internal interface ChannelApi {
     fun queryChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: QueryChannelRequest,
     ): RetrofitCall<ChannelResponse>
 
@@ -147,9 +143,8 @@ internal interface ChannelApi {
     fun markRead(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: MarkReadRequest,
     ): RetrofitCall<CompletableResponse>
 
@@ -158,8 +153,8 @@ internal interface ChannelApi {
     fun showChannel(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<Any, Any>,
     ): RetrofitCall<CompletableResponse>
 
@@ -168,8 +163,8 @@ internal interface ChannelApi {
     fun stopWatching(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") clientID: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<Any, Any>,
     ): RetrofitCall<CompletableResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/DeviceApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/DeviceApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.AddDeviceRequest
 import io.getstream.chat.android.client.api2.model.response.CompletableResponse
 import io.getstream.chat.android.client.api2.model.response.DevicesResponse
@@ -17,24 +18,21 @@ internal interface DeviceApi {
 
     @GET("/devices")
     fun getDevices(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<DevicesResponse>
 
     @POST("devices")
     fun addDevices(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: AddDeviceRequest,
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/devices")
     fun deleteDevice(
         @Query("id") deviceId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<CompletableResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/GeneralApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/GeneralApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.QueryMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.SearchMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.SyncHistoryRequest
@@ -24,22 +25,21 @@ internal interface GeneralApi {
     @POST("/sync")
     fun getSyncHistory(
         @Body body: SyncHistoryRequest,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<SyncHistoryResponse>
 
     @GET("/search")
     fun searchMessages(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: SearchMessagesRequest,
     ): RetrofitCall<SearchMessagesResponse>
 
     @GET("/members")
     fun queryMembers(
-        @Query("api_key") apiKey: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryMembersRequest,
     ): RetrofitCall<QueryMembersResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/GuestApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/GuestApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AnonymousApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
 import io.getstream.chat.android.client.api2.model.response.TokenResponse
 import io.getstream.chat.android.client.call.RetrofitCall
@@ -14,7 +15,7 @@ internal interface GuestApi {
 
     @POST("/guest")
     fun getGuestUser(
-        @Query("api_key") apiKey: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
         @Body body: GuestUserRequest,
     ): RetrofitCall<TokenResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MessageApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MessageApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.MessageRequest
 import io.getstream.chat.android.client.api2.model.requests.ReactionRequest
 import io.getstream.chat.android.client.api2.model.requests.SendActionRequest
@@ -25,52 +26,46 @@ internal interface MessageApi {
     fun sendMessage(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body message: MessageRequest,
     ): RetrofitCall<MessageResponse>
 
     @GET("/messages/{id}")
     fun getMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<MessageResponse>
 
     @POST("/messages/{id}")
     fun updateMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body message: MessageRequest,
     ): RetrofitCall<MessageResponse>
 
     @DELETE("/messages/{id}")
     fun deleteMessage(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<MessageResponse>
 
     @POST("/messages/{id}/action")
     fun sendAction(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: SendActionRequest,
     ): RetrofitCall<MessageResponse>
 
     @POST("/messages/{id}/reaction")
     fun sendReaction(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: ReactionRequest,
     ): RetrofitCall<ReactionResponse>
 
@@ -78,16 +73,15 @@ internal interface MessageApi {
     fun deleteReaction(
         @Path("id") messageId: String,
         @Path("type") reactionType: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<MessageResponse>
 
     @GET("/messages/{id}/reactions")
     fun getReactions(
         @Path("id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("offset") offset: Int,
         @Query("limit") limit: Int,
     ): RetrofitCall<ReactionsResponse>
@@ -95,27 +89,24 @@ internal interface MessageApi {
     @POST("/messages/{messageId}/translate")
     fun translate(
         @Path("messageId") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: TranslateMessageRequest,
     ): RetrofitCall<MessageResponse>
 
     @GET("/messages/{parent_id}/replies")
     fun getReplies(
         @Path("parent_id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("limit") limit: Int,
     ): RetrofitCall<MessagesResponse>
 
     @GET("/messages/{parent_id}/replies")
     fun getRepliesMore(
         @Path("parent_id") messageId: String,
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("limit") limit: Int,
         @Query("id_lt") firstId: String,
     ): RetrofitCall<MessagesResponse>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ModerationApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
@@ -22,63 +23,57 @@ internal interface ModerationApi {
 
     @POST("/moderation/mute")
     fun muteUser(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteUserRequest,
     ): RetrofitCall<MuteUserResponse>
 
     @POST("/moderation/unmute")
     fun unmuteUser(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteUserRequest,
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/mute/channel")
     fun muteChannel(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteChannelRequest,
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/unmute/channel")
     fun unmuteChannel(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: MuteChannelRequest,
     ): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/flag")
     fun flag(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/unflag")
     fun unflag(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<String, String>
     ): RetrofitCall<FlagResponse>
 
     @POST("/moderation/ban")
     fun banUser(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: BanUserRequest
     ): RetrofitCall<CompletableResponse>
 
     @DELETE("/moderation/ban")
     fun unbanUser(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Query("target_user_id") targetUserId: String,
         @Query("type") channelType: String,
         @Query("id") channelId: String,
@@ -87,9 +82,8 @@ internal interface ModerationApi {
 
     @GET("/query_banned_users")
     fun queryBannedUsers(
-        @Query("api_key") apiKey: String,
-        @Query("user_id") userId: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryBannedUsersRequest,
     ): RetrofitCall<QueryBannedUsersResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -110,7 +110,6 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             message = MessageRequest(message.toDto()),
         ).map { response -> response.message.toDomain() }
@@ -120,7 +119,6 @@ internal class MoshiChatApi(
         return messageApi.updateMessage(
             messageId = message.id,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             message = MessageRequest(message.toDto()),
         ).map { response -> response.message.toDomain() }
@@ -130,7 +128,6 @@ internal class MoshiChatApi(
         return messageApi.getMessage(
             messageId = messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).map { response -> response.message.toDomain() }
     }
@@ -139,7 +136,6 @@ internal class MoshiChatApi(
         return messageApi.deleteMessage(
             messageId = messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).map { response -> response.message.toDomain() }
     }
@@ -162,7 +158,6 @@ internal class MoshiChatApi(
         return messageApi.sendReaction(
             messageId = reaction.messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = ReactionRequest(
                 reaction = reaction.toDto(),
@@ -179,7 +174,6 @@ internal class MoshiChatApi(
             messageId = messageId,
             reactionType = reactionType,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).map { response -> response.message.toDomain() }
     }
@@ -187,7 +181,6 @@ internal class MoshiChatApi(
     override fun addDevice(firebaseToken: String): Call<Unit> {
         return deviceApi.addDevices(
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = AddDeviceRequest(id = firebaseToken),
         ).toUnitCall()
@@ -197,7 +190,6 @@ internal class MoshiChatApi(
         return deviceApi.deleteDevice(
             deviceId = firebaseToken,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).toUnitCall()
     }
@@ -205,7 +197,6 @@ internal class MoshiChatApi(
     override fun getDevices(): Call<List<Device>> {
         return deviceApi.getDevices(
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).map { response -> response.devices.map(DeviceDto::toDomain) }
     }
@@ -221,7 +212,6 @@ internal class MoshiChatApi(
     override fun muteUser(userId: String): Call<Mute> {
         return moderationApi.muteUser(
             apiKey = apiKey,
-            userId = this.userId,
             connectionId = connectionId,
             body = MuteUserRequest(userId, this.userId),
         ).map { response -> response.mute.toDomain() }
@@ -230,7 +220,6 @@ internal class MoshiChatApi(
     override fun unmuteUser(userId: String): Call<Unit> {
         return moderationApi.unmuteUser(
             apiKey = apiKey,
-            userId = this.userId,
             connectionId = this.connectionId,
             body = MuteUserRequest(userId, this.userId),
         ).toUnitCall()
@@ -239,7 +228,6 @@ internal class MoshiChatApi(
     override fun muteChannel(channelType: String, channelId: String): Call<Unit> {
         return moderationApi.muteChannel(
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             body = MuteChannelRequest("$channelType:$channelId"),
         ).toUnitCall()
@@ -248,7 +236,6 @@ internal class MoshiChatApi(
     override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
         return moderationApi.unmuteChannel(
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             body = MuteChannelRequest("$channelType:$channelId"),
         ).toUnitCall()
@@ -362,19 +349,17 @@ internal class MoshiChatApi(
 
     private fun flag(body: MutableMap<String, String>): Call<Flag> {
         return moderationApi.flag(
-            apiKey,
-            userId,
-            connectionId,
-            body
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = body
         ).map { response -> response.flag.toDomain() }
     }
 
     private fun unflag(body: MutableMap<String, String>): Call<Flag> {
         return moderationApi.unflag(
-            apiKey,
-            userId,
-            connectionId,
-            body
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = body
         ).map { response -> response.flag.toDomain() }
     }
 
@@ -429,7 +414,6 @@ internal class MoshiChatApi(
         return moderationApi.queryBannedUsers(
             apiKey = apiKey,
             connectionId = connectionId,
-            userId = userId,
             payload = QueryBannedUsersRequest(
                 filter_conditions = filter.toMap(),
                 sort = sort.toDto(),
@@ -471,18 +455,18 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = UpdateCooldownRequest(cooldownTimeInSeconds),
         ).map(this::flattenChannel)
     }
 
     override fun stopWatching(channelType: String, channelId: String): Call<Unit> {
         return channelApi.stopWatching(
-            channelType,
-            channelId,
-            apiKey,
-            connectionId,
-            emptyMap(),
+            channelType = channelType,
+            channelId = channelId,
+            apiKey = apiKey,
+            connectionId = connectionId,
+            body = emptyMap(),
         ).toUnitCall()
     }
 
@@ -496,7 +480,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = UpdateChannelRequest(extraData, updateMessage?.toDto()),
         ).map(this::flattenChannel)
     }
@@ -509,7 +493,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = emptyMap(),
         ).toUnitCall()
     }
@@ -523,7 +507,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = HideChannelRequest(clearHistory),
         ).toUnitCall()
     }
@@ -533,7 +517,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = RejectInviteRequest(),
         ).map(this::flattenChannel)
     }
@@ -547,7 +531,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
             body = AcceptInviteRequest.create(userId = userId, message = message),
         ).map(this::flattenChannel)
     }
@@ -557,7 +541,7 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            clientID = connectionId,
+            connectionId = connectionId,
         ).map(this::flattenChannel)
     }
 
@@ -566,7 +550,6 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = MarkReadRequest(messageId),
         ).toUnitCall()
@@ -575,7 +558,6 @@ internal class MoshiChatApi(
     override fun markAllRead(): Call<Unit> {
         return channelApi.markAllRead(
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).toUnitCall()
     }
@@ -624,7 +606,6 @@ internal class MoshiChatApi(
         return messageApi.getReplies(
             messageId = messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             limit = limit,
         ).map { response -> response.messages.map(DownstreamMessageDto::toDomain) }
@@ -634,7 +615,6 @@ internal class MoshiChatApi(
         return messageApi.getRepliesMore(
             messageId = messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             limit = limit,
             firstId = firstId,
@@ -645,7 +625,6 @@ internal class MoshiChatApi(
         return messageApi.sendAction(
             messageId = request.messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = SendActionRequest(
                 channel_id = request.channelId,
@@ -678,7 +657,6 @@ internal class MoshiChatApi(
         return messageApi.translate(
             messageId = messageId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = TranslateMessageRequest(language),
         ).map { response -> response.message.toDomain() }
@@ -719,8 +697,7 @@ internal class MoshiChatApi(
 
         return channelApi.queryChannels(
             apiKey = apiKey,
-            userId = userId,
-            clientID = connectionId,
+            connectionId = connectionId,
             payload = request,
         ).map { response -> response.channels.map(this::flattenChannel) }
     }
@@ -740,8 +717,7 @@ internal class MoshiChatApi(
             channelApi.queryChannel(
                 channelType = channelType,
                 apiKey = apiKey,
-                userId = userId,
-                clientID = connectionId,
+                connectionId = connectionId,
                 request = request,
             )
         } else {
@@ -749,8 +725,7 @@ internal class MoshiChatApi(
                 channelType = channelType,
                 channelId = channelId,
                 apiKey = apiKey,
-                userId = userId,
-                clientID = connectionId,
+                connectionId = connectionId,
                 request = request,
             )
         }.map(::flattenChannel)
@@ -810,7 +785,6 @@ internal class MoshiChatApi(
             channelType = channelType,
             channelId = channelId,
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
             request = SendEventRequest(map),
         ).map { response -> response.event.toDomain() }
@@ -823,7 +797,6 @@ internal class MoshiChatApi(
         return generalApi.getSyncHistory(
             body = SyncHistoryRequest(channelIds, lastSyncAt),
             apiKey = apiKey,
-            userId = userId,
             connectionId = connectionId,
         ).map { response -> response.events.map(ChatEventDto::toDomain) }
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/UserApi.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
+import io.getstream.chat.android.client.api.QueryParams
 import io.getstream.chat.android.client.api2.model.requests.QueryUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.response.UpdateUsersResponse
@@ -16,15 +17,15 @@ import retrofit2.http.Query
 internal interface UserApi {
     @POST("/users")
     fun updateUsers(
-        @Query("api_key") apiKey: String,
-        @Query("connection_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateUsersRequest,
     ): RetrofitCall<UpdateUsersResponse>
 
     @GET("/users")
     fun queryUsers(
-        @Query("api_key") apiKey: String,
-        @Query("client_id") connectionId: String,
+        @Query(QueryParams.API_KEY) apiKey: String,
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @UrlQueryPayload @Query("payload") payload: QueryUsersRequest,
     ): RetrofitCall<UsersResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
@@ -29,7 +29,6 @@ internal class StreamFileUploader(
             channelId,
             part,
             apiKey,
-            userId,
             connectionId
         ).execute()
 
@@ -58,7 +57,6 @@ internal class StreamFileUploader(
             channelId,
             part,
             apiKey,
-            userId,
             connectionId
         ).execute()
 
@@ -86,7 +84,6 @@ internal class StreamFileUploader(
                 channelId,
                 part,
                 apiKey,
-                userId,
                 connectionId
             ).execute()
 
@@ -115,7 +112,6 @@ internal class StreamFileUploader(
             channelId,
             part,
             apiKey,
-            userId,
             connectionId
         ).execute()
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -52,7 +52,6 @@ internal class ChannelsApiCallsTests {
                 mock.channelType,
                 mock.channelId,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -73,7 +72,6 @@ internal class ChannelsApiCallsTests {
                 mock.channelType,
                 mock.channelId,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -336,7 +334,6 @@ internal class ChannelsApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.markAllRead(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroSuccess(CompletableResponse()).toRetrofitCall())
@@ -352,7 +349,6 @@ internal class ChannelsApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.markAllRead(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroError<CompletableResponse>(mock.serverErrorCode).toRetrofitCall())
@@ -380,7 +376,6 @@ internal class ChannelsApiCallsTests {
                 mock.channelType,
                 mock.channelId,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MarkReadRequest(messageId)
             )
@@ -401,7 +396,6 @@ internal class ChannelsApiCallsTests {
                 mock.channelType,
                 mock.channelId,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MarkReadRequest(messageId)
             )
@@ -430,7 +424,6 @@ internal class ChannelsApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.queryChannels(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -455,7 +448,6 @@ internal class ChannelsApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.queryChannels(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -505,7 +497,6 @@ internal class ChannelsApiCallsTests {
         whenever(
             mock.retrofitApi.muteChannel(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MuteChannelRequest("${mock.channelType}:${mock.channelId}")
             )
@@ -521,7 +512,6 @@ internal class ChannelsApiCallsTests {
         whenever(
             mock.retrofitApi.unmuteChannel(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MuteChannelRequest("${mock.channelType}:${mock.channelId}")
             )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
@@ -31,7 +31,6 @@ internal class DevicesApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.getDevices(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroSuccess(GetDevicesResponse(listOf(device))).toRetrofitCall())
@@ -47,7 +46,6 @@ internal class DevicesApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.getDevices(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroError<GetDevicesResponse>(mock.serverErrorCode).toRetrofitCall())
@@ -66,7 +64,6 @@ internal class DevicesApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.addDevices(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -86,7 +83,6 @@ internal class DevicesApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.addDevices(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 request
             )
@@ -106,7 +102,6 @@ internal class DevicesApiCallsTests {
             mock.retrofitApi.deleteDevice(
                 device.id,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroSuccess(CompletableResponse()).toRetrofitCall())
@@ -125,7 +120,6 @@ internal class DevicesApiCallsTests {
             mock.retrofitApi.deleteDevice(
                 device.id,
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId
             )
         ).thenReturn(RetroError<CompletableResponse>(mock.serverErrorCode).toRetrofitCall())

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessageIdGenerationTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessageIdGenerationTests.kt
@@ -57,7 +57,6 @@ internal class MessageIdGenerationTests {
                 channelType,
                 channelId,
                 apiKey,
-                userId,
                 connectionId,
                 MessageRequest(message)
             )
@@ -81,7 +80,6 @@ internal class MessageIdGenerationTests {
                 channelType,
                 channelId,
                 apiKey,
-                userId,
                 connectionId,
                 MessageRequest(message)
             )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
@@ -39,7 +39,7 @@ internal class MessagesApiCallsTests {
 
         Mockito.`when`(
             mock.retrofitApi
-                .getMessage(messageId, mock.apiKey, mock.userId, mock.connectionId)
+                .getMessage(messageId, mock.apiKey, mock.connectionId)
         ).thenReturn(
             RetroSuccess(MessageResponse(message)).toRetrofitCall()
         )
@@ -56,7 +56,7 @@ internal class MessagesApiCallsTests {
 
         Mockito.`when`(
             mock.retrofitApi
-                .getMessage(messageId, mock.apiKey, mock.userId, mock.connectionId)
+                .getMessage(messageId, mock.apiKey, mock.connectionId)
         ).thenReturn(
             RetroError<MessageResponse>(mock.serverErrorCode).toRetrofitCall()
         )
@@ -78,7 +78,7 @@ internal class MessagesApiCallsTests {
 
         Mockito.`when`(
             mock.retrofitApi
-                .deleteMessage(messageId, mock.apiKey, mock.userId, mock.connectionId)
+                .deleteMessage(messageId, mock.apiKey, mock.connectionId)
         ).thenReturn(
             RetroSuccess(MessageResponse(message)).toRetrofitCall()
         )
@@ -95,7 +95,7 @@ internal class MessagesApiCallsTests {
 
         Mockito.`when`(
             mock.retrofitApi
-                .deleteMessage(messageId, mock.apiKey, mock.userId, mock.connectionId)
+                .deleteMessage(messageId, mock.apiKey, mock.connectionId)
         ).thenReturn(
             RetroError<MessageResponse>(mock.serverErrorCode).toRetrofitCall()
         )
@@ -178,7 +178,6 @@ internal class MessagesApiCallsTests {
                     mock.channelType,
                     mock.channelId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     MessageRequest(message)
                 )
@@ -201,7 +200,6 @@ internal class MessagesApiCallsTests {
                     mock.channelType,
                     mock.channelId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     MessageRequest(message)
                 )
@@ -227,7 +225,6 @@ internal class MessagesApiCallsTests {
                 .sendAction(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     request
                 )
@@ -249,7 +246,6 @@ internal class MessagesApiCallsTests {
                 .sendAction(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     request
                 )
@@ -274,7 +270,6 @@ internal class MessagesApiCallsTests {
                 .getReplies(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     limit
                 )
@@ -296,7 +291,6 @@ internal class MessagesApiCallsTests {
                 .getReplies(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     limit
                 )
@@ -322,7 +316,6 @@ internal class MessagesApiCallsTests {
                 .getRepliesMore(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     limit,
                     firstId
@@ -346,7 +339,6 @@ internal class MessagesApiCallsTests {
                 .getRepliesMore(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     limit,
                     firstId
@@ -373,7 +365,6 @@ internal class MessagesApiCallsTests {
                     messageId,
                     reactionType,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId
                 )
         ).thenReturn(RetroSuccess(MessageResponse(message)).toRetrofitCall())
@@ -395,7 +386,6 @@ internal class MessagesApiCallsTests {
                     messageId,
                     reactionType,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId
                 )
         ).thenReturn(RetroError<MessageResponse>(mock.serverErrorCode).toRetrofitCall())
@@ -470,7 +460,6 @@ internal class MessagesApiCallsTests {
                 .updateMessage(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     MessageRequest(message)
                 )
@@ -497,7 +486,6 @@ internal class MessagesApiCallsTests {
                 .updateMessage(
                     messageId,
                     mock.apiKey,
-                    mock.userId,
                     mock.connectionId,
                     MessageRequest(message)
                 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -112,7 +112,6 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.flag(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 mapOf(Pair("target_user_id", targetUserId))
             )
@@ -146,7 +145,6 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.flag(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 mapOf(Pair("target_user_id", targetUserId))
             )
@@ -179,7 +177,6 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.flag(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 mapOf(Pair("target_message_id", targetMessageId))
             )
@@ -248,7 +245,6 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.muteUser(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MuteUserRequest(targetUser.id, mock.userId)
             )
@@ -267,7 +263,6 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.unmuteUser(
                 mock.apiKey,
-                mock.userId,
                 mock.connectionId,
                 MuteUserRequest(targetUser.id, mock.userId)
             )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
@@ -52,7 +52,7 @@ internal class StreamFileUploaderTest {
 
     @Test
     fun `Should send file to api when sending file without progress callback`() {
-        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse("file")).toRetrofitCall()
         )
 
@@ -63,7 +63,6 @@ internal class StreamFileUploaderTest {
             eq(channelId),
             file = any(),
             eq(apiKey),
-            eq(userId),
             eq(connectionId)
         )
     }
@@ -71,7 +70,7 @@ internal class StreamFileUploaderTest {
     @Test
     fun `Should return file when successfully sent file without progress callback`() {
         val file = "file"
-        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse(file)).toRetrofitCall()
         )
 
@@ -83,7 +82,7 @@ internal class StreamFileUploaderTest {
 
     @Test
     fun `Should return null when sending file without progress callback failed`() {
-        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any())).thenReturn(
             RetroError<UploadFileResponse>(500).toRetrofitCall()
         )
 
@@ -95,7 +94,7 @@ internal class StreamFileUploaderTest {
 
     @Test
     fun `Should send file to api when sending file with progress callback`() {
-        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendFile(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse("file")).toRetrofitCall()
         )
 
@@ -113,14 +112,13 @@ internal class StreamFileUploaderTest {
             eq(channelId),
             file = any(),
             eq(apiKey),
-            eq(userId),
             eq(connectionId)
         )
     }
 
     @Test
     fun `Should send image to api when sending image without progress callback`() {
-        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse("file")).toRetrofitCall()
         )
 
@@ -131,7 +129,6 @@ internal class StreamFileUploaderTest {
             eq(channelId),
             file = any(),
             eq(apiKey),
-            eq(userId),
             eq(connectionId)
         )
     }
@@ -139,7 +136,7 @@ internal class StreamFileUploaderTest {
     @Test
     fun `Should return file when successfully sent image without progress callback`() {
         val file = "file"
-        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse(file)).toRetrofitCall()
         )
 
@@ -151,7 +148,7 @@ internal class StreamFileUploaderTest {
 
     @Test
     fun `Should return null when sending image without progress callback failed`() {
-        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any())).thenReturn(
             RetroError<UploadFileResponse>(500).toRetrofitCall()
         )
 
@@ -163,7 +160,7 @@ internal class StreamFileUploaderTest {
 
     @Test
     fun `Should send image to api when sending image with progress callback`() {
-        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any(), any())).thenReturn(
+        whenever(retrofitCdnApi.sendImage(any(), any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse("file")).toRetrofitCall()
         )
 
@@ -181,7 +178,6 @@ internal class StreamFileUploaderTest {
             eq(channelId),
             file = any(),
             eq(apiKey),
-            eq(userId),
             eq(connectionId)
         )
     }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-747

### Description

- Removed `user_id` parameter which is currently sent as in a query with is not required anymore (`user_token` which is sent in the header is actually used by backend).
- Replaced `client_id` parameter with `connection_id`, as `client_id` parameter in deprecated on the backend.

Introduced `api_key` and `connection_id` constants not to make a typo. These two query parameters are used in almost every request, therefore I will move them later to the corresponding interceptor.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
