### PR TITLE
Fix ChannelListHeaderView's title position when user avatar or action button is invisible

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -63,6 +63,7 @@
 - Now it is possible to change the color of `MessageListHeaderView` from the XML.
 - Fixed the `MessageListView::setUserClickListener` method.
 - Fixed bugs in handling empty states for `ChannelListView`. Deprecated manual methods for showing/hiding empty state changes.
+- Fix `ChannelListHeaderView`'s title position when user avatar or action button is invisible
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
@@ -8,6 +8,7 @@ import android.view.LayoutInflater
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.use
+import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.ui.R
@@ -48,7 +49,7 @@ public class ChannelListHeaderView : ConstraintLayout {
     private fun configUserAvatar(typedArray: TypedArray) {
         val showAvatar = typedArray.getBoolean(R.styleable.ChannelListHeaderView_streamUiShowUserAvatar, true)
         binding.userAvatar.apply {
-            isVisible = showAvatar
+            isInvisible = !showAvatar
             isClickable = showAvatar
         }
     }
@@ -76,7 +77,7 @@ public class ChannelListHeaderView : ConstraintLayout {
             val showActionButton =
                 typedArray.getBoolean(R.styleable.ChannelListHeaderView_streamUiShowActionButton, true)
 
-            isVisible = showActionButton
+            isInvisible = !showActionButton
             isClickable = showActionButton
 
             imageTintList = typedArray.getColorStateList(R.styleable.ChannelListHeaderView_streamUiActionButtonTint)


### PR DESCRIPTION

### 🎯 Goal

Fix ChannelListHeaderView's title position when user avatar or action button is invisible

### 🛠 Implementation details

Making both views invisible instead of gone

### 🎨 UI Changes

| Before | After |
| --- | --- |
|<img width="325" alt="Screenshot 2021-04-06 at 09 51 49" src="https://user-images.githubusercontent.com/17440581/113678001-753fcc00-96be-11eb-8bc7-b541ec991ca9.png">|<img width="325" alt="Screenshot 2021-04-06 at 09 47 36" src="https://user-images.githubusercontent.com/17440581/113677996-73760880-96be-11eb-83ad-29f8e5bd502f.png">|
|<img width="325" alt="Screenshot 2021-04-06 at 09 49 54" src="https://user-images.githubusercontent.com/17440581/113678000-74a73580-96be-11eb-9a17-c49f364e16fc.png">|<img width="325" alt="Screenshot 2021-04-06 at 09 48 21" src="https://user-images.githubusercontent.com/17440581/113677998-74a73580-96be-11eb-92c4-8423dfacf1bb.png">|


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
