### PR TITLE
[CAS-898] Update hidden flag for a channel if new message is received

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed: local cached hidden channels stay hidden even though new message is received.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/EventHandlerImpl.kt
@@ -215,6 +215,8 @@ internal class EventHandlerImpl(
                     event.totalUnreadCount?.let(domainImpl::setTotalUnreadCount)
                     event.unreadChannels?.let(domainImpl::setChannelUnreadCount)
                     batch.addMessageData(event.cid, event.message, isNewMessage = true)
+                    domainImpl.repos.selectChannelWithoutMessages(event.cid)?.copy(hidden = false)
+                        ?.let(batch::addChannel)
                 }
                 is MessageDeletedEvent -> {
                     event.message.enrichWithCid(event.cid)
@@ -231,6 +233,7 @@ internal class EventHandlerImpl(
                     event.totalUnreadCount?.let(domainImpl::setTotalUnreadCount)
                     event.unreadChannels?.let(domainImpl::setChannelUnreadCount)
                     batch.addMessageData(event.cid, event.message, isNewMessage = true)
+                    batch.addChannel(event.channel.copy(hidden = false))
                 }
                 is NotificationAddedToChannelEvent -> {
                     batch.addChannel(event.channel)


### PR DESCRIPTION
Fix based on [Github Issue](https://github.com/GetStream/stream-chat-android/issues/1716)

### 🎯 Goal

Local cached hidden channels don't get updated even new message was received.

### 🛠 Implementation details

Update `Channel::hidden` to false when receive `NewMessageEvent`, `NotificationMessageNewEvent`

### 🧪 Testing

Given two users
1) User1 creates a unique channel with User2
2) User1 hides this channel and clear history
3) User2 sends new message in the channel
4) User1 sees the channel in the list with the new message
5) User1 reads it and returns to the channel list

Channel must be in the list.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

