### PR TITLE
[CAS-846] Create a fallback SharedPreferences in case the Encrypted one is not available

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fix Crash on some devices that are not able to create an Encrypted SharedPreferences
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/EncryptedBackgroundSyncConfigStore.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/service/sync/EncryptedBackgroundSyncConfigStore.kt
@@ -4,27 +4,38 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import io.getstream.chat.android.client.logger.ChatLogger
 
 private const val MASTER_KEY_ALIAS = "_stream_sync_config_master_key_"
-private const val SYNC_CONFIG_PREFS_NAME = "stream_livedata_sync_config_store"
+private const val ENCRYPTED_SYNC_CONFIG_PREFS_NAME = "stream_livedata_sync_config_store"
+private const val SYNC_CONFIG_PREFS_NAME = ".stream_livedata_sync_config_store"
 private const val KEY_API_KEY = "api_key"
 private const val KEY_USER_ID = "user_id"
 private const val KEY_USER_TOKEN = "user_token"
 
 internal class EncryptedBackgroundSyncConfigStore(context: Context) {
     private val prefs: SharedPreferences
+    private val logger = ChatLogger.get("EncryptedBackgroundSyncConfigStore")
 
     init {
         val masterKey = MasterKey.Builder(context, MASTER_KEY_ALIAS)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
             .build()
-        prefs = EncryptedSharedPreferences.create(
-            context,
-            SYNC_CONFIG_PREFS_NAME,
-            masterKey,
-            EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
-            EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
-        )
+        prefs = try {
+            EncryptedSharedPreferences.create(
+                context,
+                ENCRYPTED_SYNC_CONFIG_PREFS_NAME,
+                masterKey,
+                EncryptedSharedPreferences.PrefKeyEncryptionScheme.AES256_SIV,
+                EncryptedSharedPreferences.PrefValueEncryptionScheme.AES256_GCM
+            )
+        } catch (e: Exception) {
+            logger.logE("Error creating encrypted shared preferences", e)
+            context.applicationContext.getSharedPreferences(
+                SYNC_CONFIG_PREFS_NAME,
+                Context.MODE_PRIVATE
+            )
+        }
     }
 
     fun put(config: BackgroundSyncConfig) {


### PR DESCRIPTION
### 🎯 Goal
Some emulators and some Android devices are not able to created an Encrypted Shared Preferences throwing an error that is not handled. On case we are not able to generated an Encrypted Shared Preferences we fallback to a normal Shared Preferences instance

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added
