### PR TITLE
[CAS-842] Fix read indicator

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-
+- Fixed the message read indicator in the message list
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -1276,24 +1276,25 @@ internal class ChannelController(
          * before what we've last pushed to the UI. We want to ignore this, as it will cause an unread state
          * to show in the channel list.
          */
-        val incomingUserRead = incomingUserIdToReadMap[currentUserId] ?: return
+        incomingUserIdToReadMap[currentUserId]?.let {
 
-        // the previous last Read date that is most current
-        val previousLastRead = _read.value?.lastRead ?: previousUserIdToReadMap[currentUserId]?.lastRead
+            // the previous last Read date that is most current
+            val previousLastRead = _read.value?.lastRead ?: previousUserIdToReadMap[currentUserId]?.lastRead
 
-        // Use AFTER to determine if the incoming read is more current.
-        // This prevents updates if it's BEFORE or EQUAL TO the previous Read.
-        val shouldUpdateByIncoming = previousLastRead == null || incomingUserRead.lastRead?.inOffsetWith(
-            previousLastRead,
-            OFFSET_EVENT_TIME
-        ) == true
+            // Use AFTER to determine if the incoming read is more current.
+            // This prevents updates if it's BEFORE or EQUAL TO the previous Read.
+            val shouldUpdateByIncoming = previousLastRead == null || it.lastRead?.inOffsetWith(
+                previousLastRead,
+                OFFSET_EVENT_TIME
+            ) == true
 
-        if (shouldUpdateByIncoming) {
-            _read.value = incomingUserRead
-            _unreadCount.value = incomingUserRead.unreadMessages
-        } else {
-            // if the previous Read was more current, replace the item in the update map
-            incomingUserIdToReadMap[currentUserId] = ChannelUserRead(domainImpl.currentUser, previousLastRead)
+            if (shouldUpdateByIncoming) {
+                _read.value = it
+                _unreadCount.value = it.unreadMessages
+            } else {
+                // if the previous Read was more current, replace the item in the update map
+                incomingUserIdToReadMap[currentUserId] = ChannelUserRead(domainImpl.currentUser, previousLastRead)
+            }
         }
 
         // always post the newly updated map

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -1276,21 +1276,21 @@ internal class ChannelController(
          * before what we've last pushed to the UI. We want to ignore this, as it will cause an unread state
          * to show in the channel list.
          */
-        incomingUserIdToReadMap[currentUserId]?.let {
+        incomingUserIdToReadMap[currentUserId]?.let { incomingUserRead ->
 
             // the previous last Read date that is most current
             val previousLastRead = _read.value?.lastRead ?: previousUserIdToReadMap[currentUserId]?.lastRead
 
             // Use AFTER to determine if the incoming read is more current.
             // This prevents updates if it's BEFORE or EQUAL TO the previous Read.
-            val shouldUpdateByIncoming = previousLastRead == null || it.lastRead?.inOffsetWith(
+            val shouldUpdateByIncoming = previousLastRead == null || incomingUserRead.lastRead?.inOffsetWith(
                 previousLastRead,
                 OFFSET_EVENT_TIME
             ) == true
 
             if (shouldUpdateByIncoming) {
-                _read.value = it
-                _unreadCount.value = it.unreadMessages
+                _read.value = incomingUserRead
+                _unreadCount.value = incomingUserRead.unreadMessages
             } else {
                 // if the previous Read was more current, replace the item in the update map
                 incomingUserIdToReadMap[currentUserId] = ChannelUserRead(domainImpl.currentUser, previousLastRead)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-842

### 🎯 Goal

This PR fixes the message read indicator in the message list.

### 🛠 Implementation details

Incoming reads from other users were ignored. Ensured that all the incoming reads (including the reads from other users) are propagated via corresponding `StateFlow` field.

### 🧪 Testing

GIVEN user_1 is reading a channel
AND user_2 is reading the same channel
WHEN user_1 sends a message
AND user_2 receives the message
THEN user_1 should observe that the message was read (double tick mark)

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [X] Reviewers added

