### PR TITLE
Avoid memory leaks

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -700,6 +700,7 @@ public class ChatClient internal constructor(
         connectionListener = null
         clientStateService.onDisconnectRequested()
         socket.disconnect()
+        lifecycleObserver.dispose()
     }
 
     //region: api calls

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/application/ChatInitializer.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import com.getstream.sdk.chat.ChatUI
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
-import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.sample.BuildConfig
@@ -13,7 +12,7 @@ import io.getstream.chat.sample.R
 class ChatInitializer(private val context: Context) {
 
     @Suppress("UNUSED_VARIABLE")
-    fun init(apiKey: String, user: User? = null) {
+    fun init(apiKey: String) {
         val notificationConfig =
             NotificationConfig(
                 firebaseMessageIdKey = "message_id",
@@ -29,7 +28,7 @@ class ChatInitializer(private val context: Context) {
             .logLevel(logLevel)
             .build()
 
-        val domain = ChatDomain.Builder(client, user, context)
+        val domain = ChatDomain.Builder(client, context)
             .offlineEnabled()
             .build()
 

--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginViewModel.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/user_login/UserLoginViewModel.kt
@@ -30,8 +30,8 @@ class UserLoginViewModel : ViewModel() {
      * but since we allow changing API keys at runtime in this demo app, we have to
      * reinitialize the Chat SDK here with the new API key.
      */
-    private fun initChatSdk(user: ChatUser) {
-        App.instance.chatInitializer.init(AppConfig.apiKey, user)
+    private fun initChatSdk() {
+        App.instance.chatInitializer.init(AppConfig.apiKey)
     }
 
     private fun initChatUser(user: SampleUser, cid: String? = null) {
@@ -41,7 +41,7 @@ class UserLoginViewModel : ViewModel() {
             image = user.image
             name = user.name
         }
-        initChatSdk(chatUser)
+        initChatSdk()
         ChatClient.instance().connectUser(chatUser, user.token)
             .enqueue { result ->
                 if (result.isSuccess) {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -3,7 +3,6 @@ package io.getstream.chat.ui.sample.application
 import android.content.Context
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
-import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.ui.sample.BuildConfig
@@ -12,7 +11,7 @@ import io.getstream.chat.ui.sample.R
 class ChatInitializer(private val context: Context) {
 
     @Suppress("UNUSED_VARIABLE")
-    fun init(apiKey: String, user: User? = null) {
+    fun init(apiKey: String) {
         val notificationConfig =
             NotificationConfig(
                 firebaseMessageIdKey = "message_id",
@@ -29,7 +28,7 @@ class ChatInitializer(private val context: Context) {
             .useNewSerialization(true)
             .build()
 
-        val domain = ChatDomain.Builder(client, user, context)
+        val domain = ChatDomain.Builder(client, context)
             .userPresenceEnabled()
             .offlineEnabled()
             .build()

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
@@ -44,7 +44,7 @@ class UserLoginViewModel : ViewModel() {
             image = user.image
             name = user.name
         }
-        initChatSdk(user.apiKey, chatUser)
+        initChatSdk(user.apiKey)
 
         ChatClient.instance().connectUser(chatUser, user.token)
             .enqueue { result ->
@@ -63,8 +63,8 @@ class UserLoginViewModel : ViewModel() {
      * but since we allow changing API keys at runtime in this demo app, we have to
      * reinitialize the Chat SDK here with the new API key.
      */
-    private fun initChatSdk(apiKey: String, user: ChatUser) {
-        App.instance.chatInitializer.init(apiKey, user)
+    private fun initChatSdk(apiKey: String) {
+        App.instance.chatInitializer.init(apiKey)
     }
 
     sealed class State {


### PR DESCRIPTION
### Description

- Lifecycle observer which is responsible for connecting/disconnecting to/from the WS was never disposed. Disposing it on `ChatClient.disconnect()`.
- We were using the deprecated `ChatDomain.Builder` constructor with user overwrite in our sample app. But we didn't call `ChatDomain.disonnect()` on log out. As a consequence, `ChatDomain` was never disposed. Using the new constructor without user overwrite.

Only one instance of `ChatCllient` and `ChatDomain` exists in memory now. Checked with weak references.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
