### PR TITLE
[CAS-789] Fix crash when sending GIF from Samsung keyboard

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -16,6 +16,7 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 
 ## stream-chat-android
 ### 🐞 Fixed
+- Fixed crash when sending GIF from Samsung keyboard
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/model/AttachmentMetaData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/model/AttachmentMetaData.kt
@@ -49,4 +49,9 @@ public data class AttachmentMetaData(
             }
         }
     } ?: ModelType.attach_file
+
+    @InternalStreamChatApi
+    public companion object {
+        public const val DEFAULT_ATTACHMENT_TITLE: String = "attachment"
+    }
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -80,7 +80,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         override fun sendToThread(
             parentMessage: Message,
             messageText: String,
-            alsoSendToChannel: Boolean
+            alsoSendToChannel: Boolean,
         ) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
@@ -89,7 +89,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>
+            attachmentsFiles: List<File>,
         ) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
@@ -298,7 +298,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         parentMessage: Message,
         message: String,
         alsoSendToChannel: Boolean,
-        attachmentFiles: List<File>
+        attachmentFiles: List<File>,
     ) {
         messageSendHandler.sendToThreadWithAttachments(
             parentMessage,
@@ -325,7 +325,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
 
     private fun sendGifFromKeyboard(
         inputContentInfo: InputContentInfoCompat,
-        flags: Int
+        flags: Int,
     ): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
             flags and InputConnectionCompat.INPUT_CONTENT_GRANT_READ_URI_PERMISSION != 0
@@ -336,13 +336,14 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
                 return false
             }
         }
+        val title = inputContentInfo.contentUri.pathSegments.lastOrNull() ?: AttachmentMetaData.DEFAULT_ATTACHMENT_TITLE
         messageInputController.setSelectedAttachments(
             setOf(
                 AttachmentMetaData(
                     uri = inputContentInfo.contentUri,
                     type = ModelType.attach_image,
                     mimeType = ModelType.attach_mime_gif,
-                    title = inputContentInfo.description.label.toString(),
+                    title = title,
                 )
             )
         )
@@ -447,7 +448,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>
+            attachmentsFiles: List<File>,
         )
 
         public fun editMessage(oldMessage: Message, newMessageText: String)


### PR DESCRIPTION
closes #1550 

The crash was caused because of the wrong `title`. Unfortunately, we cannot rely on the value returned by `inputContentInfo.description.label` because Samsung keyboard doesn't set the correct value (mime type instead of label).
Replacing that with the last `contentUri`'s path segment and adding default value just in case it's null.


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
