### PR TITLE
[CAS-808] Fix refreshing not messaging channels which don't contain current user as a member

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -53,6 +53,7 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed an issue that didn't find the user when obtaining the list of messages
+- Fix refreshing not messaging channels which don't contain current user as a member
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/controller/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/controller/QueryChannelsController.kt
@@ -221,7 +221,10 @@ internal class QueryChannelsController(
         val existingChannelMap = _channels.value.toMutableMap()
 
         newChannels.forEach { channel ->
-            if (channel.members.any { member -> member.getUserId() == domainImpl.currentUser.id }) {
+            // TODO: Update after channel's filtering refactoring is done.
+            // In order to interact with messaging channel user needs to be a member so for now,
+            // we are removing only channels of messaging type
+            if (channel.type != "messaging" || channel.members.any { member -> member.getUserId() == domainImpl.currentUser.id }) {
                 existingChannelMap[channel.cid] = channel
             } else {
                 domainImpl.scope.launch {


### PR DESCRIPTION
fixes #1585 
We shouldn't assume that we don't want to display channels in which the current user is not a member - the assumption is correct only for messaging channels.
`refreshChannels` method should be refactored after the channel's filtering is done. 
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
