### PR TITLE
[CAS-870] Make suggestion list an internal part of MessageInputView

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `MessageInputView#setSuggestionListView` <br/>*ui-components* | 2021.04.13 | 2021.04.27 ⌛ | 2021.05.25 ⌛ | Setting external SuggestionListView is no longer necessary |
 | `ChatDomain.usecases` <br/>*offline* | 2021.04.6 | 2021.05.6 ⌛ | 2021.06.6 ⌛ | Replace this property call by obtaining a specific use case directly from ChatDomain |
 | `MessageInputView#setMembers` <br/>*ui-components* | 2021.04.07 | 2021.04.21 ⌛ | 2021.05.05 ⌛ | Use MessageInputView::setUserLookupHandler instead of manually passing the list of users |
 | `ChannelListView's empty state methods` <br/>*ui-components* | 2021.04.05 | 2021.04.19 ⌛ | 2021.05.05 ⌛ | These methods no longer need to be called directly, `setChannel` handles empty state changes automatically |

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -97,7 +97,7 @@
 ### 🐞 Fixed
 - Fixed not perfectly rounded avatars
 ### ⬆️ Improved
-
+- Setting external SuggestionListView is no longer necessary to display suggestions popup
 ### ✅ Added
 
 ### ⚠️ Changed

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -157,9 +157,6 @@ class ChatFragment : Fragment() {
                 editMessage.postValue(it)
             }
         }
-
-        // set external suggestion view which is displayed over message list
-        binding.messageInputView.setSuggestionListView(binding.suggestionListView)
     }
 
     private fun initMessagesViewModel() {

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
@@ -26,15 +26,6 @@
         app:layout_constraintTop_toBottomOf="@+id/messagesHeaderView"
         />
 
-    <io.getstream.chat.android.ui.suggestion.list.SuggestionListView
-        android:id="@+id/suggestionListView"
-        android:layout_width="0dp"
-        android:layout_height="wrap_content"
-        app:layout_constraintBottom_toTopOf="@id/messageInputView"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toStartOf="parent"
-        />
-
     <io.getstream.chat.android.ui.message.input.MessageInputView
         android:id="@+id/messageInputView"
         android:layout_width="0dp"

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1578,14 +1578,14 @@ public final class io/getstream/chat/android/ui/search/list/viewmodel/SearchView
 	public static final fun bind (Lio/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel;Lio/getstream/chat/android/ui/search/list/SearchResultListView;Landroidx/lifecycle/LifecycleOwner;)V
 }
 
-public final class io/getstream/chat/android/ui/suggestion/list/SuggestionListView : android/widget/FrameLayout {
+public final class io/getstream/chat/android/ui/suggestion/list/SuggestionListView : android/widget/FrameLayout, io/getstream/chat/android/ui/suggestion/internal/SuggestionListUi {
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
-	public final fun hideSuggestionList ()V
-	public final fun isSuggestionListVisible ()Z
+	public fun hideSuggestionList ()V
+	public fun isSuggestionListVisible ()Z
 	public final fun setOnSuggestionClickListener (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView$OnSuggestionClickListener;)V
-	public final fun showSuggestionList (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView$Suggestions;)V
+	public fun showSuggestionList (Lio/getstream/chat/android/ui/suggestion/list/SuggestionListView$Suggestions;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/suggestion/list/SuggestionListView$OnSuggestionClickListener {
@@ -1594,6 +1594,7 @@ public abstract interface class io/getstream/chat/android/ui/suggestion/list/Sug
 }
 
 public abstract class io/getstream/chat/android/ui/suggestion/list/SuggestionListView$Suggestions {
+	public final fun hasSuggestions ()Z
 }
 
 public final class io/getstream/chat/android/ui/suggestion/list/SuggestionListView$Suggestions$CommandSuggestions : io/getstream/chat/android/ui/suggestion/list/SuggestionListView$Suggestions {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/SuggestionListPopupWindow.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/SuggestionListPopupWindow.kt
@@ -1,0 +1,43 @@
+package io.getstream.chat.android.ui.message.input.internal
+
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import io.getstream.chat.android.ui.message.input.MessageInputView
+import io.getstream.chat.android.ui.suggestion.internal.SuggestionListUi
+import io.getstream.chat.android.ui.suggestion.list.SuggestionListView
+
+internal class SuggestionListPopupWindow(
+    private val suggestionListView: SuggestionListView,
+    private val messageInputView: MessageInputView,
+) : PopupWindow(suggestionListView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
+    SuggestionListUi {
+
+    override fun showSuggestionList(suggestions: SuggestionListView.Suggestions) {
+        suggestionListView.showSuggestionList(suggestions)
+
+        if (suggestions.hasSuggestions()) {
+            suggestionListView.measure(
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
+                View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
+            )
+            val popupWindowOffset: Int = suggestionListView.measuredHeight + messageInputView.height
+            if (isShowing) {
+                update(messageInputView, 0, -popupWindowOffset, -1, -1)
+            } else {
+                showAsDropDown(messageInputView, 0, -popupWindowOffset)
+            }
+        } else {
+            dismiss()
+        }
+    }
+
+    override fun hideSuggestionList() {
+        dismiss()
+        suggestionListView.hideSuggestionList()
+    }
+
+    override fun isSuggestionListVisible(): Boolean {
+        return suggestionListView.isSuggestionListVisible()
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/CommandsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/CommandsAdapter.kt
@@ -1,12 +1,10 @@
 package io.getstream.chat.android.ui.suggestion.internal
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.internal.SimpleListAdapter
 import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiItemCommandBinding
 
@@ -14,17 +12,7 @@ internal class CommandsAdapter(
     var commandsNameStyle: TextStyle? = null,
     var commandsDescriptionStyle: TextStyle? = null,
     private val onCommandSelected: (Command) -> Unit,
-) : ListAdapter<Command, CommandsAdapter.CommandViewHolder>(
-    object : DiffUtil.ItemCallback<Command>() {
-        override fun areItemsTheSame(oldItem: Command, newItem: Command): Boolean {
-            return oldItem.name == newItem.name
-        }
-
-        override fun areContentsTheSame(oldItem: Command, newItem: Command): Boolean {
-            return oldItem == newItem
-        }
-    }
-) {
+) : SimpleListAdapter<Command, CommandsAdapter.CommandViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommandViewHolder {
         return StreamUiItemCommandBinding
             .inflate(parent.inflater, parent, false)
@@ -36,14 +24,10 @@ internal class CommandsAdapter(
             }
     }
 
-    override fun onBindViewHolder(holder: CommandViewHolder, position: Int) {
-        return holder.bind(getItem(position))
-    }
-
     class CommandViewHolder(
         private val binding: StreamUiItemCommandBinding,
         private val onCommandClicked: (Command) -> Unit,
-    ) : RecyclerView.ViewHolder(binding.root) {
+    ) : SimpleListAdapter.ViewHolder<Command>(binding.root) {
 
         lateinit var command: Command
 
@@ -51,7 +35,7 @@ internal class CommandsAdapter(
             binding.root.setOnClickListener { onCommandClicked(command) }
         }
 
-        fun bind(command: Command) {
+        override fun bind(command: Command) {
             this.command = command
             binding.apply {
                 commandNameTextView.text = command.name.capitalize()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/MentionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/MentionsAdapter.kt
@@ -2,13 +2,11 @@ package io.getstream.chat.android.ui.suggestion.internal
 
 import android.graphics.drawable.Drawable
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
-import androidx.recyclerview.widget.ListAdapter
-import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.utils.extensions.inflater
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.internal.SimpleListAdapter
 import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionBinding
 
@@ -17,17 +15,7 @@ internal class MentionsAdapter(
     var mentionNameStyle: TextStyle? = null,
     var mentionIcon: Drawable? = null,
     private val onMentionSelected: (User) -> Unit,
-) : ListAdapter<User, MentionsAdapter.MentionViewHolder>(
-    object : DiffUtil.ItemCallback<User>() {
-        override fun areItemsTheSame(oldItem: User, newItem: User): Boolean {
-            return oldItem.id == newItem.id
-        }
-
-        override fun areContentsTheSame(oldItem: User, newItem: User): Boolean {
-            return oldItem == newItem
-        }
-    }
-) {
+) : SimpleListAdapter<User, MentionsAdapter.MentionViewHolder>() {
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MentionViewHolder {
         return StreamUiItemMentionBinding
             .inflate(parent.inflater, parent, false)
@@ -42,14 +30,10 @@ internal class MentionsAdapter(
             }
     }
 
-    override fun onBindViewHolder(holder: MentionViewHolder, position: Int) {
-        holder.bind(getItem(position))
-    }
-
     class MentionViewHolder(
         private val binding: StreamUiItemMentionBinding,
-        private val onUserClicked: (User) -> Unit
-    ) : RecyclerView.ViewHolder(binding.root) {
+        private val onUserClicked: (User) -> Unit,
+    ) : SimpleListAdapter.ViewHolder<User>(binding.root) {
 
         lateinit var user: User
 
@@ -57,7 +41,7 @@ internal class MentionsAdapter(
             binding.root.setOnClickListener { onUserClicked(user) }
         }
 
-        fun bind(user: User) {
+        override fun bind(user: User) {
             this.user = user
 
             binding.apply {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 import java.util.regex.Pattern
 
 internal class SuggestionListController(
-    private val suggestionListView: SuggestionListView,
+    private val suggestionListUi: SuggestionListUi,
     private val dismissListener: SuggestionListDismissListener,
 ) {
     var commands: List<Command> = emptyList()
@@ -30,7 +30,7 @@ internal class SuggestionListController(
         this.messageText = messageText
         when {
             commandsEnabled && messageText.isCommandMessage() -> {
-                suggestionListView.showSuggestionList(messageText.getCommandSuggestions())
+                suggestionListUi.showSuggestionList(messageText.getCommandSuggestions())
             }
             mentionsEnabled && messageText.isMentionMessage() -> {
                 handleUserLookup(userLookupHandler, messageText)
@@ -48,23 +48,23 @@ internal class SuggestionListController(
                 ?.let(SuggestionListView.Suggestions::MentionSuggestions)
         }
         withContext(DispatcherProvider.Main) {
-            suggestions?.let(suggestionListView::showSuggestionList)
+            suggestions?.let(suggestionListUi::showSuggestionList)
         }
     }
 
     fun showAvailableCommands() {
         if (commandsEnabled) {
-            suggestionListView.showSuggestionList(SuggestionListView.Suggestions.CommandSuggestions(commands))
+            suggestionListUi.showSuggestionList(SuggestionListView.Suggestions.CommandSuggestions(commands))
         }
     }
 
     fun hideSuggestionList() {
-        suggestionListView.hideSuggestionList()
+        suggestionListUi.hideSuggestionList()
         dismissListener.onDismissed()
     }
 
     fun isSuggestionListVisible(): Boolean {
-        return suggestionListView.isSuggestionListVisible()
+        return suggestionListUi.isSuggestionListVisible()
     }
 
     private fun String.isCommandMessage() = COMMAND_PATTERN.matcher(this).find()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListUi.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListUi.kt
@@ -1,0 +1,12 @@
+package io.getstream.chat.android.ui.suggestion.internal
+
+import io.getstream.chat.android.ui.suggestion.list.SuggestionListView
+
+internal interface SuggestionListUi {
+
+    fun showSuggestionList(suggestions: SuggestionListView.Suggestions)
+
+    fun hideSuggestionList()
+
+    fun isSuggestionListVisible(): Boolean
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
@@ -13,8 +13,9 @@ import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiSuggestionListViewBinding
 import io.getstream.chat.android.ui.suggestion.internal.CommandsAdapter
 import io.getstream.chat.android.ui.suggestion.internal.MentionsAdapter
+import io.getstream.chat.android.ui.suggestion.internal.SuggestionListUi
 
-public class SuggestionListView : FrameLayout {
+public class SuggestionListView : FrameLayout, SuggestionListUi {
 
     internal val binding: StreamUiSuggestionListViewBinding = LayoutInflater.from(context).let {
         StreamUiSuggestionListViewBinding.inflate(it, this)
@@ -41,14 +42,14 @@ public class SuggestionListView : FrameLayout {
         }
     }
 
-    public fun showSuggestionList(suggestions: Suggestions) {
+    override fun showSuggestionList(suggestions: Suggestions) {
         binding.suggestionsCardView.isVisible = true
         when (suggestions) {
             is Suggestions.MentionSuggestions -> {
                 if (suggestions.users.isEmpty()) {
                     hideSuggestionList()
                 } else {
-                    mentionsAdapter.submitList(suggestions.users)
+                    mentionsAdapter.setItems(suggestions.users)
                     binding.commandsTitleTextView.isVisible = false
                 }
             }
@@ -56,14 +57,14 @@ public class SuggestionListView : FrameLayout {
                 if (suggestions.commands.isEmpty()) {
                     hideSuggestionList()
                 } else {
-                    commandsAdapter.submitList(suggestions.commands)
+                    commandsAdapter.setItems(suggestions.commands)
                     binding.commandsTitleTextView.isVisible = true
                 }
             }
         }
     }
 
-    public fun isSuggestionListVisible(): Boolean {
+    override fun isSuggestionListVisible(): Boolean {
         return binding.suggestionsCardView.isVisible
     }
 
@@ -91,10 +92,10 @@ public class SuggestionListView : FrameLayout {
         this.listener = listener
     }
 
-    public fun hideSuggestionList() {
+    override fun hideSuggestionList() {
         if (binding.suggestionsCardView.isVisible) {
-            commandsAdapter.submitList(emptyList())
-            mentionsAdapter.submitList(emptyList())
+            commandsAdapter.clear()
+            mentionsAdapter.clear()
             binding.suggestionsCardView.isVisible = false
         }
     }
@@ -106,6 +107,14 @@ public class SuggestionListView : FrameLayout {
     }
 
     public sealed class Suggestions {
+
+        public fun hasSuggestions(): Boolean {
+            return when (this) {
+                is CommandSuggestions -> commands.isNotEmpty()
+                is MentionSuggestions -> users.isNotEmpty()
+            }
+        }
+
         public data class MentionSuggestions(val users: List<User>) : Suggestions()
         public data class CommandSuggestions(val commands: List<Command>) : Suggestions()
     }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-870

### 🎯 Goal

Make `SugestionListView` should an internal part of `MessageInputView`.

### 🛠 Implementation details

Displaying suggesting list in `PopupWindow`

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114547356-0555b680-9c67-11eb-8e29-2c9f34fc96d1.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114547249-e0614380-9c66-11eb-8749-74321f39b611.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (7)](https://user-images.githubusercontent.com/9600921/114546644-1225da80-9c66-11eb-9b54-a6ed0a9a5b1b.gif)

