### PR TITLE
[CAS-594] Keystroke tests

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/usecase/KeystrokeImplTest.kt
@@ -1,21 +1,69 @@
 package io.getstream.chat.android.livedata.usecase
 
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth
-import io.getstream.chat.android.livedata.BaseConnectedIntegrationTest
-import kotlinx.coroutines.test.runBlockingTest
-import org.junit.Test
-import org.junit.runner.RunWith
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.controller.ChannelControllerImpl
+import io.getstream.chat.android.test.randomCID
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 
-@RunWith(AndroidJUnit4::class)
-internal class KeystrokeImplTest : BaseConnectedIntegrationTest() {
+@ExperimentalCoroutinesApi
+internal class KeystrokeImplTest {
+
+    private lateinit var chatDomainImpl: ChatDomainImpl
+    private lateinit var sut: KeystrokeImpl
+
+    @BeforeEach
+    fun before() {
+        chatDomainImpl = mock()
+        sut = KeystrokeImpl(chatDomainImpl)
+    }
 
     @Test
-    fun keystroke() = runBlockingTest {
-        var channelState = chatDomain.useCases.watchChannel(data.channel1.cid, 10).execute().data()
-        val result = chatDomain.useCases.keystroke(data.channel1.cid).execute()
+    fun `Given empty cid When invoke Should throw exception`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            sut.invoke(cid = "")
+        }
+    }
+
+    @Test
+    fun `Given inappropriate formatted cid When invoke Should throw exception`() {
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            sut.invoke(cid = "31dse1")
+        }
+    }
+
+    @Test
+    fun `Given appropriate cid When invoke Should invoke keystroke to channel controller`() {
+        val channelController = mock<ChannelControllerImpl>()
+        whenever(chatDomainImpl.channel(any<String>())) doReturn channelController
+        whenever(chatDomainImpl.scope) doReturn TestCoroutineScope()
+
+        sut.invoke(cid = randomCID(), parentId = null).execute()
+
+        verify(channelController).keystroke(null)
+    }
+
+    @Test
+    fun `Given appropriate cid When invoke Should invoke keystroke to chat domain`() {
+        val channelController = mock<ChannelControllerImpl> {
+            on { keystroke(null) } doReturn Result(true)
+        }
+        whenever(chatDomainImpl.channel(any<String>())) doReturn channelController
+        whenever(chatDomainImpl.scope) doReturn TestCoroutineScope()
+
+        val result = sut.invoke(cid = randomCID(), parentId = null).execute()
+
+        Truth.assertThat(result.isSuccess).isTrue()
         Truth.assertThat(result.data()).isTrue()
-        val result2 = chatDomain.useCases.keystroke(data.channel1.cid).execute()
-        Truth.assertThat(result2.data()).isFalse()
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
@@ -4,8 +4,9 @@ import androidx.annotation.CallSuper
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.livedata.ChatDomainImpl
-import io.getstream.chat.android.livedata.controller.helper.MessageHelper
+import io.getstream.chat.android.livedata.repository.RepositoryFacade
 import io.getstream.chat.android.offline.channel.ChannelController
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineScope
@@ -14,20 +15,27 @@ import org.junit.jupiter.api.BeforeEach
 internal open class BaseChannelControllerTests {
     protected val channelType = "channelType"
     protected val channelId = "channelId"
+    protected val cid: String
+        get() = "$channelType:$channelId"
     protected lateinit var sut: ChannelController
     protected lateinit var chatClient: ChatClient
     protected lateinit var chatDomainImpl: ChatDomainImpl
-    protected lateinit var messageHelper: MessageHelper
+    protected lateinit var channelClient: ChannelClient
+    protected lateinit var repos: RepositoryFacade
 
     @ExperimentalCoroutinesApi
     @BeforeEach
     @CallSuper
     open fun before() {
-        chatClient = mock()
+        repos = mock()
+        channelClient = mock()
+        chatClient = mock {
+            on { channel(channelType, channelId) } doReturn channelClient
+        }
         chatDomainImpl = mock {
             on { scope } doReturn TestCoroutineScope()
+            on { repos } doReturn repos
         }
-        messageHelper = mock()
-        sut = ChannelController(channelType, channelId, chatClient, chatDomainImpl, messageHelper)
+        sut = ChannelController(channelType, channelId, chatClient, chatDomainImpl)
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
@@ -1,0 +1,33 @@
+package io.getstream.chat.android.offline.channel.controller
+
+import androidx.annotation.CallSuper
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.livedata.ChatDomainImpl
+import io.getstream.chat.android.livedata.controller.helper.MessageHelper
+import io.getstream.chat.android.offline.channel.ChannelController
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.jupiter.api.BeforeEach
+
+internal open class BaseChannelControllerTests {
+    protected val channelType = "channelType"
+    protected val channelId = "channelId"
+    protected lateinit var sut: ChannelController
+    protected lateinit var chatClient: ChatClient
+    protected lateinit var chatDomainImpl: ChatDomainImpl
+    protected lateinit var messageHelper: MessageHelper
+
+    @ExperimentalCoroutinesApi
+    @BeforeEach
+    @CallSuper
+    open fun before() {
+        chatClient = mock()
+        chatDomainImpl = mock {
+            on { scope } doReturn TestCoroutineScope()
+        }
+        messageHelper = mock()
+        sut = ChannelController(channelType, channelId, chatClient, chatDomainImpl, messageHelper)
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenHide.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenHide.kt
@@ -1,4 +1,4 @@
-package io.getstream.chat.android.offline.channel
+package io.getstream.chat.android.offline.channel.controller
 
 import com.google.common.truth.Truth
 import com.nhaarman.mockitokotlin2.any
@@ -14,6 +14,7 @@ import io.getstream.chat.android.livedata.ChatDomainImpl
 import io.getstream.chat.android.livedata.randomMessage
 import io.getstream.chat.android.livedata.randomUser
 import io.getstream.chat.android.livedata.repository.RepositoryFacade
+import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.randomDateBefore
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import java.util.Date
 
 @ExperimentalCoroutinesApi
-internal class ChannelControllerHideChannelTest {
+internal class WhenHide {
 
     companion object {
         @JvmField
@@ -68,7 +69,7 @@ internal class ChannelControllerHideChannelTest {
     }
 
     @Test
-    fun `When hiding channel Should mark it as hidden`() = runBlockingTest {
+    fun `Should mark channel as hidden`() = runBlockingTest {
         val response = Result(Unit)
         whenever(channelClient.hide(any())).thenReturn(TestCall(response))
 
@@ -79,7 +80,7 @@ internal class ChannelControllerHideChannelTest {
     }
 
     @Test
-    fun `Given failed response When hiding channel Should return server error`() =
+    fun `Given failed response Should return server error`() =
         runBlockingTest {
             val response = Result<Unit>(error = ChatError())
             whenever(channelClient.hide(any())).thenReturn(TestCall(response))
@@ -90,7 +91,7 @@ internal class ChannelControllerHideChannelTest {
         }
 
     @Test
-    fun `Given successful response When hiding channel without clearing history Should update channel in database`() =
+    fun `Given successful response And channel without clearing history Should update channel in database`() =
         runBlockingTest {
             val response = Result(Unit)
             whenever(channelClient.hide(any())).thenReturn(TestCall(response))
@@ -103,7 +104,7 @@ internal class ChannelControllerHideChannelTest {
         }
 
     @Test
-    fun `Given successful response When hiding channel with clearing history Should hide messages sent before`() =
+    fun `Given successful response And channel with clearing history Should hide messages sent before`() =
         runBlockingTest {
             val response = Result(Unit)
             whenever(channelClient.hide(any())).thenReturn(TestCall(response))
@@ -115,7 +116,7 @@ internal class ChannelControllerHideChannelTest {
         }
 
     @Test
-    fun `Given successful response When hiding channel with clearing history Should update channel in database`() =
+    fun `Given successful response And channel with clearing history Should update channel in database`() =
         runBlockingTest {
             val response = Result(Unit)
             whenever(channelClient.hide(any())).thenReturn(TestCall(response))
@@ -133,7 +134,7 @@ internal class ChannelControllerHideChannelTest {
         }
 
     @Test
-    fun `Given successful response When hiding channel with clearing history Should delete hidden messages from database`() =
+    fun `Given successful response And channel with clearing history Should delete hidden messages from database`() =
         runBlockingTest {
             val response = Result(Unit)
             whenever(channelClient.hide(any())).thenReturn(TestCall(response))
@@ -150,7 +151,7 @@ internal class ChannelControllerHideChannelTest {
         }
 
     @Test
-    fun `Given successful response When hiding channel with clearing history Should clear messages sent before channel was hidden`() =
+    fun `Given successful response And channel with clearing history Should clear messages sent before channel was hidden`() =
         runBlockingTest {
             val now = Date().time
             val response = Result(Unit)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
@@ -2,8 +2,19 @@ package io.getstream.chat.android.offline.channel.controller
 
 import com.google.common.truth.Truth
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.reset
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import io.getstream.chat.android.client.channel.ChannelClient
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.randomConfig
+import io.getstream.chat.android.test.TestCall
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.jupiter.api.Test
 
 internal class WhenKeystroke : BaseChannelControllerTests() {
@@ -16,5 +27,77 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
 
         Truth.assertThat(result.isSuccess).isTrue()
         Truth.assertThat(result.data()).isFalse()
+    }
+
+    @Test
+    fun `Given config with typing events And not null parentId And no keystroke before Should invoke keystroke with parentId to ChannelClient`() {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = true)
+        val channelClient = mock<ChannelClient> {
+            on { keystroke("parentId") } doReturn TestCall(Result(mock()))
+        }
+        whenever(chatClient.channel(channelType, channelId)) doReturn channelClient
+
+        sut.keystroke("parentId")
+
+        verify(channelClient).keystroke("parentId")
+    }
+
+    @Test
+    fun `Given config with typing events And null parentId And no keystroke before Should invoke keystroke without parentId to ChannelClient`() {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = true)
+        val channelClient = mock<ChannelClient> {
+            on { keystroke() } doReturn TestCall(Result(mock()))
+        }
+        whenever(chatClient.channel(channelType, channelId)) doReturn channelClient
+
+        sut.keystroke(null)
+
+        verify(channelClient).keystroke()
+    }
+
+    @Test
+    fun `Given config with typing events And successful response And no keystroke before Should return result with True`() {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = true)
+        val channelClient = mock<ChannelClient> {
+            on { keystroke() } doReturn TestCall(Result(mock<ChatEvent>()))
+        }
+        whenever(chatClient.channel(channelType, channelId)) doReturn channelClient
+
+        val result = sut.keystroke(null)
+
+        Truth.assertThat(result.isSuccess).isTrue()
+        Truth.assertThat(result.data()).isTrue()
+    }
+
+    @Test
+    fun `Given config with typing events And failed response And no keystroke before Should return result with error`() {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = true)
+        val channelClient = mock<ChannelClient> {
+            on { keystroke() } doReturn TestCall(Result(mock<ChatError>()))
+        }
+        whenever(chatClient.channel(channelType, channelId)) doReturn channelClient
+
+        val result = sut.keystroke(null)
+
+        Truth.assertThat(result.isSuccess).isFalse()
+        Truth.assertThat(result.error()).isNotNull()
+    }
+
+    @Test
+    fun `Given first keystroke less than 3 sec ago Should return result with false`() = runBlockingTest {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = true)
+        val channelClient = mock<ChannelClient> {
+            on { keystroke() } doReturn TestCall(Result(mock<ChatEvent>()))
+        }
+        whenever(chatClient.channel(channelType, channelId)) doReturn channelClient
+        sut.keystroke(null)
+        delay(2000L)
+        reset(chatClient)
+
+        val result = sut.keystroke(null)
+
+        Truth.assertThat(result.isSuccess).isTrue()
+        Truth.assertThat(result.data()).isFalse()
+        verify(chatClient, never()).channel(channelType, channelId)
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
@@ -31,11 +31,10 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
 
     @Test
     fun `Given config with typing events And not null parentId And no keystroke before Should invoke keystroke with parentId to ChannelClient`() {
-        val channelClient = mock<ChannelClient>()
         Fixture()
             .givenTypingEvents(true)
             .givenParentId("parentId")
-            .givenSuccessfulResponse(channelClient)
+            .givenSuccessfulResponse()
 
         sut.keystroke("parentId")
 
@@ -44,10 +43,9 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
 
     @Test
     fun `Given config with typing events And null parentId And no keystroke before Should invoke keystroke without parentId to ChannelClient`() {
-        val channelClient = mock<ChannelClient>()
         Fixture()
             .givenTypingEvents(true)
-            .givenSuccessfulResponse(channelClient)
+            .givenSuccessfulResponse()
 
         sut.keystroke(null)
 
@@ -59,7 +57,7 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
         val channelClient = mock<ChannelClient>()
         Fixture()
             .givenTypingEvents(true)
-            .givenSuccessfulResponse(channelClient)
+            .givenSuccessfulResponse()
 
         val result = sut.keystroke(null)
 
@@ -72,7 +70,7 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
         val channelClient = mock<ChannelClient>()
         Fixture()
             .givenTypingEvents(true)
-            .givenFailedResponse(channelClient)
+            .givenFailedResponse()
 
         val result = sut.keystroke(null)
 
@@ -103,24 +101,20 @@ internal class WhenKeystroke : BaseChannelControllerTests() {
             this.parentId = parentId
         }
 
-        fun givenSuccessfulResponse(mockChannelClient: ChannelClient) = apply {
+        fun givenSuccessfulResponse() = apply {
             if (parentId != null) {
-                whenever(mockChannelClient.keystroke(parentId!!)) doReturn TestCall(Result(mock<ChatEvent>()))
+                whenever(channelClient.keystroke(parentId!!)) doReturn TestCall(Result(mock<ChatEvent>()))
             } else {
-                whenever(mockChannelClient.keystroke()) doReturn TestCall(Result(mock<ChatEvent>()))
+                whenever(channelClient.keystroke()) doReturn TestCall(Result(mock<ChatEvent>()))
             }
-
-            whenever(chatClient.channel(channelType, channelId)) doReturn mockChannelClient
         }
 
-        fun givenFailedResponse(mockChannelClient: ChannelClient) = apply {
+        fun givenFailedResponse() = apply {
             if (parentId != null) {
-                whenever(mockChannelClient.keystroke(parentId!!)) doReturn TestCall(Result(mock<ChatError>()))
+                whenever(channelClient.keystroke(parentId!!)) doReturn TestCall(Result(mock<ChatError>()))
             } else {
-                whenever(mockChannelClient.keystroke()) doReturn TestCall(Result(mock<ChatError>()))
+                whenever(channelClient.keystroke()) doReturn TestCall(Result(mock<ChatError>()))
             }
-
-            whenever(chatClient.channel(channelType, channelId)) doReturn mockChannelClient
         }
 
         suspend fun givenKeystrokeBefore(keystrokeBefore: Long) = givenTypingEvents(true).apply {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenKeystroke.kt
@@ -1,0 +1,20 @@
+package io.getstream.chat.android.offline.channel.controller
+
+import com.google.common.truth.Truth
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
+import io.getstream.chat.android.livedata.randomConfig
+import org.junit.jupiter.api.Test
+
+internal class WhenKeystroke : BaseChannelControllerTests() {
+
+    @Test
+    fun `Given config without typing events Should return false result`() {
+        whenever(chatDomainImpl.getChannelConfig(channelType)) doReturn randomConfig(isTypingEvents = false)
+
+        val result = sut.keystroke(null)
+
+        Truth.assertThat(result.isSuccess).isTrue()
+        Truth.assertThat(result.data()).isFalse()
+    }
+}


### PR DESCRIPTION
### Description

Rewrite keystroke tests:
1) Rewrite tests for use case (later we can move them to `ChatDomain` when use cases are deprecated)
2) Write tests for `ChannelController::keystroke`
3) Create base class with dependencies for `BaseChannelControllerTests`
4) Refactor `ChannelController::hide` tests rebasing them on the base class

### Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Reviewers added
