### PR TITLE
[CAS- 851] Fix - Attachment gallery crash

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -53,6 +53,10 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+Added theme to all activities all the SDK. You can override then in your project by redefining the styles:
+- StreamUiAttachmentGalleryActivityStyle
+- StreamUiAttachmentMediaActivityStyle
+- StreamUiAttachmentActivityStyle
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components/src/main/AndroidManifest.xml
+++ b/stream-chat-android-ui-components/src/main/AndroidManifest.xml
@@ -25,8 +25,17 @@
                 />
         </provider>
 
-        <activity android:name=".gallery.AttachmentGalleryActivity" />
-        <activity android:name=".gallery.AttachmentMediaActivity" />
-        <activity android:name=".gallery.AttachmentActivity" />
+        <activity
+            android:name=".gallery.AttachmentGalleryActivity"
+            android:theme="@style/StreamUiAttachmentGalleryActivityStyle"
+            />
+        <activity
+            android:name=".gallery.AttachmentMediaActivity"
+            android:theme="@style/StreamUiAttachmentMediaActivityStyle"
+            />
+        <activity
+            android:name=".gallery.AttachmentActivity"
+            android:theme="@style/StreamUiAttachmentActivityStyle"
+            />
     </application>
 </manifest>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -245,4 +245,10 @@
         <item name="android:textSize">22sp</item>
         <item name="android:textColor">@color/stream_ui_text_color_primary</item>
     </style>
+
+    <style name="StreamUiAttachmentGalleryActivityStyle" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+
+    <style name="StreamUiAttachmentMediaActivityStyle" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
+
+    <style name="StreamUiAttachmentActivityStyle" parent="Theme.MaterialComponents.DayNight.NoActionBar" />
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-851

### 🎯 Goal

Add default themes to all activities of the SDK, which can be overwritten by the client app. Fixes #1661. 

### 🛠 Implementation details

Because we don't set default theme for all activities, it will use the theme from the app tag from the client app manifest. Using the wrong theme can cause runtime problems when using libraries from `com.google.android.material:material` like `BottomSheetDialog`. 

### 🎨 UI Changes

No change. 

### 🧪 Testing

1 - Go in the StreamUiAttachmentGalleryActivityStyle and remove the `parent="Theme.Design.Light.NoActionBar"` part
2 - Go to the app and click in some attachment (a picture, for example)
3 - Crash. I'll see that the logs are very similar to the one of #1661 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/10619102/113618659-5f82c600-962e-11eb-8a97-ae8d7e0315a1.gif)
_Fixed now_