### PR TITLE
[CAS-832] Feature/allow custom key cache for avatar bitmap factory

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -103,7 +103,9 @@ It is possible now to configure the max size of the file upload using
 - Add `streamUiCommandsEnabled` attribute to `MessageInputView` and `MessageInputView::setCommandsEnabled` method to enable/disable commands
 - Add `ChannelListItemPredicate` to our `channelListView` to allow filter `ChannelListItem` before they are rendered
 - Open `AvatarBitmapFactory` class
-- Add `AvatarBitmapFactory::setInstance` method to allow custom implementation of `AvatarBitmapFactory`
+- Add `ChatUI::avatarBitmapFactory` property to allow custom implementation of `AvatarBitmapFactory`
+- Add `AvatarBitmapFactory::userBitmapKey` method to generate cache key for a given User
+- Add `AvatarBitmapFactory::channelBitmapKey` method to generate cache key for a given Channel
 - Add `StyleTransformer` class to allow application-wide style customizations
 - Add the default font field to `TextStyle`
 - Add new method `ChatFonts::setFont(textStyle: TextStyle, textView: TextView, defaultTypeface: Typeface)`

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -88,7 +88,6 @@ public class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory {
 }
 
 public final class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory$Companion {
-	public final fun setInstance (Lio/getstream/chat/android/ui/avatar/AvatarBitmapFactory;)V
 }
 
 public final class io/getstream/chat/android/ui/avatar/AvatarStyle {

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -34,11 +34,13 @@ public final class io/getstream/chat/android/ui/BuildConfig {
 
 public final class io/getstream/chat/android/ui/ChatUI {
 	public static final field INSTANCE Lio/getstream/chat/android/ui/ChatUI;
+	public final fun getAvatarBitmapFactory ()Lio/getstream/chat/android/ui/avatar/AvatarBitmapFactory;
 	public final fun getFonts ()Lio/getstream/chat/android/ui/common/style/ChatFonts;
 	public final fun getMarkdown ()Lio/getstream/chat/android/ui/common/markdown/ChatMarkdown;
 	public final fun getNavigator ()Lio/getstream/chat/android/ui/common/navigation/ChatNavigator;
 	public final fun getStyle ()Lio/getstream/chat/android/ui/common/style/ChatStyle;
 	public final fun getUrlSigner ()Lio/getstream/chat/android/ui/common/UrlSigner;
+	public final fun setAvatarBitmapFactory (Lio/getstream/chat/android/ui/avatar/AvatarBitmapFactory;)V
 	public final fun setFonts (Lio/getstream/chat/android/ui/common/style/ChatFonts;)V
 	public final fun setMarkdown (Lio/getstream/chat/android/ui/common/markdown/ChatMarkdown;)V
 	public final fun setNavigator (Lio/getstream/chat/android/ui/common/navigation/ChatNavigator;)V

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -73,6 +73,7 @@ public final class io/getstream/chat/android/ui/TransformStyle {
 public class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory {
 	public static final field Companion Lio/getstream/chat/android/ui/avatar/AvatarBitmapFactory$Companion;
 	public fun <init> (Landroid/content/Context;)V
+	public fun channelBitmapKey (Lio/getstream/chat/android/client/models/Channel;)Ljava/lang/String;
 	public fun createChannelBitmap (Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;Lio/getstream/chat/android/ui/avatar/AvatarStyle;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun createChannelBitmapBlocking (Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;Lio/getstream/chat/android/ui/avatar/AvatarStyle;I)Landroid/graphics/Bitmap;
 	public fun createDefaultChannelBitmap (Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;Lio/getstream/chat/android/ui/avatar/AvatarStyle;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -81,6 +82,7 @@ public class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory {
 	public fun createDefaultUserBitmapBlocking (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/ui/avatar/AvatarStyle;I)Landroid/graphics/Bitmap;
 	public fun createUserBitmap (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/ui/avatar/AvatarStyle;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun createUserBitmapBlocking (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/ui/avatar/AvatarStyle;I)Landroid/graphics/Bitmap;
+	public fun userBitmapKey (Lio/getstream/chat/android/client/models/User;)Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory$Companion {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.ui
 
 import android.content.Context
+import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory
 import io.getstream.chat.android.ui.common.UrlSigner
 import io.getstream.chat.android.ui.common.markdown.ChatMarkdown
 import io.getstream.chat.android.ui.common.markdown.ChatMarkdownImpl
@@ -15,6 +16,7 @@ import io.getstream.chat.android.ui.common.style.ChatStyle
  * @param fonts allows you to overwrite fonts
  * @param markdown interface to to customize the markdown parsing behaviour, useful if you want to use more markdown modules
  * @param urlSigner url signing logic, enables you to add authorization tokens for images, video etc
+ * @param avatarBitmapFactory allows you to generate custom bitmap for avatarView
  *
  * @see ChatMarkdown
  * @see UrlSigner
@@ -41,5 +43,13 @@ public object ChatUI {
         get() = markdownOverride ?: defaultMarkdown
         set(value) {
             markdownOverride = value
+        }
+
+    private var avatarBitmapFactoryOverride: AvatarBitmapFactory? = null
+    private val defaultAvatarBitmapFactory: AvatarBitmapFactory by lazy { AvatarBitmapFactory(appContext) }
+    public var avatarBitmapFactory: AvatarBitmapFactory
+        get() = avatarBitmapFactoryOverride ?: defaultAvatarBitmapFactory
+        set(value) {
+            avatarBitmapFactoryOverride = value
         }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
@@ -342,10 +342,5 @@ public open class AvatarBitmapFactory(private val context: Context) {
          * Marker object to detect whether methods have been implemented by custom subclasses.
          */
         private val NOT_IMPLEMENTED_MARKER = Bitmap.createBitmap(1, 1, Bitmap.Config.ALPHA_8)
-        internal lateinit var instance: AvatarBitmapFactory
-
-        public fun setInstance(avatarBitmapFactory: AvatarBitmapFactory) {
-            instance = avatarBitmapFactory
-        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
@@ -9,10 +9,12 @@ import android.graphics.Shader
 import android.graphics.Typeface
 import androidx.annotation.Px
 import com.getstream.sdk.chat.images.StreamImageLoader
+import com.getstream.sdk.chat.utils.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.image
 import io.getstream.chat.android.client.models.initials
+import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.avatar.AvatarView.Companion.MAX_AVATAR_SECTIONS
@@ -237,6 +239,34 @@ public open class AvatarBitmapFactory(private val context: Context) {
     ): List<Bitmap> {
         return users.take(MAX_AVATAR_SECTIONS).map { createUserBitmapInternal(it, style, avatarSize) }
     }
+
+    /**
+     * Compute the memory cache key for [user].
+     *
+     * Items with the same cache key will be treated as equivalent by the memory cache.
+     *
+     * Returning null will prevent the result of [createUserBitmap] from being added to the memory cache.
+     */
+    public open fun userBitmapKey(user: User): String? = "${user.name}${user.image}"
+
+    /**
+     * Compute the memory cache key for [channel].
+     *
+     * Items with the same cache key will be treated as equivalent by the memory cache.
+     *
+     * Returning null will prevent the result of [createChannelBitmap] from being added to the memory cache.
+     */
+    public open fun channelBitmapKey(channel: Channel): String? =
+        buildString {
+            append(channel.name)
+            append(channel.image)
+            channel.getUsers()
+                .take(4)
+                .forEach {
+                    append(it.name)
+                    append(it.image)
+                }
+        }
 
     private fun createInitialsBitmap(
         avatarStyle: AvatarStyle,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
@@ -10,7 +10,7 @@ import coil.fetch.Fetcher
 import coil.size.PixelSize
 import coil.size.Size
 import com.getstream.sdk.chat.utils.extensions.getUsers
-import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.avatar.internal.Avatar
 
 internal class AvatarFetcher() : Fetcher<Avatar> {
@@ -28,14 +28,14 @@ internal class AvatarFetcher() : Fetcher<Avatar> {
                 resources,
                 when (data) {
                     is Avatar.UserAvatar -> {
-                        AvatarBitmapFactory.instance.createUserBitmapInternal(
+                        ChatUI.avatarBitmapFactory.createUserBitmapInternal(
                             data.user,
                             data.avatarStyle,
                             targetSize
                         )
                     }
                     is Avatar.ChannelAvatar -> {
-                        AvatarBitmapFactory.instance.createChannelBitmapInternal(
+                        ChatUI.avatarBitmapFactory.createChannelBitmapInternal(
                             data.channel,
                             data.channel.getUsers(),
                             data.avatarStyle,
@@ -50,7 +50,7 @@ internal class AvatarFetcher() : Fetcher<Avatar> {
     }
 
     override fun key(data: Avatar): String? = when (data) {
-        is Avatar.UserAvatar -> AvatarBitmapFactory.instance.userBitmapKey(data.user)
-        is Avatar.ChannelAvatar -> AvatarBitmapFactory.instance.channelBitmapKey(data.channel)
+        is Avatar.UserAvatar -> ChatUI.avatarBitmapFactory.userBitmapKey(data.user)
+        is Avatar.ChannelAvatar -> ChatUI.avatarBitmapFactory.channelBitmapKey(data.channel)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
@@ -10,8 +10,6 @@ import coil.fetch.Fetcher
 import coil.size.PixelSize
 import coil.size.Size
 import com.getstream.sdk.chat.utils.extensions.getUsers
-import io.getstream.chat.android.client.models.image
-import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory
 import io.getstream.chat.android.ui.avatar.internal.Avatar
 
@@ -51,23 +49,8 @@ internal class AvatarFetcher() : Fetcher<Avatar> {
         )
     }
 
-    override fun key(data: Avatar): String {
-        return when (data) {
-            is Avatar.UserAvatar -> {
-                "${data.user.name}${data.user.image}"
-            }
-            is Avatar.ChannelAvatar -> {
-                buildString {
-                    append(data.channel.name)
-                    append(data.channel.image)
-                    data.channel.getUsers()
-                        .take(4)
-                        .forEach {
-                            append(it.name)
-                            append(it.image)
-                        }
-                }
-            }
-        }
+    override fun key(data: Avatar): String? = when (data) {
+        is Avatar.UserAvatar -> AvatarBitmapFactory.instance.userBitmapKey(data.user)
+        is Avatar.ChannelAvatar -> AvatarBitmapFactory.instance.channelBitmapKey(data.channel)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ImageLoaderFactoryInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ImageLoaderFactoryInitializer.kt
@@ -8,12 +8,10 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import com.getstream.sdk.chat.coil.StreamCoil
 import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
-import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory
 
 @Suppress("unused")
 internal class ImageLoaderFactoryInitializer : Initializer<ImageLoaderFactory> {
     override fun create(context: Context): ImageLoaderFactory {
-        AvatarBitmapFactory.instance = AvatarBitmapFactory(context)
         return StreamImageLoaderFactory(context) {
             componentRegistry {
                 // duplicated as we can not extend component


### PR DESCRIPTION
### Description
Our `AvatarFetcher` use a `key` for the cache and it is generated from our `AvatarBitmapFactory` now to allow our customers to implement it by themselves.
The `AvatarBitmapFactory` used now is the one from `ChatUI` and any reference to the singleton one used inside of `AvatarBitmapFactory` has been removed

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
