### PR TITLE
Improve Moshi error logging

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
@@ -34,6 +34,6 @@ internal fun DownstreamUserDto.toDomain(): User =
         unreadChannels = unread_channels,
         mutes = mutes.map(DownstreamMuteDto::toDomain),
         teams = teams,
-        channelMutes = channel_mutes.map(DownstreamChannelMuteDto::toDomain),
+        channelMutes = channel_mutes.orEmpty().map(DownstreamChannelMuteDto::toDomain),
         extraData = extraData.toMutableMap(),
     )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -39,7 +39,7 @@ internal data class DownstreamUserDto(
     val unread_count: Int = 0,
     val mutes: List<DownstreamMuteDto> = emptyList(),
     val teams: List<String> = emptyList(),
-    val channel_mutes: List<DownstreamChannelMuteDto> = emptyList(),
+    val channel_mutes: List<DownstreamChannelMuteDto>?,
 
     val extraData: Map<String, Any>,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -62,7 +62,7 @@ internal class MoshiChatParser : ChatParser {
     override fun configRetrofit(builder: Retrofit.Builder): Retrofit.Builder {
         return builder
             .addConverterFactory(MoshiUrlQueryPayloadFactory(moshi))
-            .addConverterFactory(MoshiConverterFactory.create(moshi))
+            .addConverterFactory(MoshiConverterFactory.create(moshi).withErrorLogging())
     }
 
     override fun toJson(any: Any): String {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiErrorLogging.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiErrorLogging.kt
@@ -1,0 +1,50 @@
+package io.getstream.chat.android.client.parser2
+
+import io.getstream.chat.android.client.logger.ChatLogger
+import okhttp3.RequestBody
+import okhttp3.ResponseBody
+import retrofit2.Converter
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+import java.lang.reflect.Type
+
+internal fun MoshiConverterFactory.withErrorLogging(): Converter.Factory {
+    val originalFactory = this
+    val logger = ChatLogger.get("NEW_SERIALIZATION_ERROR")
+
+    return object : Converter.Factory() {
+        override fun responseBodyConverter(
+            type: Type,
+            annotations: Array<out Annotation>,
+            retrofit: Retrofit,
+        ): Converter<ResponseBody, *> {
+            val originalConverter: Converter<ResponseBody, *> =
+                originalFactory.responseBodyConverter(type, annotations, retrofit)!!
+            return Converter { value ->
+                try {
+                    originalConverter.convert(value)
+                } catch (e: Throwable) {
+                    logger.logE(e)
+                    throw e
+                }
+            }
+        }
+
+        override fun requestBodyConverter(
+            type: Type,
+            parameterAnnotations: Array<out Annotation>,
+            methodAnnotations: Array<out Annotation>,
+            retrofit: Retrofit,
+        ): Converter<*, RequestBody>? {
+            return originalFactory.requestBodyConverter(type, parameterAnnotations, methodAnnotations, retrofit)
+        }
+
+        override fun stringConverter(
+            type: Type,
+            annotations: Array<out Annotation>,
+            retrofit: Retrofit,
+        ): Converter<*, String>? {
+            return originalFactory.stringConverter(type, annotations, retrofit)
+        }
+    }
+}

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/MapCall.kt
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 
 internal class MapCall<T : Any, K : Any>(
     private val call: Call<T>,
-    private val mapper: (T) -> K
+    private val mapper: (T) -> K,
 ) : Call<K> {
 
     protected var canceled = AtomicBoolean(false)


### PR DESCRIPTION
### 🎯 Goal

We currently have no logs when Moshi parsing fails, and in some cases this means they'll fail silently and produce odd behaviour. This PR makes it easier to notice and fix Moshi serialization related problems.

Also fixes a specific problem with `channel_mutes` occasionally being `null` in responses.

### 🛠 Implementation details

The `MoshiConverterFactory` that integrates Moshi parsing with Retrofit is wrapped with a new implementation that delegates to the old one, but logs errors when they happen.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/1RkDDoIVs3ntm/giphy.gif)