### PR TITLE
[CAS-870] Dismiss suggestion list on touch outside

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -6,6 +6,7 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Build
 import android.util.AttributeSet
+import android.widget.PopupWindow
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updatePadding
@@ -25,8 +26,8 @@ import io.getstream.chat.android.ui.message.input.attachment.internal.Attachment
 import io.getstream.chat.android.ui.message.input.attachment.internal.AttachmentSelectionListener
 import io.getstream.chat.android.ui.message.input.attachment.internal.AttachmentSource
 import io.getstream.chat.android.ui.message.input.internal.MessageInputFieldView
-import io.getstream.chat.android.ui.message.input.internal.SuggestionListPopupWindow
 import io.getstream.chat.android.ui.suggestion.internal.SuggestionListController
+import io.getstream.chat.android.ui.suggestion.internal.SuggestionListPopupWindow
 import io.getstream.chat.android.ui.suggestion.list.SuggestionListView
 import kotlinx.coroutines.flow.collect
 import java.io.File
@@ -210,14 +211,15 @@ public class MessageInputView : ConstraintLayout {
 
         suggestionListView.binding.suggestionsCardView.setCardBackgroundColor(style.suggestionsBackground)
 
+        val dismissListener = PopupWindow.OnDismissListener {
+            binding.commandsButton.isSelected = false
+        }
         val suggestionListUi = if (popupWindow) {
-            SuggestionListPopupWindow(suggestionListView, this)
+            SuggestionListPopupWindow(suggestionListView, this, dismissListener)
         } else {
             suggestionListView
         }
-        suggestionListController = SuggestionListController(suggestionListUi) {
-            binding.commandsButton.isSelected = false
-        }.also {
+        suggestionListController = SuggestionListController(suggestionListUi, dismissListener).also {
             it.mentionsEnabled = mentionsEnabled
             it.commandsEnabled = commandsEnabled
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListController.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.ui.suggestion.internal
 
+import android.widget.PopupWindow
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.ui.common.extensions.internal.EMPTY
@@ -11,7 +12,7 @@ import java.util.regex.Pattern
 
 internal class SuggestionListController(
     private val suggestionListUi: SuggestionListUi,
-    private val dismissListener: SuggestionListDismissListener,
+    private val dismissListener: PopupWindow.OnDismissListener,
 ) {
     var commands: List<Command> = emptyList()
         set(value) {
@@ -60,7 +61,7 @@ internal class SuggestionListController(
 
     fun hideSuggestionList() {
         suggestionListUi.hideSuggestionList()
-        dismissListener.onDismissed()
+        dismissListener.onDismiss()
     }
 
     fun isSuggestionListVisible(): Boolean {
@@ -76,10 +77,6 @@ internal class SuggestionListController(
         return commands
             .filter { it.name.startsWith(commandPattern) }
             .let { SuggestionListView.Suggestions.CommandSuggestions(it) }
-    }
-
-    internal fun interface SuggestionListDismissListener {
-        fun onDismissed()
     }
 
     companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListPopupWindow.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/internal/SuggestionListPopupWindow.kt
@@ -1,17 +1,22 @@
-package io.getstream.chat.android.ui.message.input.internal
+package io.getstream.chat.android.ui.suggestion.internal
 
 import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupWindow
 import io.getstream.chat.android.ui.message.input.MessageInputView
-import io.getstream.chat.android.ui.suggestion.internal.SuggestionListUi
 import io.getstream.chat.android.ui.suggestion.list.SuggestionListView
 
 internal class SuggestionListPopupWindow(
     private val suggestionListView: SuggestionListView,
     private val messageInputView: MessageInputView,
+    dismissListener: OnDismissListener,
 ) : PopupWindow(suggestionListView, ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.WRAP_CONTENT),
     SuggestionListUi {
+
+    init {
+        isOutsideTouchable = true
+        setOnDismissListener(dismissListener)
+    }
 
     override fun showSuggestionList(suggestions: SuggestionListView.Suggestions) {
         suggestionListView.showSuggestionList(suggestions)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-870

### 🎯 Goal

Dismiss suggestions popup on touch outside. Otherwise there can be potential situations when popup is not dismissed. E.g. when using `ViewPager` and the adjacent tab is in "resumed" state.

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [X] Reviewers added

