### PR TITLE
Make channel config blocklist optional

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/ConfigMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/ConfigMapping.kt
@@ -24,6 +24,6 @@ internal fun ConfigDto.toDomain(): Config =
         maxMessageLength = max_message_length,
         automod = automod,
         automodBehavior = automod_behavior,
-        blocklistBehavior = blocklist_behavior,
+        blocklistBehavior = blocklist_behavior ?: "",
         commands = commands.map(CommandDto::toDomain),
     )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ConfigDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ConfigDto.kt
@@ -23,6 +23,6 @@ internal data class ConfigDto(
     val max_message_length: Int,
     val automod: String,
     val automod_behavior: String,
-    val blocklist_behavior: String,
+    val blocklist_behavior: String?,
     val commands: List<CommandDto>,
 )


### PR DESCRIPTION
### Description

Moshi impl bug: this field isn't always present in Channel objects, crashing our serialization logic in some cases

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Reviewers added
