### PR TITLE
[CAS-872] Hotfix/user lookup handler

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -96,6 +96,8 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed not perfectly rounded avatars
+- `MessageInputView::UserLookupHandler` is not overrided everytime that members livedata is updated
+
 ### ⬆️ Improved
 - Setting external SuggestionListView is no longer necessary to display suggestions popup
 ### ✅ Added

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -834,7 +834,9 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView$C
 
 public final class io/getstream/chat/android/ui/message/input/MessageInputView$DefaultUserLookupHandler : io/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler {
 	public fun <init> (Ljava/util/List;)V
+	public final fun getUsers ()Ljava/util/List;
 	public fun handleUserLookup (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun setUsers (Ljava/util/List;)V
 }
 
 public abstract class io/getstream/chat/android/ui/message/input/MessageInputView$InputMode {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -598,7 +598,7 @@ public class MessageInputView : ConstraintLayout {
         public suspend fun handleUserLookup(query: String): List<User>
     }
 
-    public class DefaultUserLookupHandler(private val users: List<User>) : UserLookupHandler {
+    public class DefaultUserLookupHandler(public var users: List<User>) : UserLookupHandler {
         override suspend fun handleUserLookup(query: String): List<User> {
             return users.filter { it.name.contains(query, true) }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
@@ -17,8 +17,10 @@ import java.io.File
  */
 @JvmName("bind")
 public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner: LifecycleOwner) {
+    val handler = MessageInputView.DefaultUserLookupHandler(emptyList())
+    view.setUserLookupHandler(handler)
     members.observe(lifecycleOwner) { members ->
-        view.setUserLookupHandler(MessageInputView.DefaultUserLookupHandler(members.map(Member::user)))
+        handler.users = members.map(Member::user)
     }
     commands.observe(lifecycleOwner, view::setCommands)
     maxMessageLength.observe(lifecycleOwner, view::setMaxMessageLength)


### PR DESCRIPTION
### 🎯 Goal
Don't override the UserLookupHandler every time that the members livedata is updated

### 🛠 Implementation details
`DefaultUserLookupHandler` has a mutable property for users that can be updated every time members' livedata is updated but keeping the previous `UserLookupHandler` instance. With this implementation, we keep the previous behavior but allow our customers to use their own implementation without overriding it

### 🧪 Testing
Add your custom `UserLookupHandler` implementation just after the binding method is called and your instance should be the one used anytime a mentions suggestion want to be shown

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/4047514/114580394-1b6f7100-9c7f-11eb-86a1-c465b53492cc.gif)

