### PR TITLE
[CAS-813] Feature - Divider configuration for message input view

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -151,7 +151,7 @@ It is now possible to customize the following attributes for `ChannelListView`:
 It is now possible to configure new fields in MessageInputView:
 - `streamUiMessageInputTextStyle` - customize message input text style.
 - `streamUiMessageInputFont` - customize message input text font.
-- `streamUiMessageInputFontAssets` - customize message input text font assets. 
+- `streamUiMessageInputFontAssets` - customize message input text font assets.
 - `streamUiMessageInputEditTextBackgroundDrawable` - customize message input EditText drawable.
 - `streamUiMessageInputCustomCursorDrawable` - customize message input EditText cursor drawable.
 - `streamUiCommandsTitleTextSize` - customize command title text size
@@ -173,6 +173,7 @@ It is now possible to configure new fields in MessageInputView:
 - `streamUiCommandsDescriptionFont` - customize command description text font
 - `streamUiCommandsDescriptionStyle` - customize command description text style
 - `streamUiSuggestionBackgroundColor` - customize suggestion view background
+- `streamUiMessageInputDividerBackgroundDrawable` - customize the background of divider of MessageInputView
 
 
 

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -21,4 +21,7 @@
 
     <!--Attachment Display-->
     <string name="stream_ui_attachment_display_error">Error. File can\'t be displayed</string>
+
+    <!-- Hint default message -->
+    <string name="stream_ui_message_input_default_hint">Write something here</string>
 </resources>

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -555,11 +555,12 @@ public final class io/getstream/chat/android/ui/common/style/ChatStyle {
 public final class io/getstream/chat/android/ui/common/style/TextStyle {
 	public static final field UNSET_COLOR I
 	public static final field UNSET_FONT_RESOURCE I
+	public static final field UNSET_HINT Ljava/lang/String;
 	public static final field UNSET_HINT_COLOR I
 	public static final field UNSET_SIZE I
 	public fun <init> ()V
-	public fun <init> (ILjava/lang/String;IIIILandroid/graphics/Typeface;)V
-	public synthetic fun <init> (ILjava/lang/String;IIIILandroid/graphics/Typeface;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILjava/lang/String;IIILjava/lang/String;ILandroid/graphics/Typeface;)V
+	public synthetic fun <init> (ILjava/lang/String;IIILjava/lang/String;ILandroid/graphics/Typeface;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun apply (Landroid/widget/TextView;)V
 	public final fun colorOrNull ()Ljava/lang/Integer;
 	public final fun component1 ()I
@@ -567,16 +568,18 @@ public final class io/getstream/chat/android/ui/common/style/TextStyle {
 	public final fun component3 ()I
 	public final fun component4 ()I
 	public final fun component5 ()I
-	public final fun component6 ()I
-	public final fun component7 ()Landroid/graphics/Typeface;
-	public final fun copy (ILjava/lang/String;IIIILandroid/graphics/Typeface;)Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/style/TextStyle;ILjava/lang/String;IIIILandroid/graphics/Typeface;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()I
+	public final fun component8 ()Landroid/graphics/Typeface;
+	public final fun copy (ILjava/lang/String;IIILjava/lang/String;ILandroid/graphics/Typeface;)Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/style/TextStyle;ILjava/lang/String;IIILjava/lang/String;ILandroid/graphics/Typeface;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getColor ()I
 	public final fun getDefaultFont ()Landroid/graphics/Typeface;
 	public final fun getFont ()Landroid/graphics/Typeface;
 	public final fun getFontAssetsPath ()Ljava/lang/String;
 	public final fun getFontResource ()I
+	public final fun getHint ()Ljava/lang/String;
 	public final fun getHintColor ()I
 	public final fun getSize ()I
 	public final fun getStyle ()I
@@ -591,6 +594,7 @@ public final class io/getstream/chat/android/ui/common/style/TextStyle$Builder {
 	public final fun color (II)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
 	public final fun font (II)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
 	public final fun font (IILandroid/graphics/Typeface;)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
+	public final fun hint (ILjava/lang/String;)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
 	public final fun hintColor (II)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
 	public final fun size (I)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;
 	public final fun size (II)Lio/getstream/chat/android/ui/common/style/TextStyle$Builder;

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -881,7 +881,7 @@ public abstract interface class io/getstream/chat/android/ui/message/input/Messa
 
 public final class io/getstream/chat/android/ui/message/input/MessageInputViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle$Companion;
-	public fun <init> (ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;)V
+	public fun <init> (ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;)V
 	public final fun component1 ()Z
 	public final fun component10 ()Z
 	public final fun component11 ()Z
@@ -901,6 +901,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputViewSt
 	public final fun component24 ()I
 	public final fun component25 ()Landroid/graphics/drawable/Drawable;
 	public final fun component26 ()Landroid/graphics/drawable/Drawable;
+	public final fun component27 ()Landroid/graphics/drawable/Drawable;
 	public final fun component3 ()Z
 	public final fun component4 ()Landroid/graphics/drawable/Drawable;
 	public final fun component5 ()F
@@ -908,8 +909,8 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputViewSt
 	public final fun component7 ()I
 	public final fun component8 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component9 ()Z
-	public final fun copy (ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;
+	public final fun copy (ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;FIILio/getstream/chat/android/ui/common/style/TextStyle;ZZZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;IILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/MessageInputViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachButtonEnabled ()Z
 	public final fun getAttachButtonIcon ()Landroid/graphics/drawable/Drawable;
@@ -919,6 +920,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputViewSt
 	public final fun getCommandsNameTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getCommandsTitleTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getCustomCursorDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getDividerBackground ()Landroid/graphics/drawable/Drawable;
 	public final fun getEditTextBackgroundDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getLightningButtonEnabled ()Z
 	public final fun getLightningButtonIcon ()Landroid/graphics/drawable/Drawable;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
@@ -12,6 +12,7 @@ public data class TextStyle(
     public val style: Int = Typeface.NORMAL,
     public val size: Int = UNSET_SIZE,
     public val color: Int = UNSET_COLOR,
+    public val hint: String = UNSET_HINT,
     public val hintColor: Int = UNSET_HINT_COLOR,
     public val defaultFont: Typeface = Typeface.DEFAULT,
 ) {
@@ -20,6 +21,7 @@ public data class TextStyle(
         const val UNSET_COLOR = Integer.MAX_VALUE
         const val UNSET_HINT_COLOR = Integer.MAX_VALUE
         const val UNSET_FONT_RESOURCE = -1
+        const val UNSET_HINT = ""
     }
 
     public val font: Typeface?
@@ -35,6 +37,9 @@ public data class TextStyle(
         }
         if (color != UNSET_COLOR) {
             textView.setTextColor(color)
+        }
+        if (hint != UNSET_HINT) {
+            textView.hint = hint
         }
         if (hintColor != UNSET_HINT_COLOR) {
             textView.setHintTextColor(hintColor)
@@ -55,6 +60,7 @@ public data class TextStyle(
         private var style: Int = Typeface.NORMAL
         private var size: Int = UNSET_SIZE
         private var color: Int = UNSET_COLOR
+        private var hint: String = UNSET_HINT
         private var hintColor: Int = UNSET_HINT_COLOR
         private var defaultFont: Typeface = Typeface.DEFAULT
 
@@ -83,6 +89,10 @@ public data class TextStyle(
             this.hintColor = array.getColor(ref, defValue)
         }
 
+        public fun hint(ref: Int, defValue: String): Builder = apply {
+            this.hint = array.getString(ref) ?: defValue
+        }
+
         public fun style(ref: Int, defValue: Int): Builder = apply {
             this.style = array.getInt(ref, defValue)
         }
@@ -94,6 +104,7 @@ public data class TextStyle(
                 style = style,
                 size = size,
                 color = color,
+                hint = hint,
                 hintColor = hintColor,
                 defaultFont = defaultFont
             )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -344,11 +344,13 @@ public class MessageInputView : ConstraintLayout {
             setTextSizePx(style.messageInputTextSize)
             setInputFieldScrollBarEnabled(style.messageInputScrollbarEnabled)
             setInputFieldScrollbarFadingEnabled(style.messageInputScrollbarFadingEnabled)
-            style.messageInputTextStyle.font?.let(::setTextInputTypeface)
-            setTextInputTypefaceStyle(style.messageInputTextStyle.style)
             setCustomBackgroundDrawable(style.editTextBackgroundDrawable)
+
+            style.messageInputTextStyle.apply(binding.messageEditText)
             style.customCursorDrawable?.let(::setCustomCursor)
         }
+
+        binding.separator.background = style.dividerBackground
     }
 
     private fun handleKeyStroke() {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -20,9 +20,9 @@ public data class MessageInputViewStyle(
     public val attachButtonIcon: Drawable,
     public val lightningButtonEnabled: Boolean,
     public val lightningButtonIcon: Drawable,
-    public val messageInputTextSize: Float,
-    public val messageInputTextColor: Int,
-    public val messageInputHintTextColor: Int,
+    @Deprecated("Use messageInputTextStyle") public val messageInputTextSize: Float,
+    @Deprecated("Use messageInputTextStyle") public val messageInputTextColor: Int,
+    @Deprecated("Use messageInputTextStyle") public val messageInputHintTextColor: Int,
     public val messageInputTextStyle: TextStyle,
     public val messageInputScrollbarEnabled: Boolean,
     public val messageInputScrollbarFadingEnabled: Boolean,
@@ -42,6 +42,7 @@ public data class MessageInputViewStyle(
     @ColorRes public val suggestionsBackground: Int,
     public val editTextBackgroundDrawable: Drawable,
     public val customCursorDrawable: Drawable?,
+    public val dividerBackground: Drawable
 ) {
 
     internal companion object {
@@ -174,6 +175,14 @@ public data class MessageInputViewStyle(
                 )
 
                 val messageInputTextStyle = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.MessageInputView_streamUiMessageInputTextSize,
+                        context.resources.getDimensionPixelSize(R.dimen.stream_ui_text_size_input)
+                    )
+                    .color(
+                        R.styleable.MessageInputView_streamUiMessageInputTextColor,
+                        context.getColorCompat(R.color.stream_ui_text_color_primary)
+                    )
                     .font(
                         R.styleable.MessageInputView_streamUiMessageInputFontAssets,
                         R.styleable.MessageInputView_streamUiMessageInputFont
@@ -182,13 +191,17 @@ public data class MessageInputViewStyle(
                         R.styleable.MessageInputView_streamUiMessageInputTextStyle,
                         Typeface.NORMAL
                     )
+                    .hintColor(
+                        R.styleable.MessageInputView_streamUiMessageInputHintTextColor,
+                        context.getColorCompat(R.color.stream_ui_text_color_hint)
+                    )
                     .build()
 
                 val commandsEnabled = a.getBoolean(R.styleable.MessageInputView_streamUiCommandsEnabled, true)
 
                 val commandsBackground = a.getColor(
                     R.styleable.MessageInputView_streamUiSuggestionBackgroundColor,
-                    ContextCompat.getColor(context, R.color.stream_ui_white)
+                    context.getColorCompat(R.color.stream_ui_white)
                 )
 
                 val commandsTitleTextStyle = TextStyle.Builder(a)
@@ -198,7 +211,7 @@ public data class MessageInputViewStyle(
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsTitleTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_text_color_secondary)
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsTitleFontAssets,
@@ -217,7 +230,7 @@ public data class MessageInputViewStyle(
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_black)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsNameFontAssets,
@@ -236,7 +249,7 @@ public data class MessageInputViewStyle(
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsDescriptionTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_black)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsDescriptionFontAssets,
@@ -255,7 +268,7 @@ public data class MessageInputViewStyle(
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiMentionsUserNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_black)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiMentionsUserNameFontAssets,
@@ -274,7 +287,7 @@ public data class MessageInputViewStyle(
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiMentionsNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_text_color_secondary)
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiMentionsNameFontAssets,
@@ -289,11 +302,11 @@ public data class MessageInputViewStyle(
                 val mentionsIcon: Drawable =
                     a.getDrawable(
                         R.styleable.MessageInputView_streamUiMentionsIcon
-                    ) ?: ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_mention)!!
+                    ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_mention)!!
 
                 var backgroundColor: Int
                 context.obtainStyledAttributes(attrs, intArrayOf(android.R.attr.background)).use {
-                    backgroundColor = it.getColor(0, ContextCompat.getColor(context, R.color.stream_ui_white))
+                    backgroundColor = it.getColor(0, context.getColorCompat(R.color.stream_ui_white))
                 }
 
                 val customCursorDrawable = a.getDrawable(
@@ -302,7 +315,11 @@ public data class MessageInputViewStyle(
 
                 val editTextBackgroundDrawable = a.getDrawable(
                     R.styleable.MessageInputView_streamUiMessageInputEditTextBackgroundDrawable
-                ) ?: ContextCompat.getDrawable(context, R.drawable.stream_ui_shape_edit_text_round)!!
+                ) ?: context.getDrawableCompat(R.drawable.stream_ui_shape_edit_text_round)!!
+
+                val dividerBackground = a.getDrawable(
+                    R.styleable.MessageInputView_streamUiMessageInputDividerBackgroundDrawable
+                ) ?: context.getDrawableCompat(R.drawable.stream_ui_divider)!!
 
                 return MessageInputViewStyle(
                     attachButtonEnabled = attachButtonEnabled,
@@ -311,10 +328,10 @@ public data class MessageInputViewStyle(
                     lightningButtonIcon = lightningButtonIcon,
                     messageInputTextSize = messageInputTextSize,
                     messageInputTextColor = messageInputTextColor,
-                    messageInputHintTextColor = messageInputHintTextColor,
                     messageInputTextStyle = messageInputTextStyle,
                     messageInputScrollbarEnabled = messageInputScrollbarEnabled,
                     messageInputScrollbarFadingEnabled = messageInputScrollbarFadingEnabled,
+                    messageInputHintTextColor = messageInputHintTextColor,
                     sendButtonEnabled = sendButtonEnabled,
                     sendButtonEnabledIcon = sendButtonEnabledIcon,
                     sendButtonDisabledIcon = sendButtonDisabledIcon,
@@ -331,6 +348,7 @@ public data class MessageInputViewStyle(
                     suggestionsBackground = commandsBackground,
                     editTextBackgroundDrawable = editTextBackgroundDrawable,
                     customCursorDrawable = customCursorDrawable,
+                    dividerBackground = dividerBackground,
                 ).let(TransformStyle.messageInputStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -191,7 +191,7 @@ public data class MessageInputViewStyle(
                         Typeface.NORMAL
                     )
                     .hint(
-                        R.styleable.MessageInputView_streamUiMessageInputHintTextColor,
+                        R.styleable.MessageInputView_streamUiMessageInputHintText,
                         context.getString(R.string.stream_ui_message_input_default_hint)
                     )
                     .hintColor(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -190,6 +190,10 @@ public data class MessageInputViewStyle(
                         R.styleable.MessageInputView_streamUiMessageInputTextStyle,
                         Typeface.NORMAL
                     )
+                    .hint(
+                        R.styleable.MessageInputView_streamUiMessageInputHintTextColor,
+                        context.getString(R.string.stream_ui_message_input_default_hint)
+                    )
                     .hintColor(
                         R.styleable.MessageInputView_streamUiMessageInputHintTextColor,
                         context.getColorCompat(R.color.stream_ui_text_color_hint)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -5,7 +5,6 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import androidx.annotation.ColorRes
-import androidx.core.content.ContextCompat
 import androidx.core.graphics.drawable.DrawableCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.ui.message.input.internal
 
 import android.content.Context
-import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
@@ -137,10 +136,6 @@ internal class MessageInputFieldView : FrameLayout {
         val originalTypeface = binding.messageEditText.typeface
 
         binding.messageEditText.setTypeface(originalTypeface, typeface)
-    }
-
-    fun setTextInputTypeface(typeface: Typeface) {
-        binding.messageEditText.typeface = typeface
     }
 
     fun autoCompleteCommand(command: Command) {

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
@@ -19,6 +19,7 @@
         <!--Input Text-->
         <attr name="streamUiMessageInputTextSize" format="dimension|reference" />
         <attr name="streamUiMessageInputTextColor" format="color|reference" />
+        <attr name="streamUiMessageInputHintText" format="string" />
         <attr name="streamUiMessageInputHintTextColor" format="color|reference" />
         <attr name="streamUiMessageInputScrollbarEnabled" format="boolean" />
         <attr name="streamUiMessageInputScrollbarFadingEnabled" format="boolean" />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
@@ -31,7 +31,7 @@
             <enum name="bold" value="1"/>
             <enum name="italic" value="2"/>
         </attr>
-
+        <attr name="streamUiMessageInputDividerBackgroundDrawable" format="reference" />
 
         <!--Send Button-->
         <attr name="streamUiSendButtonEnabledIconColor" format="color|reference" />


### PR DESCRIPTION
[CAS-813](https://stream-io.atlassian.net/browse/CAS-813)

### Description

Adding configuration for divider and making TextStyle the default for hint and text input.

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
