### PR TITLE
Add `ChannelListItemPredicate` to our `ChannelListView`

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -85,6 +85,7 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 - Add `streamUiMentionsEnabled` attribute to `MessageInputView` and `MessageInputView::setMentionsEnabled` method to enable/disable mentions
 - Add `streamUiThreadsEnabled` attribute to `MessageListView` and `MessageListView::setThreadsEnabled` method to enable/disable the thread replies feature
 - Add `streamUiCommandsEnabled` attribute to `MessageInputView` and `MessageInputView::setCommandsEnabled` method to enable/disable commands
+- Add `ChannelListItemPredicate` to our `channelListView` to allow filter `ChannelListItem` before they are rendered
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -28,6 +28,7 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListView : a
 	public final fun setChannelInfoClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
 	public final fun setChannelItemClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
 	public final fun setChannelLeaveClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
+	public final fun setChannelListItemPredicate (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelListItemPredicate;)V
 	public final fun setChannelLongClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelLongClickListener;)V
 	public final fun setChannels (Ljava/util/List;)V
 	public final fun setEmptyStateView (Landroid/view/View;)V
@@ -57,6 +58,10 @@ public abstract interface class io/getstream/chat/android/ui/channel/list/Channe
 }
 
 public final class io/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener$Companion {
+}
+
+public abstract interface class io/getstream/chat/android/ui/channel/list/ChannelListView$ChannelListItemPredicate {
+	public abstract fun predicate (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem;)Z
 }
 
 public abstract interface class io/getstream/chat/android/ui/channel/list/ChannelListView$ChannelLongClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -34,6 +34,8 @@ public class ChannelListView @JvmOverloads constructor(
 
     private var loadingView: View = defaultLoadingView()
 
+    private var channelListItemPredicate: ChannelListItemPredicate = ChannelListItemPredicate { true }
+
     private val simpleChannelListView: SimpleChannelListView =
         SimpleChannelListView(context, attrs, defStyleAttr).apply { id = CHANNEL_LIST_VIEW_ID }
 
@@ -200,8 +202,18 @@ public class ChannelListView @JvmOverloads constructor(
         simpleChannelListView.setOnEndReachedListener(listener)
     }
 
+    /**
+     * Allows a client to set a ChannelListItemPredicate to filter ChannelListItems before they are drawn
+     *
+     * @param channelListItemPredicate - ChannelListItemsPredicate used to filter the list of ChannelListItem
+     */
+    public fun setChannelListItemPredicate(channelListItemPredicate: ChannelListItemPredicate) {
+        this.channelListItemPredicate = channelListItemPredicate
+        simpleChannelListView.currentChannelItemList()?.let(::setChannels)
+    }
+
     public fun setChannels(channels: List<ChannelListItem>) {
-        simpleChannelListView.setChannels(channels)
+        simpleChannelListView.setChannels(channels.filter(channelListItemPredicate::predicate))
     }
 
     public fun hideLoadingView() {
@@ -326,6 +338,14 @@ public class ChannelListView @JvmOverloads constructor(
 
     public fun interface EndReachedListener {
         public fun onEndReached()
+    }
+
+    /**
+     * Predicate object with a filter condition for ChannelListItem. Used to filter a list of ChannelListItem
+     * before applying it to ChannelListView.
+     */
+    public fun interface ChannelListItemPredicate {
+        public fun predicate(channelListItem: ChannelListItem): Boolean
     }
 
     public interface SwipeListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
@@ -68,6 +68,9 @@ internal class SimpleChannelListView @JvmOverloads constructor(
         this.setAdapter(adapter)
     }
 
+    internal fun currentChannelItemList(): List<ChannelListItem>? =
+        if (::adapter.isInitialized) adapter.currentList else null
+
     fun setViewHolderFactory(viewHolderFactory: ChannelListItemViewHolderFactory) {
         check(::adapter.isInitialized.not()) { "Adapter was already initialized, please set ChannelListItemViewHolderFactory first" }
 


### PR DESCRIPTION
### Description
Add `ChannelListItemPredicate` to our `channelListView` to allow filter `ChannelListItem` before they are rendered
Fixes #1549 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
