### PR TITLE
[CAS-866] Suspend user lookup

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `MessageInputView#setMembers` <br/>*ui-components* | 2021.04.07 | 2021.04.21 ⌛ | 2021.05.05 ⌛ | Use MessageInputView::setUserLookupHandler instead of manually passing the list of users |
 | `ChannelListView's empty state methods` <br/>*ui-components* | 2021.04.05 | 2021.04.19 ⌛ | 2021.05.05 ⌛ | These methods no longer need to be called directly, `setChannel` handles empty state changes automatically |
 | `MessageListItemStyle#messageTextColorTheirs` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use MessageListItemStyle::textStyleTheirs::colorOrNull() instead |
 | `MessageListItemStyle#messageTextColorMine` <br/>*ui-components* | 2021.03.25 | 2021.04.25 ⌛ | 2021.05.25 ⌛ | Use MessageListItemStyle::textStyleMine::colorOrNull() instead |

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -80,6 +80,7 @@ Added theme to all activities all the SDK. You can override then in your project
 
 ### ✅ Added
 - Now it is possible to change the back button of MessageListHeaderView using `app:streamUiMessageListHeaderBackButtonIcon`
+- Now it is possible to inject `UserLookupHandler` into `MessageInputView` in order to implement custom users' mention lookup algorithm
 ### ⚠️ Changed
 
 ### ❌ Removed

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -815,6 +815,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setMembers (Ljava/util/List;)V
 	public final fun setMentionsEnabled (Z)V
 	public final fun setOnSendButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnMessageSendButtonClickListener;)V
+	public final fun setOnUserLookupListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnUserLookupListener;)V
 	public final fun setSendMessageHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$MessageSendHandler;)V
 	public final fun setSuggestionListView (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView;)V
 	public final fun setTypingListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$TypingListener;)V
@@ -887,6 +888,10 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView$M
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$OnMessageSendButtonClickListener {
 	public abstract fun onClick ()V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$OnUserLookupListener {
+	public abstract fun onUserLookup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$TypingListener {

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -833,6 +833,11 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView$C
 	public static fun values ()[Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
 }
 
+public final class io/getstream/chat/android/ui/message/input/MessageInputView$DefaultUserLookupHandler : io/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler {
+	public fun <init> (Ljava/util/List;)V
+	public fun handleUserLookup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
 public abstract class io/getstream/chat/android/ui/message/input/MessageInputView$InputMode {
 }
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -445,6 +445,7 @@ public final class io/getstream/chat/android/ui/common/Debouncer {
 	public fun <init> (J)V
 	public final fun shutdown ()V
 	public final fun submit (Lkotlin/jvm/functions/Function0;)V
+	public final fun submitSuspendable (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class io/getstream/chat/android/ui/common/ReactionType : java/lang/Enum {
@@ -815,10 +816,10 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setMembers (Ljava/util/List;)V
 	public final fun setMentionsEnabled (Z)V
 	public final fun setOnSendButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnMessageSendButtonClickListener;)V
-	public final fun setOnUserLookupListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnUserLookupListener;)V
 	public final fun setSendMessageHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$MessageSendHandler;)V
 	public final fun setSuggestionListView (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView;)V
 	public final fun setTypingListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$TypingListener;)V
+	public final fun setUserLookupHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$BigFileSelectionListener {
@@ -890,13 +891,13 @@ public abstract interface class io/getstream/chat/android/ui/message/input/Messa
 	public abstract fun onClick ()V
 }
 
-public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$OnUserLookupListener {
-	public abstract fun onUserLookup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$TypingListener {
 	public abstract fun onKeystroke ()V
 	public abstract fun onStopTyping ()V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler {
+	public abstract fun handleUserLookup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/chat/android/ui/message/input/MessageInputViewStyle {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/Debouncer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/Debouncer.kt
@@ -26,6 +26,14 @@ public class Debouncer(private val debounceMs: Long) {
         }
     }
 
+    public fun submitSuspendable(work: suspend () -> Unit) {
+        job?.cancel()
+        job = scope.launch {
+            delay(debounceMs)
+            work()
+        }
+    }
+
     /**
      * Cleans up any pending work.
      *

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -576,18 +576,17 @@ public class MessageInputView : ConstraintLayout {
      */
     public interface UserLookupHandler {
         /**
-         * Performs users lookup by given [input] in suspend way. It's executed on background, so it can perform heavy operations.
+         * Performs users lookup by given [query] in suspend way. It's executed on background, so it can perform heavy operations.
          *
-         * @param input String as user input for lookup algorithm.
+         * @param query String as user input for lookup algorithm.
          * @return List of users as result of lookup.
          */
-        public suspend fun handleUserLookup(input: String): List<User>
+        public suspend fun handleUserLookup(query: String): List<User>
     }
 
-    internal class DefaultUserLookupHandler(private val users: List<User>) : UserLookupHandler {
-        override suspend fun handleUserLookup(input: String): List<User> {
-            val namePattern = input.substringAfterLast("@")
-            return users.filter { it.name.contains(namePattern, true) }
+    public class DefaultUserLookupHandler(private val users: List<User>) : UserLookupHandler {
+        override suspend fun handleUserLookup(query: String): List<User> {
+            return users.filter { it.name.contains(query, true) }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -571,7 +571,16 @@ public class MessageInputView : ConstraintLayout {
         public fun handleBigFileSelected(hasBigFile: Boolean)
     }
 
+    /**
+     * Users lookup functional interface. Used to create custom users lookup algorithm.
+     */
     public interface UserLookupHandler {
+        /**
+         * Performs users lookup by given [input] in suspend way. It's executed on background, so it can perform heavy operations.
+         *
+         * @param input String as user input for lookup algorithm.
+         * @return List of users as result of lookup.
+         */
         public suspend fun handleUserLookup(input: String): List<User>
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
@@ -4,6 +4,7 @@ package io.getstream.chat.android.ui.message.input.viewmodel
 
 import androidx.lifecycle.LifecycleOwner
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
+import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.message.input.MessageInputView
 import io.getstream.chat.android.ui.message.input.MessageInputView.ChatMode.DIRECT_CHAT
@@ -16,7 +17,9 @@ import java.io.File
  */
 @JvmName("bind")
 public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner: LifecycleOwner) {
-    members.observe(lifecycleOwner, view::setMembers)
+    members.observe(lifecycleOwner) { members ->
+        view.setUserLookupHandler(MessageInputView.DefaultUserLookupHandler(members.map(Member::user)))
+    }
     commands.observe(lifecycleOwner, view::setCommands)
     maxMessageLength.observe(lifecycleOwner, view::setMaxMessageLength)
     getActiveThread().observe(lifecycleOwner) {
@@ -61,7 +64,7 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
                 parentMessage: Message,
                 message: String,
                 alsoSendToChannel: Boolean,
-                attachmentsFiles: List<File>
+                attachmentsFiles: List<File>,
             ) {
                 viewModel.sendMessageWithAttachments(message, attachmentsFiles) {
                     this.parentId = parentMessage.id

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
@@ -44,7 +44,7 @@ internal class SuggestionListController(
         messageText: String,
     ) {
         val suggestions = withContext(DispatcherProvider.IO) {
-            userLookupHandler?.handleUserLookup(messageText)
+            userLookupHandler?.handleUserLookup(messageText.substringAfterLast("@"))
                 ?.let(SuggestionListView.Suggestions::MentionSuggestions)
         }
         withContext(DispatcherProvider.Main) {


### PR DESCRIPTION
Read requirements in [Jira task](https://stream-io.atlassian.net/browse/CAS-866?atlOrigin=eyJpIjoiYTEyMGVhNzY1YjZkNDdiMTkzMTY0ZjZlYTk2MDE2YjUiLCJwIjoiaiJ9)

### 🎯 Goal
We want to provide an abstract mechanism for the user suggested list in `MessageInputView`. Some customers want to do it using network requests for their live stream channels (such channels usually don't have members).

### 🛠 Implementation details

- Add new `UserLookupHandler` with suspend function to execute lookups
- Deprecate `MessageInputView::setMembers`

### 🎨 UI Changes
UX doesn't get changed

### 🧪 Testing

Put delay in `SuggestionListController`, here:
![image](https://user-images.githubusercontent.com/11807573/113895812-9d682180-97c9-11eb-9286-a19748c0cbed.png)

and play a little bit

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![image](https://user-images.githubusercontent.com/11807573/113896632-68a89a00-97ca-11eb-9aa2-d14b48f4a9ea.png)

