### PR TITLE
[CAS-959] Feature/repository facade null object pattern

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -304,11 +304,11 @@ internal class ChatDomainImpl internal constructor(
             client.preSetUserListeners.add {
                 setUser(it)
             }
-            // disconnect if the low level client disconnects
-            client.disconnectListeners.add {
-                scope.launch {
-                    disconnect()
-                }
+        }
+        // disconnect if the low level client disconnects
+        client.disconnectListeners.add {
+            scope.launch {
+                disconnect()
             }
         }
         storeBgSyncDataWhenUserConnects()
@@ -345,6 +345,7 @@ internal class ChatDomainImpl internal constructor(
         job.cancelChildren()
         stopListening()
         stopClean()
+        clearState()
     }
 
     override fun getVersion(): String {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -150,7 +150,6 @@ internal class ChatDomainImpl internal constructor(
     private val useCaseProvider: UseCaseHelper = UseCaseHelper(this)
 
     override lateinit var currentUser: User
-    lateinit var database: ChatDatabase
     private val syncModule by lazy { SyncProvider(appContext) }
 
     /** a helper object which lists all the initialized use cases for the chat domain */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -220,7 +220,9 @@ internal class ChatDomainImpl internal constructor(
         }
     }
 
-    internal lateinit var repos: RepositoryFacade
+    internal val job = SupervisorJob()
+    internal var scope = CoroutineScope(job + DispatcherProvider.IO)
+    internal var repos: RepositoryFacade = createNoOpRepos()
     private val syncStateFlow: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     internal var initJob: Deferred<SyncState?>? = null
 
@@ -236,6 +238,7 @@ internal class ChatDomainImpl internal constructor(
         _mutedUsers.value = emptyList()
         activeChannelMapImpl.clear()
         activeQueryMapImpl.clear()
+        repos = createNoOpRepos()
     }
 
     private fun isTestRunner(): Boolean {
@@ -285,9 +288,6 @@ internal class ChatDomainImpl internal constructor(
         startListening()
         initClean()
     }
-
-    internal val job = SupervisorJob()
-    internal var scope = CoroutineScope(job + DispatcherProvider.IO)
 
     init {
         logger.logI("Initializing ChatDomain with version " + getVersion())
@@ -824,21 +824,12 @@ internal class ChatDomainImpl internal constructor(
     suspend fun selectAndEnrichChannel(
         channelId: String,
         pagination: QueryChannelPaginationRequest,
-    ): Channel? {
-        // Workaround to avoid crashes when user is not connected yet. Review and remove after final solution is implemented
-        return if (!this::repos.isInitialized) {
-            null
-        } else {
-            selectAndEnrichChannels(listOf(channelId), pagination.toAnyChannelPaginationRequest()).getOrNull(0)
-        }
-    }
+    ): Channel? = selectAndEnrichChannels(listOf(channelId), pagination.toAnyChannelPaginationRequest()).getOrNull(0)
 
     suspend fun selectAndEnrichChannel(
         channelId: String,
         pagination: QueryChannelsPaginationRequest,
-    ): Channel? {
-        return selectAndEnrichChannels(listOf(channelId), pagination.toAnyChannelPaginationRequest()).getOrNull(0)
-    }
+    ): Channel? = selectAndEnrichChannels(listOf(channelId), pagination.toAnyChannelPaginationRequest()).getOrNull(0)
 
     suspend fun selectAndEnrichChannels(
         channelIds: List<String>,
@@ -850,9 +841,7 @@ internal class ChatDomainImpl internal constructor(
     private suspend fun selectAndEnrichChannels(
         channelIds: List<String>,
         pagination: AnyChannelPaginationRequest,
-    ): List<Channel> {
-        return repos.selectChannels(channelIds, pagination).applyPagination(pagination)
-    }
+    ): List<Channel> = repos.selectChannels(channelIds, pagination).applyPagination(pagination)
 
     override fun clean() {
         for (channelController in activeChannelMapImpl.values.toList()) {
@@ -860,13 +849,8 @@ internal class ChatDomainImpl internal constructor(
         }
     }
 
-    override fun getChannelConfig(channelType: String): Config {
-        // Workaround to avoid crashes when user is not connected yet. Review and remove after final solution is implemented
-        if (!this::repos.isInitialized) {
-            return defaultConfig
-        }
-        return repos.selectChannelConfig(channelType)?.config ?: defaultConfig
-    }
+    override fun getChannelConfig(channelType: String): Config =
+        repos.selectChannelConfig(channelType)?.config ?: defaultConfig
 
     // region use-case functions
     override fun replayEventsForActiveChannels(cid: String): Call<List<ChatEvent>> =
@@ -1002,6 +986,13 @@ internal class ChatDomainImpl internal constructor(
         }
     }
     // end region
+
+    private fun createNoOpRepos(): RepositoryFacade = RepositoryFacadeBuilder {
+        context(appContext)
+        scope(scope)
+        defaultConfig(defaultConfig)
+        setOfflineEnabled(false)
+    }.build()
 
     companion object {
         val EMPTY_DISPOSABLE = object : Disposable {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFacadeBuilder.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFacadeBuilder.kt
@@ -8,6 +8,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.repository.RepositoryFacade
 import io.getstream.chat.android.livedata.repository.database.ChatDatabase
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 
 internal class RepositoryFacadeBuilder {
     companion object {
@@ -30,14 +31,16 @@ internal class RepositoryFacadeBuilder {
     fun scope(scope: CoroutineScope): RepositoryFacadeBuilder = apply { this.coroutineScope = scope }
     fun defaultConfig(config: Config): RepositoryFacadeBuilder = apply { this.defaultConfig = config }
 
-    private fun createDatabase(context: Context, user: User, offlineEnabled: Boolean) = if (offlineEnabled) {
+    private fun createDatabase(scope: CoroutineScope, context: Context, user: User, offlineEnabled: Boolean) = if (offlineEnabled) {
         ChatDatabase.getDatabase(context, user.id)
     } else {
-        Room.inMemoryDatabaseBuilder(context, ChatDatabase::class.java).build()
+        Room.inMemoryDatabaseBuilder(context, ChatDatabase::class.java).build().also { inMemoryDatabase ->
+            scope.launch { inMemoryDatabase.clearAllTables() }
+        }
     }
 
-    private fun getChatDatabase(): ChatDatabase {
-        return database ?: createDatabase(requireNotNull(context), requireNotNull(currentUser), isOfflineEnabled)
+    private fun getChatDatabase(scope: CoroutineScope): ChatDatabase {
+        return database ?: createDatabase(scope, requireNotNull(context), requireNotNull(currentUser), isOfflineEnabled)
     }
 
     fun build(): RepositoryFacade {
@@ -45,7 +48,7 @@ internal class RepositoryFacadeBuilder {
         val scope = requireNotNull(coroutineScope)
         val user = requireNotNull(currentUser)
 
-        val factory = RepositoryFactory(getChatDatabase(), user)
+        val factory = RepositoryFactory(getChatDatabase(scope), user)
 
         val userRepository = factory.createUserRepository()
         val getUser: suspend (userId: String) -> User = { userId ->

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFacadeBuilder.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFacadeBuilder.kt
@@ -31,7 +31,7 @@ internal class RepositoryFacadeBuilder {
     fun scope(scope: CoroutineScope): RepositoryFacadeBuilder = apply { this.coroutineScope = scope }
     fun defaultConfig(config: Config): RepositoryFacadeBuilder = apply { this.defaultConfig = config }
 
-    private fun createDatabase(scope: CoroutineScope, context: Context, user: User, offlineEnabled: Boolean) = if (offlineEnabled) {
+    private fun createDatabase(scope: CoroutineScope, context: Context, user: User?, offlineEnabled: Boolean) = if (offlineEnabled && user != null) {
         ChatDatabase.getDatabase(context, user.id)
     } else {
         Room.inMemoryDatabaseBuilder(context, ChatDatabase::class.java).build().also { inMemoryDatabase ->
@@ -40,15 +40,14 @@ internal class RepositoryFacadeBuilder {
     }
 
     private fun getChatDatabase(scope: CoroutineScope): ChatDatabase {
-        return database ?: createDatabase(scope, requireNotNull(context), requireNotNull(currentUser), isOfflineEnabled)
+        return database ?: createDatabase(scope, requireNotNull(context), currentUser, isOfflineEnabled)
     }
 
     fun build(): RepositoryFacade {
         val config = requireNotNull(defaultConfig)
         val scope = requireNotNull(coroutineScope)
-        val user = requireNotNull(currentUser)
 
-        val factory = RepositoryFactory(getChatDatabase(scope), user)
+        val factory = RepositoryFactory(getChatDatabase(scope), currentUser)
 
         val userRepository = factory.createUserRepository()
         val getUser: suspend (userId: String) -> User = { userId ->

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/builder/RepositoryFactory.kt
@@ -20,7 +20,7 @@ import io.getstream.chat.android.livedata.repository.domain.user.UserRepositoryI
 
 internal class RepositoryFactory(
     private val database: ChatDatabase,
-    private val currentUser: User,
+    private val currentUser: User?,
 ) {
     fun createUserRepository(): UserRepository = UserRepositoryImpl(database.userDao(), currentUser, 100)
     fun createChannelConfigRepository(): ChannelConfigRepository =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/user/UserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/repository/domain/user/UserRepository.kt
@@ -18,11 +18,12 @@ internal interface UserRepository {
 
 internal class UserRepositoryImpl(
     private val userDao: UserDao,
-    private val currentUser: User,
+    currentUser: User?,
     cacheSize: Int = 100,
 ) : UserRepository {
     // the user cache is simple, just keeps the last 100 users in memory
     private val userCache = LruCache<String, User>(cacheSize)
+    private val currentUserMap: Map<String, User> = currentUser?.let { mapOf(it.id to it) } ?: emptyMap()
 
     override suspend fun insertUsers(users: Collection<User>) {
         if (users.isEmpty()) return
@@ -65,7 +66,7 @@ internal class UserRepositoryImpl(
     }
 
     override suspend fun selectUserMap(userIds: List<String>): Map<String, User> =
-        selectUsers(userIds).associateBy(User::id) + (currentUser.id to currentUser)
+        selectUsers(userIds).associateBy(User::id) + currentUserMap
 
     override suspend fun selectAllUsers(limit: Int, offset: Int): List<User> {
         return userDao.selectAllUser(limit, offset).map(::toModel)


### PR DESCRIPTION
### 🎯 Goal
Create a NoOp RepositoryFacade that is used whenever an user is not set into our `ChatDomain`.
The same RepositoryFacade is used when an user is disconnected to avoid wrong data from another user

### 🛠 Implementation details
The NoOp RepositoryFacade use an InMemory implementation with empty data, with this implementation we don't need null-checking before to use it anymore.
This PR remove the Workaround added on the PR #1767 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF
![source (1)](https://user-images.githubusercontent.com/4047514/115860702-2a4de480-a432-11eb-9e26-d0911f816487.gif)

