### PR TITLE
[CAS-810] Fix customization of channel dividers

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
@@ -15,6 +15,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListI
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal.ChannelItemSwipeListener
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal.ChannelListListenerContainerImpl
 import io.getstream.chat.android.ui.common.extensions.internal.cast
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 
 internal class SimpleChannelListView @JvmOverloads constructor(
     context: Context,
@@ -24,7 +25,7 @@ internal class SimpleChannelListView @JvmOverloads constructor(
 
     private val layoutManager: ScrollPauseLinearLayoutManager
     private val scrollListener: EndReachedScrollListener = EndReachedScrollListener()
-    private val dividerDecoration: SimpleVerticalListDivider = SimpleVerticalListDivider()
+    private val dividerDecoration: SimpleVerticalListDivider = SimpleVerticalListDivider(context)
 
     private var endReachedListener: ChannelListView.EndReachedListener? = null
 
@@ -102,7 +103,7 @@ internal class SimpleChannelListView @JvmOverloads constructor(
     }
 
     fun setItemSeparator(@DrawableRes drawableResource: Int) {
-        dividerDecoration.drawableResource = drawableResource
+        dividerDecoration.drawable = context.getDrawableCompat(drawableResource)!!
     }
 
     fun setItemSeparatorHeight(height: Int) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleVerticalListDivider.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleVerticalListDivider.kt
@@ -1,35 +1,31 @@
 package io.getstream.chat.android.ui.channel.list.internal
 
+import android.content.Context
 import android.graphics.Canvas
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.view.View
-import androidx.annotation.DrawableRes
-import androidx.core.content.ContextCompat
 import androidx.core.view.children
 import androidx.recyclerview.widget.RecyclerView
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import kotlin.math.roundToInt
 
-internal class SimpleVerticalListDivider : RecyclerView.ItemDecoration() {
+internal class SimpleVerticalListDivider(context: Context) : RecyclerView.ItemDecoration() {
 
-    @DrawableRes
-    var drawableResource: Int = R.drawable.stream_ui_divider
+    var drawable: Drawable = context.getDrawableCompat(R.drawable.stream_ui_divider)!!
 
     /**
      * Drawable height in pixels
      */
     var drawableHeight: Int? = null
 
-    var drawOnLastItem: Boolean = false
+    var drawOnLastItem = false
 
-    private lateinit var drawable: Drawable
+    private val bounds = Rect()
 
     override fun getItemOffsets(outRect: Rect, view: View, parent: RecyclerView, state: RecyclerView.State) {
-        parent.context
-            .let { ContextCompat.getDrawable(it, R.drawable.stream_ui_divider) }
-            ?.also { drawable = it }
-            ?.let { outRect.set(0, 0, 0, determineHeight()) }
+        outRect.set(0, 0, 0, determineHeight())
     }
 
     override fun onDraw(canvas: Canvas, parent: RecyclerView, state: RecyclerView.State) {
@@ -52,7 +48,6 @@ internal class SimpleVerticalListDivider : RecyclerView.ItemDecoration() {
 
         for (index in drawRange) {
             parent.getChildAt(index).let { item ->
-                val bounds = Rect()
                 parent.getDecoratedBoundsWithMargins(item, bounds)
                 val bottom = bounds.bottom + item.translationY.roundToInt()
                 val top = bottom - determineHeight()


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-810

### Description

- Fixed `channelListView.setItemSeparator()` method.
- Left `channelListView::setShouldDrawItemSeparatorOnLastItem` as is as it is not clear what is the expected behavior. We have channel list item `ViewHolder` and loading `ViewHolder`, both of them extend from `BaseChannelListItemViewHolder`. In case of custom `ViewHolders` it is impossible to distinguish them without introducing additional method to `BaseChannelListItemViewHolder` (e.g. `BaseChannelListItemViewHolder::shouldShowDivider`) and forcing clients to override it. 

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
