### PR TITLE
Fix initial controls state in MessageInputView

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -81,6 +81,7 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 ### 🐞 Fixed
 - Now replied messages are shown correctly with the replied part in message options
 - `MessageListView::enterThreadListener` is properly notified when entering into a thread
+- Fix initial controls state in `MessageInputView`
 
 ### ⬆️ Improved
 - Add support of non-image attachment types to the default attachment click listener.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -208,6 +208,8 @@ public class MessageInputView : ConstraintLayout {
         setCommandsEnabled(style.commandsEnabled)
         val horizontalPadding = resources.getDimensionPixelSize(R.dimen.stream_ui_spacing_tiny)
         updatePadding(left = horizontalPadding, right = horizontalPadding)
+
+        refreshControlsState()
     }
 
     private fun dismissInputMode(inputMode: InputMode) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -96,7 +96,6 @@ internal class MessageInputFieldView : FrameLayout {
                 R.drawable.stream_ui_ic_command,
                 R.dimen.stream_ui_message_input_command_icon_size
             )
-            onModeChanged(mode)
         }
     }
 


### PR DESCRIPTION
### Description

`app:streamUiAttachButtonEnabled` attribute is not working when external `SuggestionListView` is not attached. Ensured that controls state is refreshed after initialization.

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added
