### PR TITLE
[CAS-953] Fix oofline reaction sync

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -35,6 +35,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed offline reactions sync
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -309,6 +309,8 @@ public final class io/getstream/chat/android/livedata/repository/domain/message/
 	public fun select (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectSyncNeeded (Lio/getstream/chat/android/client/utils/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun selectSyncNeeded$default (Lio/getstream/chat/android/livedata/repository/domain/message/MessageDao;Lio/getstream/chat/android/client/utils/SyncStatus;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public fun upsertMessageInnerEntities (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun upsertMessageInnerEntity (Lio/getstream/chat/android/livedata/repository/domain/message/MessageInnerEntity;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public final class io/getstream/chat/android/livedata/repository/domain/queryChannels/QueryChannelsDao_Impl {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-953

### 🎯 Goal

Fix offline reaction sync

### 🛠 Implementation details

Room treats `@Insert(onConflict = OnConflictStrategy.REPLACE)` as two separate operations and destroys child constraints. Specifying `deferred = true` doesn't help. Therefore, implemented as "upsert" to keep the existing reactions.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/115870085-6d668280-a447-11eb-8357-869ff9506db9.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/115869840-21b3d900-a447-11eb-8ea8-0a74adae4d45.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Steps to reproduce:
-. Open a chat
-. Disable network connection
-. Add a reaction over a message
-. Connect to network again

Expected behavior:
-. Message is sync properly in backend
-. Reaction keeps its selected state

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (4)](https://user-images.githubusercontent.com/9600921/115870466-f4b3f600-a447-11eb-8a68-77c643d35915.gif)

