### PR TITLE
[CAS-902] Moshi ErrorResponse handling

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -26,6 +26,7 @@
 ### 🐞 Fixed
 - Fixed: local cached hidden channels stay hidden even though new message is received.
 - Make `Flag::approvedAt` nullable
+- Fixed error event parsing with new serialization implementation
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/SocketErrorMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/SocketErrorMapping.kt
@@ -6,14 +6,17 @@ import io.getstream.chat.android.client.socket.SocketErrorMessage
 
 internal fun SocketErrorResponse.toDomain(): SocketErrorMessage {
     return SocketErrorMessage(
-        error = error?.let {
-            ErrorResponse(
-                code = error.code,
-                message = error.message,
-                statusCode = error.StatusCode,
-            ).apply {
-                duration = error.duration
-            }
-        }
+        error = error?.toDomain()
     )
+}
+
+internal fun SocketErrorResponse.ErrorResponse.toDomain(): ErrorResponse {
+    val dto = this
+    return ErrorResponse(
+        code = dto.code,
+        message = dto.message,
+        statusCode = dto.StatusCode,
+    ).apply {
+        duration = dto.duration
+    }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.client.events.ReactionDeletedEvent
 import io.getstream.chat.android.client.events.ReactionNewEvent
 import io.getstream.chat.android.client.events.ReactionUpdateEvent
 import io.getstream.chat.android.client.extensions.enrichWithCid
+import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.parser.ChatParser
 import io.getstream.chat.android.client.parser2.adapters.AttachmentDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.DateAdapter
@@ -39,6 +40,8 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 internal class MoshiChatParser : ChatParser {
+
+    val logger = ChatLogger.get("NEW_SERIALIZATION_ERROR")
 
     private val moshi: Moshi by lazy {
         Moshi.Builder()
@@ -92,21 +95,26 @@ internal class MoshiChatParser : ChatParser {
     }
 
     override fun <T : Any> fromJson(raw: String, clazz: Class<T>): T {
-        if (clazz == ChatEvent::class.java) {
-            @Suppress("UNCHECKED_CAST")
-            return parseAndProcessEvent(raw) as T
-        }
-        if (clazz == SocketErrorMessage::class.java) {
-            @Suppress("UNCHECKED_CAST")
-            return parseSocketError(raw) as T
-        }
-        if (clazz == ErrorResponse::class.java) {
-            @Suppress("UNCHECKED_CAST")
-            return parseErrorResponse(raw) as T
-        }
+        try {
+            if (clazz == ChatEvent::class.java) {
+                @Suppress("UNCHECKED_CAST")
+                return parseAndProcessEvent(raw) as T
+            }
+            if (clazz == SocketErrorMessage::class.java) {
+                @Suppress("UNCHECKED_CAST")
+                return parseSocketError(raw) as T
+            }
+            if (clazz == ErrorResponse::class.java) {
+                @Suppress("UNCHECKED_CAST")
+                return parseErrorResponse(raw) as T
+            }
 
-        val adapter = moshi.adapter(clazz)
-        return adapter.fromJson(raw)!!
+            val adapter = moshi.adapter(clazz)
+            return adapter.fromJson(raw)!!
+        } catch (e: Exception) {
+            logger.logE(e)
+            throw e
+        }
     }
 
     private val socketErrorResponseAdapter = moshi.adapter(SocketErrorResponse::class.java)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.client.parser2.adapters.UpstreamChannelDtoAdapt
 import io.getstream.chat.android.client.parser2.adapters.UpstreamMessageDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamReactionDtoAdapter
 import io.getstream.chat.android.client.parser2.adapters.UpstreamUserDtoAdapter
+import io.getstream.chat.android.client.socket.ErrorResponse
 import io.getstream.chat.android.client.socket.SocketErrorMessage
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
@@ -99,6 +100,10 @@ internal class MoshiChatParser : ChatParser {
             @Suppress("UNCHECKED_CAST")
             return parseSocketError(raw) as T
         }
+        if (clazz == ErrorResponse::class.java) {
+            @Suppress("UNCHECKED_CAST")
+            return parseErrorResponse(raw) as T
+        }
 
         val adapter = moshi.adapter(clazz)
         return adapter.fromJson(raw)!!
@@ -109,6 +114,13 @@ internal class MoshiChatParser : ChatParser {
     @Suppress("UNCHECKED_CAST")
     private fun parseSocketError(raw: String): SocketErrorMessage {
         return socketErrorResponseAdapter.fromJson(raw)!!.toDomain()
+    }
+
+    private val errorResponseAdapter = moshi.adapter(SocketErrorResponse.ErrorResponse::class.java)
+
+    @Suppress("UNCHECKED_CAST")
+    private fun parseErrorResponse(raw: String): ErrorResponse {
+        return errorResponseAdapter.fromJson(raw)!!.toDomain()
     }
 
     private val chatEventDtoAdapter = moshi.adapter(ChatEventDto::class.java)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-902

### 🎯 Goal

When `ChatParser` attempts to deserialize the Gson-based `ErrorResponse` class, it calls into `MoshiChatParser` which can't handle this type.

### 🛠 Implementation details

This PR adds special handling so that Moshi recognizes this query, parses its own `ErrorResponse`, and then converts it into the Gson-based / domain model.

Bonus: added logging to whenever there's a failure in event parsing.

### 🧪 Testing

Tested by creating duplicate flag requests for a message, which cause these kinds of errors to be returned by the server.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/MVUyVpyjakkRW/giphy.gif)