### PR TITLE
[CAS-648] Implement remove member use case

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -41,7 +41,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-
+- Add `ChatDomain::removeMembers` method
 ### ⚠️ Changed
 
 ### ❌ Removed

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -73,6 +73,7 @@ public abstract interface class io/getstream/chat/android/livedata/ChatDomain {
 	public abstract fun isInitialized ()Z
 	public abstract fun isOffline ()Z
 	public abstract fun isOnline ()Z
+	public abstract fun removeMembers (Ljava/lang/String;[Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun setCurrentUser (Lio/getstream/chat/android/client/models/User;)V
 	public abstract fun setOfflineEnabled (Z)V
 	public abstract fun setRetryPolicy (Lio/getstream/chat/android/livedata/utils/RetryPolicy;)V

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -5,7 +5,9 @@ import android.os.Handler
 import android.os.Looper
 import androidx.lifecycle.LiveData
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Config
 import io.getstream.chat.android.client.models.Mute
 import io.getstream.chat.android.client.models.TypingEvent
@@ -95,6 +97,7 @@ public interface ChatDomain {
     public fun clean()
     public fun getChannelConfig(channelType: String): Config
     public fun getVersion(): String
+    public fun removeMembers(cid: String, vararg userIds: String): Call<Channel>
 
     public data class Builder(
         private val appContext: Context,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.call.CoroutineCall
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
@@ -55,6 +56,7 @@ import io.getstream.chat.android.livedata.usecase.UseCaseHelper
 import io.getstream.chat.android.livedata.utils.DefaultRetryPolicy
 import io.getstream.chat.android.livedata.utils.Event
 import io.getstream.chat.android.livedata.utils.RetryPolicy
+import io.getstream.chat.android.livedata.utils.validateCid
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
@@ -448,6 +450,14 @@ internal class ChatDomainImpl internal constructor(
 
     fun setTotalUnreadCount(newCount: Int) {
         _totalUnreadCount.value = newCount
+    }
+
+    override fun removeMembers(cid: String, vararg userIds: String): Call<Channel> {
+        validateCid(cid)
+        val channelController = channel(cid)
+        return CoroutineCall(scope) {
+            channelController.removeMembers(*userIds)
+        }
     }
 
     private fun storeBgSyncDataWhenUserConnects() {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -116,6 +116,7 @@ internal class ChannelControllerImpl(
 
     fun upsertMembers(members: List<Member>) = channelControllerStateFlow.upsertMembers(members)
     fun upsertMember(member: Member) = channelControllerStateFlow.upsertMember(member)
+    suspend fun removeMembers(vararg userIds: String): Result<Channel> = channelControllerStateFlow.removeMembers(*userIds)
 
     fun updateLiveDataFromChannel(c: Channel) = channelControllerStateFlow.updateDataFromChannel(c)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -1264,6 +1264,10 @@ internal class ChannelController(
         _members.value = _members.value + members.associateBy { it.user.id }
     }
 
+    suspend fun removeMembers(vararg userIds: String): Result<Channel> {
+        return channelClient.removeMembers(*userIds).await()
+    }
+
     fun upsertMember(member: Member) = upsertMembers(listOf(member))
 
     private fun updateReads(reads: List<ChannelUserRead>) {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
@@ -7,10 +7,8 @@ import androidx.lifecycle.Transformations
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.call.await
-import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.livedata.ChatDomain
@@ -20,13 +18,11 @@ import io.getstream.chat.ui.sample.common.isDraft
 import kotlinx.coroutines.launch
 
 class GroupChatInfoMemberOptionsViewModel(
-    cid: String,
+    private val cid: String,
     private val memberId: String,
     private val chatDomain: ChatDomain = ChatDomain.instance(),
-    chatClient: ChatClient = ChatClient.instance(),
 ) : ViewModel() {
 
-    private val channelClient: ChannelClient = chatClient.channel(cid)
     private val _events = MutableLiveData<Event<UiEvent>>()
     private val _state: MediatorLiveData<State> = MediatorLiveData()
     val events: LiveData<Event<UiEvent>> = _events
@@ -94,7 +90,7 @@ class GroupChatInfoMemberOptionsViewModel(
 
     private fun removeFromChannel() {
         viewModelScope.launch {
-            val result = channelClient.removeMembers(memberId).await()
+            val result = chatDomain.removeMembers(cid, memberId).await()
             if (result.isSuccess) {
                 _events.value = Event(UiEvent.Dismiss)
             } else {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-648

### 🎯 Goal

Be able to remove members using `ChatDomain`

### 🛠 Implementation details

To be consistent with other use cases, wrapping the call into `ChatDomain` scope. The call will not be interrupted even if user leaves corresponding fragment/activity.

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/113755923-8538c980-9719-11eb-9408-f860348db0d1.mov

### 🧪 Testing

Given we are on the channel info screen
When user is removed from the channel
Then the user should disappear from the members list

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [X] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [X] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [X] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/9600921/113756446-0d1ed380-971a-11eb-8a7a-7bb7590735dc.gif)
