### PR TITLE
cas-830 custom online indicator colors

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -78,6 +78,7 @@ It is possible now to configure the max size of the file upload using
 - Show AttachmentMediaActivity for video attachments
 
 ### ✅ Added
+- `AvatarView.streamUiAvatarOnlineIndicatorColor` and `AvatarView.streamUiAvatarOnlineIndicatorBorderColor` attrs
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/avatarview/ComponentBrowserAvatarViewFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/avatarview/ComponentBrowserAvatarViewFragment.kt
@@ -127,5 +127,14 @@ class ComponentBrowserAvatarViewFragment : Fragment() {
         binding.avatarViewLargeIndicatorBorder.apply {
             setUserData(user3)
         }
+        binding.avatarViewSmallColors.apply {
+            setUserData(user1)
+        }
+        binding.avatarViewMediumColors.apply {
+            setUserData(user2)
+        }
+        binding.avatarViewLargeColors.apply {
+            setUserData(user3)
+        }
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_avatar_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_avatar_view.xml
@@ -159,6 +159,40 @@
                 app:streamUiAvatarBorderWidth="4dp"
                 app:streamUiAvatarBorderColor="@color/grey_dark"
                 />
+
+            <TextView
+                style="@style/ComponentBrowserLabel"
+                android:text="Custom indicator colors"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                style="@style/StreamUiMessageListAvatarStyle"
+                android:id="@+id/avatarViewSmallColors"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarBorderWidth="4dp"
+                app:streamUiAvatarBorderColor="@color/grey_dark"
+                app:streamUiAvatarOnlineIndicatorColor="@color/stream_ui_accent_blue"
+                app:streamUiAvatarOnlineIndicatorBorderColor="@color/stream_ui_avatar_gradient_yellow"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                style="@style/StreamUiUserAvatarStyle"
+                android:id="@+id/avatarViewMediumColors"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarBorderWidth="4dp"
+                app:streamUiAvatarBorderColor="@color/grey_dark"
+                app:streamUiAvatarOnlineIndicatorColor="@color/stream_ui_accent_blue"
+                app:streamUiAvatarOnlineIndicatorBorderColor="@color/stream_ui_avatar_gradient_yellow"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                style="@style/StreamUiGroupActionsAvatarStyle"
+                android:id="@+id/avatarViewLargeColors"
+                app:streamUiAvatarBorderWidth="4dp"
+                app:streamUiAvatarBorderColor="@color/grey_dark"
+                app:streamUiAvatarOnlineIndicatorColor="@color/stream_ui_accent_blue"
+                app:streamUiAvatarOnlineIndicatorBorderColor="@color/stream_ui_avatar_gradient_yellow"
+                />
         </LinearLayout>
     </ScrollView>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -92,18 +92,22 @@ public final class io/getstream/chat/android/ui/avatar/AvatarBitmapFactory$Compa
 
 public final class io/getstream/chat/android/ui/avatar/AvatarStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/avatar/AvatarStyle$Companion;
-	public fun <init> (IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;)V
+	public fun <init> (IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;II)V
 	public final fun component1 ()I
 	public final fun component2 ()I
 	public final fun component3 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component4 ()Z
 	public final fun component5 ()Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
-	public final fun copy (IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;)Lio/getstream/chat/android/ui/avatar/AvatarStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/avatar/AvatarStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;ILjava/lang/Object;)Lio/getstream/chat/android/ui/avatar/AvatarStyle;
+	public final fun component6 ()I
+	public final fun component7 ()I
+	public final fun copy (IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;II)Lio/getstream/chat/android/ui/avatar/AvatarStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/avatar/AvatarStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ZLio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;IIILjava/lang/Object;)Lio/getstream/chat/android/ui/avatar/AvatarStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarBorderColor ()I
 	public final fun getAvatarBorderWidth ()I
 	public final fun getAvatarInitialText ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun getOnlineIndicatorBorderColor ()I
+	public final fun getOnlineIndicatorColor ()I
 	public final fun getOnlineIndicatorEnabled ()Z
 	public final fun getOnlineIndicatorPosition ()Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
 	public fun hashCode ()I

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
@@ -5,6 +5,7 @@ import android.graphics.Color
 import android.graphics.Typeface
 import android.util.AttributeSet
 import androidx.annotation.ColorInt
+import androidx.annotation.ColorRes
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
@@ -17,6 +18,8 @@ public data class AvatarStyle(
     public val avatarInitialText: TextStyle,
     public val onlineIndicatorEnabled: Boolean,
     public val onlineIndicatorPosition: AvatarView.OnlineIndicatorPosition,
+    @ColorRes public val onlineIndicatorColor: Int,
+    @ColorRes public val onlineIndicatorBorderColor: Int,
 ) {
 
     internal companion object {
@@ -61,12 +64,16 @@ public data class AvatarStyle(
                     R.styleable.AvatarView_streamUiAvatarOnlineIndicatorPosition,
                     AvatarView.OnlineIndicatorPosition.TOP
                 )
+                val onlineIndicatorColor = it.getColor(R.styleable.AvatarView_streamUiAvatarOnlineIndicatorColor, Color.GREEN)
+                val onlineIndicatorBorderColor = it.getColor(R.styleable.AvatarView_streamUiAvatarOnlineIndicatorBorderColor, Color.WHITE)
                 AvatarStyle(
                     avatarBorderWidth = avatarBorderWidth,
                     avatarBorderColor = avatarBorderColor,
                     avatarInitialText = avatarInitialText,
                     onlineIndicatorEnabled = onlineIndicatorEnabled,
                     onlineIndicatorPosition = onlineIndicatorPosition,
+                    onlineIndicatorColor = onlineIndicatorColor,
+                    onlineIndicatorBorderColor = onlineIndicatorBorderColor,
                 ).let(TransformStyle.avatarStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
@@ -14,21 +14,9 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.ui.avatar.internal.Avatar
 
 public class AvatarView : AppCompatImageView {
-    private val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        style = Paint.Style.STROKE
-    }
-    private val onlineIndicatorOutlinePaint by lazy {
-        Paint().apply {
-            style = Paint.Style.FILL
-            color = avatarStyle.onlineIndicatorBorderColor
-        }
-    }
-    private val onlineIndicatorPaint by lazy {
-        Paint().apply {
-            style = Paint.Style.FILL
-            color = avatarStyle.onlineIndicatorColor
-        }
-    }
+    private val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply { style = Paint.Style.STROKE }
+    private val onlineIndicatorOutlinePaint = Paint().apply { style = Paint.Style.FILL }
+    private val onlineIndicatorPaint = Paint().apply { style = Paint.Style.FILL }
 
     private lateinit var avatarStyle: AvatarStyle
     private var isOnline: Boolean = false
@@ -97,6 +85,8 @@ public class AvatarView : AppCompatImageView {
         borderPaint.strokeWidth = avatarStyle.avatarBorderWidth.toFloat()
         val padding = this.avatarStyle.avatarBorderWidth - 1
         setPadding(padding, padding, padding, padding)
+        onlineIndicatorOutlinePaint.color = avatarStyle.onlineIndicatorBorderColor
+        onlineIndicatorPaint.color = avatarStyle.onlineIndicatorColor
     }
 
     private fun drawOnlineStatus(canvas: Canvas) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.ui.avatar
 
 import android.content.Context
 import android.graphics.Canvas
-import android.graphics.Color
 import android.graphics.Paint
 import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageView
@@ -18,13 +17,17 @@ public class AvatarView : AppCompatImageView {
     private val borderPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         style = Paint.Style.STROKE
     }
-    private val onlineIndicatorOutlinePaint = Paint().apply {
-        style = Paint.Style.FILL
-        color = Color.WHITE
+    private val onlineIndicatorOutlinePaint by lazy {
+        Paint().apply {
+            style = Paint.Style.FILL
+            color = avatarStyle.onlineIndicatorBorderColor
+        }
     }
-    private val onlineIndicatorPaint = Paint().apply {
-        style = Paint.Style.FILL
-        color = Color.GREEN
+    private val onlineIndicatorPaint by lazy {
+        Paint().apply {
+            style = Paint.Style.FILL
+            color = avatarStyle.onlineIndicatorColor
+        }
     }
 
     private lateinit var avatarStyle: AvatarStyle

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_avatar_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_avatar_view.xml
@@ -17,5 +17,7 @@
             <enum name="top" value="0" />
             <enum name="bottom" value="1" />
         </attr>
+        <attr name="streamUiAvatarOnlineIndicatorColor" format="color|reference" />
+        <attr name="streamUiAvatarOnlineIndicatorBorderColor" format="color|reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-830
### Description
Allowing to customize avatar's online indicator color.

Added  `AvatarView.streamUiAvatarOnlineIndicatorColor` and `AvatarView.streamUiAvatarOnlineIndicatorBorderColor` xml attrs.


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Reviewers added
