### PR TITLE
Fix restoring custom user in sample app

### DIFF
--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -10,96 +10,112 @@ object AppConfig {
 
     val availableUsers: List<SampleUser> = listOf(
         SampleUser(
+            apiKey = apiKey,
             name = "Jc",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FJc.png?alt=media",
             id = "1f37e58d-d8b0-476a-a4f2-f8611e0d85d9",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWYzN2U1OGQtZDhiMC00NzZhLWE0ZjItZjg2MTFlMGQ4NWQ5In0.l3u9P1NKhJ91rI1tzOcABGh045Kj69-iVkC2yUtohVw"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Fra",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FFra.png?alt=media",
             id = "Fra",
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiRnJhIn0.ENQGHEsAL3WjVhd_qTiJa_9ojGKi2ftJ8xlocT8SVX4"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Carter",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FCarter.png?alt=media",
             id = "6d95273b-33f0-40f5-b07c-0da261092074",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNmQ5NTI3M2ItMzNmMC00MGY1LWIwN2MtMGRhMjYxMDkyMDc0In0.lT5O4EmWzhRKPTau6dHP4F6M42EA2aN_8-iAPuiFPLc"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Dmitrii",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FDmitrii.png?alt=media",
             id = "1e330111-670d-49a7-8f08-e6734338c641",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWUzMzAxMTEtNjcwZC00OWE3LThmMDgtZTY3MzQzMzhjNjQxIn0.YEFdEMWj5rurQKr0QMrvO72jGZHU-AlpUIbyY4jxYdU"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Leandro",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FLeandro.png?alt=media",
             id = "29e46def-88f4-4b6a-a10c-584d10c4fdc9",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMjllNDZkZWYtODhmNC00YjZhLWExMGMtNTg0ZDEwYzRmZGM5In0.Mxr4Prnb1-EVM5NSSP2EugLApSChoKnVFwe7ZO15V_U"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Marton",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FMarton.png?alt=media",
             id = "1f052c08-f682-4a83-896c-9f19a68bd2bb",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMWYwNTJjMDgtZjY4Mi00YTgzLTg5NmMtOWYxOWE2OGJkMmJiIn0.L-cQ-DYubOzFpsg94OEwlTRYjat9G4cqfAgzBPALW0g"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Oleg",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FOleg.png?alt=media",
             id = "0d3e6e63-6200-4dd1-a841-4050664891e2",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMGQzZTZlNjMtNjIwMC00ZGQxLWE4NDEtNDA1MDY2NDg5MWUyIn0.osFIgnle17f6yEkK7rPJguQaKhOiawAO3BylYaiRTqE"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Rafal",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FRafal.png?alt=media",
             id = "12fb0ed9-93d8-48a5-9885-28e41f2e4c43",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMTJmYjBlZDktOTNkOC00OGE1LTk4ODUtMjhlNDFmMmU0YzQzIn0.t_oc_DEwTav7ni0z4bi8Xla_5Zj5cI6l3rKxwoCvtB0"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Samuel",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FSam.png?alt=media",
             id = "5531a8cb-3b81-4a54-b424-7ae4e27bf8ba",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiNTUzMWE4Y2ItM2I4MS00YTU0LWI0MjQtN2FlNGUyN2JmOGJhIn0.PXkmukg3JU4igH_YUMr7WC7a1EcwKBr_C5V2ouBlmIs"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Tommaso",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FTommaso.png?alt=media",
             id = "06356564-149f-4b2c-8525-d22056fec404",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMDYzNTY1NjQtMTQ5Zi00YjJjLTg1MjUtZDIyMDU2ZmVjNDA0In0.R3-HY9Cno62yIhCjLXDBR8LF7y1udwX8m4LLNP2dIZo"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Thierry",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FThierry.png?alt=media",
             id = "ad7d9314-5071-4d61-98a1-ffa643ce824a",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYWQ3ZDkzMTQtNTA3MS00ZDYxLTk4YTEtZmZhNjQzY2U4MjRhIn0.iF4UWGFtX0eTAIBTCum7fjD_TKn8wjEqb3PVxJrwbuM"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Zetra",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FZetra.png?alt=media",
             id = "cebf562a-4806-4c64-a827-59d50aac42ba",
             token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiY2ViZjU2MmEtNDgwNi00YzY0LWE4MjctNTlkNTBhYWM0MmJhIn0.kuXab7RhQRHdsErEW5tTN_mmuyLPNU4ZbprvuPXM4OY"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Qatest0",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FQatest0.png?alt=media",
             id = "qatest0",
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicWF0ZXN0MCJ9.Vow00KvvhLvWRZIPKomXQOYpBL_P-_-eDeDKmBRvEj4"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Qatest1",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FQatest1.png?alt=media",
             id = "qatest1",
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicWF0ZXN0MSJ9.H1nlYibjgp1HfaOd0sA_T4038tjsN61mJWxvUjmRQI0"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Qatest2",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FQatest2.png?alt=media",
             id = "qatest2",
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicWF0ZXN0MiJ9.GYp9ikLtU2eG9Mq7tmHThzbV7C8W82j18sExuO7-ogc"
         ),
         SampleUser(
+            apiKey = apiKey,
             name = "Qatest3",
             image = "https://firebasestorage.googleapis.com/v0/b/stream-chat-internal.appspot.com/o/users%2FQatest3.png?alt=media",
             id = "qatest3",

--- a/stream-chat-android-ui-components-sample/src/full/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/full/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -9,24 +9,28 @@ object AppConfig {
     const val cndTimeout: Int = 30000
 
     private val user1 = SampleUser(
+        apiKey = apiKey,
         id = "80c26629-bc25-4ee5-a8ae-4824f8097b53",
         name = "paul",
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiODBjMjY2MjktYmMyNS00ZWU1LWE4YWUtNDgyNGY4MDk3YjUzIn0.ca55fO4jAbexSSZKqBMT0OaxCZaPtYmo1HWgvjBnOY4",
         image = "https://getstream.io/random_png?id=80c26629-bc25-4ee5-a8ae-4824f8097b53&name=paul&size=200"
     )
     private val user2 = SampleUser(
+        apiKey = apiKey,
         id = "a97a21dd-d993-42e0-8e52-31d6b3cea82c",
         name = "chani",
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiYTk3YTIxZGQtZDk5My00MmUwLThlNTItMzFkNmIzY2VhODJjIn0.7Hv38I8xq328_nyKdMA8m1ehz3jrNdnaH1GzSj6yuzk",
         image = "https://getstream.io/random_png?id=a97a21dd-d993-42e0-8e52-31d6b3cea82c&name=chani&size=200"
     )
     private val user3 = SampleUser(
+        apiKey = apiKey,
         id = "d39f2878-2e97-49bd-9148-6e3fd85bbce5",
         name = "duncan",
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiZDM5ZjI4NzgtMmU5Ny00OWJkLTkxNDgtNmUzZmQ4NWJiY2U1In0.Do_LACAzy5pxApqJx0kpztMm_vXNRLkAVE79LEafXZg",
         image = "https://getstream.io/random_png?id=d39f2878-2e97-49bd-9148-6e3fd85bbce5&name=duncan&size=200"
     )
     private val user4 = SampleUser(
+        apiKey = apiKey,
         id = "3761c83e-2a2e-4d6f-94ff-69c452386f8a",
         name = "leto",
         token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJ1c2VyX2lkIjoiMzc2MWM4M2UtMmEyZS00ZDZmLTk0ZmYtNjljNDUyMzg2ZjhhIn0.SrnLIH0bthY0yc-QwbsImI6mXTmQTz9-a7_95MPFwsA",

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/data/user/SampleUser.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/data/user/SampleUser.kt
@@ -1,13 +1,14 @@
 package io.getstream.chat.ui.sample.data.user
 
 data class SampleUser(
+    val apiKey: String,
     val id: String,
     val name: String,
     val token: String,
-    val image: String
+    val image: String,
 ) {
 
     companion object {
-        val None: SampleUser = SampleUser("", "", "", "https://getstream.io/random_png?id=none&name=none&size=200")
+        val None: SampleUser = SampleUser("", "", "", "", "https://getstream.io/random_png?id=none&name=none&size=200")
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/data/user/UserRepository.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/data/user/UserRepository.kt
@@ -10,12 +10,13 @@ class UserRepository(context: Context) {
     }
 
     fun getUser(): SampleUser {
+        val apiKey = prefs.getString(KEY_API_KEY, null)
         val id = prefs.getString(KEY_ID, null)
         val name = prefs.getString(KEY_NAME, null)
         val token = prefs.getString(KEY_TOKEN, null)
         val image = prefs.getString(KEY_IMAGE, null)
-        return if (id != null && name != null && token != null && image != null) {
-            SampleUser(id, name, token, image)
+        return if (apiKey != null && id != null && name != null && token != null && image != null) {
+            SampleUser(apiKey = apiKey, id = id, name = name, token = token, image = image)
         } else {
             SampleUser.None
         }
@@ -23,21 +24,21 @@ class UserRepository(context: Context) {
 
     fun setUser(user: SampleUser) {
         prefs.edit()
+            .putString(KEY_API_KEY, user.apiKey)
             .putString(KEY_ID, user.id)
             .putString(KEY_NAME, user.name)
             .putString(KEY_TOKEN, user.token)
             .putString(KEY_IMAGE, user.image)
-            .commit()
+            .apply()
     }
 
     fun clearUser() {
-        prefs.edit()
-            .clear()
-            .commit()
+        prefs.edit().clear().apply()
     }
 
     private companion object {
         private const val USER_PREFS_NAME = "logged_in_user"
+        private const val KEY_API_KEY = "api_key"
         private const val KEY_ID = "id"
         private const val KEY_NAME = "name"
         private const val KEY_TOKEN = "token"

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/custom_login/CustomLoginViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/custom_login/CustomLoginViewModel.kt
@@ -51,6 +51,7 @@ class CustomLoginViewModel : ViewModel() {
 
                     App.instance.userRepository.setUser(
                         SampleUser(
+                            apiKey = loginCredentials.apiKey,
                             id = loginCredentials.userId,
                             name = loginCredentials.userName,
                             token = loginCredentials.userToken,

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
@@ -44,7 +44,7 @@ class UserLoginViewModel : ViewModel() {
             image = user.image
             name = user.name
         }
-        initChatSdk(chatUser)
+        initChatSdk(user.apiKey, chatUser)
 
         ChatClient.instance().connectUser(chatUser, user.token)
             .enqueue { result ->
@@ -63,8 +63,8 @@ class UserLoginViewModel : ViewModel() {
      * but since we allow changing API keys at runtime in this demo app, we have to
      * reinitialize the Chat SDK here with the new API key.
      */
-    private fun initChatSdk(user: ChatUser) {
-        App.instance.chatInitializer.init(AppConfig.apiKey, user)
+    private fun initChatSdk(apiKey: String, user: ChatUser) {
+        App.instance.chatInitializer.init(apiKey, user)
     }
 
     sealed class State {

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -882,7 +882,6 @@ public final class io/getstream/chat/android/ui/message/list/MessageListItemStyl
 	public final fun getStyleTextColor (Z)Ljava/lang/Integer;
 	public final fun getThreadsEnabled ()Z
 	public fun hashCode ()I
-	public final fun setReactionsEnabled (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -1070,7 +1069,6 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun getReactionsEnabled ()Z
 	public final fun getScrollButtonViewStyle ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public fun hashCode ()I
-	public final fun setReactionsEnabled (Z)V
 	public fun toString ()Ljava/lang/String;
 }
 


### PR DESCRIPTION

### Description

Setting a custom user in the sample app didn't save the custom API key, which is one of the custom details provided. Therefore, after restarting the app, reloading a custom user would fail, since we try to log them in with the hardcoded sample API key.

These changes add an `apiKey` property to `SampleUser` and persist/restore it.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
