### PR TITLE
File upload fixes

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -70,6 +70,8 @@ Added theme to all activities all the SDK. You can override then in your project
 - Fixed the `MessageListView::setUserClickListener` method.
 - Fixed bugs in handling empty states for `ChannelListView`. Deprecated manual methods for showing/hiding empty state changes.
 - Fix `ChannelListHeaderView`'s title position when user avatar or action button is invisible
+- Fix UI behaviour for in-progress file uploads
+- Fix extension problems with file uploads when attachment names contain spaces
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/StorageHelper.kt
@@ -148,7 +148,7 @@ public class StorageHelper {
 }
 
 private fun AttachmentMetaData.getTitleWithExtension(): String {
-    val extension = MimeTypeMap.getFileExtensionFromUrl(title)
+    val extension = title?.substringAfterLast('.')
     return if (extension.isNullOrEmpty() && !mimeType.isNullOrEmpty()) {
         "$title.${MimeTypeMap.getSingleton().getExtensionFromMimeType(mimeType)}"
     } else {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/AttachmentExtension.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/AttachmentExtension.kt
@@ -5,7 +5,7 @@ import com.getstream.sdk.chat.utils.StringUtils
 import io.getstream.chat.android.client.models.Attachment
 
 public fun Attachment.getDisplayableName(): String? {
-    return StringUtils.removeTimePrefix(title ?: name, StorageHelper.TIME_FORMAT)
+    return StringUtils.removeTimePrefix(title ?: name ?: upload?.name, StorageHelper.TIME_FORMAT)
 }
 
 public val Attachment.imagePreviewUrl: String?

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
@@ -1,14 +1,17 @@
 package io.getstream.chat.android.ui.common.internal
 
 import android.content.Context
+import android.webkit.MimeTypeMap
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.view.isVisible
+import com.getstream.sdk.chat.StreamFileProvider
 import com.getstream.sdk.chat.images.StreamImageLoader.ImageTransformation.RoundedCorners
 import com.getstream.sdk.chat.images.load
 import com.getstream.sdk.chat.images.loadVideoThumbnail
 import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
+import com.getstream.sdk.chat.utils.extensions.getDisplayableName
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.uploader.ProgressTrackerFactory
 import io.getstream.chat.android.ui.R
@@ -27,7 +30,21 @@ internal fun ImageView.loadAttachmentThumb(attachment: Attachment) {
                 load(data = thumbUrl, transformation = FILE_THUMB_TRANSFORMATION)
             type == ModelType.attach_image && !imageUrl.isNullOrBlank() ->
                 load(data = imageUrl, transformation = FILE_THUMB_TRANSFORMATION)
-            else -> load(data = UiUtils.getIcon(mimeType))
+            else -> {
+                // The mime type, or a best guess based on the extension
+                val actualMimeType = mimeType ?: MimeTypeMap.getSingleton()
+                    .getMimeTypeFromExtension(attachment.getDisplayableName()?.substringAfterLast('.'))
+
+                // We don't have icons for image types, but we can load the actual image in this case
+                if (actualMimeType?.startsWith("image") == true && attachment.upload != null) {
+                    load(
+                        data = StreamFileProvider.getUriForFile(context, attachment.upload!!),
+                        transformation = FILE_THUMB_TRANSFORMATION
+                    )
+                } else {
+                    load(data = UiUtils.getIcon(actualMimeType))
+                }
+            }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
@@ -138,7 +138,10 @@ private class FileAttachmentViewHolder(
             fileTypeIcon.loadAttachmentThumb(attachment)
             fileTitle.text = attachment.getDisplayableName()
 
-            if (attachment.uploadState is Attachment.UploadState.Failed || attachment.fileSize == 0) {
+            if (attachment.uploadState == Attachment.UploadState.InProgress) {
+                actionButton.setImageDrawable(null)
+                fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0L)
+            } else if (attachment.uploadState is Attachment.UploadState.Failed || attachment.fileSize == 0) {
                 actionButton.setImageResource(R.drawable.stream_ui_ic_warning)
                 val tintColor = ContextCompat.getColor(context, R.color.stream_ui_accent_red)
                 ImageViewCompat.setImageTintList(actionButton, ColorStateList.valueOf(tintColor))


### PR DESCRIPTION
### 🎯 Goal

Fixes odd UI behaviour around file uploads, namely:
- Blank names for files while they're being uploaded
- Failed indicator being displayed for in-progress file uploads (#1689)
- `.pdf.pdf` extension stacking for files with spaces in their names
- In-progress files having no file type icons displayed

### 🛠 Implementation details

Please see commit messages and descriptions for the details of the changes.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/12054216/113725247-69bac800-96f3-11eb-8033-2b30e5d730ee.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/12054216/113730241-01bab080-96f8-11eb-9268-6053194e31fa.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

As seen in the videos above.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
