### PR TITLE
Remove docs module dependency on old UI module

### DIFF
--- a/stream-chat-android-docs/build.gradle
+++ b/stream-chat-android-docs/build.gradle
@@ -71,7 +71,6 @@ android {
 }
 
 dependencies {
-    implementation project(":stream-chat-android")
     implementation project(":stream-chat-android-ui-components")
     implementation Dependencies.constraintLayout
     implementation Dependencies.fragmentKtx

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
@@ -13,7 +13,6 @@ import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
-import com.getstream.sdk.chat.viewmodel.channels.ChannelsViewModel
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QuerySort
@@ -84,7 +83,7 @@ class Android {
                         Filters.eq("type", "messaging"),
                         Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id)),
                     ),
-                    sort = ChannelsViewModel.DEFAULT_SORT,
+                    sort = ChannelListViewModel.DEFAULT_SORT,
                     limit = 30,
                 )
             }


### PR DESCRIPTION
### Description

Our docs work with the new UI module, removing the old module as a dependency here to prevent accidental usages of it in the docs.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
