### PR TITLE
[CAS-831] Add customization of unread count badge test style

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -119,6 +119,7 @@ It is possible now to configure the max size of the file upload using
     - Deleted message text and background
     - Reactions style in list view and in options view
     - Indicator icons in footer of Message
+    - Unread count badge on scroll to bottom button
 It is now possible to customize the following attributes for `ChannelListView`:
 - `streamUiChannelOptionsIcon` - customize options icon
 - `streamUiChannelDeleteIcon` - customize delete icon

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1214,17 +1214,19 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 }
 
 public final class io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle {
-	public fun <init> (ZZIIILandroid/graphics/drawable/Drawable;)V
+	public fun <init> (ZZIIILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()I
 	public final fun component4 ()I
 	public final fun component5 ()I
 	public final fun component6 ()Landroid/graphics/drawable/Drawable;
-	public final fun copy (ZZIIILandroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;ZZIIILandroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
+	public final fun component7 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun copy (ZZIIILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;)Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;ZZIIILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getScrollButtonBadgeColor ()I
+	public final fun getScrollButtonBadgeTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getScrollButtonColor ()I
 	public final fun getScrollButtonEnabled ()Z
 	public final fun getScrollButtonIcon ()Landroid/graphics/drawable/Drawable;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -449,6 +449,7 @@ public class MessageListView : ConstraintLayout {
             setButtonIcon(messageListViewStyle.scrollButtonViewStyle.scrollButtonIcon)
             setButtonColor(messageListViewStyle.scrollButtonViewStyle.scrollButtonColor)
             setUnreadBadgeColor(messageListViewStyle.scrollButtonViewStyle.scrollButtonBadgeColor)
+            setUnreadBadgeTextStyle(messageListViewStyle.scrollButtonViewStyle.scrollButtonBadgeTextStyle)
         }
         scrollHelper.scrollToBottomButtonEnabled = messageListViewStyle.scrollButtonViewStyle.scrollButtonEnabled
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -26,7 +26,7 @@ public data class MessageListViewStyle(
                 0,
                 0
             ).use { attributes ->
-                val scrollButtonViewStyle = ScrollButtonViewStyle.Builder(attributes)
+                val scrollButtonViewStyle = ScrollButtonViewStyle.Builder(context, attributes)
                     .scrollButtonEnabled(
                         R.styleable.MessageListView_streamUiScrollButtonEnabled,
                         true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle.kt
@@ -1,10 +1,16 @@
 package io.getstream.chat.android.ui.message.list
 
+import android.content.Context
 import android.content.res.TypedArray
+import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
 import androidx.annotation.StyleableRes
+import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
+import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getDimension
+import io.getstream.chat.android.ui.common.style.TextStyle
 
 public data class ScrollButtonViewStyle(
     public val scrollButtonEnabled: Boolean,
@@ -13,9 +19,10 @@ public data class ScrollButtonViewStyle(
     public val scrollButtonRippleColor: Int,
     public val scrollButtonBadgeColor: Int,
     public val scrollButtonIcon: Drawable?,
+    public val scrollButtonBadgeTextStyle: TextStyle
 ) {
 
-    internal class Builder(private val a: TypedArray) {
+    internal class Builder(private val context: Context, private val attrs: TypedArray) {
         private var scrollButtonEnabled: Boolean = false
         private var scrollButtonUnreadEnabled: Boolean = false
         private var scrollButtonColor: Int = 0
@@ -27,52 +34,69 @@ public data class ScrollButtonViewStyle(
             @StyleableRes scrollButtonEnabledStyleableId: Int,
             defaultValue: Boolean,
         ) = apply {
-            scrollButtonEnabled = a.getBoolean(scrollButtonEnabledStyleableId, defaultValue)
+            scrollButtonEnabled = attrs.getBoolean(scrollButtonEnabledStyleableId, defaultValue)
         }
 
         fun scrollButtonUnreadEnabled(
             @StyleableRes scrollButtonUnreadEnabledStyleableId: Int,
             defaultValue: Boolean,
         ) = apply {
-            scrollButtonUnreadEnabled = a.getBoolean(scrollButtonUnreadEnabledStyleableId, defaultValue)
+            scrollButtonUnreadEnabled = attrs.getBoolean(scrollButtonUnreadEnabledStyleableId, defaultValue)
         }
 
         fun scrollButtonColor(
             @StyleableRes scrollButtonColorStyleableId: Int,
             @ColorInt defaultValue: Int,
         ) = apply {
-            scrollButtonColor = a.getColor(scrollButtonColorStyleableId, defaultValue)
+            scrollButtonColor = attrs.getColor(scrollButtonColorStyleableId, defaultValue)
         }
 
         fun scrollButtonRippleColor(
             @StyleableRes scrollButtonRippleColorStyleableId: Int,
             @ColorInt defaultColor: Int,
         ) = apply {
-            scrollButtonRippleColor = a.getColor(scrollButtonRippleColorStyleableId, defaultColor)
+            scrollButtonRippleColor = attrs.getColor(scrollButtonRippleColorStyleableId, defaultColor)
         }
 
         fun scrollButtonBadgeColor(
             @StyleableRes scrollButtonBadgeColorStyleableId: Int,
             @ColorInt defaultColor: Int,
         ) = apply {
-            scrollButtonBadgeColor = a.getColor(scrollButtonBadgeColorStyleableId, defaultColor)
+            scrollButtonBadgeColor = attrs.getColor(scrollButtonBadgeColorStyleableId, defaultColor)
         }
 
         fun scrollButtonIcon(
             @StyleableRes scrollButtonIconStyleableId: Int,
             defaultIcon: Drawable?,
         ) = apply {
-            scrollButtonIcon = a.getDrawable(scrollButtonIconStyleableId) ?: defaultIcon
+            scrollButtonIcon = attrs.getDrawable(scrollButtonIconStyleableId) ?: defaultIcon
         }
 
         fun build(): ScrollButtonViewStyle {
+            val scrollButtonBadgeTextStyle = TextStyle.Builder(attrs)
+                .size(
+                    R.styleable.MessageListView_streamUiScrollButtonBadgeTextSize,
+                    context.getDimension(R.dimen.stream_ui_scroll_button_unread_badge_text_size)
+                )
+                .color(
+                    R.styleable.MessageListView_streamUiScrollButtonBadgeTextColor,
+                    context.getColorCompat(R.color.stream_ui_literal_white)
+                )
+                .font(
+                    R.styleable.MessageListView_streamUiScrollButtonBadgeFontAssets,
+                    R.styleable.MessageListView_streamUiScrollButtonBadgeTextFont,
+                )
+                .style(R.styleable.MessageListView_streamUiScrollButtonBadgeTextStyle, Typeface.BOLD)
+                .build()
+
             return ScrollButtonViewStyle(
                 scrollButtonEnabled = scrollButtonEnabled,
                 scrollButtonUnreadEnabled = scrollButtonUnreadEnabled,
                 scrollButtonColor = scrollButtonColor,
                 scrollButtonRippleColor = scrollButtonRippleColor,
                 scrollButtonBadgeColor = scrollButtonBadgeColor,
-                scrollButtonIcon = scrollButtonIcon
+                scrollButtonIcon = scrollButtonIcon,
+                scrollButtonBadgeTextStyle = scrollButtonBadgeTextStyle
             ).let(TransformStyle.scrollButtonStyleTransformer::transform)
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import android.widget.FrameLayout
 import androidx.annotation.ColorInt
 import androidx.core.view.isVisible
+import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiScrollButtonViewBinding
 
 internal class ScrollButtonView : FrameLayout {
@@ -48,6 +49,10 @@ internal class ScrollButtonView : FrameLayout {
 
     fun setUnreadBadgeColor(@ColorInt color: Int) {
         binding.unreadCountTextView.backgroundTintList = ColorStateList.valueOf(color)
+    }
+
+    fun setUnreadBadgeTextStyle(textStyle: TextStyle) {
+        textStyle.apply(binding.unreadCountTextView)
     }
 
     override fun setOnClickListener(listener: OnClickListener?) {

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -9,6 +9,16 @@
         <attr name="streamUiScrollButtonBadgeColor" format="color|reference" />
         <attr name="streamUiScrollButtonIcon" format="reference" />
 
+        <attr name="streamUiScrollButtonBadgeTextSize" format="dimension|reference" />
+        <attr name="streamUiScrollButtonBadgeTextColor" format="color|reference" />
+        <attr name="streamUiScrollButtonBadgeTextFont" format="reference" />
+        <attr name="streamUiScrollButtonBadgeFontAssets" format="string" />
+        <attr name="streamUiScrollButtonBadgeTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
         <attr name="streamUiLoadMoreThreshold" format="integer" />
         <attr name="streamUiNewMessagesBehaviour" format="enum">
             <enum name="scroll_to_bottom" value="0" />
@@ -143,13 +153,13 @@
         <attr name="streamUiMessageReactionsBubbleBorderColorMine" format="color|reference" />
 
         <!-- Message edit reactions view style -->
-        <attr name="streamUiEditReactionsBubbleColorMine" format="color"/>
-        <attr name="streamUiEditReactionsBubbleColorTheirs" format="color"/>
+        <attr name="streamUiEditReactionsBubbleColorMine" format="color" />
+        <attr name="streamUiEditReactionsBubbleColorTheirs" format="color" />
 
         <!-- Indicator icons -->
-        <attr name="streamUiIconIndicatorSent" format="reference"/>
-        <attr name="streamUiIconIndicatorRead" format="reference"/>
-        <attr name="streamUiIconIndicatorPendingSync" format="reference"/>
+        <attr name="streamUiIconIndicatorSent" format="reference" />
+        <attr name="streamUiIconIndicatorRead" format="reference" />
+        <attr name="streamUiIconIndicatorPendingSync" format="reference" />
 
         <!-- Message deleted style -->
         <attr name="streamUiDeletedMessageBackgroundColor" format="color" />


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-831

### Description

Added the possibility to customize the `TextStyle` of the "Unread count" label of the button. Used the same approach as in `MessageListItemStyle`, but eventually style classes which use builders need to be refactored.

No customization applied
| Before | After |
| --- | --- |
| ![photo_2021-03-29 19 07 51](https://user-images.githubusercontent.com/9600921/112866125-1aa4df80-90c2-11eb-9cda-d8cf5192db45.jpeg) | ![photo_2021-03-29 19 07 53](https://user-images.githubusercontent.com/9600921/112866123-1a0c4900-90c2-11eb-85cc-6c1acf766215.jpeg) |

Custom transformer

```
TransformStyle.scrollButtonStyleTransformer = StyleTransformer {
     it.copy(
         scrollButtonBadgeTextStyle = it.scrollButtonBadgeTextStyle.copy(
             style = Typeface.ITALIC,
             color = ContextCompat.getColor(this, R.color.red)
           )
      )
}
```

<img src="https://user-images.githubusercontent.com/9600921/112866116-18428580-90c2-11eb-8bde-a2fdb15dbfed.jpeg" width="40%">

### Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [X] Reviewers added
