### PR TITLE
Disable block user

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -104,5 +104,6 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Now the "block user" feature is disabled. We're planning to improve the feature later. Stay tuned!
 
 ### ❌ Removed

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoFragment.kt
@@ -84,7 +84,8 @@ class ChatInfoFragment : Fragment() {
 
                 if (state.member != null) {
                     add(ChatInfoItem.Option.Stateful.MuteUser(isChecked = state.isMemberMuted))
-                    add(ChatInfoItem.Option.Stateful.Block(isChecked = state.isMemberBlocked))
+                    // TODO disable block until we improve this feature
+                    // add(ChatInfoItem.Option.Stateful.Block(isChecked = state.isMemberBlocked))
                 }
             }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -41,6 +41,7 @@ internal class MessageOptionsView : FrameLayout {
         } else {
             configureMineMessage(configuration, style, syncStatus)
         }
+        binding.blockTV.isVisible = false
     }
 
     private fun configureTheirsMessage(configuration: Configuration, style: MessageListViewStyle) {


### PR DESCRIPTION
### 🎯 Goal

According to the inner discussion, the block user feature should be better specified and supported on BE side. As an immediate action, we should disable it

### 🛠 Implementation details

1. Make `visibility = View.GONE` in the `MessageOptionsView`
2. Do not add this option in the adapter of `ChatInfoFragment`


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added