### PR TITLE
[CAS-839] Fix - Customise background for message list header view

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -59,7 +59,8 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-Fixed attr streamUiCopyMessageActionEnabled. From color to boolean. 
+Fixed attr streamUiCopyMessageActionEnabled. From color to boolean.
+Now it is possible to change the color of `MessageListHeaderView` from the XML.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
@@ -26,7 +26,7 @@ import io.getstream.chat.android.ui.databinding.StreamUiMessageListHeaderViewBin
 public class MessageListHeaderView : ConstraintLayout {
 
     private val binding: StreamUiMessageListHeaderViewBinding =
-        StreamUiMessageListHeaderViewBinding.inflate(LayoutInflater.from(context), this, true)
+        StreamUiMessageListHeaderViewBinding.inflate(LayoutInflater.from(context), this)
 
     private var subtitleState: SubtitleState = SubtitleState(emptyList(), OnlineState.NONE)
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_header_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_header_view.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/stream_ui_default_header_height"
-    android:background="@color/stream_ui_white"
+    android:layout_height="wrap_content"
+    tools:parentTag="androidx.constraintlayout.widget.ConstraintLayout"
     >
 
     <androidx.constraintlayout.widget.ConstraintLayout
@@ -66,7 +66,6 @@
         android:id="@+id/subtitleContainer"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginBottom="8dp"
         app:layout_constraintLeft_toLeftOf="@+id/back_button_container"
         app:layout_constraintRight_toRightOf="@+id/avatar"
         app:layout_constraintTop_toBottomOf="@+id/title"
@@ -79,6 +78,7 @@
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
+            android:layout_marginBottom="8dp"
             >
 
             <ProgressBar
@@ -106,6 +106,7 @@
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
+            android:layout_marginBottom="8dp"
             >
 
             <TextView
@@ -135,6 +136,7 @@
             android:gravity="center"
             android:orientation="horizontal"
             android:visibility="gone"
+            android:layout_marginBottom="8dp"
             >
 
             <io.getstream.chat.android.ui.typing.TypingIndicatorView
@@ -150,6 +152,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
+            android:layout_marginBottom="8dp"
             >
 
             <TextView
@@ -185,4 +188,4 @@
         app:layout_constraintStart_toStartOf="parent"
         />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</merge>


### PR DESCRIPTION
[CAS-839](https://stream-io.atlassian.net/browse/CAS-839)

### 🎯 Goal

Make `MessageListHeaderView` background customisable. Now it is possible to customise the background when declaring the view. using `android:background` field. 

This problem was pointed in this issue: #1656

### 🛠 Implementation details

Now we use <merge> instead of `ConstraintLayout` as the root view of the `StreamUiMessageListHeaderViewBinding` which is correct since `MessageListHeaderView` is already a `ConstraintLayout`

### 🎨 UI Changes

Now you can change the background of the header view:

![Screenshot_20210401-114123](https://user-images.githubusercontent.com/10619102/113311214-713b3500-92df-11eb-8ef5-54c096754bbf.png)
_Red is probably not a good color for this o.O_
### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~~
- [x] Reviewers added

