### PR TITLE
Move old ChatUI class to the proper package

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1,3 +1,30 @@
+public final class com/getstream/sdk/chat/ChatUI {
+	public static final field Companion Lcom/getstream/sdk/chat/ChatUI$Companion;
+	public final fun getFonts ()Lio/getstream/chat/android/ui/common/style/ChatFonts;
+	public final fun getMarkdown ()Lcom/getstream/sdk/chat/ChatMarkdown;
+	public final fun getNavigator ()Lcom/getstream/sdk/chat/navigation/ChatNavigator;
+	public final fun getStrings ()Lcom/getstream/sdk/chat/utils/strings/ChatStrings;
+	public final fun getUrlSigner ()Lcom/getstream/sdk/chat/UrlSigner;
+	public final fun getVersion ()Ljava/lang/String;
+	public static final fun instance ()Lcom/getstream/sdk/chat/ChatUI;
+}
+
+public final class com/getstream/sdk/chat/ChatUI$Builder {
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/livedata/ChatDomain;Landroid/content/Context;)V
+	public final fun build ()Lcom/getstream/sdk/chat/ChatUI;
+	public final fun withFonts (Lio/getstream/chat/android/ui/common/style/ChatFonts;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+	public final fun withMarkdown (Lcom/getstream/sdk/chat/ChatMarkdown;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+	public final fun withNavigationHandler (Lcom/getstream/sdk/chat/navigation/ChatNavigationHandler;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+	public final fun withStrings (Lcom/getstream/sdk/chat/utils/strings/ChatStrings;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+	public final fun withStyle (Lcom/getstream/sdk/chat/style/ChatStyle;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+	public final fun withUrlSigner (Lcom/getstream/sdk/chat/UrlSigner;)Lcom/getstream/sdk/chat/ChatUI$Builder;
+}
+
+public final class com/getstream/sdk/chat/ChatUI$Companion {
+	public final fun instance ()Lcom/getstream/sdk/chat/ChatUI;
+}
+
 public final class com/getstream/sdk/chat/style/ChatStyle {
 	public fun <init> ()V
 	public final fun getDefaultTextStyle ()Lcom/getstream/sdk/chat/style/TextStyle;
@@ -1436,32 +1463,5 @@ public final class io/getstream/chat/android/ui/typing/viewmodel/factory/TypingI
 	public fun <init> (Ljava/lang/String;Lio/getstream/chat/android/livedata/ChatDomain;)V
 	public synthetic fun <init> (Ljava/lang/String;Lio/getstream/chat/android/livedata/ChatDomain;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
-}
-
-public final class io/getstream/sdk/chat/ChatUI {
-	public static final field Companion Lio/getstream/sdk/chat/ChatUI$Companion;
-	public final fun getFonts ()Lio/getstream/chat/android/ui/common/style/ChatFonts;
-	public final fun getMarkdown ()Lcom/getstream/sdk/chat/ChatMarkdown;
-	public final fun getNavigator ()Lcom/getstream/sdk/chat/navigation/ChatNavigator;
-	public final fun getStrings ()Lcom/getstream/sdk/chat/utils/strings/ChatStrings;
-	public final fun getUrlSigner ()Lcom/getstream/sdk/chat/UrlSigner;
-	public final fun getVersion ()Ljava/lang/String;
-	public static final fun instance ()Lio/getstream/sdk/chat/ChatUI;
-}
-
-public final class io/getstream/sdk/chat/ChatUI$Builder {
-	public fun <init> (Landroid/content/Context;)V
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/livedata/ChatDomain;Landroid/content/Context;)V
-	public final fun build ()Lio/getstream/sdk/chat/ChatUI;
-	public final fun withFonts (Lio/getstream/chat/android/ui/common/style/ChatFonts;)Lio/getstream/sdk/chat/ChatUI$Builder;
-	public final fun withMarkdown (Lcom/getstream/sdk/chat/ChatMarkdown;)Lio/getstream/sdk/chat/ChatUI$Builder;
-	public final fun withNavigationHandler (Lcom/getstream/sdk/chat/navigation/ChatNavigationHandler;)Lio/getstream/sdk/chat/ChatUI$Builder;
-	public final fun withStrings (Lcom/getstream/sdk/chat/utils/strings/ChatStrings;)Lio/getstream/sdk/chat/ChatUI$Builder;
-	public final fun withStyle (Lcom/getstream/sdk/chat/style/ChatStyle;)Lio/getstream/sdk/chat/ChatUI$Builder;
-	public final fun withUrlSigner (Lcom/getstream/sdk/chat/UrlSigner;)Lio/getstream/sdk/chat/ChatUI$Builder;
-}
-
-public final class io/getstream/sdk/chat/ChatUI$Companion {
-	public final fun instance ()Lio/getstream/sdk/chat/ChatUI;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/ChatUI.kt
@@ -1,9 +1,7 @@
-package io.getstream.sdk.chat
+package com.getstream.sdk.chat
 
 import android.content.Context
 import android.widget.TextView
-import com.getstream.sdk.chat.ChatMarkdown
-import com.getstream.sdk.chat.UrlSigner
 import com.getstream.sdk.chat.navigation.ChatNavigationHandler
 import com.getstream.sdk.chat.navigation.ChatNavigator
 import com.getstream.sdk.chat.navigation.destinations.ChatDestination


### PR DESCRIPTION
### Description

Move old ChatUI class to the proper package
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
