### PR TITLE
[CAS-775] Fix - Max lines for link description

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -3,7 +3,8 @@
 Group channels with 1<>1 behaviour the same way as group channels with many users
 It is not possible to remove users from distinct channels anymore.
 ### ⬆️ Improved
-
+it is now possible to configure the max lines of a link description. Just use
+`app:streamUiLinkDescriptionMaxLines` when defining MessageListView
 ### ✅ Added
 Configure enable/disable of replies using XML in `MessageListView`
 Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable reactions

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -963,7 +963,8 @@ public final class io/getstream/chat/android/ui/message/list/header/viewmodel/Me
 
 public final class io/getstream/chat/android/ui/message/list/internal/MessageListItemStyle : java/io/Serializable {
 	public static final field Companion Lio/getstream/chat/android/ui/message/list/internal/MessageListItemStyle$Companion;
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getLinkDescriptionMaxLines ()I
 	public final fun getMessageBackgroundColorMine ()Ljava/lang/Integer;
 	public final fun getMessageBackgroundColorTheirs ()Ljava/lang/Integer;
 	public final fun getMessageLinkTextColorMine ()Ljava/lang/Integer;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/LinkAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/LinkAttachmentView.kt
@@ -72,6 +72,10 @@ internal class LinkAttachmentView : FrameLayout {
         }
     }
 
+    internal fun setLinkDescriptionMaxLines(maxLines: Int) {
+        binding.descriptionTextView.maxLines = maxLines
+    }
+
     fun setLinkPreviewClickListener(linkPreviewClickListener: LinkPreviewClickListener) {
         setOnClickListener {
             previewUrl?.let { url ->

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory.kt
@@ -83,6 +83,7 @@ public open class AttachmentViewFactory {
             setLinkPreviewClickListener(listeners.linkClickListener::onLinkClick)
             setLongClickTarget(parent)
             style.getStyleTextColor(isMine)?.also(::setTextColor)
+            setLinkDescriptionMaxLines(style.linkDescriptionMaxLines)
             showLinkAttachment(linkAttachment)
         }
         return linkAttachmentView

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/TextAndAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/TextAndAttachmentsViewHolder.kt
@@ -55,7 +55,7 @@ internal class TextAndAttachmentsViewHolder(
             LongClickFriendlyLinkMovementMethod.set(
                 textView = messageText,
                 longClickTarget = root,
-                onLinkClicked = { url -> listeners.linkClickListener.onLinkClick(url) }
+                onLinkClicked = listeners.linkClickListener::onLinkClick
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListItemStyle.kt
@@ -14,6 +14,7 @@ public class MessageListItemStyle private constructor(
     @ColorInt public val messageLinkTextColorTheirs: Int?,
     public var reactionsEnabled: Boolean,
     public var threadsEnabled: Boolean,
+    public val linkDescriptionMaxLines: Int
 ) : Serializable {
 
     @ColorInt
@@ -51,6 +52,8 @@ public class MessageListItemStyle private constructor(
 
         private var reactionsEnabled: Boolean = true
         private var threadsEnabled: Boolean = true
+
+        private var linkDescriptionMaxLines: Int = 5
 
         fun messageBackgroundColorMine(
             @StyleableRes messageBackgroundColorMineStyleableId: Int,
@@ -108,6 +111,13 @@ public class MessageListItemStyle private constructor(
             this.threadsEnabled = attributes.getBoolean(threadsEnabled, defaultValue)
         }
 
+        fun linkDescriptionMaxLines(
+            maxLines: Int,
+            defaultValue: Int = 5,
+        ) = apply {
+            this.linkDescriptionMaxLines = attributes.getInt(maxLines, defaultValue)
+        }
+
         fun build(): MessageListItemStyle {
             return MessageListItemStyle(
                 messageBackgroundColorMine = messageBackgroundColorMine.nullIfNotSet(),
@@ -118,6 +128,7 @@ public class MessageListItemStyle private constructor(
                 messageLinkTextColorTheirs = messageLinkTextColorTheirs.nullIfNotSet(),
                 reactionsEnabled = reactionsEnabled,
                 threadsEnabled = threadsEnabled,
+                linkDescriptionMaxLines = linkDescriptionMaxLines
             )
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListViewStyle.kt
@@ -57,6 +57,7 @@ internal class MessageListViewStyle(context: Context, attrs: AttributeSet?) {
                 .messageLinkTextColorTheirs(R.styleable.MessageListView_streamUiMessageLinkColorTheirs)
                 .reactionsEnabled(R.styleable.MessageListView_streamUiReactionsEnabled)
                 .threadsEnabled(R.styleable.MessageListView_streamUiThreadsEnabled)
+                .linkDescriptionMaxLines(R.styleable.MessageListView_streamUiLinkDescriptionMaxLines)
                 .build()
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_link_attachments_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_link_attachments_view.xml
@@ -85,6 +85,7 @@
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textColor="@color/stream_ui_text_color_secondary"
         android:visibility="gone"
+        android:ellipsize="end"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/titleTextView"

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -40,9 +40,10 @@
         <attr name="streamUiMessageBackgroundColorMine" format="color" />
         <attr name="streamUiMessageBackgroundColorTheirs" format="color" />
 
-        <!-- Message link color -->
+        <!-- Message link -->
         <attr name="streamUiMessageLinkColorMine" format="color" />
         <attr name="streamUiMessageLinkColorTheirs" format="color" />
+        <attr name="streamUiLinkDescriptionMaxLines" format="integer" />
 
         <attr name="streamUiReactionsEnabled" format="boolean" />
     </declare-styleable>


### PR DESCRIPTION
[CAS-775](https://stream-io.atlassian.net/browse/CAS-775)

### Description

Adding max lines for link description, so we don't have extremely long link descriptions. The max lines can be configured. 

| Before | After | 
| --- | --- |
| ![Screenshot_20210319-150316](https://user-images.githubusercontent.com/10619102/111824117-88802880-88c4-11eb-867a-ca70eac82a2c.png) | ![Screenshot_20210319-145911](https://user-images.githubusercontent.com/10619102/111824100-8027ed80-88c4-11eb-8d71-228e60754905.png)| 

_It is a nice game, by the way..._

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
