### PR TITLE
Automatically scroll channel list to the top

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal.Cha
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal.ChannelListListenerContainerImpl
 import io.getstream.chat.android.ui.common.extensions.internal.cast
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
+import io.getstream.chat.android.ui.common.internal.SnapToTopDataObserver
 
 internal class SimpleChannelListView @JvmOverloads constructor(
     context: Context,
@@ -67,6 +68,8 @@ internal class SimpleChannelListView @JvmOverloads constructor(
         adapter = ChannelListItemAdapter(viewHolderFactory)
 
         this.setAdapter(adapter)
+
+        adapter.registerAdapterDataObserver(SnapToTopDataObserver(this))
     }
 
     internal fun currentChannelItemList(): List<ChannelListItem>? =

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
@@ -1,0 +1,43 @@
+package io.getstream.chat.android.ui.common.internal
+
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+
+/**
+ * Automatically scrolls [RecyclerView] to the top when the first item is completely visible and
+ * a new range of items is inserted or moved to the position above.
+ */
+internal class SnapToTopDataObserver(
+    private val recyclerView: RecyclerView,
+) : RecyclerView.AdapterDataObserver() {
+
+    val layoutManager = recyclerView.layoutManager as? LinearLayoutManager
+        ?: throw IllegalStateException("Auto scroll only works with LinearLayoutManager")
+
+    override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
+        super.onItemRangeMoved(fromPosition, toPosition, itemCount)
+        autoScrollToTopIfNecessary(minOf(fromPosition, toPosition))
+    }
+
+    override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
+        super.onItemRangeInserted(positionStart, itemCount)
+        autoScrollToTopIfNecessary(positionStart)
+    }
+
+    /**
+     * Scrolls the list to the top if the user is is not dragging it
+     * and the list is scrolled to the top prior to the update.
+     */
+    private fun autoScrollToTopIfNecessary(itemPosition: Int) {
+        if (
+            itemPosition != 0 ||
+            recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE ||
+            recyclerView.canScrollVertically(-1) ||
+            layoutManager.findFirstVisibleItemPosition() == 0
+        ) {
+            return
+        }
+
+        layoutManager.scrollToPosition(0)
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
@@ -19,7 +19,6 @@ internal class SnapToTopDataObserver(
     }
 
     override fun onItemRangeInserted(positionStart: Int, itemCount: Int) {
-        super.onItemRangeInserted(positionStart, itemCount)
         autoScrollToTopIfNecessary(positionStart)
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
@@ -15,7 +15,6 @@ internal class SnapToTopDataObserver(
         ?: throw IllegalStateException("Auto scroll only works with LinearLayoutManager")
 
     override fun onItemRangeMoved(fromPosition: Int, toPosition: Int, itemCount: Int) {
-        super.onItemRangeMoved(fromPosition, toPosition, itemCount)
         autoScrollToTopIfNecessary(minOf(fromPosition, toPosition))
     }
 


### PR DESCRIPTION
### 🎯 Goal

Scroll channel list to the top if:
- we are at the top prior to the update
- user is added to a new channel or existing channel is updated and bumped to the top

### 🛠 Implementation details

Custom `RecyclerView.AdapterDataObserver` which automatically scrolls channel list to the top when necessary.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114022253-42423780-987a-11eb-8de9-f90943fd487a.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114022266-453d2800-987a-11eb-8146-b588593b3590.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

GIVEN channel list is scrolled to the top
WHEN a message is sent to any channel other that the first one
THEN updated channel should be visible on the screen

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [X] Reviewers added

### 🎉 GIF

![giphy (4)](https://user-images.githubusercontent.com/9600921/114021848-cfd15780-9879-11eb-949f-20da5d19770b.gif)

