### PR TITLE
[CAS-853] Move empty view handling from binding to ChannelListView

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,8 +4,9 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `MessageListItemStyle#messageTextColorTheirs` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use Use MessageListItemStyle::textStyleTheirs::colorOrNull() instead |
-| `MessageListItemStyle#messageTextColorMine` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use Use MessageListItemStyle::textStyleMine::colorOrNull() instead |
+| `ChannelListView's empty state methods` <br/>*ui-components* | 2021.04.05 | 2021.04.19 ⌛ | 2021.05.05 ⌛ | These methods no longer need to be called directly, `setChannel` handles empty state changes automatically |
+| `MessageListItemStyle#messageTextColorTheirs` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use MessageListItemStyle::textStyleTheirs::colorOrNull() instead |
+| `MessageListItemStyle#messageTextColorMine` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use MessageListItemStyle::textStyleMine::colorOrNull() instead |
 | `com.getstream.sdk.chat.ChatUI`<br/>*ui-components* | 2021.03.19<br/>4.8.0 | 2021.04.19 ⌛ | 2021.05.19 ⌛ | Use the new ChatUI implementation `io.getstream.chat.android.ui.ChatUI`
 | `GetTotalUnreadCount#invoke`<br/> | 2021.03.17<br/>4.7.2  | 2021.04.17 ⌛ | 2021.05.17 ⌛ | Use ChatDomain::totalUnreadCount instead |
 | `GetUnreadChannelCount#invoke`<br/> | 2021.03.17<br/>4.7.2  | 2021.04.17 ⌛ | 2021.05.17 ⌛ | Use ChatDomain::channelUnreadCount instead |

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -62,10 +62,12 @@
 - Fixed attr streamUiCopyMessageActionEnabled. From color to boolean.
 - Now it is possible to change the color of `MessageListHeaderView` from the XML.
 - Fixed the `MessageListView::setUserClickListener` method.
+- Fixed bugs in handling empty states for `ChannelListView`. Deprecated manual methods for showing/hiding empty state changes.
+
 ### ⬆️ Improved
 
 ### ✅ Added
-Now it is possible to change the back button of MessageListHeaderView using `app:streamUiMessageListHeaderBackButtonIcon`
+- Now it is possible to change the back button of MessageListHeaderView using `app:streamUiMessageListHeaderBackButtonIcon`
 ### ⚠️ Changed
 
 ### ❌ Removed

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -219,6 +219,7 @@ public class ChannelListView @JvmOverloads constructor(
     public fun setChannels(channels: List<ChannelListItem>) {
         val filteredChannels = channels.filter(channelListItemPredicate::predicate)
 
+        @Suppress("DEPRECATION")
         if (filteredChannels.isEmpty()) {
             showEmptyStateView()
         } else {
@@ -245,10 +246,26 @@ public class ChannelListView @JvmOverloads constructor(
         this.simpleChannelListView.showLoadingMore(false)
     }
 
+    /**
+     * Shouldn't generally be called directly. Empty state updates are handled by
+     * [setChannels] automatically.
+     */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "setChannels handles these changes automatically"
+    )
     public fun showEmptyStateView() {
         this.emptyStateView.isVisible = true
     }
 
+    /**
+     * Shouldn't generally be called directly. Empty state updates are handled by
+     * [setChannels] automatically.
+     */
+    @Deprecated(
+        level = DeprecationLevel.WARNING,
+        message = "setChannels handles these changes automatically"
+    )
     public fun hideEmptyStateView() {
         this.emptyStateView.isVisible = false
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -16,6 +16,10 @@ import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.actions.internal.ChannelActionsDialogFragment
+import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelClickListener
+import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelListItemPredicate
+import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelLongClickListener
+import io.getstream.chat.android.ui.channel.list.ChannelListView.UserClickListener
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.SwipeViewHolder
@@ -213,7 +217,15 @@ public class ChannelListView @JvmOverloads constructor(
     }
 
     public fun setChannels(channels: List<ChannelListItem>) {
-        simpleChannelListView.setChannels(channels.filter(channelListItemPredicate::predicate))
+        val filteredChannels = channels.filter(channelListItemPredicate::predicate)
+
+        if (filteredChannels.isEmpty()) {
+            showEmptyStateView()
+        } else {
+            hideEmptyStateView()
+        }
+
+        simpleChannelListView.setChannels(filteredChannels)
     }
 
     public fun hideLoadingView() {
@@ -221,6 +233,7 @@ public class ChannelListView @JvmOverloads constructor(
     }
 
     public fun showLoadingView() {
+        hideEmptyStateView()
         this.loadingView.isVisible = true
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModelBinding.kt
@@ -9,30 +9,24 @@ import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 @JvmName("bind")
 public fun ChannelListViewModel.bindView(
     view: ChannelListView,
-    lifecycle: LifecycleOwner
+    lifecycle: LifecycleOwner,
 ) {
     state.observe(lifecycle) { channelState ->
         if (channelState.isLoading) {
-            view.hideEmptyStateView()
             view.showLoadingView()
         } else {
             view.hideLoadingView()
-            if (channelState.channels.isEmpty()) {
-                view.showEmptyStateView()
-            } else {
-                channelState
-                    .channels
-                    .map(ChannelListItem::ChannelItem)
-                    .let(view::setChannels)
-                view.hideEmptyStateView()
-            }
+            channelState
+                .channels
+                .map(ChannelListItem::ChannelItem)
+                .let(view::setChannels)
         }
     }
 
-    paginationState.observe(lifecycle) {
-        view.setPaginationEnabled(!it.endOfChannels && !it.loadingMore)
+    paginationState.observe(lifecycle) { paginationState ->
+        view.setPaginationEnabled(!paginationState.endOfChannels && !paginationState.loadingMore)
 
-        if (it.loadingMore) {
+        if (paginationState.loadingMore) {
             view.showLoadingMore()
         } else {
             view.hideLoadingMore()


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-853

Two related GitHub issues: #1658 #1673  

### 🎯 Goal

Bugs in how ChannelListView is displaying its empty view.

### 🛠 Implementation details

Our binding code for ChannelListView was handling when the empty view on it should be shown. This didn't take into account the internal filtering that ChannelListView performs with the predicate, and also had a bug where it didn't submit the new list to ChannelListView if it was empty.

### 🧪 Testing

Can be tested by setting a predicate that filters out all channels (`{ false }`), or by removing the last channel in a channel list.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/UtQHZEv5M7POO8t2WW/giphy.gif)