### PR TITLE
[CAS-867] Add missing team field to ChannelEntity and ChannelData

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -39,6 +39,7 @@
 ### 🐞 Fixed
 - Fix Crash on some devices that are not able to create an Encrypted SharedPreferences
 - Fixed the message read indicator in the message list
+- Added missing `team` field to `ChannelEntity` and `ChannelData`
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -7,11 +7,12 @@ public final class io/getstream/chat/android/livedata/BuildConfig {
 
 public final class io/getstream/chat/android/livedata/ChannelData {
 	public fun <init> (Lio/getstream/chat/android/client/models/Channel;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()I
-	public final fun component11 ()Ljava/util/Map;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Map;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lio/getstream/chat/android/client/models/User;
@@ -20,8 +21,8 @@ public final class io/getstream/chat/android/livedata/ChannelData {
 	public final fun component7 ()Ljava/util/Date;
 	public final fun component8 ()Ljava/util/Date;
 	public final fun component9 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/util/Map;)Lio/getstream/chat/android/livedata/ChannelData;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/livedata/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/livedata/ChannelData;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;)Lio/getstream/chat/android/livedata/ChannelData;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/livedata/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/livedata/ChannelData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ljava/lang/String;
 	public final fun getCid ()Ljava/lang/String;
@@ -32,6 +33,7 @@ public final class io/getstream/chat/android/livedata/ChannelData {
 	public final fun getExtraData ()Ljava/util/Map;
 	public final fun getFrozen ()Z
 	public final fun getMemberCount ()I
+	public final fun getTeam ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getUpdatedAt ()Ljava/util/Date;
 	public fun hashCode ()I
@@ -44,6 +46,7 @@ public final class io/getstream/chat/android/livedata/ChannelData {
 	public final fun setExtraData (Ljava/util/Map;)V
 	public final fun setFrozen (Z)V
 	public final fun setMemberCount (I)V
+	public final fun setTeam (Ljava/lang/String;)V
 	public final fun setType (Ljava/lang/String;)V
 	public final fun setUpdatedAt (Ljava/util/Date;)V
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChannelData.kt
@@ -32,6 +32,8 @@ public data class ChannelData(
     var deletedAt: Date? = null,
     /** channel member count */
     var memberCount: Int = 0,
+    /** channel's team */
+    var team: String = "",
     /** all the custom data provided for this channel */
     var extraData: MutableMap<String, Any> = mutableMapOf()
 ) {
@@ -47,11 +49,12 @@ public data class ChannelData(
         extraData = c.extraData
 
         createdBy = c.createdBy
+        team = c.team
     }
 
     /** convert a channelEntity into a channel object */
     internal fun toChannel(messages: List<Message>, members: List<Member>, reads: List<ChannelUserRead>, watchers: List<User>, watcherCount: Int): Channel {
-        val c = Channel(cooldown = cooldown)
+        val c = Channel(cooldown = cooldown, team = team)
         c.type = type
         c.id = channelId
         c.cid = cid

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/database/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/database/ChatDatabase.kt
@@ -44,7 +44,7 @@ import io.getstream.chat.android.livedata.repository.domain.user.UserEntity
         CommandInnerEntity::class,
         SyncStateEntity::class
     ],
-    version = 40,
+    version = 41,
     exportSchema = false
 )
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/channel/ChannelEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/channel/ChannelEntity.kt
@@ -48,6 +48,8 @@ internal data class ChannelEntity(
     val extraData: Map<String, Any>,
     /** if the channel has been synced to the servers */
     val syncStatus: SyncStatus,
+    /** channel's team */
+    val team: String,
 ) {
     @PrimaryKey
     var cid: String = "%s:%s".format(type, channelId)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/channel/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/channel/ChannelMapper.kt
@@ -39,6 +39,7 @@ internal fun Channel.toEntity(): ChannelEntity {
         lastMessageId = lastMessage?.messageInnerEntity?.id,
         lastMessageAt = lastMessageAt,
         createdByUserId = createdBy.id,
+        team = team,
     )
 }
 
@@ -62,5 +63,6 @@ internal suspend fun ChannelEntity.toModel(
     members = members.values.map { it.toModel(getUser) },
     messages = listOfNotNull(lastMessageId?.let { getMessage(it) }),
     read = reads.values.map { it.toModel(getUser) },
-    createdBy = getUser(createdByUserId)
+    createdBy = getUser(createdByUserId),
+    team = team,
 )


### PR DESCRIPTION
### 🎯 Goal

Fix filtering channel based on `Channel::team` property.

### 🛠 Implementation details

Filtering wasn't working properly because `Channel::team` was always empty. In [`QueryChannelsController::refreshChannels` ](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/controller/QueryChannelsController.kt#L221) we are creating `Channel` from `ChannelController` which internally uses `ChannelData`. `Team` property was missing in both `ChannelData` and `ChannelEntity` and that's why filtering wasn't working properly (the property was always empty (default value) even if it was present in API response)

### 🧪 Testing

1. Add `Filters.eq("team", "someTeam")` filter to `ChannelListViewModelFactory` and ensure that API returns at least one channel
2. ChannelListView should contain this channel
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
