### PR TITLE
[CAS-585] Feature - Refactor chat error

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
@@ -3,38 +3,33 @@ package io.getstream.chat.android.livedata
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
 import io.getstream.chat.android.client.errors.ChatNetworkError
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.extensions.isPermanent
 import org.junit.Test
 import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
-internal class ChatErrorTest : BaseConnectedIntegrationTest() {
-    // https://getstream.io/chat/docs/api_errors_response/?language=js
+internal class ChatErrorTest {
+
     @Test
     fun invalidMessageInput() {
-        val message = Message(text = "hi", id = "thesame")
-        client.sendMessage("messaging", data.channel1.id, message).execute()
-        // this will always fail since the id is the same
-        val result2 = client.sendMessage("messaging", data.channel1.id, message).execute()
-        val error = result2.error()
+        val error = ChatNetworkError.create(4, "a message with ID thesame already exists", 400, null)
         Truth.assertThat(error.isPermanent()).isTrue()
     }
 
     @Test
-    fun rateLimit() {
+    fun `rateLimit error should be temporary`() {
         val error = ChatNetworkError.create(9, "", 429, null)
         Truth.assertThat(error.isPermanent()).isFalse()
     }
 
     @Test
-    fun `request timeout should be temporary`() {
+    fun `request timeout should be a temporary error`() {
         val error = ChatNetworkError.create(23, "", 408, null)
         Truth.assertThat(error.isPermanent()).isFalse()
     }
 
     @Test
-    fun brokenAPI() {
+    fun `broken api should be a temporary error`() {
         val error = ChatNetworkError.create(0, "", 500, null)
         Truth.assertThat(error.isPermanent()).isFalse()
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/ChatErrorTest.kt
@@ -11,8 +11,8 @@ import org.junit.runner.RunWith
 internal class ChatErrorTest {
 
     @Test
-    fun invalidMessageInput() {
-        val error = ChatNetworkError.create(4, "a message with ID thesame already exists", 400, null)
+    fun `error for messages with the same ID should be permanent`() {
+        val error = ChatNetworkError.create(4, "a message with ID the same id already exists", 400, null)
         Truth.assertThat(error.isPermanent()).isTrue()
     }
 


### PR DESCRIPTION
[CAS-585](https://stream-io.atlassian.net/browse/CAS-585)

### Description

Refactoring `ChatErrorTest`  so it is no longer a integration test. No need to test chatClient with 2 message of the same ID, that test was only testing the API. 
### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Reviewers added
