### PR TITLE
Fix ScrollButtonStyles

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -443,14 +443,7 @@ public class MessageListView : ConstraintLayout {
             }
         }
 
-        with(binding.scrollToBottomButton) {
-            setUnreadBadgeEnabled(messageListViewStyle.scrollButtonViewStyle.scrollButtonUnreadEnabled)
-            setButtonRippleColor(messageListViewStyle.scrollButtonViewStyle.scrollButtonRippleColor)
-            setButtonIcon(messageListViewStyle.scrollButtonViewStyle.scrollButtonIcon)
-            setButtonColor(messageListViewStyle.scrollButtonViewStyle.scrollButtonColor)
-            setUnreadBadgeColor(messageListViewStyle.scrollButtonViewStyle.scrollButtonBadgeColor)
-            setUnreadBadgeTextStyle(messageListViewStyle.scrollButtonViewStyle.scrollButtonBadgeTextStyle)
-        }
+        binding.scrollToBottomButton.setScrollButtonViewStyle(messageListViewStyle.scrollButtonViewStyle)
         scrollHelper.scrollToBottomButtonEnabled = messageListViewStyle.scrollButtonViewStyle.scrollButtonEnabled
 
         NewMessagesBehaviour.parseValue(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
@@ -2,24 +2,19 @@ package io.getstream.chat.android.ui.message.list.internal
 
 import android.content.Context
 import android.content.res.ColorStateList
-import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.FrameLayout
-import androidx.annotation.ColorInt
 import androidx.core.view.isVisible
-import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiScrollButtonViewBinding
+import io.getstream.chat.android.ui.message.list.ScrollButtonViewStyle
 
 internal class ScrollButtonView : FrameLayout {
 
+    private lateinit var scrollButtonViewStyle: ScrollButtonViewStyle
+    private var unreadCount: Int = 0
     private val binding: StreamUiScrollButtonViewBinding =
         StreamUiScrollButtonViewBinding.inflate(LayoutInflater.from(context), this)
-
-    private var unreadBadgeEnabled: Boolean = true
-
-    private var unreadCount: Int = 0
-    private var isVisible: Boolean = false
 
     constructor(context: Context) : super(context)
 
@@ -31,28 +26,13 @@ internal class ScrollButtonView : FrameLayout {
         defStyleAttr
     )
 
-    fun setUnreadBadgeEnabled(enabled: Boolean) {
-        this.unreadBadgeEnabled = enabled
-    }
-
-    fun setButtonRippleColor(@ColorInt color: Int) {
-        binding.scrollActionButton.rippleColor = color
-    }
-
-    fun setButtonIcon(icon: Drawable?) {
-        binding.scrollActionButton.setImageDrawable(icon)
-    }
-
-    fun setButtonColor(@ColorInt color: Int) {
-        binding.scrollActionButton.backgroundTintList = ColorStateList.valueOf(color)
-    }
-
-    fun setUnreadBadgeColor(@ColorInt color: Int) {
-        binding.unreadCountTextView.backgroundTintList = ColorStateList.valueOf(color)
-    }
-
-    fun setUnreadBadgeTextStyle(textStyle: TextStyle) {
-        textStyle.apply(binding.unreadCountTextView)
+    fun setScrollButtonViewStyle(scrollButtonViewStyle: ScrollButtonViewStyle) {
+        this.scrollButtonViewStyle = scrollButtonViewStyle
+        binding.scrollActionButton.rippleColor = scrollButtonViewStyle.scrollButtonRippleColor
+        binding.scrollActionButton.setImageDrawable(scrollButtonViewStyle.scrollButtonIcon)
+        binding.scrollActionButton.backgroundTintList = ColorStateList.valueOf(scrollButtonViewStyle.scrollButtonColor)
+        binding.unreadCountTextView.backgroundTintList = ColorStateList.valueOf(scrollButtonViewStyle.scrollButtonBadgeColor)
+        scrollButtonViewStyle.scrollButtonBadgeTextStyle.apply(binding.unreadCountTextView)
     }
 
     override fun setOnClickListener(listener: OnClickListener?) {
@@ -60,7 +40,7 @@ internal class ScrollButtonView : FrameLayout {
     }
 
     fun setUnreadCount(unreadCount: Int) {
-        if (unreadBadgeEnabled) {
+        if (scrollButtonViewStyle.scrollButtonUnreadEnabled) {
             setUnreadCountValue(unreadCount)
             setUnreadCountTextViewVisible(unreadCount > 0)
         } else {
@@ -76,10 +56,7 @@ internal class ScrollButtonView : FrameLayout {
     }
 
     private fun setUnreadCountTextViewVisible(isVisible: Boolean) {
-        if (this.isVisible != isVisible) {
-            this.isVisible = isVisible
-            binding.unreadCountTextView.isVisible = isVisible
-        }
+        binding.unreadCountTextView.isVisible = isVisible
     }
 
     private fun formatUnreadCount(unreadCount: Int): CharSequence {

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_scroll_button_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_scroll_button_view.xml
@@ -14,12 +14,13 @@
         android:layout_centerHorizontal="true"
         android:layout_gravity="center_horizontal"
         android:layout_margin="@dimen/stream_ui_spacing_small"
-        android:backgroundTint="@color/stream_ui_literal_white"
-        android:src="@drawable/stream_ui_ic_down"
+        tools:backgroundTint="@color/stream_ui_literal_white"
+        tools:src="@drawable/stream_ui_ic_down"
+        app:tint="@null"
         app:borderWidth="0dp"
         app:elevation="3dp"
         app:fabCustomSize="@dimen/stream_ui_scroll_button_size"
-        app:rippleColor="@color/stream_ui_grey"
+        tools:rippleColor="@color/stream_ui_grey"
         tools:ignore="ContentDescription"
         />
 


### PR DESCRIPTION
### Description
Fix ScrollButtonStyles.
We are using internally Material FAB Button and for some reason, it applies a tint to any Drawable that has been previously tinted, the only way I have found "not to apply this tint" is by adding it as `null` on the xml as suggested [this comment](https://github.com/material-components/material-components-android/issues/1106#issuecomment-764739409)
Now, you can edit the ScrollButtonStyle in runtime by something like:

```
TransformStyle.scrollButtonStyleTransformer = StyleTransformer {
                scrollButtonViewStyle ->
            scrollButtonViewStyle.copy(
                scrollButtonColor = getColor(android.R.color.holo_green_light),
                scrollButtonIcon = scrollButtonViewStyle.scrollButtonIcon
                    ?.mutate()?.apply {
                    DrawableCompat.setTint(this, getColor(android.R.color.holo_red_dark))
                },
                scrollButtonBadgeColor = getColor(android.R.color.holo_blue_bright),
                scrollButtonBadgeTextStyle = scrollButtonViewStyle.scrollButtonBadgeTextStyle.copy(
                    color = getColor(android.R.color.holo_green_dark)
                )
            )
        }
```

| Before | After |
| --- | --- |
| ![photo_2021-03-30_17-44-47](https://user-images.githubusercontent.com/4047514/113017356-a6307600-917f-11eb-9caf-9701335b1f0b.jpg) | ![photo_2021-03-30_17-44-50](https://user-images.githubusercontent.com/4047514/113017372-aaf52a00-917f-11eb-882b-9c1f264e2db3.jpg) | 

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Reviewers added
