### PR TITLE
Clean up chat UI deprecation params

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/ChatUI.kt
@@ -31,7 +31,8 @@ import io.getstream.chat.android.ui.common.style.ChatFontsImpl
  */
 @Deprecated(
     level = DeprecationLevel.WARNING,
-    message = "Use ChatUI",
+    message = "Use new ChatUI implementation",
+    replaceWith = ReplaceWith("ChatUI", "io.getstream.chat.android.ui.ChatUI"),
 )
 public class ChatUI internal constructor(
     public val fonts: ChatFonts,
@@ -78,7 +79,6 @@ public class ChatUI internal constructor(
         }
 
         public fun withNavigationHandler(handler: ChatNavigationHandler): Builder = apply {
-            // TODO: update new ChatUI.navigator
             this.navigationHandler = handler
         }
 


### PR DESCRIPTION
### Description

1. Clean up code
2. Add `replaceWith` param to `@Deprecated`

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Reviewers added
