### PR TITLE
Fix Context wrapper handling

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -83,6 +83,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Fixed compatibility with latest Dagger Hilt versions
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/common/Extensions.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/common/Extensions.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.ui.sample.common
 
 import android.app.Activity
 import android.content.Context
-import android.view.ContextThemeWrapper
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.Toast
@@ -13,7 +12,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentManager
 import androidx.navigation.NavController
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
@@ -99,14 +97,6 @@ fun BottomNavigationView.setBadgeNumber(@IdRes menuItemId: Int, badgeNumber: Int
         backgroundColor = context.getColorFromRes(R.color.stream_ui_accent_red)
         isVisible = badgeNumber > 0
         number = badgeNumber
-    }
-}
-
-fun Context?.getFragmentManager(): FragmentManager? {
-    return when (this) {
-        is AppCompatActivity -> supportFragmentManager
-        is ContextThemeWrapper -> baseContext.getFragmentManager()
-        else -> null
     }
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Context.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Context.kt
@@ -3,8 +3,8 @@ package io.getstream.chat.android.ui.common.extensions.internal
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.drawable.Drawable
-import android.view.ContextThemeWrapper
 import androidx.annotation.ArrayRes
 import androidx.annotation.ColorInt
 import androidx.annotation.ColorRes
@@ -36,7 +36,7 @@ internal fun Context.getDrawableCompat(@DrawableRes id: Int): Drawable? {
 internal fun Context?.getFragmentManager(): FragmentManager? {
     return when (this) {
         is AppCompatActivity -> supportFragmentManager
-        is ContextThemeWrapper -> baseContext.getFragmentManager()
+        is ContextWrapper -> baseContext.getFragmentManager()
         else -> null
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Using Dagger Hilt makes our `getFragmentManager` method fail. In previous versions, the `Context` that Hilt wrapped Activities with used to be a `ContextThemeWrapper`, so we checked for that specifically, but it's now just a `ContextWrapper` (see [here](https://github.com/google/dagger/blob/41c4e04da79b5edc6f4f2dff485f10896cb31849/java/dagger/hilt/android/internal/managers/ViewComponentManager.java#L171)).

### 🧪 Testing

Tested by locally publishing with the changes and importing it into a Dagger Hilt app.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/JE5PtgQdM7BGo/giphy.gif)