### PR TITLE
[CAS-845] Fix - Customise back button for message list header view

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -59,11 +59,11 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-Fixed attr streamUiCopyMessageActionEnabled. From color to boolean. 
+Fixed attr streamUiCopyMessageActionEnabled. From color to boolean.
 ### ⬆️ Improved
 
 ### ✅ Added
-
+Now it is possible to change the back button of MessageListHeaderView using `app:streamUiMessageListHeaderBackButtonIcon`
 ### ⚠️ Changed
 
 ### ❌ Removed

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
@@ -19,6 +19,7 @@ import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.EMPTY
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.setTextSizePx
 import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiMessageListHeaderViewBinding
@@ -310,6 +311,12 @@ public class MessageListHeaderView : ConstraintLayout {
             isVisible = showBackButton
             isClickable = showBackButton
         }
+
+        val backIcon = attrs.getDrawable(R.styleable.MessageListHeaderView_streamUiMessageListHeaderBackButtonIcon)
+            ?: context.getDrawableCompat(R.drawable.stream_ui_arrow_left)
+
+        binding.backButton.setImageDrawable(backIcon)
+
         binding.backButtonBadge.apply {
             isVisible =
                 attrs.getBoolean(R.styleable.MessageListHeaderView_streamUiMessageListHeaderShowBackButtonBadge, false)

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_header_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_header_view.xml
@@ -50,5 +50,6 @@
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
+        <attr name="streamUiMessageListHeaderBackButtonIcon" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
[CAS-845](https://stream-io.atlassian.net/browse/CAS-845)

### 🎯 Goal

Making a way to change the back button of `MessageListHeaderView`.

### 🛠 Implementation details

Adding the customisation with XML styles. 

### 🎨 UI Changes

Now you can do this: 

![Untitled](https://user-images.githubusercontent.com/10619102/113357994-5a1a3880-931b-11eb-8fd9-33e9a70e791b.png)
I know, right? =D

### 🧪 Testing

Change the icon using: `app:streamUiMessageListHeaderBackButtonIcon`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes. Todo
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/113358051-74541680-931b-11eb-9c3b-114d6a1db416.gif)
_Paint it the way you prefer_