### PR TITLE
Fix last seen text

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -98,6 +98,7 @@
 ### 🐞 Fixed
 - Fixed not perfectly rounded avatars
 - `MessageInputView::UserLookupHandler` is not overrided everytime that members livedata is updated
+- Fixed incorrect "last seen" text
 
 ### ⬆️ Improved
 - Setting external SuggestionListView is no longer necessary to display suggestions popup

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/User.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/User.kt
@@ -12,11 +12,14 @@ public fun User.getLastSeenText(context: Context): String {
         return context.getString(R.string.stream_ui_message_list_header_online)
     }
 
-    return (updatedAt ?: lastActive ?: createdAt)?.let {
-        val date = when {
-            it.isInLastMinute() -> context.getString(R.string.stream_ui_message_list_header_just_now)
-            else -> DateUtils.getRelativeTimeSpanString(it.time).toString()
+    return (lastActive ?: updatedAt ?: createdAt)?.let {
+        if (it.isInLastMinute()) {
+            context.getString(R.string.stream_ui_message_list_header_last_seen_just_now)
+        } else {
+            context.getString(
+                R.string.stream_ui_message_list_header_last_seen_template,
+                DateUtils.getRelativeTimeSpanString(it.time).toString()
+            )
         }
-        context.getString(R.string.stream_ui_message_list_header_last_seen, date)
     } ?: String.EMPTY
 }

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -49,8 +49,8 @@
     <string name="stream_ui_message_list_header_try_again">Try Again</string>
     <string name="stream_ui_message_list_header_typing">is typing</string>
     <string name="stream_ui_message_list_header_online">Online</string>
-    <string name="stream_ui_message_list_header_last_seen">Last seen %s</string>
-    <string name="stream_ui_message_list_header_just_now">just now</string>
+    <string name="stream_ui_message_list_header_last_seen_template">Last seen %s</string>
+    <string name="stream_ui_message_list_header_last_seen_just_now">Last seen just now</string>
     <string name="stream_ui_message_list_header_group_member_count_with_online">%s, %d Online</string>
     <plurals name="stream_ui_message_list_header_group_member_count">
         <item quantity="one">%1d Member</item>


### PR DESCRIPTION
### 🎯 Goal

Fix incorrect "last seen" text.

### 🛠 Implementation details

We must rely primarily on `lastActive` field for the "last seen" text to be correct. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114744766-b5561d00-9d56-11eb-9e19-9923143a50b1.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/114744795-bc7d2b00-9d56-11eb-897e-23b07a8afc04.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/9600921/114745168-15e55a00-9d57-11eb-942d-d85a9974b78e.gif)

