### PR TITLE
[CAS-798] Fix - Default icon for null thumbnail

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
@@ -22,9 +22,11 @@ private val FILE_THUMB_TRANSFORMATION = RoundedCorners(3.dpToPxPrecise())
 
 internal fun ImageView.loadAttachmentThumb(attachment: Attachment) {
     with(attachment) {
-        when (type) {
-            ModelType.attach_video -> load(data = thumbUrl, transformation = FILE_THUMB_TRANSFORMATION)
-            ModelType.attach_image -> load(data = imageUrl, transformation = FILE_THUMB_TRANSFORMATION)
+        when {
+            type == ModelType.attach_video && !thumbUrl.isNullOrBlank() ->
+                load(data = thumbUrl, transformation = FILE_THUMB_TRANSFORMATION)
+            type == ModelType.attach_image && !imageUrl.isNullOrBlank() ->
+                load(data = imageUrl, transformation = FILE_THUMB_TRANSFORMATION)
             else -> load(data = UiUtils.getIcon(mimeType))
         }
     }


### PR DESCRIPTION
[CAS-798](https://stream-io.atlassian.net/browse/CAS-798)

### Description

Using default icon instead of (unsuccessfully) trying to load the thumbUrl if it is `null`. It is still necessary to understand why we are getting this values as null, but that can be done in another PR. 

| Before | After | 
| --- | --- | 
| ![Screenshot_20210319-165041](https://user-images.githubusercontent.com/10619102/111835367-a43efb00-88d3-11eb-8f50-98543a7b3c3a.png) | ![Screenshot_20210319-164046](https://user-images.githubusercontent.com/10619102/111835300-8c677700-88d3-11eb-9d77-daec2bcf8c0c.png) | 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
