### PR TITLE
[CAS-817] Docs - Documenting message input view style

### DIFF
--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
@@ -701,14 +701,16 @@ public class Android {
     }
 
     /**
-     * @see <a href="https://getstream.io/nessy/docs/chat_docs/android_chat_ux/message_input_view?language=kotlin">Message Input View</a>
+     * @see <a href="https://getstream.io/nessy/docs/chat_docs/android_chat_ux/message_input_view?language=java">Message Input View</a>
      */
     public class TransformStyleMessageInput extends Fragment {
         public void messageInputCustomisation() {
-            TransformStyle.INSTANCE.messageInputStyleTransformer = (viewStyle) -> {
-                // Create a new viewStyle!
-                return viewStyle;
-            };
+            TransformStyle.INSTANCE.setMessageInputStyleTransformer(
+                    viewStyle -> {
+                        // Create a new viewStyle!
+                        return viewStyle;
+                    }
+            );
         }
     }
 }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
@@ -43,6 +43,7 @@ import io.getstream.chat.android.livedata.controller.ChannelController;
 import io.getstream.chat.android.livedata.controller.QueryChannelsController;
 import io.getstream.chat.android.livedata.controller.ThreadController;
 import io.getstream.chat.android.livedata.utils.RetryPolicy;
+import io.getstream.chat.android.ui.TransformStyle;
 import io.getstream.chat.android.ui.channel.list.ChannelListView;
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem;
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder;
@@ -696,6 +697,18 @@ public class Android {
                     // Handle result.error()
                 }
             });
+        }
+    }
+
+    /**
+     * @see <a href="https://getstream.io/nessy/docs/chat_docs/android_chat_ux/message_input_view?language=kotlin">Message Input View</a>
+     */
+    public class TransformStyleMessageInput extends Fragment {
+        public void messageInputCustomisation() {
+            TransformStyle.INSTANCE.messageInputStyleTransformer = (viewStyle) -> {
+                // Create a new viewStyle!
+                return viewStyle;
+            };
         }
     }
 }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
@@ -1,5 +1,7 @@
 package io.getstream.chat.docs.java;
 
+import android.graphics.Typeface;
+import android.graphics.drawable.Drawable;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.ViewGroup;
@@ -7,6 +9,7 @@ import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.core.content.ContextCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
@@ -54,9 +57,11 @@ import io.getstream.chat.android.ui.channel.list.header.viewmodel.ChannelListHea
 import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModel;
 import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModelBinding;
 import io.getstream.chat.android.ui.channel.list.viewmodel.factory.ChannelListViewModelFactory;
+import io.getstream.chat.android.ui.common.style.TextStyle;
 import io.getstream.chat.android.ui.gallery.AttachmentGalleryDestination;
 import io.getstream.chat.android.ui.gallery.AttachmentGalleryItem;
 import io.getstream.chat.android.ui.message.input.MessageInputView;
+import io.getstream.chat.android.ui.message.input.MessageInputViewStyle;
 import io.getstream.chat.android.ui.message.input.viewmodel.MessageInputViewModelBinding;
 import io.getstream.chat.android.ui.message.list.MessageListView;
 import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder;
@@ -705,11 +710,53 @@ public class Android {
      */
     public class TransformStyleMessageInput extends Fragment {
         public void messageInputCustomisation() {
+            TextStyle textStyleGeneric = new TextStyle(
+                    0,
+                    "fontAsserts",
+                    Typeface.NORMAL,
+                    requireContext().getResources().getDimensionPixelSize(R.dimen.stream_ui_text_medium),
+                    ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                    "some hint",
+                    ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                    Typeface.DEFAULT
+            );
+
+            Drawable genericDrawable =
+                    ContextCompat.getDrawable(getContext(), R.drawable.stream_ui_ic_command);
+
             TransformStyle.INSTANCE.setMessageInputStyleTransformer(
-                    viewStyle -> {
-                        // Create a new viewStyle!
-                        return viewStyle;
-                    }
+                    viewStyle ->
+                        new MessageInputViewStyle(
+                                true,
+                                genericDrawable,
+                                true,
+                                genericDrawable,
+                                requireContext().getResources().getDimension(R.dimen.stream_ui_text_medium),
+                                ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                                ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                                textStyleGeneric,
+                                true,
+                                true,
+                                true,
+                                genericDrawable,
+                                genericDrawable,
+                                true,
+                                true,
+                                textStyleGeneric,
+                                textStyleGeneric,
+                                textStyleGeneric,
+                                true,
+                                textStyleGeneric,
+                                textStyleGeneric,
+                                genericDrawable,
+                                ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                                ContextCompat.getColor(getContext(), R.color.stream_ui_black),
+                                genericDrawable,
+                                genericDrawable,
+                                20,
+                                genericDrawable
+                        )
+
             );
         }
     }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/cookbook/ui/MessageListView.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/cookbook/ui/MessageListView.kt
@@ -1,0 +1,20 @@
+package io.getstream.chat.docs.cookbook.ui
+
+import android.content.Context
+import androidx.core.content.ContextCompat
+import io.getstream.chat.android.ui.StyleTransformer
+import io.getstream.chat.android.ui.TransformStyle
+import io.getstream.chat.docs.R
+
+/**
+ * @see <a href="https://github.com/GetStream/stream-chat-android/wiki/UI-Cookbook#ui-customisation">Message List View</a>
+ */
+class MessageListView {
+    fun customiseMessageListViewProgrammatically(context: Context) {
+        TransformStyle.messageInputStyleTransformer = StyleTransformer { viewStyle ->
+            viewStyle.copy(
+                messageInputTextColor = ContextCompat.getColor(context, R.color.stream_ui_white)
+            )
+        }
+    }
+}

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
@@ -6,6 +6,7 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.ProgressBar
 import android.widget.TextView
+import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import com.getstream.sdk.chat.adapter.MessageListItem
@@ -24,6 +25,8 @@ import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.utils.RetryPolicy
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.StyleTransformer
+import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.channel.list.ChannelListView
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder
@@ -629,6 +632,20 @@ class Android {
                 } else {
                     // Handle result.error()
                 }
+            }
+        }
+    }
+
+    /**
+     * @see <a href="https://getstream.io/nessy/docs/chat_docs/android_chat_ux/message_input_view?language=kotlin">Message Input View</a>
+     */
+    class TransformStyleMessageInput() : Fragment() {
+
+        fun messageInputCustomisation() {
+            TransformStyle.messageInputStyleTransformer = StyleTransformer { viewStyle ->
+                viewStyle.copy(
+                    messageInputTextColor = ContextCompat.getColor(requireContext(), R.color.stream_ui_white)
+                )
             }
         }
     }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -932,6 +932,8 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputViewSt
 	public final fun getAttachButtonIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getAttachmentMaxFileSize ()I
 	public final fun getBackgroundColor ()I
+	public final fun getCommandsButtonEnabled ()Z
+	public final fun getCommandsButtonIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getCommandsDescriptionTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getCommandsEnabled ()Z
 	public final fun getCommandsNameTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
@@ -939,8 +941,6 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputViewSt
 	public final fun getCustomCursorDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getDividerBackground ()Landroid/graphics/drawable/Drawable;
 	public final fun getEditTextBackgroundDrawable ()Landroid/graphics/drawable/Drawable;
-	public final fun getLightningButtonEnabled ()Z
-	public final fun getLightningButtonIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getMentionsEnabled ()Z
 	public final fun getMentionsIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getMentionsNameTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -290,7 +290,7 @@ public class MessageInputView : ConstraintLayout {
 
     private fun configLightningButton() {
         binding.commandsButton.run {
-            style.lightningButtonIcon.let(this::setImageDrawable)
+            style.commandsButtonIcon.let(this::setImageDrawable)
             setOnClickListener {
                 suggestionListController?.let {
                     if (it.isSuggestionListVisible()) {
@@ -404,7 +404,7 @@ public class MessageInputView : ConstraintLayout {
 
     private fun shouldShowCommandsButton(): Boolean {
         val hasCommands = suggestionListController?.commands?.isNotEmpty() ?: false
-        return hasCommands && style.lightningButtonEnabled && commandsEnabled
+        return hasCommands && style.commandsButtonEnabled && commandsEnabled
     }
 
     private fun sendMessage(messageReplyTo: Message? = null) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -17,11 +17,49 @@ import io.getstream.chat.android.ui.common.style.TextStyle
 
 private const val DEFAULT_ATTACHMENT_MAX_SIZE_MB = 20
 
+/*
+* Style for MessageInputView
+*
+* Use this class to style MessageInputView programmatically. You can pass this class to TransformStyle.messageInputStyleTransformer
+* to change the configuration of the View.
+*
+* @constructor Create the data class with all the information necessary to customize MessageInputView
+*
+* @property attachButtonEnabled Enables/disabled the attachment button. If this parameter is set as false, the button gets invisible.
+* @property attachButtonIcon Selects the icon for the attachment button.
+* @property commandsButtonEnabled Enables/disables the commands button. If this parameter is set as false, the button gets invisible.
+* @property commandsButtonIcon Selects the icon for the commands button.
+* @property messageInputTextSize Selects the size of the text in the input edit text. Deprecated - Use messageInputTextStyle
+* @property messageInputTextColor Selects the colour of the text in the input edit text. Deprecated - Use messageInputTextStyle
+* @property messageInputHintTextColor Selects the colour of the hint text in the input edit text. Deprecated - Use messageInputTextStyle
+* @property messageInputTextStyle Select the style of the EditText of the input. Use to customise size, colour, hint, hint colour, font and style (ex: bold)
+* @property messageInputScrollbarEnabled Enables/disables scroll bar
+* @property messageInputScrollbarFadingEnabled Enables/disables enables/disables FadingEdge for the EditText of the input
+* @property sendButtonEnabled Enables/disables the button to send messages.
+* @property sendButtonEnabledIcon Sets the icon for the button to send messages.
+* @property sendButtonDisabledIcon Sets the icon for the button send messages in the disabled state
+* @property showSendAlsoToChannelCheckbox Show the checkbox to send a message to the channel when inside a thread.
+* @property commandsEnabled Enables/disables commands for the MessageInputView.
+* @property commandsTitleTextStyle Sets the styles for title for the commands box. Use to customise size, colour, font and style (ex: bold)
+* @property commandsNameTextStyle Sets the styles for the name of the command in the command list. Use to customise size, colour, font and style (ex: bold)
+* @property commandsDescriptionTextStyle Sets the styles for the description of the command in the command list. Use to customise size, colour, font and style (ex: bold)
+* @property mentionsEnabled Enables/disables mentions.
+* @property mentionsUsernameTextStyle Configure the appearance for username in the mention list
+* @property mentionsNameTextStyle Configure the appearance for username in the mention list
+* @property mentionsIcon Icon for mentions. It is normally "@"
+* @property backgroundColor background color of MessageInputView
+* @property suggestionsBackground background color of the suggestions box (command and mentions)
+* @property editTextBackgroundDrawable background color of message input box inside MessageInputView
+* @property customCursorDrawable custom cursor of message input box inside MessageInputView
+* @property attachmentMaxFileSize the max attachment size. Be aware that currently the back end of Stream allow 20MB as
+* the max size, use this only if you use your own backend.
+* @property dividerBackground the background of the divider in the top of MessageInputView.
+*/
 public data class MessageInputViewStyle(
     public val attachButtonEnabled: Boolean,
     public val attachButtonIcon: Drawable,
-    public val lightningButtonEnabled: Boolean,
-    public val lightningButtonIcon: Drawable,
+    public val commandsButtonEnabled: Boolean,
+    public val commandsButtonIcon: Drawable,
     @Deprecated("Use messageInputTextStyle") public val messageInputTextSize: Float,
     @Deprecated("Use messageInputTextStyle") @ColorInt public val messageInputTextColor: Int,
     @Deprecated("Use messageInputTextStyle") @ColorInt public val messageInputHintTextColor: Int,
@@ -335,8 +373,8 @@ public data class MessageInputViewStyle(
                 return MessageInputViewStyle(
                     attachButtonEnabled = attachButtonEnabled,
                     attachButtonIcon = attachButtonIcon,
-                    lightningButtonEnabled = lightningButtonEnabled,
-                    lightningButtonIcon = lightningButtonIcon,
+                    commandsButtonEnabled = lightningButtonEnabled,
+                    commandsButtonIcon = lightningButtonIcon,
                     messageInputTextSize = messageInputTextSize,
                     messageInputTextColor = messageInputTextColor,
                     messageInputTextStyle = messageInputTextStyle,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
-import androidx.annotation.ColorRes
+import androidx.annotation.ColorInt
 import androidx.core.graphics.drawable.DrawableCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
@@ -23,8 +23,8 @@ public data class MessageInputViewStyle(
     public val lightningButtonEnabled: Boolean,
     public val lightningButtonIcon: Drawable,
     @Deprecated("Use messageInputTextStyle") public val messageInputTextSize: Float,
-    @Deprecated("Use messageInputTextStyle") public val messageInputTextColor: Int,
-    @Deprecated("Use messageInputTextStyle") public val messageInputHintTextColor: Int,
+    @Deprecated("Use messageInputTextStyle") @ColorInt public val messageInputTextColor: Int,
+    @Deprecated("Use messageInputTextStyle") @ColorInt public val messageInputHintTextColor: Int,
     public val messageInputTextStyle: TextStyle,
     public val messageInputScrollbarEnabled: Boolean,
     public val messageInputScrollbarFadingEnabled: Boolean,
@@ -40,8 +40,8 @@ public data class MessageInputViewStyle(
     public val mentionsUsernameTextStyle: TextStyle,
     public val mentionsNameTextStyle: TextStyle,
     public val mentionsIcon: Drawable,
-    @ColorRes public val backgroundColor: Int,
-    @ColorRes public val suggestionsBackground: Int,
+    @ColorInt public val backgroundColor: Int,
+    @ColorInt public val suggestionsBackground: Int,
     public val editTextBackgroundDrawable: Drawable,
     public val customCursorDrawable: Drawable?,
     public val attachmentMaxFileSize: Int,


### PR DESCRIPTION
[CAS-817](https://stream-io.atlassian.net/browse/CAS-817)

### Description

Documentation for `MessageInputViewStyle` and how to change `MessageInputView` layout programatically.

See https://getstream.io/nessy/docs/chat_docs/android_chat_ux/message_input_view

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
