### PR TITLE
Fix mentions and commands text style

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
@@ -91,10 +91,11 @@ public class ChannelListHeaderView : ConstraintLayout {
     }
 
     private fun getOnlineTitleTextStyle(typedArray: TypedArray): TextStyle {
-        return TextStyle.Builder(typedArray).size(
-            R.styleable.ChannelListHeaderView_streamUiOnlineTitleTextSize,
-            context.getDimension(R.dimen.stream_ui_text_large)
-        )
+        return TextStyle.Builder(typedArray)
+            .size(
+                R.styleable.ChannelListHeaderView_streamUiOnlineTitleTextSize,
+                context.getDimension(R.dimen.stream_ui_text_large)
+            )
             .color(
                 R.styleable.ChannelListHeaderView_streamUiOnlineTitleTextColor,
                 context.getColorCompat(R.color.stream_ui_text_color_primary)
@@ -110,10 +111,11 @@ public class ChannelListHeaderView : ConstraintLayout {
     }
 
     private fun getOfflineTitleTextStyle(typedArray: TypedArray): TextStyle {
-        return TextStyle.Builder(typedArray).size(
-            R.styleable.ChannelListHeaderView_streamUiOfflineTitleTextSize,
-            context.getDimension(R.dimen.stream_ui_text_large)
-        )
+        return TextStyle.Builder(typedArray)
+            .size(
+                R.styleable.ChannelListHeaderView_streamUiOfflineTitleTextSize,
+                context.getDimension(R.dimen.stream_ui_text_large)
+            )
             .color(
                 R.styleable.ChannelListHeaderView_streamUiOfflineTitleTextColor,
                 context.getColorCompat(R.color.stream_ui_text_color_primary)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
@@ -4,6 +4,9 @@ import android.content.res.TypedArray
 import android.graphics.Typeface
 import android.util.TypedValue
 import android.widget.TextView
+import androidx.annotation.ColorInt
+import androidx.annotation.Px
+import androidx.annotation.StyleableRes
 import io.getstream.chat.android.ui.ChatUI
 
 public data class TextStyle(
@@ -58,32 +61,36 @@ public data class TextStyle(
         private var hintColor: Int = UNSET_HINT_COLOR
         private var defaultFont: Typeface = Typeface.DEFAULT
 
-        public fun size(ref: Int): Builder = size(ref, -1)
+        public fun size(@StyleableRes ref: Int): Builder = size(ref, -1)
 
-        public fun size(ref: Int, defValue: Int): Builder = apply {
+        public fun size(@StyleableRes ref: Int, @Px defValue: Int): Builder = apply {
             this.size = array.getDimensionPixelSize(ref, defValue)
         }
 
-        public fun font(assetsPath: Int, resId: Int): Builder = apply {
+        public fun font(@StyleableRes assetsPath: Int, @StyleableRes resId: Int): Builder = apply {
             this.fontAssetsPath = array.getString(assetsPath)
             this.fontResource = array.getResourceId(resId, -1)
         }
 
-        public fun font(assetsPath: Int, resId: Int, defaultFont: Typeface): Builder = apply {
+        public fun font(
+            @StyleableRes assetsPath: Int,
+            @StyleableRes resId: Int,
+            defaultFont: Typeface,
+        ): Builder = apply {
             this.fontAssetsPath = array.getString(assetsPath)
             this.fontResource = array.getResourceId(resId, -1)
             this.defaultFont = defaultFont
         }
 
-        public fun color(ref: Int, defValue: Int): Builder = apply {
+        public fun color(@StyleableRes ref: Int, @ColorInt defValue: Int): Builder = apply {
             this.color = array.getColor(ref, defValue)
         }
 
-        public fun hintColor(ref: Int, defValue: Int): Builder = apply {
+        public fun hintColor(@StyleableRes ref: Int, @ColorInt defValue: Int): Builder = apply {
             this.hintColor = array.getColor(ref, defValue)
         }
 
-        public fun style(ref: Int, defValue: Int): Builder = apply {
+        public fun style(@StyleableRes ref: Int, defValue: Int): Builder = apply {
             this.style = array.getInt(ref, defValue)
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -10,6 +10,7 @@ import androidx.core.graphics.drawable.DrawableCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.use
 import io.getstream.chat.android.ui.common.internal.getColorList
@@ -194,11 +195,11 @@ public data class MessageInputViewStyle(
                 val commandsTitleTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageInputView_streamUiCommandsTitleTextSize,
-                        R.dimen.stream_ui_text_medium
+                        context.getDimension(R.dimen.stream_ui_text_medium)
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsTitleTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_text_color_secondary)
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsTitleFontAssets,
@@ -213,11 +214,11 @@ public data class MessageInputViewStyle(
                 val commandsNameTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageInputView_streamUiCommandsNameTextSize,
-                        R.dimen.stream_ui_text_medium
+                        context.getDimension(R.dimen.stream_ui_text_medium)
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_text_color_primary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsNameFontAssets,
@@ -232,11 +233,11 @@ public data class MessageInputViewStyle(
                 val commandsDescriptionTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageInputView_streamUiCommandsDescriptionTextSize,
-                        R.dimen.stream_ui_text_medium
+                        context.getDimension(R.dimen.stream_ui_text_medium)
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiCommandsDescriptionTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_text_color_primary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiCommandsDescriptionFontAssets,
@@ -251,11 +252,11 @@ public data class MessageInputViewStyle(
                 val mentionsUsernameTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageInputView_streamUiMentionsUserNameTextSize,
-                        R.dimen.stream_ui_text_medium
+                        context.getDimension(R.dimen.stream_ui_text_medium)
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiMentionsUserNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_black)
+                        context.getColorCompat(R.color.stream_ui_text_color_primary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiMentionsUserNameFontAssets,
@@ -270,11 +271,11 @@ public data class MessageInputViewStyle(
                 val mentionsNameTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageInputView_streamUiMentionsNameTextSize,
-                        R.dimen.stream_ui_text_medium
+                        context.getDimension(R.dimen.stream_ui_text_medium)
                     )
                     .color(
                         R.styleable.MessageInputView_streamUiMentionsNameTextColor,
-                        ContextCompat.getColor(context, R.color.stream_ui_text_color_secondary)
+                        context.getColorCompat(R.color.stream_ui_text_color_secondary)
                     )
                     .font(
                         R.styleable.MessageInputView_streamUiMentionsNameFontAssets,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
@@ -165,7 +165,10 @@ public data class MessageListItemStyle(
             val boldTypeface = ResourcesCompat.getFont(context, R.font.roboto_bold) ?: Typeface.DEFAULT_BOLD
 
             val textStyleMine = TextStyle.Builder(attributes)
-                .size(R.styleable.MessageListView_streamUiMessageTextSizeMine, context.getDimension(DEFAULT_TEXT_SIZE))
+                .size(
+                    R.styleable.MessageListView_streamUiMessageTextSizeMine,
+                    context.getDimension(DEFAULT_TEXT_SIZE)
+                )
                 .color(
                     R.styleable.MessageListView_streamUiMessageTextColorMine,
                     context.getColorCompat(DEFAULT_TEXT_COLOR)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
@@ -216,10 +216,11 @@ public class MessageListHeaderView : ConstraintLayout {
     }
 
     private fun getSearchingForNetworkTextStyle(attrs: TypedArray): TextStyle {
-        return TextStyle.Builder(attrs).size(
-            R.styleable.MessageListHeaderView_streamUiMessageListHeaderSearchingForNetworkLabelTextSize,
-            context.getDimension(R.dimen.stream_ui_text_small)
-        )
+        return TextStyle.Builder(attrs)
+            .size(
+                R.styleable.MessageListHeaderView_streamUiMessageListHeaderSearchingForNetworkLabelTextSize,
+                context.getDimension(R.dimen.stream_ui_text_small)
+            )
             .color(
                 R.styleable.MessageListHeaderView_streamUiMessageListHeaderSearchingForNetworkLabelColor,
                 context.getColorCompat(R.color.stream_ui_text_color_secondary)
@@ -249,10 +250,11 @@ public class MessageListHeaderView : ConstraintLayout {
     }
 
     private fun getOfflineTextStyle(typedArray: TypedArray): TextStyle {
-        return TextStyle.Builder(typedArray).size(
-            R.styleable.MessageListHeaderView_streamUiMessageListHeaderOfflineLabelTextSize,
-            context.getDimension(R.dimen.stream_ui_text_small)
-        )
+        return TextStyle.Builder(typedArray)
+            .size(
+                R.styleable.MessageListHeaderView_streamUiMessageListHeaderOfflineLabelTextSize,
+                context.getDimension(R.dimen.stream_ui_text_small)
+            )
             .color(
                 R.styleable.MessageListHeaderView_streamUiMessageListHeaderOfflineLabelTextColor,
                 context.getColorCompat(R.color.stream_ui_text_color_secondary)
@@ -279,10 +281,11 @@ public class MessageListHeaderView : ConstraintLayout {
     }
 
     private fun getOnlineTextStyle(typedArray: TypedArray): TextStyle {
-        return TextStyle.Builder(typedArray).size(
-            R.styleable.MessageListHeaderView_streamUiMessageListHeaderDefaultLabelTextSize,
-            context.getDimension(R.dimen.stream_ui_text_small)
-        )
+        return TextStyle.Builder(typedArray)
+            .size(
+                R.styleable.MessageListHeaderView_streamUiMessageListHeaderDefaultLabelTextSize,
+                context.getDimension(R.dimen.stream_ui_text_small)
+            )
             .color(
                 R.styleable.MessageListHeaderView_streamUiMessageListHeaderDefaultLabelTextColor,
                 context.getColorCompat(R.color.stream_ui_text_color_secondary)
@@ -325,10 +328,11 @@ public class MessageListHeaderView : ConstraintLayout {
     }
 
     private fun getTitleTextStyle(typedArray: TypedArray): TextStyle {
-        return TextStyle.Builder(typedArray).size(
-            R.styleable.MessageListHeaderView_streamUiMessageListHeaderTitleTextSize,
-            context.getDimension(R.dimen.stream_ui_text_large)
-        )
+        return TextStyle.Builder(typedArray)
+            .size(
+                R.styleable.MessageListHeaderView_streamUiMessageListHeaderTitleTextSize,
+                context.getDimension(R.dimen.stream_ui_text_large)
+            )
             .color(
                 R.styleable.MessageListHeaderView_streamUiMessageListHeaderTitleTextColor,
                 context.getColorCompat(R.color.stream_ui_text_color_primary)

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_command.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_command.xml
@@ -27,6 +27,7 @@
         android:layout_width="wrap_content"
         android:layout_height="0dp"
         android:layout_marginStart="@dimen/stream_ui_spacing_small"
+        android:gravity="start|center_vertical"
         android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toEndOf="@id/commandIconImageView"


### PR DESCRIPTION
### Description

- Fixed incorrect values passed to the `TextStyle.Build::size()` method
- Ensured that this won't happen again by providing  `@StyleableRes`, `@ColorInt` and `@Px` hints to the compiler

| Before | After |
| --- | --- |
| ![photo_2021-03-28 19 39 45](https://user-images.githubusercontent.com/9600921/112759822-63469500-8ffd-11eb-8b5b-ee027dec2ba6.jpeg) | ![photo_2021-03-28 19 39 49](https://user-images.githubusercontent.com/9600921/112759820-60e43b00-8ffd-11eb-9742-85eb6ec170af.jpeg) |

| Before | After |
| --- | --- |
| ![photo_2021-03-28 19 39 43](https://user-images.githubusercontent.com/9600921/112759823-63469500-8ffd-11eb-8262-c94b69069807.jpeg) | ![photo_2021-03-28 19 39 46](https://user-images.githubusercontent.com/9600921/112759821-62adfe80-8ffd-11eb-9d49-b01891c06fa4.jpeg) |


### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added
