### PR TITLE
[CAS-857] Fix crash when recovering from process death

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -83,8 +83,8 @@ internal class MoshiChatApi(
 
     val logger = ChatLogger.get("MoshiChatApi")
 
-    lateinit var userId: String
-    lateinit var connectionId: String
+    private var userId: String = ""
+    private var connectionId: String = ""
 
     override fun setConnection(userId: String, connectionId: String) {
         this.userId = userId

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -84,7 +84,19 @@ internal class MoshiChatApi(
     val logger = ChatLogger.get("MoshiChatApi")
 
     private var userId: String = ""
+        get() {
+            if (field == "") {
+                logger.logE("userId accessed before being set")
+            }
+            return field
+        }
     private var connectionId: String = ""
+        get() {
+            if (field == "") {
+                logger.logE("connectionId accessed before being set")
+            }
+            return field
+        }
 
     override fun setConnection(userId: String, connectionId: String) {
         this.userId = userId

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/HostActivity.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/HostActivity.kt
@@ -1,6 +1,17 @@
 package io.getstream.chat.ui.sample.feature
 
+import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.ui.sample.R
 
-class HostActivity : AppCompatActivity(R.layout.activity_main)
+class HostActivity : AppCompatActivity(R.layout.activity_main) {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (savedInstanceState != null && lastNonConfigurationInstance == null) {
+            // the application process was killed by the OS
+            startActivity(packageManager.getLaunchIntentForPackage(packageName))
+            finishAffinity()
+        }
+    }
+}


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-857

### 🎯 Goal

Ensure that sample app doesn't crash when:
- starting in offline mode
- restarting the app after it was killed

### 🛠 Implementation details

- detecting when the app was killed and restarting from launcher activity
- `lateinit` properties in `MoshiChatApi` can be accessed before they are initialized (e.g. login without network connection and proceed to the chat screen), so assigning default values to them

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114000611-d48b1100-9863-11eb-816b-606b3f87dc79.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114000646-d94fc500-9863-11eb-8fa1-3981be8bb63e.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114000582-cfc65d00-9863-11eb-8d91-8caf2464a48b.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114000623-d6ed6b00-9863-11eb-8062-72978fb7c699.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

GIVEN the application is in background and the application process is killed
WHEN selecting the application in task manager
THEN the app should not crash

GIVEN we are on the login screen and network is disabled
WHEN navigating to the chat screen
THEN the app should not crash

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] ~~Changelog is updated with client-facing changes~~
- [ ] ~~New code is covered by unit tests~~
- [X] Comparison screenshots added for visual changes
- [ ] ~~Affected documentation updated (CMS, cookbooks, tutorial)~~
- [X] Reviewers added

### 🎉 GIF

![giphy (3)](https://user-images.githubusercontent.com/9600921/114003062-1ddc6000-9866-11eb-9eba-79a094ebb7c9.gif)

