### PR TITLE
[CAS-836] Message borders attributes

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -123,6 +123,7 @@ It is possible now to configure the max size of the file upload using
     - Reactions style in list view and in options view
     - Indicator icons in footer of Message
     - Unread count badge on scroll to bottom button
+    - Message stroke width and color for mine and theirs types
 It is now possible to customize the following attributes for `ChannelListView`:
 - `streamUiChannelOptionsIcon` - customize options icon
 - `streamUiChannelDeleteIcon` - customize delete icon

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -963,7 +963,7 @@ public final class io/getstream/chat/android/ui/message/input/viewmodel/MessageI
 
 public final class io/getstream/chat/android/ui/message/list/MessageListItemStyle : java/io/Serializable {
 	public static final field Companion Lio/getstream/chat/android/ui/message/list/MessageListItemStyle$Companion;
-	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;I)V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;IIFIF)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component10 ()Z
 	public final fun component11 ()I
@@ -984,15 +984,19 @@ public final class io/getstream/chat/android/ui/message/list/MessageListItemStyl
 	public final fun component25 ()I
 	public final fun component26 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component27 ()I
+	public final fun component28 ()I
+	public final fun component29 ()F
 	public final fun component3 ()Ljava/lang/Integer;
+	public final fun component30 ()I
+	public final fun component31 ()F
 	public final fun component4 ()Ljava/lang/Integer;
 	public final fun component5 ()Ljava/lang/Integer;
 	public final fun component6 ()Ljava/lang/Integer;
 	public final fun component7 ()I
 	public final fun component8 ()I
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;I)Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;IILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;IIFIF)Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;IIILio/getstream/chat/android/ui/common/style/TextStyle;IIFIFILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDateSeparatorBackgroundColor ()I
 	public final fun getEditReactionsViewStyle ()Lio/getstream/chat/android/ui/message/list/reactions/edit/EditReactionsViewStyle;
@@ -1007,6 +1011,10 @@ public final class io/getstream/chat/android/ui/message/list/MessageListItemStyl
 	public final fun getMessageLinkBackgroundColorTheirs ()I
 	public final fun getMessageLinkTextColorMine ()Ljava/lang/Integer;
 	public final fun getMessageLinkTextColorTheirs ()Ljava/lang/Integer;
+	public final fun getMessageStrokeColorMine ()I
+	public final fun getMessageStrokeColorTheirs ()I
+	public final fun getMessageStrokeWidthMine ()F
+	public final fun getMessageStrokeWidthTheirs ()F
 	public final fun getMessageTextColorMine ()Ljava/lang/Integer;
 	public final fun getMessageTextColorTheirs ()Ljava/lang/Integer;
 	public final fun getReactionsEnabled ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
@@ -8,6 +8,7 @@ import androidx.annotation.StyleableRes
 import androidx.core.content.res.ResourcesCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
+import io.getstream.chat.android.ui.common.extensions.internal.dpToPxPrecise
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.style.TextStyle
@@ -45,6 +46,10 @@ public data class MessageListItemStyle(
     public val iconIndicatorPendingSync: Int,
     public val textStyleMessageDeleted: TextStyle,
     @ColorInt public val messageDeletedBackground: Int,
+    @ColorInt public val messageStrokeColorMine: Int,
+    public val messageStrokeWidthMine: Float,
+    @ColorInt public val messageStrokeColorTheirs: Int,
+    public val messageStrokeWidthTheirs: Float,
 ) : Serializable {
 
     @ColorInt
@@ -80,6 +85,11 @@ public data class MessageListItemStyle(
 
         internal val DEFAULT_TEXT_COLOR_DATE_SEPARATOR = R.color.stream_ui_white
         internal val DEFAULT_TEXT_SIZE_DATE_SEPARATOR = R.dimen.stream_ui_text_small
+
+        internal val MESSAGE_STROKE_COLOR_MINE = R.color.stream_ui_literal_transparent
+        internal const val MESSAGE_STROKE_WIDTH_MINE: Float = 0f
+        internal val MESSAGE_STROKE_COLOR_THEIRS = R.color.stream_ui_grey_whisper
+        internal val MESSAGE_STROKE_WIDTH_THEIRS: Float = 1.dpToPxPrecise()
     }
 
     internal class Builder(private val attributes: TypedArray, private val context: Context) {
@@ -349,6 +359,28 @@ public data class MessageListItemStyle(
                 .style(R.styleable.MessageListView_streamUiMessageTextStyleMessageDeleted, Typeface.ITALIC)
                 .build()
 
+            val messageStrokeColorMine = attributes.getColor(
+                R.styleable.MessageListView_streamUiMessageStrokeColorMine,
+                context.getColorCompat(MESSAGE_STROKE_COLOR_MINE)
+            )
+            val messageStrokeWidthMine =
+                attributes.getDimension(
+                    R.styleable.MessageListView_streamUiMessageStrokeWidthMine,
+                    MESSAGE_STROKE_WIDTH_MINE
+                )
+            val messageStrokeColorTheirs =
+                attributes.getColor(
+                    R.styleable.MessageListView_streamUiMessageStrokeColorTheirs,
+                    context.getColorCompat(
+                        MESSAGE_STROKE_COLOR_THEIRS
+                    )
+                )
+            val messageStrokeWidthTheirs =
+                attributes.getDimension(
+                    R.styleable.MessageListView_streamUiMessageStrokeWidthTheirs,
+                    MESSAGE_STROKE_WIDTH_THEIRS
+                )
+
             return MessageListItemStyle(
                 messageBackgroundColorMine = messageBackgroundColorMine.nullIfNotSet(),
                 messageBackgroundColorTheirs = messageBackgroundColorTheirs.nullIfNotSet(),
@@ -377,6 +409,10 @@ public data class MessageListItemStyle(
                 iconIndicatorPendingSync = iconIndicatorPendingSync,
                 messageDeletedBackground = messageDeletedBackground,
                 textStyleMessageDeleted = textStyleMessageDeleted,
+                messageStrokeColorMine = messageStrokeColorMine,
+                messageStrokeWidthMine = messageStrokeWidthMine,
+                messageStrokeColorTheirs = messageStrokeColorTheirs,
+                messageStrokeWidthTheirs = messageStrokeWidthTheirs,
             ).let(TransformStyle.messageListItemStyleTransformer::transform)
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/BackgroundDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/BackgroundDecorator.kt
@@ -74,7 +74,9 @@ internal class BackgroundDecorator(val style: MessageListItemStyle) : BaseDecora
         view.background = MaterialShapeDrawable(shapeAppearanceModel).apply {
             val hasLink = data.message.attachments.any(Attachment::hasLink)
             if (data.isMine) {
-                paintStyle = Paint.Style.FILL
+                paintStyle = Paint.Style.FILL_AND_STROKE
+                setStrokeTint(style.messageStrokeColorMine)
+                strokeWidth = style.messageStrokeWidthMine
                 // for messages with links, we use a different background color than other messages by default.
                 // however, if a user has specified a background color attribute, we use it for _all_ message backgrounds.
                 val backgroundTintColor = if (hasLink) {
@@ -89,8 +91,8 @@ internal class BackgroundDecorator(val style: MessageListItemStyle) : BaseDecora
                 setTint(backgroundTintColor)
             } else {
                 paintStyle = Paint.Style.FILL_AND_STROKE
-                setStrokeTint(ContextCompat.getColor(view.context, MESSAGE_OTHER_STROKE_COLOR))
-                strokeWidth = DEFAULT_STROKE_WIDTH
+                setStrokeTint(style.messageStrokeColorTheirs)
+                strokeWidth = style.messageStrokeWidthTheirs
 
                 val backgroundTintColor = if (hasLink) {
                     style.messageLinkBackgroundColorTheirs
@@ -107,10 +109,8 @@ internal class BackgroundDecorator(val style: MessageListItemStyle) : BaseDecora
     }
 
     companion object {
-        private val MESSAGE_OTHER_STROKE_COLOR = R.color.stream_ui_grey_whisper
         private val MESSAGE_OTHER_USER_BACKGROUND = R.color.stream_ui_white
         private val MESSAGE_CURRENT_USER_BACKGROUND = R.color.stream_ui_grey_gainsboro
-        private val DEFAULT_STROKE_WIDTH = 1.dpToPxPrecise()
         private val SMALL_CARD_VIEW_CORNER_RADIUS = 2.dpToPxPrecise()
         private val IMAGE_VIEW_CORNER_RADIUS = 8.dpToPxPrecise()
 

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -173,5 +173,10 @@
             <flag name="italic" value="2" />
         </attr>
 
+        <attr name="streamUiMessageStrokeColorMine" format="color" />
+        <attr name="streamUiMessageStrokeWidthMine" format="dimension|reference" />
+        <attr name="streamUiMessageStrokeColorTheirs" format="color" />
+        <attr name="streamUiMessageStrokeWidthTheirs" format="dimension|reference" />
+
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### Description

Message stroke attributes for color and width

![image](https://user-images.githubusercontent.com/11807573/112970292-57b6b380-914e-11eb-8a0b-d208d0540725.png)


### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
