### PR TITLE
[CAS-827] Fix usages of RegisterExtension in unit tests

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -24,19 +24,27 @@ import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
-import org.junit.Before
-import org.junit.Test
+import io.getstream.chat.android.test.TestCoroutineExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito
 import java.util.Date
 
 internal class ChannelsApiCallsTests {
 
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
+
     lateinit var mock: MockClientBuilder
     lateinit var client: ChatClient
 
-    @Before
+    @BeforeEach
     fun before() {
-        mock = MockClientBuilder()
+        mock = MockClientBuilder(testCoroutines.scope)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -26,6 +26,10 @@ import java.util.Date
 internal class ChatClientTest {
 
     companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+
         val eventA = ConnectedEvent(EventType.HEALTH_CHECK, Date(), User(), "")
         val eventB = NewMessageEvent(EventType.MESSAGE_NEW, Date(), User(), "type:id", "type", "id", Message(), 0, 0, 0)
         val eventC = DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date())
@@ -35,13 +39,8 @@ internal class ChatClientTest {
         val eventF = UnknownEvent("f", Date(), emptyMap<Any, Any>())
     }
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
-
     lateinit var socket: FakeChatSocket
     lateinit var client: ChatClient
-
     lateinit var result: MutableList<ChatEvent>
 
     @BeforeEach

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
@@ -8,18 +8,26 @@ import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
-import org.junit.Before
-import org.junit.Test
+import io.getstream.chat.android.test.TestCoroutineExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito
 
 internal class DevicesApiCallsTests {
 
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
+
     lateinit var mock: MockClientBuilder
     lateinit var client: ChatClient
 
-    @Before
+    @BeforeEach
     fun before() {
-        mock = MockClientBuilder()
+        mock = MockClientBuilder(testCoroutines.scope)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessageIdGenerationTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessageIdGenerationTests.kt
@@ -12,11 +12,17 @@ import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.UuidGenerator
 import io.getstream.chat.android.test.TestCoroutineExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class MessageIdGenerationTests {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     val userId = "user-id"
     val connectionId = "connection-id"
@@ -26,15 +32,12 @@ internal class MessageIdGenerationTests {
     val randomUuid = "random-uuid"
     val messageText = "message-text"
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
     lateinit var uuidGenerator: UuidGenerator
     private lateinit var retroApi: RetrofitApi
     private lateinit var retroAnonymousApi: RetrofitAnonymousApi
     private lateinit var api: GsonChatApi
 
-    @Before
+    @BeforeEach
     fun before() {
         retroApi = mock()
         retroAnonymousApi = mock()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
@@ -15,18 +15,26 @@ import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
-import org.junit.Before
-import org.junit.Test
+import io.getstream.chat.android.test.TestCoroutineExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito
 
 internal class MessagesApiCallsTests {
 
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
+
     lateinit var mock: MockClientBuilder
     lateinit var client: ChatClient
 
-    @Before
+    @BeforeEach
     fun before() {
-        mock = MockClientBuilder()
+        mock = MockClientBuilder(testCoroutines.scope)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
@@ -17,16 +17,16 @@ import io.getstream.chat.android.client.token.FakeTokenManager
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.UuidGeneratorImpl
 import io.getstream.chat.android.client.utils.observable.FakeChatSocket
-import io.getstream.chat.android.test.TestCoroutineExtension
-import org.junit.jupiter.api.extension.RegisterExtension
+import kotlinx.coroutines.test.TestCoroutineScope
 import java.util.Date
 
 /**
  * Used for integrations tests.
  * Initialises mock internals of [ChatClient]
  */
-internal class MockClientBuilder {
-
+internal class MockClientBuilder(
+    private val testCoroutineScope: TestCoroutineScope,
+) {
     val userId = "test-id"
     val connectionId = "connection-id"
     val apiKey = "api-key"
@@ -42,9 +42,6 @@ internal class MockClientBuilder {
         connectionId
     )
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
     private lateinit var socket: FakeChatSocket
     private lateinit var fileUploader: FileUploader
 
@@ -76,11 +73,11 @@ internal class MockClientBuilder {
             retrofitAnonymousApi,
             UuidGeneratorImpl(),
             fileUploader,
-            testCoroutines.scope
+            testCoroutineScope
         )
 
         val clientStateService = ClientStateService()
-        val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(api, clientStateService, testCoroutines.scope)
+        val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(api, clientStateService, testCoroutineScope)
         client = ChatClient(
             config,
             api,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -16,25 +16,32 @@ import io.getstream.chat.android.client.models.Mute
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifySuccess
-import org.junit.Before
-import org.junit.Test
+import io.getstream.chat.android.test.TestCoroutineExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito
 import java.util.Date
 
 internal class UsersApiCallsTests {
 
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
+
     lateinit var client: ChatClient
     lateinit var mock: MockClientBuilder
 
-    @Before
+    @BeforeEach
     fun before() {
-        mock = MockClientBuilder()
+        mock = MockClientBuilder(testCoroutines.scope)
         client = mock.build()
     }
 
     @Test
     fun banSuccess() {
-
         val targetUserId = "target-id"
         val timeout = 13
         val reason = "reason"
@@ -62,7 +69,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun unbanSuccess() {
-
         val targetUserId = "target-id"
 
         Mockito.`when`(
@@ -89,7 +95,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun flagSuccess() {
-
         val targetUserId = "target-id"
         val user = User("user-id")
         val targetUser = User(targetUserId)
@@ -121,7 +126,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun flagUserSuccess() {
-
         val targetUserId = "target-id"
         val user = User("user-id")
         val targetUser = User(targetUserId)
@@ -153,7 +157,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun flagMessageSuccess() {
-
         val targetMessageId = "message-id"
         val user = User("user-id")
         val date = Date()
@@ -184,7 +187,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun getUsersSuccess() {
-
         val user = User().apply { id = "a-user" }
 
         val request = QueryUsersRequest(Filters.eq("id", "1"), 0, 1)
@@ -205,7 +207,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun removeMembersSuccess() {
-
         val channel = Channel()
             .apply { id = "a-channel" }
 
@@ -226,7 +227,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun muteUserSuccess() {
-
         val targetUser = User().apply { id = "target-id" }
         val mute = Mute(
             mock.user,
@@ -249,7 +249,6 @@ internal class UsersApiCallsTests {
 
     @Test
     fun unmuteUserSuccess() {
-
         val targetUser = User().apply { id = "target-id" }
 
         Mockito.`when`(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
@@ -25,8 +25,8 @@ import io.getstream.chat.android.client.token.FakeTokenManager
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.UuidGeneratorImpl
 import io.getstream.chat.android.test.TestCoroutineExtension
-import org.junit.Before
-import org.junit.Test
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
@@ -34,6 +34,12 @@ import org.mockito.Mockito.verify
 import java.util.Date
 
 internal class ClientConnectionTests {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     private val userId = "test-id"
     private val connectionId = "connection-id"
@@ -60,9 +66,6 @@ internal class ClientConnectionTests {
     )
     private val disconnectedEvent = DisconnectedEvent(EventType.CONNECTION_DISCONNECTED, Date())
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
     private lateinit var api: GsonChatApi
     private lateinit var socket: ChatSocket
     private lateinit var retrofitApi: RetrofitApi
@@ -74,7 +77,7 @@ internal class ClientConnectionTests {
     private lateinit var initCallback: Call.Callback<ConnectionData>
     private lateinit var socketListener: SocketListener
 
-    @Before
+    @BeforeEach
     fun before() {
         val clientStateService = ClientStateService()
         val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(mock(), clientStateService, testCoroutines.scope)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/ChatSocketServiceImplTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/ChatSocketServiceImplTest.kt
@@ -16,6 +16,13 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
 internal class ChatSocketServiceImplTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
+
     private lateinit var tokenManager: TokenManager
     private lateinit var socketFactory: SocketFactory
     private lateinit var eventsParser: EventsParser
@@ -23,9 +30,6 @@ internal class ChatSocketServiceImplTest {
     private lateinit var socketListener: SocketListener
     private lateinit var socketService: ChatSocketServiceImpl
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
     @BeforeEach
     fun setup() {
         tokenManager = mock()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
@@ -17,9 +17,6 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 internal class DevTokenTest(private val userId: String, private val expectedToken: String) {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
     private val clientStateService = ClientStateService()
     private val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(mock(), clientStateService, testCoroutines.scope)
     private val client = ChatClient(
@@ -38,6 +35,9 @@ internal class DevTokenTest(private val userId: String, private val expectedToke
     }
 
     companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
 
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{index}: {0} => {1}")

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplCreateChannelTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplCreateChannelTest.kt
@@ -32,9 +32,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class ChatDomainImplCreateChannelTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     private val currentUser = User()
     private val channelId = "ChannelId"

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplReplayEventsForActiveChannelsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplReplayEventsForActiveChannelsTest.kt
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class ChatDomainImplReplayEventsForActiveChannelsTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Test
     fun `when replaying events for active channels should add channel to active channels`() =

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatDomainImplTest.kt
@@ -20,11 +20,13 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class ChatDomainImplTest {
 
-    private lateinit var sut: ChatDomainImpl
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    private lateinit var sut: ChatDomainImpl
 
     @BeforeEach
     fun setUp() {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplReactionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplReactionsTest.kt
@@ -36,9 +36,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class ChannelControllerImplReactionsTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     private val currentUser = User()
     private val myReactions: List<Reaction> = listOf(

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplTypingTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplTypingTest.kt
@@ -32,9 +32,11 @@ import java.util.Date
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class ChannelControllerImplTypingTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Test
     fun `When clean is invoked Then old typing indicators should be removed`() = runBlockingTest {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/QueryChannelsControllerImplTest.kt
@@ -36,9 +36,11 @@ import java.util.Date
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class QueryChannelsControllerImplTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Test
     fun `when add channel if filter matches should update LiveData from channel to channel controller`() =

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessageOfflineTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/SendMessageOfflineTest.kt
@@ -36,9 +36,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class SendMessageOfflineTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Test
     fun `when calling watch, local messages should not be lost`() = testCoroutines.scope.runBlockingTest {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/event/TotalUnreadCountTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/event/TotalUnreadCountTest.kt
@@ -25,9 +25,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class TotalUnreadCountTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     private val data = TestDataHelper()
 

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
@@ -15,14 +15,18 @@ public class TestCoroutineExtension : BeforeAllCallback, AfterEachCallback, Afte
     public val dispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
     public val scope: TestCoroutineScope = TestCoroutineScope(dispatcher)
 
+    private var beforeAllCalled: Boolean = false
+
     override fun beforeAll(context: ExtensionContext) {
         DispatcherProvider.set(
             mainDispatcher = dispatcher,
             ioDispatcher = dispatcher
         )
+        beforeAllCalled = true
     }
 
     override fun afterEach(context: ExtensionContext) {
+        check(beforeAllCalled) { "TestCoroutineExtension field must be static" }
         scope.cleanupTestCoroutines()
     }
 

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
@@ -10,9 +10,11 @@ import org.junit.jupiter.api.extension.RegisterExtension
 @ExperimentalCoroutinesApi
 internal class StartStopBufferTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Test
     fun `data should only be propagated when enqueueData and subscribe are done`() {

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/view/messageinput/attachments/BaseAttachmentsControllerTests.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/view/messageinput/attachments/BaseAttachmentsControllerTests.kt
@@ -28,9 +28,11 @@ internal open class BaseAttachmentsControllerTests {
 
     protected lateinit var sut: AttachmentsController
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @ExperimentalCoroutinesApi
     @BeforeEach

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/CreateChannelViewModelTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/CreateChannelViewModelTest.kt
@@ -35,10 +35,6 @@ private val CHANNEL = createChannel(CID)
 @ExtendWith(InstantTaskExecutorExtension::class)
 internal class CreateChannelViewModelTest {
 
-    @JvmField
-    @RegisterExtension
-    val testCoroutines = TestCoroutineExtension()
-
     private val chatClient: ChatClient = mock()
     private val chatDomain: ChatDomain = mock()
     private val useCases: UseCaseHelper = mock()
@@ -107,6 +103,10 @@ internal class CreateChannelViewModelTest {
         }
 
     companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+
         @JvmStatic
         fun provideChannelName() = listOf(
             Arguments.of(""),


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-827

### Description

Since`TestCoroutineExtension` extension implements `BeforeAllCallback` and `AfterAllCallback`, they have to be in static fields instead of instance fields, i.e. it should always be put in the companion object. Otherwise these callbacks are ignored, and it won't mock/reset the dispatchers in `CoroutineDispatchers`.

- Moved all the JUnit extensions to companion objects
- Updated `ChannelsApiCallsTests`, `MessageIdGenerationTests`, `DevicesApiCallsTests`, `MessagesApiCallsTests` `UsersApiCallsTests`, `ClientConnectionTests` to JUnit5 so that they are able to run extensions
- Removed `TestCoroutineExtension` from `MockClientBuilder`. Moved `TestCoroutineExtension` registration to corresponding tests which use `MockClientBuilder`
- Added a check to `TestCoroutineExtension` which verifies that the extension is registered from a companion object

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [X] Reviewers added

![giphy](https://user-images.githubusercontent.com/9600921/112756530-4e163a00-8fee-11eb-89cb-81657d457ce8.gif)
