### PR TITLE
[CAS-812] Add missing attributes on ChannelListViewStyle

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -99,6 +99,38 @@ Option `app:streamUiReactionsEnabled` in `MessageListView` to enable or disable 
 - Open `AvatarBitmapFactory` class
 - Add `AvatarBitmapFactory::setInstance` method to allow custom implementation of `AvatarBitmapFactory`
 - Add `StyleTransformer` class to allow application-wide style customizations
+It is now possible to customize the following attributes for `ChannelListView`:
+- `streamUiChannelOptionsIcon` - customize options icon
+- `streamUiChannelDeleteIcon` - customize delete icon
+- `streamUiChannelOptionsEnabled` - hide/show options icon
+- `streamUiChannelDeleteEnabled` - hide/show delete button
+- `streamUiSwipeEnabled` - enable/disable swipe action
+- `streamUiBackgroundLayoutColor` - customize the color of "background layout"
+- `streamUiChannelTitleTextSize` - customize channel name text size
+- `streamUiChannelTitleTextColor` - customize channel name text color
+- `streamUiChannelTitleTextFont` - customize channel name text font
+- `streamUiChannelTitleFontAssets` - customize channel name font asset
+- `streamUiChannelTitleTextStyle` - customize channel name text style (normal / bold / italic)
+- `streamUiLastMessageTextSize` - customize last message text size
+- `streamUiLastMessageTextColor` - customize last message text color
+- `streamUiLastMessageTextFont` - customize last message text font
+- `streamUiLastMessageFontAssets` - customize last message font asset
+- `streamUiLastMessageTextStyle` - customize last message text style (normal / bold / italic)
+- `streamUiLastMessageDateTextSize` - customize last message date text size
+- `streamUiLastMessageDateTextColor` - customize last message date text color
+- `streamUiLastMessageDateTextFont` - customize last message date text font
+- `streamUiLastMessageDateFontAssets` - customize last message date font asset
+- `streamUiLastMessageDateTextStyle` - customize last message date text style (normal / bold / italic)
+- `streamUiIndicatorSentIcon` - customize drawable indicator for sent
+- `streamUiIndicatorReadIcon` - customize drawable indicator for read
+- `streamUiIndicatorPendingSyncIcon` - customize drawable indicator for pending sync
+- `streamUiForegroundLayoutColor` - customize the color of "foreground layout"
+- `streamUiUnreadMessageCounterBackgroundColor` - customize the color of message counter badge
+- `streamUiUnreadMessageCounterTextSize` - customize message counter text size
+- `streamUiUnreadMessageCounterTextColor` - customize message counter text color
+- `streamUiUnreadMessageCounterTextFont` - customize message counter text font
+- `streamUiUnreadMessageCounterFontAssets` - customize message counter font asset
+- `streamUiUnreadMessageCounterTextStyle` - customize message counter text style (normal / bold / italic)
 
 ### ⚠️ Changed
 - Deprecated `ChatUI` class

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -257,16 +257,40 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListView$Use
 
 public final class io/getstream/chat/android/ui/channel/list/ChannelListViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle$Companion;
-	public fun <init> (FFF)V
-	public final fun component1 ()F
-	public final fun component2 ()F
-	public final fun component3 ()F
-	public final fun copy (FFF)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;FFFILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILcom/getstream/sdk/chat/style/TextStyle;I)V
+	public final fun component1 ()Landroid/graphics/drawable/Drawable;
+	public final fun component10 ()Landroid/graphics/drawable/Drawable;
+	public final fun component11 ()Landroid/graphics/drawable/Drawable;
+	public final fun component12 ()Landroid/graphics/drawable/Drawable;
+	public final fun component13 ()I
+	public final fun component14 ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun component15 ()I
+	public final fun component2 ()Landroid/graphics/drawable/Drawable;
+	public final fun component3 ()Z
+	public final fun component4 ()Z
+	public final fun component5 ()Z
+	public final fun component6 ()I
+	public final fun component7 ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun component8 ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun component9 ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILcom/getstream/sdk/chat/style/TextStyle;I)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Lcom/getstream/sdk/chat/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILcom/getstream/sdk/chat/style/TextStyle;IILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelTitleTextSize ()F
-	public final fun getLastMessageDateTextSize ()F
-	public final fun getLastMessageSize ()F
+	public final fun getBackgroundLayoutColor ()I
+	public final fun getChannelTitleText ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun getDeleteEnabled ()Z
+	public final fun getDeleteIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getForegroundLayoutColor ()I
+	public final fun getIndicatorPendingSyncIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getIndicatorReadIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getIndicatorSentIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getLastMessageDateText ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun getLastMessageText ()Lcom/getstream/sdk/chat/style/TextStyle;
+	public final fun getOptionsEnabled ()Z
+	public final fun getOptionsIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getSwipeEnabled ()Z
+	public final fun getUnreadMessageCounterBackgroundColor ()I
+	public final fun getUnreadMessageCounterText ()Lcom/getstream/sdk/chat/style/TextStyle;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -348,6 +372,7 @@ public abstract class io/getstream/chat/android/ui/channel/list/adapter/viewhold
 	public abstract fun getSwipeDeltaRange ()Lkotlin/ranges/ClosedFloatingPointRange;
 	public abstract fun getSwipeView ()Landroid/view/View;
 	protected final fun getSwiping ()Z
+	public abstract fun isSwipeEnabled ()Z
 	protected final fun setListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$SwipeListener;)V
 	public final fun setSwipeListener (Landroid/view/View;Lio/getstream/chat/android/ui/channel/list/ChannelListView$SwipeListener;)V
 	protected final fun setSwiping (Z)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
@@ -1,16 +1,33 @@
 package io.getstream.chat.android.ui.channel.list
 
 import android.content.Context
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
-import androidx.annotation.Px
+import com.getstream.sdk.chat.style.TextStyle
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
+import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getDimension
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.use
 
 public data class ChannelListViewStyle(
-    @Px public val channelTitleTextSize: Float,
-    @Px public val lastMessageSize: Float,
-    @Px public val lastMessageDateTextSize: Float,
+    public val optionsIcon: Drawable,
+    public val deleteIcon: Drawable,
+    public val optionsEnabled: Boolean,
+    public val deleteEnabled: Boolean,
+    public val swipeEnabled: Boolean,
+    public val backgroundLayoutColor: Int,
+    public val channelTitleText: TextStyle,
+    public val lastMessageText: TextStyle,
+    public val lastMessageDateText: TextStyle,
+    public val indicatorSentIcon: Drawable,
+    public val indicatorReadIcon: Drawable,
+    public val indicatorPendingSyncIcon: Drawable,
+    public val foregroundLayoutColor: Int,
+    public val unreadMessageCounterText: TextStyle,
+    public val unreadMessageCounterBackgroundColor: Int,
 ) {
 
     internal companion object {
@@ -21,27 +38,144 @@ public data class ChannelListViewStyle(
                 0,
                 0
             ).use { a ->
-                val resources = context.resources
+                val optionsIcon = a.getDrawable(R.styleable.ChannelListView_streamUiChannelOptionsIcon)
+                    ?: context.getDrawableCompat(R.drawable.stream_ui_ic_more)!!
 
-                val channelTitleTextSize = a.getDimensionPixelSize(
-                    R.styleable.ChannelListView_streamUiChannelTitleTextSize,
-                    resources.getDimensionPixelSize(R.dimen.stream_ui_channel_item_title)
-                ).toFloat()
+                val deleteIcon = a.getDrawable(R.styleable.ChannelListView_streamUiChannelDeleteIcon)
+                    ?: context.getDrawableCompat(R.drawable.stream_ui_ic_delete)!!
 
-                val lastMessageSize = a.getDimensionPixelSize(
-                    R.styleable.ChannelListView_streamUiLastMessageTextSize,
-                    resources.getDimensionPixelSize(R.dimen.stream_ui_channel_item_message)
-                ).toFloat()
+                val moreOptionsEnabled = a.getBoolean(
+                    R.styleable.ChannelListView_streamUiChannelOptionsEnabled,
+                    true
+                )
 
-                val lastMessageDateTextSize = a.getDimensionPixelSize(
-                    R.styleable.ChannelListView_streamUiLastMessageDateTextSize,
-                    resources.getDimensionPixelSize(R.dimen.stream_ui_channel_item_message_date)
-                ).toFloat()
+                val deleteEnabled = a.getBoolean(
+                    R.styleable.ChannelListView_streamUiChannelDeleteEnabled,
+                    true
+                )
+
+                val swipeEnabled = a.getBoolean(
+                    R.styleable.ChannelListView_streamUiSwipeEnabled,
+                    true
+                )
+
+                val backgroundLayoutColor = a.getColor(
+                    R.styleable.ChannelListView_streamUiBackgroundLayoutColor,
+                    context.getColorCompat(R.color.stream_ui_white_smoke)
+                )
+
+                val channelTitleText = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.ChannelListView_streamUiChannelTitleTextSize,
+                        context.getDimension(R.dimen.stream_ui_channel_item_title)
+                    )
+                    .color(
+                        R.styleable.ChannelListView_streamUiChannelTitleTextColor,
+                        context.getColorCompat(R.color.stream_ui_text_color_primary)
+                    )
+                    .font(
+                        R.styleable.ChannelListView_streamUiChannelTitleFontAssets,
+                        R.styleable.ChannelListView_streamUiChannelTitleTextFont
+                    )
+                    .style(
+                        R.styleable.ChannelListView_streamUiChannelTitleTextStyle,
+                        Typeface.BOLD
+                    )
+                    .build()
+
+                val lastMessageText = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.ChannelListView_streamUiLastMessageTextSize,
+                        context.getDimension(R.dimen.stream_ui_channel_item_message)
+                    )
+                    .color(
+                        R.styleable.ChannelListView_streamUiLastMessageTextColor,
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
+                    )
+                    .font(
+                        R.styleable.ChannelListView_streamUiLastMessageFontAssets,
+                        R.styleable.ChannelListView_streamUiLastMessageTextFont
+                    )
+                    .style(
+                        R.styleable.ChannelListView_streamUiLastMessageTextStyle,
+                        Typeface.NORMAL
+                    )
+                    .build()
+
+                val lastMessageDateText = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.ChannelListView_streamUiLastMessageDateTextSize,
+                        context.getDimension(R.dimen.stream_ui_channel_item_message_date)
+                    )
+                    .color(
+                        R.styleable.ChannelListView_streamUiLastMessageDateTextColor,
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
+                    )
+                    .font(
+                        R.styleable.ChannelListView_streamUiLastMessageDateFontAssets,
+                        R.styleable.ChannelListView_streamUiLastMessageDateTextFont
+                    )
+                    .style(
+                        R.styleable.ChannelListView_streamUiLastMessageDateTextStyle,
+                        Typeface.NORMAL
+                    )
+                    .build()
+
+                val indicatorSentIcon = a.getDrawable(R.styleable.ChannelListView_streamUiIndicatorSentIcon)
+                    ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_single)!!
+
+                val indicatorReadIcon = a.getDrawable(R.styleable.ChannelListView_streamUiIndicatorReadIcon)
+                    ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_double)!!
+
+                val indicatorPendingSyncIcon =
+                    a.getDrawable(R.styleable.ChannelListView_streamUiIndicatorPendingSyncIcon)
+                        ?: context.getDrawableCompat(R.drawable.stream_ui_ic_clock)!!
+
+                val foregroundLayoutColor = a.getColor(
+                    R.styleable.ChannelListView_streamUiForegroundLayoutColor,
+                    context.getColorCompat(R.color.stream_ui_white_snow)
+                )
+
+                val unreadMessageCounterText = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.ChannelListView_streamUiUnreadMessageCounterTextSize,
+                        context.getDimension(R.dimen.stream_ui_text_small)
+                    )
+                    .color(
+                        R.styleable.ChannelListView_streamUiUnreadMessageCounterTextColor,
+                        context.getColorCompat(R.color.stream_ui_literal_white)
+                    )
+                    .font(
+                        R.styleable.ChannelListView_streamUiUnreadMessageCounterFontAssets,
+                        R.styleable.ChannelListView_streamUiUnreadMessageCounterTextFont
+                    )
+                    .style(
+                        R.styleable.ChannelListView_streamUiUnreadMessageCounterTextStyle,
+                        Typeface.NORMAL
+                    )
+                    .build()
+
+                val unreadMessageCounterBackgroundColor = a.getColor(
+                    R.styleable.ChannelListView_streamUiUnreadMessageCounterBackgroundColor,
+                    context.getColorCompat(R.color.stream_ui_accent_red)
+                )
 
                 return ChannelListViewStyle(
-                    channelTitleTextSize = channelTitleTextSize,
-                    lastMessageSize = lastMessageSize,
-                    lastMessageDateTextSize = lastMessageDateTextSize
+                    optionsIcon = optionsIcon,
+                    deleteIcon = deleteIcon,
+                    optionsEnabled = moreOptionsEnabled,
+                    deleteEnabled = deleteEnabled,
+                    swipeEnabled = swipeEnabled,
+                    backgroundLayoutColor = backgroundLayoutColor,
+                    channelTitleText = channelTitleText,
+                    lastMessageText = lastMessageText,
+                    lastMessageDateText = lastMessageDateText,
+                    indicatorSentIcon = indicatorSentIcon,
+                    indicatorReadIcon = indicatorReadIcon,
+                    indicatorPendingSyncIcon = indicatorPendingSyncIcon,
+                    foregroundLayoutColor = foregroundLayoutColor,
+                    unreadMessageCounterText = unreadMessageCounterText,
+                    unreadMessageCounterBackgroundColor = unreadMessageCounterBackgroundColor
                 ).let(TransformStyle.channelListStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/SwipeViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/SwipeViewHolder.kt
@@ -14,6 +14,7 @@ public abstract class SwipeViewHolder(itemView: View) : BaseChannelListItemViewH
     public abstract fun getOpenedX(): Float
     public abstract fun getClosedX(): Float
     public abstract fun getSwipeDeltaRange(): ClosedFloatingPointRange<Float>
+    public abstract fun isSwipeEnabled(): Boolean
     protected var listener: ChannelListView.SwipeListener? = null
     protected var swiping: Boolean = false
 
@@ -26,6 +27,10 @@ public abstract class SwipeViewHolder(itemView: View) : BaseChannelListItemViewH
         listener = swipeListener
 
         view.setOnTouchListener { _, event ->
+            if (!isSwipeEnabled()) {
+                return@setOnTouchListener false
+            }
+
             val rawX = event.rawX
             val rawY = event.rawY
 

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
@@ -3,8 +3,61 @@
     <!--ChannelListView-->
     <declare-styleable name="ChannelListView">
         <attr name="streamUiChannelsItemSeparatorDrawable" format="reference" />
+
+        <!--Background layout-->
+        <attr name="streamUiChannelOptionsIcon" format="reference" />
+        <attr name="streamUiChannelDeleteIcon" format="reference" />
+        <attr name="streamUiChannelOptionsEnabled" format="boolean" />
+        <attr name="streamUiChannelDeleteEnabled" format="boolean" />
+        <attr name="streamUiSwipeEnabled" format="boolean" />
+        <attr name="streamUiBackgroundLayoutColor" format="color|reference" />
+
+        <!--Foreground layout-->
         <attr name="streamUiChannelTitleTextSize" format="dimension|reference" />
-        <attr name="streamUiLastMessageDateTextSize" format="dimension|reference" />
+        <attr name="streamUiChannelTitleTextColor" format="color|reference" />
+        <attr name="streamUiChannelTitleTextFont" format="reference" />
+        <attr name="streamUiChannelTitleFontAssets" format="string" />
+        <attr name="streamUiChannelTitleTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
         <attr name="streamUiLastMessageTextSize" format="dimension|reference" />
+        <attr name="streamUiLastMessageTextColor" format="color|reference" />
+        <attr name="streamUiLastMessageTextFont" format="reference" />
+        <attr name="streamUiLastMessageFontAssets" format="string" />
+        <attr name="streamUiLastMessageTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamUiLastMessageDateTextSize" format="dimension|reference" />
+        <attr name="streamUiLastMessageDateTextColor" format="color|reference" />
+        <attr name="streamUiLastMessageDateTextFont" format="reference" />
+        <attr name="streamUiLastMessageDateFontAssets" format="string" />
+        <attr name="streamUiLastMessageDateTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamUiIndicatorSentIcon" format="reference" />
+        <attr name="streamUiIndicatorReadIcon" format="reference" />
+        <attr name="streamUiIndicatorPendingSyncIcon" format="reference" />
+        <attr name="streamUiForegroundLayoutColor" format="color|reference" />
+
+        <attr name="streamUiUnreadMessageCounterTextSize" format="dimension|reference" />
+        <attr name="streamUiUnreadMessageCounterTextColor" format="color|reference" />
+        <attr name="streamUiUnreadMessageCounterTextFont" format="reference" />
+        <attr name="streamUiUnreadMessageCounterFontAssets" format="string" />
+        <attr name="streamUiUnreadMessageCounterTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamUiUnreadMessageCounterBackgroundColor" format="color|reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-812

### Description

Added the possibility to customize the following attributes for `ChannelListView`:
- Option Icon Drawable
- Delete Icon Drawable
- Hide Delete Icon
- Hide Option Icon
- Disable swipe action
- Background color of "background layout"
- TextStyle for channelName
- TextStyle for lastMessage
- TextStyle for Date
- Drawable indicator for sent
- Drawable indicator for read
- Drawable indicator for Pending Sync
- Background color of "foreground layout"
- Background color for “Unread message counter”
- TextStyle for “Unread message counter”

The customization can be done using `TransformStyle` class:

```
TransformStyle.channelListStyleTransformer = StyleTransformer {
    it.copy(
        optionsIcon = getDrawable(R.drawable.stream_ui_arrow_left_rounded)!!,
        deleteIcon = getDrawable(R.drawable.stream_ui_arrow_right_rounded)!!,
        deleteEnabled = true,
        optionsEnabled = true,
        swipeEnabled = true,
        backgroundLayoutColor = ContextCompat.getColor(this, R.color.stream_ui_avatar_gradient_yellow),
        indicatorSentIcon = getDrawable(R.drawable.stream_ui_arrow_left_rounded)!!,
        indicatorReadIcon = getDrawable(R.drawable.stream_ui_arrow_right_rounded)!!,
        indicatorPendingSyncIcon = getDrawable(R.drawable.stream_ic_close)!!,
        foregroundLayoutColor = ContextCompat.getColor(this, R.color.stream_ui_accent_blue),
        unreadMessageCounterBackgroundColor = ContextCompat.getColor(this, R.color.stream_ui_accent_green),
    ).also {
        it.channelTitleText.size = Utils.dpToPx(12)
        it.channelTitleText.color = ContextCompat.getColor(this, R.color.stream_ui_avatar_gradient_yellow)
        it.channelTitleText.style = Typeface.ITALIC
        it.lastMessageText.size = Utils.dpToPx(12)
        it.lastMessageText.color = ContextCompat.getColor(this, R.color.stream_ui_avatar_gradient_yellow)
        it.lastMessageText.style = Typeface.ITALIC
        it.lastMessageDateText.size = Utils.dpToPx(12)
        it.lastMessageDateText.color = ContextCompat.getColor(this, R.color.stream_ui_avatar_gradient_yellow)
        it.lastMessageDateText.style = Typeface.ITALIC
        it.unreadMessageCounterText.size = Utils.dpToPx(14)
        it.unreadMessageCounterText.color = ContextCompat.getColor(this, R.color.stream_ui_avatar_gradient_yellow)
        it.unreadMessageCounterText.style = Typeface.ITALIC
    }
}
```
| Before | After|
| --- | --- |
| ![photo_2021-03-26 04 53 32](https://user-images.githubusercontent.com/9600921/112566010-42a8f000-8def-11eb-8093-a9a54790184e.jpeg) | ![photo_2021-03-26 04 52 25](https://user-images.githubusercontent.com/9600921/112565951-260cb800-8def-11eb-888b-c8029e2fc184.jpeg) |

| Channel list | Channel list with actions |
| --- | --- |
| <img src="https://user-images.githubusercontent.com/9600921/112565662-818a7600-8dee-11eb-8ad5-4d0c2db7cea6.jpeg"> | <img src="https://user-images.githubusercontent.com/9600921/112565672-87805700-8dee-11eb-9a49-e57c8d1b05ba.jpeg"> |

Notes: 
- `TextStyle` class should be converted to data class
- Delete icon tint is hardcoded

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added
