### PR TITLE
[CAS-855] Refactor MessageOptionsConfig

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -558,7 +558,7 @@ public final class io/getstream/chat/android/ui/common/style/ChatStyle {
 	public final fun setDefaultTextStyle (Lio/getstream/chat/android/ui/common/style/TextStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/common/style/TextStyle {
+public final class io/getstream/chat/android/ui/common/style/TextStyle : java/io/Serializable {
 	public static final field UNSET_COLOR I
 	public static final field UNSET_FONT_RESOURCE I
 	public static final field UNSET_HINT Ljava/lang/String;
@@ -1219,25 +1219,57 @@ public abstract interface class io/getstream/chat/android/ui/message/list/Messag
 	public abstract fun onUserMute (Lio/getstream/chat/android/client/models/User;)V
 }
 
-public final class io/getstream/chat/android/ui/message/list/MessageListViewStyle {
+public final class io/getstream/chat/android/ui/message/list/MessageListViewStyle : java/io/Serializable {
 	public static final field Companion Lio/getstream/chat/android/ui/message/list/MessageListViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZI)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZIIIZIZIIZIIIIIZZZ)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
+	public final fun component10 ()I
+	public final fun component11 ()I
+	public final fun component12 ()Z
+	public final fun component13 ()I
+	public final fun component14 ()I
+	public final fun component15 ()I
+	public final fun component16 ()I
+	public final fun component17 ()I
+	public final fun component18 ()Z
+	public final fun component19 ()Z
 	public final fun component2 ()Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
+	public final fun component20 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()I
-	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZI)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public final fun component5 ()I
+	public final fun component6 ()I
+	public final fun component7 ()Z
+	public final fun component8 ()I
+	public final fun component9 ()Z
+	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZIIIZIZIIZIIIIIZZZ)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;ZIIIZIZIIZIIIIIZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
+	public final fun getBlockIcon ()I
+	public final fun getCopyIcon ()I
+	public final fun getCopyTextEnabled ()Z
+	public final fun getDeleteConfirmationEnabled ()Z
+	public final fun getDeleteIcon ()I
+	public final fun getDeleteMessageEnabled ()Z
+	public final fun getEditIcon ()I
+	public final fun getEditMessageEnabled ()Z
+	public final fun getFlagIcon ()I
+	public final fun getIconsTint ()I
 	public final fun getItemStyle ()Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
+	public final fun getMuteIcon ()I
 	public final fun getReactionsEnabled ()Z
+	public final fun getReplyEnabled ()Z
+	public final fun getReplyIcon ()I
+	public final fun getRetryIcon ()I
 	public final fun getScrollButtonViewStyle ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
+	public final fun getThreadReplyIcon ()I
+	public final fun getThreadsEnabled ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle {
+public final class io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle : java/io/Serializable {
 	public fun <init> (ZZIIILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/TextStyle.kt
@@ -9,6 +9,7 @@ import androidx.annotation.ColorInt
 import androidx.annotation.Px
 import androidx.annotation.StyleableRes
 import io.getstream.chat.android.ui.ChatUI
+import java.io.Serializable
 
 public data class TextStyle(
     @AnyRes public val fontResource: Int = UNSET_FONT_RESOURCE,
@@ -19,7 +20,7 @@ public data class TextStyle(
     public val hint: String = UNSET_HINT,
     @ColorInt public val hintColor: Int = UNSET_HINT_COLOR,
     public val defaultFont: Typeface = Typeface.DEFAULT,
-) {
+) : Serializable {
     private companion object {
         const val UNSET_SIZE = -1
         const val UNSET_COLOR = Integer.MAX_VALUE

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -77,6 +77,7 @@ import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.A
 import io.getstream.chat.android.ui.message.list.internal.HiddenMessageListItemPredicate
 import io.getstream.chat.android.ui.message.list.internal.MessageListScrollHelper
 import io.getstream.chat.android.ui.message.list.options.message.internal.MessageOptionsDialogFragment
+import io.getstream.chat.android.ui.message.list.options.message.internal.MessageOptionsView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -228,10 +229,12 @@ public class MessageListView : ConstraintLayout {
                 MessageOptionsDialogFragment
                     .newMessageOptionsInstance(
                         message,
-                        messageListViewStyle.copy(
-                            threadsEnabled = !adapter.isThread && !message.isInThread() && messageListViewStyle.threadsEnabled,
-                            reactionsEnabled = channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
-                        )
+                        MessageOptionsView.Configuration(
+                            viewStyle = messageListViewStyle,
+                            channelConfig = channel.config,
+                            suppressThreads = !adapter.isThread && !message.isInThread()
+                        ),
+                        messageListViewStyle,
                     )
                     .apply {
                         setReactionClickHandler { message, reactionType ->

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -3,7 +3,6 @@ package io.getstream.chat.android.ui.message.list
 import android.animation.LayoutTransition
 import android.app.AlertDialog
 import android.content.Context
-import android.content.res.TypedArray
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
@@ -11,7 +10,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -79,7 +77,6 @@ import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.A
 import io.getstream.chat.android.ui.message.list.internal.HiddenMessageListItemPredicate
 import io.getstream.chat.android.ui.message.list.internal.MessageListScrollHelper
 import io.getstream.chat.android.ui.message.list.options.message.internal.MessageOptionsDialogFragment
-import io.getstream.chat.android.ui.message.list.options.message.internal.MessageOptionsView
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -209,9 +206,6 @@ public class MessageListView : ConstraintLayout {
     }
 
     private var messageListItemPredicate: MessageListItemPredicate = HiddenMessageListItemPredicate
-
-    private lateinit var messageOptionsConfiguration: MessageOptionsView.Configuration
-
     private lateinit var loadMoreListener: EndlessScrollListener
 
     private lateinit var channel: Channel
@@ -234,11 +228,10 @@ public class MessageListView : ConstraintLayout {
                 MessageOptionsDialogFragment
                     .newMessageOptionsInstance(
                         message,
-                        messageOptionsConfiguration.copy(
-                            threadsEnabled = !adapter.isThread && !message.isInThread() && messageOptionsConfiguration.threadsEnabled,
-                        ),
-                        messageListViewStyle.itemStyle,
-                        channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
+                        messageListViewStyle.copy(
+                            threadsEnabled = !adapter.isThread && !message.isInThread() && messageListViewStyle.threadsEnabled,
+                            reactionsEnabled = channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
+                        )
                     )
                     .apply {
                         setReactionClickHandler { message, reactionType ->
@@ -326,8 +319,9 @@ public class MessageListView : ConstraintLayout {
             context.getFragmentManager()?.let {
                 MessageOptionsDialogFragment.newReactionOptionsInstance(
                     message,
-                    messageListViewStyle.itemStyle,
-                    channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
+                    messageListViewStyle.copy(
+                        reactionsEnabled = channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
+                    ),
                 ).apply {
                     setReactionClickHandler { message, reactionType ->
                         messageReactionHandler.onMessageReaction(message, reactionType)
@@ -455,96 +449,10 @@ public class MessageListView : ConstraintLayout {
             scrollHelper.alwaysScrollToBottom = it == NewMessagesBehaviour.SCROLL_TO_BOTTOM
         }
 
-        configureMessageOptions(tArray)
         tArray.recycle()
         if (background == null) {
             setBackgroundColor(messageListViewStyle.backgroundColor)
         }
-    }
-
-    private fun configureMessageOptions(tArray: TypedArray) {
-        val iconsTint = tArray.getColor(
-            R.styleable.MessageListView_streamUiMessageOptionIconColor,
-            ContextCompat.getColor(context, R.color.stream_ui_grey)
-        )
-
-        val replyIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiReplyOptionIcon,
-            R.drawable.stream_ui_ic_arrow_curve_left
-        )
-
-        val replyEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiReplyEnabled, true)
-
-        val threadReplyIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiThreadReplyOptionIcon,
-            R.drawable.stream_ui_ic_thread_reply
-        )
-
-        val retryIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiRetryOptionIcon,
-            R.drawable.stream_ui_ic_send
-        )
-
-        val copyIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiCopyOptionIcon,
-            R.drawable.stream_ui_ic_copy
-        )
-
-        val editIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiEditOptionIcon,
-            R.drawable.stream_ui_ic_edit
-        )
-
-        val flagIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiFlagOptionIcon,
-            R.drawable.stream_ui_ic_flag
-        )
-
-        val muteIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiMuteOptionIcon,
-            R.drawable.stream_ui_ic_mute
-        )
-
-        val blockIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiBlockOptionIcon,
-            R.drawable.stream_ui_ic_user_block
-        )
-
-        val deleteIcon = tArray.getResourceId(
-            R.styleable.MessageListView_streamUiDeleteOptionIcon,
-            R.drawable.stream_ui_ic_delete
-        )
-
-        val copyTextEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
-
-        val deleteConfirmationEnabled =
-            tArray.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)
-
-        val deleteMessageEnabled =
-            tArray.getBoolean(R.styleable.MessageListView_streamUiDeleteMessageEnabled, true)
-
-        val editMessageEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiEditMessageEnabled, true)
-
-        val threadsEnabled = tArray.getBoolean(R.styleable.MessageListView_streamUiThreadsEnabled, true)
-
-        messageOptionsConfiguration = MessageOptionsView.Configuration(
-            iconsTint = iconsTint,
-            replyIcon = replyIcon,
-            threadReplyIcon = threadReplyIcon,
-            retryIcon = retryIcon,
-            copyIcon = copyIcon,
-            editMessageEnabled = editMessageEnabled,
-            editIcon = editIcon,
-            flagIcon = flagIcon,
-            muteIcon = muteIcon,
-            blockIcon = blockIcon,
-            deleteIcon = deleteIcon,
-            replyEnabled = replyEnabled,
-            threadsEnabled = threadsEnabled,
-            copyTextEnabled = copyTextEnabled,
-            deleteConfirmationEnabled = deleteConfirmationEnabled,
-            deleteMessageEnabled = deleteMessageEnabled
-        )
     }
 
     override fun onAttachedToWindow() {
@@ -592,9 +500,9 @@ public class MessageListView : ConstraintLayout {
         this.channel = channel
         initAdapter()
 
-        messageOptionsConfiguration = messageOptionsConfiguration.copy(
-            replyEnabled = messageOptionsConfiguration.replyEnabled && channel.config.isRepliesEnabled,
-            threadsEnabled = messageOptionsConfiguration.threadsEnabled && channel.config.isRepliesEnabled,
+        messageListViewStyle = messageListViewStyle.copy(
+            replyEnabled = messageListViewStyle.replyEnabled && channel.config.isRepliesEnabled,
+            threadsEnabled = messageListViewStyle.threadsEnabled && channel.config.isRepliesEnabled,
         )
     }
 
@@ -684,7 +592,7 @@ public class MessageListView : ConstraintLayout {
      * @param enabled True if editing a message is enabled, false otherwise.
      */
     public fun setEditMessageEnabled(enabled: Boolean) {
-        updateMessageOptionsConfiguration { copy(editMessageEnabled = enabled) }
+        messageListViewStyle = messageListViewStyle.copy(editMessageEnabled = enabled)
     }
 
     /**
@@ -693,7 +601,7 @@ public class MessageListView : ConstraintLayout {
      * @param enabled True if deleting a message is enabled, false otherwise.
      */
     public fun setDeleteMessageEnabled(enabled: Boolean) {
-        updateMessageOptionsConfiguration { copy(deleteMessageEnabled = enabled) }
+        messageListViewStyle = messageListViewStyle.copy(deleteMessageEnabled = enabled)
     }
 
     public fun setMessageViewHolderFactory(messageListItemViewHolderFactory: MessageListItemViewHolderFactory) {
@@ -746,15 +654,6 @@ public class MessageListView : ConstraintLayout {
                 }
             }
         }
-    }
-
-    private fun updateMessageOptionsConfiguration(
-        reducer: MessageOptionsView.Configuration.() -> MessageOptionsView.Configuration,
-    ) {
-        check(::messageOptionsConfiguration.isInitialized) {
-            "Message options configuration needs to be initialized first"
-        }
-        messageOptionsConfiguration = reducer(messageOptionsConfiguration)
     }
 
     //region Listener setters
@@ -937,11 +836,11 @@ public class MessageListView : ConstraintLayout {
     }
 
     public fun setRepliesEnabled(enabled: Boolean) {
-        messageOptionsConfiguration = messageOptionsConfiguration.copy(replyEnabled = enabled)
+        messageListViewStyle = messageListViewStyle.copy(replyEnabled = enabled)
     }
 
     public fun setThreadsEnabled(enabled: Boolean) {
-        updateMessageOptionsConfiguration { copy(threadsEnabled = enabled) }
+        messageListViewStyle = messageListViewStyle.copy(threadsEnabled = enabled)
     }
 
     //endregion

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -322,9 +322,11 @@ public class MessageListView : ConstraintLayout {
             context.getFragmentManager()?.let {
                 MessageOptionsDialogFragment.newReactionOptionsInstance(
                     message,
-                    messageListViewStyle.copy(
-                        reactionsEnabled = channel.config.isReactionsEnabled && messageListViewStyle.reactionsEnabled
+                    MessageOptionsView.Configuration(
+                        viewStyle = messageListViewStyle,
+                        channelConfig = channel.config,
                     ),
+                    messageListViewStyle,
                 ).apply {
                     setReactionClickHandler { message, reactionType ->
                         messageReactionHandler.onMessageReaction(message, reactionType)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -232,7 +232,7 @@ public class MessageListView : ConstraintLayout {
                         MessageOptionsView.Configuration(
                             viewStyle = messageListViewStyle,
                             channelConfig = channel.config,
-                            suppressThreads = !adapter.isThread && !message.isInThread()
+                            suppressThreads = adapter.isThread || message.isInThread()
                         ),
                         messageListViewStyle,
                     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -3,18 +3,36 @@ package io.getstream.chat.android.ui.message.list
 import android.content.Context
 import android.util.AttributeSet
 import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.use
+import java.io.Serializable
 
 public data class MessageListViewStyle(
     public val scrollButtonViewStyle: ScrollButtonViewStyle,
     public val itemStyle: MessageListItemStyle,
     public val reactionsEnabled: Boolean,
     @ColorInt public val backgroundColor: Int,
-) {
+    @ColorInt val iconsTint: Int,
+    val replyIcon: Int,
+    val replyEnabled: Boolean,
+    val threadReplyIcon: Int,
+    val threadsEnabled: Boolean,
+    val retryIcon: Int,
+    val copyIcon: Int,
+    val editMessageEnabled: Boolean,
+    val editIcon: Int,
+    val flagIcon: Int,
+    val muteIcon: Int,
+    val blockIcon: Int,
+    val deleteIcon: Int,
+    val deleteMessageEnabled: Boolean,
+    val copyTextEnabled: Boolean,
+    val deleteConfirmationEnabled: Boolean,
+) : Serializable {
 
     internal companion object {
         private val DEFAULT_BACKGROUND_COLOR = R.color.stream_ui_white_snow
@@ -72,11 +90,91 @@ public data class MessageListViewStyle(
                     .linkDescriptionMaxLines(R.styleable.MessageListView_streamUiLinkDescriptionMaxLines)
                     .build()
 
+                val iconsTint = attributes.getColor(
+                    R.styleable.MessageListView_streamUiMessageOptionIconColor,
+                    ContextCompat.getColor(context, R.color.stream_ui_grey)
+                )
+
+                val replyIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiReplyOptionIcon,
+                    R.drawable.stream_ui_ic_arrow_curve_left
+                )
+
+                val replyEnabled = attributes.getBoolean(R.styleable.MessageListView_streamUiReplyEnabled, true)
+
+                val threadReplyIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiThreadReplyOptionIcon,
+                    R.drawable.stream_ui_ic_thread_reply
+                )
+
+                val retryIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiRetryOptionIcon,
+                    R.drawable.stream_ui_ic_send
+                )
+
+                val copyIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiCopyOptionIcon,
+                    R.drawable.stream_ui_ic_copy
+                )
+
+                val editIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiEditOptionIcon,
+                    R.drawable.stream_ui_ic_edit
+                )
+
+                val flagIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiFlagOptionIcon,
+                    R.drawable.stream_ui_ic_flag
+                )
+
+                val muteIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiMuteOptionIcon,
+                    R.drawable.stream_ui_ic_mute
+                )
+
+                val blockIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiBlockOptionIcon,
+                    R.drawable.stream_ui_ic_user_block
+                )
+
+                val deleteIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiDeleteOptionIcon,
+                    R.drawable.stream_ui_ic_delete
+                )
+
+                val copyTextEnabled = attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
+
+                val deleteConfirmationEnabled =
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)
+
+                val deleteMessageEnabled =
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiDeleteMessageEnabled, true)
+
+                val editMessageEnabled = attributes.getBoolean(R.styleable.MessageListView_streamUiEditMessageEnabled, true)
+
+                val threadsEnabled = attributes.getBoolean(R.styleable.MessageListView_streamUiThreadsEnabled, true)
+
                 return MessageListViewStyle(
                     scrollButtonViewStyle = scrollButtonViewStyle,
                     reactionsEnabled = reactionsEnabled,
                     itemStyle = itemStyle,
                     backgroundColor = backgroundColor,
+                    iconsTint = iconsTint,
+                    replyIcon = replyIcon,
+                    replyEnabled = replyEnabled,
+                    threadReplyIcon = threadReplyIcon,
+                    retryIcon = retryIcon,
+                    copyIcon = copyIcon,
+                    editIcon = editIcon,
+                    flagIcon = flagIcon,
+                    muteIcon = muteIcon,
+                    blockIcon = blockIcon,
+                    deleteIcon = deleteIcon,
+                    copyTextEnabled = copyTextEnabled,
+                    deleteConfirmationEnabled = deleteConfirmationEnabled,
+                    deleteMessageEnabled = deleteMessageEnabled,
+                    editMessageEnabled = editMessageEnabled,
+                    threadsEnabled = threadsEnabled,
                 ).let(TransformStyle.messageListStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/ScrollButtonViewStyle.kt
@@ -11,6 +11,7 @@ import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.style.TextStyle
+import java.io.Serializable
 
 public data class ScrollButtonViewStyle(
     public val scrollButtonEnabled: Boolean,
@@ -20,7 +21,7 @@ public data class ScrollButtonViewStyle(
     @ColorInt public val scrollButtonBadgeColor: Int,
     public val scrollButtonIcon: Drawable?,
     public val scrollButtonBadgeTextStyle: TextStyle
-) {
+) : Serializable {
 
     internal class Builder(private val context: Context, private val attrs: TypedArray) {
         private var scrollButtonEnabled: Boolean = false

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -18,8 +18,8 @@ import io.getstream.chat.android.ui.common.extensions.internal.copyToClipboard
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.internal.FullScreenDialogFragment
 import io.getstream.chat.android.ui.databinding.StreamUiDialogMessageOptionsBinding
-import io.getstream.chat.android.ui.message.list.MessageListItemStyle
 import io.getstream.chat.android.ui.message.list.MessageListView
+import io.getstream.chat.android.ui.message.list.MessageListViewStyle
 import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
 import io.getstream.chat.android.ui.message.list.adapter.internal.MessageListItemViewTypeMapper
@@ -44,12 +44,8 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         requireArguments().getSerializable(ARG_OPTIONS_MODE) as OptionsMode
     }
 
-    private val configuration by lazy {
-        requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
-    }
-
-    private val itemStyle by lazy {
-        requireArguments().getSerializable(ARG_OPTIONS_ITEM_STYLE) as MessageListItemStyle
+    private val style by lazy {
+        requireArguments().getSerializable(ARG_OPTIONS_ITEM_STYLE) as MessageListViewStyle
     }
 
     private val messageItem: MessageListItem.MessageItem by lazy {
@@ -131,7 +127,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
 
     private fun setupEditReactionsView() {
         with(binding.editReactionsView) {
-            applyStyle(itemStyle.editReactionsViewStyle)
+            applyStyle(style.itemStyle.editReactionsViewStyle)
             if (isReactionsEnabled) {
                 setMessage(message, messageItem.isMine)
                 setReactionClickListener {
@@ -147,10 +143,10 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private fun setupMessageView() {
         viewHolder = MessageListItemViewHolderFactory()
             .apply {
-                decoratorProvider = MessageOptionsDecoratorProvider(itemStyle, currentUser)
+                decoratorProvider = MessageOptionsDecoratorProvider(style.itemStyle, currentUser)
                 setListenerContainer(MessageListListenerContainerImpl())
                 setAttachmentViewFactory(AttachmentViewFactory())
-                setMessageListItemStyle(itemStyle)
+                setMessageListItemStyle(style.itemStyle)
             }
             .createViewHolder(
                 binding.messageContainer,
@@ -180,7 +176,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private fun setupMessageOptions() {
         with(binding.messageOptionsView) {
             isVisible = true
-            configure(configuration, messageItem.isTheirs, messageItem.message.syncStatus)
+            configure(style, messageItem.isTheirs, messageItem.message.syncStatus)
             updateLayoutParams<LinearLayout.LayoutParams> {
                 gravity = if (messageItem.isMine) Gravity.END else Gravity.START
             }
@@ -223,7 +219,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                 dismiss()
             }
             setDeleteMessageListener {
-                if (configuration.deleteConfirmationEnabled) {
+                if (style.deleteConfirmationEnabled) {
                     confirmDeleteMessageClickHandler?.onConfirmDeleteMessage(message) {
                         messageOptionsHandlers.deleteClickHandler.onMessageDelete(message)
                     }
@@ -290,7 +286,6 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         const val TAG = "MessageOptionsDialogFragment"
 
         private const val ARG_OPTIONS_MODE = "optionsMode"
-        private const val ARG_OPTIONS_CONFIG = "optionsConfig"
         private const val ARG_OPTIONS_ITEM_STYLE = "optionsMessageItemStyle"
         private const val ARG_OPTIONS_REACTIONS_ENABLED = "optionsReactionsEnabled"
 
@@ -298,34 +293,27 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
 
         fun newReactionOptionsInstance(
             message: Message,
-            style: MessageListItemStyle,
-            reactionsEnabled: Boolean,
+            style: MessageListViewStyle,
         ): MessageOptionsDialogFragment {
-            return newInstance(OptionsMode.REACTION_OPTIONS, message, null, style, reactionsEnabled)
+            return newInstance(OptionsMode.REACTION_OPTIONS, message, style)
         }
 
         fun newMessageOptionsInstance(
             message: Message,
-            configuration: MessageOptionsView.Configuration,
-            style: MessageListItemStyle,
-            reactionsEnabled: Boolean,
+            style: MessageListViewStyle,
         ): MessageOptionsDialogFragment {
-            return newInstance(OptionsMode.MESSAGE_OPTIONS, message, configuration, style, reactionsEnabled)
+            return newInstance(OptionsMode.MESSAGE_OPTIONS, message, style)
         }
 
         private fun newInstance(
             optionsMode: OptionsMode,
             message: Message,
-            configuration: MessageOptionsView.Configuration?,
-            style: MessageListItemStyle,
-            reactionsEnabled: Boolean,
+            style: MessageListViewStyle,
         ): MessageOptionsDialogFragment {
             return MessageOptionsDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_OPTIONS_MODE to optionsMode,
-                    ARG_OPTIONS_CONFIG to configuration,
                     ARG_OPTIONS_ITEM_STYLE to style,
-                    ARG_OPTIONS_REACTIONS_ENABLED to reactionsEnabled
                 )
                 // pass message via static field
                 messageArg = message

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -288,15 +288,15 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         private const val ARG_OPTIONS_MODE = "optionsMode"
         private const val ARG_OPTIONS_CONFIG = "optionsConfig"
         private const val ARG_OPTIONS_ITEM_STYLE = "optionsMessageItemStyle"
-        private const val ARG_OPTIONS_REACTIONS_ENABLED = "optionsReactionsEnabled"
 
         var messageArg: Message? = null
 
         fun newReactionOptionsInstance(
             message: Message,
+            configuration: MessageOptionsView.Configuration,
             style: MessageListViewStyle,
         ): MessageOptionsDialogFragment {
-            return newInstance(OptionsMode.REACTION_OPTIONS, message, style, null)
+            return newInstance(OptionsMode.REACTION_OPTIONS, message, style, configuration)
         }
 
         fun newMessageOptionsInstance(
@@ -311,7 +311,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             optionsMode: OptionsMode,
             message: Message,
             style: MessageListViewStyle,
-            configuration: MessageOptionsView.Configuration?
+            configuration: MessageOptionsView.Configuration
         ): MessageOptionsDialogFragment {
             return MessageOptionsDialogFragment().apply {
                 arguments = bundleOf(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -11,7 +11,7 @@ import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.setLeftDrawable
 import io.getstream.chat.android.ui.databinding.StreamUiMessageOptionsViewBinding
-import java.io.Serializable
+import io.getstream.chat.android.ui.message.list.MessageListViewStyle
 
 internal class MessageOptionsView : FrameLayout {
 
@@ -28,41 +28,41 @@ internal class MessageOptionsView : FrameLayout {
         defStyleAttr
     )
 
-    internal fun configure(configuration: Configuration, isMessageTheirs: Boolean, syncStatus: SyncStatus) {
+    internal fun configure(style: MessageListViewStyle, isMessageTheirs: Boolean, syncStatus: SyncStatus) {
         if (isMessageTheirs) {
-            configureTheirsMessage(configuration)
+            configureTheirsMessage(style)
         } else {
-            configureMineMessage(configuration, syncStatus)
+            configureMineMessage(style, syncStatus)
         }
     }
 
-    private fun configureTheirsMessage(configuration: Configuration) {
-        val iconsTint = configuration.iconsTint
+    private fun configureTheirsMessage(style: MessageListViewStyle) {
+        val iconsTint = style.iconsTint
 
-        configureReply(configuration, iconsTint)
+        configureReply(style, iconsTint)
 
-        if (configuration.threadsEnabled) {
-            binding.threadReplyTV.configureListItem(configuration.threadReplyIcon, iconsTint)
+        if (style.threadsEnabled) {
+            binding.threadReplyTV.configureListItem(style.threadReplyIcon, iconsTint)
         } else {
             binding.threadReplyTV.isVisible = false
         }
 
-        configureCopyMessage(iconsTint, configuration)
+        configureCopyMessage(iconsTint, style)
 
-        binding.flagTV.configureListItem(configuration.flagIcon, iconsTint)
-        binding.muteTV.configureListItem(configuration.muteIcon, iconsTint)
-        binding.blockTV.configureListItem(configuration.blockIcon, iconsTint)
+        binding.flagTV.configureListItem(style.flagIcon, iconsTint)
+        binding.muteTV.configureListItem(style.muteIcon, iconsTint)
+        binding.blockTV.configureListItem(style.blockIcon, iconsTint)
         binding.editTV.isVisible = false
         binding.deleteTV.isVisible = false
     }
 
-    private fun configureMineMessage(configuration: Configuration, syncStatus: SyncStatus) {
-        val iconsTint = configuration.iconsTint
+    private fun configureMineMessage(style: MessageListViewStyle, syncStatus: SyncStatus) {
+        val iconsTint = style.iconsTint
 
-        configureReply(configuration, iconsTint)
+        configureReply(style, iconsTint)
 
-        if (configuration.threadsEnabled) {
-            binding.threadReplyTV.configureListItem(configuration.threadReplyIcon, iconsTint)
+        if (style.threadsEnabled) {
+            binding.threadReplyTV.configureListItem(style.threadReplyIcon, iconsTint)
         } else {
             binding.threadReplyTV.isVisible = false
         }
@@ -70,7 +70,7 @@ internal class MessageOptionsView : FrameLayout {
         when (syncStatus) {
             SyncStatus.FAILED_PERMANENTLY -> {
                 binding.retryTV.configureListItem(
-                    configuration.retryIcon,
+                    style.retryIcon,
                     ContextCompat.getColor(context, R.color.stream_ui_accent_blue)
                 )
 
@@ -85,73 +85,54 @@ internal class MessageOptionsView : FrameLayout {
             }
         }
 
-        configureCopyMessage(iconsTint, configuration)
+        configureCopyMessage(iconsTint, style)
 
-        configureEditMessage(configuration)
+        configureEditMessage(style)
         binding.flagTV.isVisible = false
         binding.muteTV.isVisible = false
         binding.blockTV.isVisible = false
-        configureDeleteMessage(configuration)
+        configureDeleteMessage(style)
     }
 
-    private fun configureEditMessage(configuration: Configuration) {
+    private fun configureEditMessage(style: MessageListViewStyle) {
         binding.editTV.apply {
-            if (configuration.editMessageEnabled) {
+            if (style.editMessageEnabled) {
                 isVisible = true
-                configureListItem(configuration.editIcon, configuration.iconsTint)
+                configureListItem(style.editIcon, style.iconsTint)
             } else {
                 isVisible = false
             }
         }
     }
 
-    private fun configureReply(configuration: Configuration, iconTint: Int) {
-        if (configuration.replyEnabled) {
-            binding.replyTV.configureListItem(configuration.replyIcon, iconTint)
+    private fun configureReply(style: MessageListViewStyle, iconTint: Int) {
+        if (style.replyEnabled) {
+            binding.replyTV.configureListItem(style.replyIcon, iconTint)
         } else {
             binding.replyTV.isVisible = false
         }
     }
 
-    private fun configureCopyMessage(iconsTint: Int, configuration: Configuration) {
-        if (configuration.copyTextEnabled) {
+    private fun configureCopyMessage(iconsTint: Int, style: MessageListViewStyle) {
+        if (style.copyTextEnabled) {
             binding.copyTV.isVisible = true
-            binding.copyTV.configureListItem(configuration.copyIcon, iconsTint)
+            binding.copyTV.configureListItem(style.copyIcon, iconsTint)
         } else {
             binding.copyTV.isVisible = false
         }
     }
 
-    private fun configureDeleteMessage(configuration: Configuration) {
-        if (configuration.deleteMessageEnabled) {
+    private fun configureDeleteMessage(style: MessageListViewStyle) {
+        if (style.deleteMessageEnabled) {
             binding.deleteTV.apply {
                 isVisible = true
-                configureListItem(configuration.deleteIcon, configuration.iconsTint)
+                configureListItem(style.deleteIcon, style.iconsTint)
                 setTextColor(ContextCompat.getColor(context, R.color.stream_ui_accent_red))
             }
         } else {
             binding.deleteTV.isVisible = false
         }
     }
-
-    internal data class Configuration(
-        val iconsTint: Int,
-        val replyIcon: Int,
-        val replyEnabled: Boolean = true,
-        val threadReplyIcon: Int,
-        val threadsEnabled: Boolean,
-        val retryIcon: Int,
-        val copyIcon: Int,
-        val editMessageEnabled: Boolean,
-        val editIcon: Int,
-        val flagIcon: Int,
-        val muteIcon: Int,
-        val blockIcon: Int,
-        val deleteIcon: Int,
-        val deleteMessageEnabled: Boolean,
-        val copyTextEnabled: Boolean,
-        val deleteConfirmationEnabled: Boolean,
-    ) : Serializable
 
     fun setReplyListener(onReplyListener: () -> Unit) {
         binding.replyTV.setOnClickListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -155,7 +155,7 @@ internal class MessageOptionsView : FrameLayout {
         val reactionsEnabled: Boolean,
     ) : Serializable {
         internal companion object {
-            operator fun invoke(viewStyle: MessageListViewStyle, channelConfig: Config, suppressThreads: Boolean) =
+            operator fun invoke(viewStyle: MessageListViewStyle, channelConfig: Config, suppressThreads: Boolean = false) =
                 Configuration(
                     replyEnabled = viewStyle.replyEnabled && channelConfig.isRepliesEnabled,
                     threadsEnabled = if (suppressThreads) false else viewStyle.threadsEnabled && channelConfig.isRepliesEnabled,


### PR DESCRIPTION
Refactor xml attributes applying, `MessageOptionsView.Config` and feature flags logic in `MessageListView`

### 🎯 Goal
Firstly we want to support dynamic updates of channel::config updates, but currently it isn't supported by BE.
We should correctly define available options in the message options screen. Their availability is logical `AND` between XML attributes and channel config.

### 🛠 Implementation details

1. Remove all UI attributes from `MessageOptionsView.Config` to `MessageListViewStyle`
2. Keep in `MessageOptionsView.Config` only feature flags and create instance only when message options is being shown
3. Add logic of feature flag calculation to operator `MessageOptionsView.Config::invoke`

### 🧪 Testing

1. Update dashboard channel config
2. Reload channel
3. Check options are updated accordingly

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
