### PR TITLE
Add a warning dialog when opening the old sample app

### DIFF
--- a/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
+++ b/stream-chat-android-sample/src/main/kotlin/io/getstream/chat/sample/feature/startup/StartupFragment.kt
@@ -1,8 +1,16 @@
 package io.getstream.chat.sample.feature.startup
 
+import android.content.Context
 import android.os.Bundle
+import android.text.Html
+import android.widget.CheckBox
+import android.widget.FrameLayout
+import androidx.appcompat.app.AlertDialog
+import androidx.core.content.edit
 import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
+import androidx.preference.PreferenceManager
+import com.getstream.sdk.chat.utils.Utils
 import io.getstream.chat.sample.R
 import io.getstream.chat.sample.application.App
 import io.getstream.chat.sample.common.navigateSafely
@@ -11,6 +19,9 @@ class StartupFragment : Fragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+
+        showDeprecationWarningIfNeeded()
+
         findNavController().navigateSafely(
             if (App.instance.chatInitializer.isUserSet()) {
                 R.id.action_startupFragmentFragment_to_channelsFragment
@@ -18,5 +29,45 @@ class StartupFragment : Fragment() {
                 R.id.action_startupFragmentFragment_to_userLoginFragment
             }
         )
+    }
+
+    private fun showDeprecationWarningIfNeeded() {
+        val context = requireContext()
+
+        if (warningShown(context)) {
+            return
+        }
+
+        val checkbox = CheckBox(context).apply { text = "Do not show this again" }
+        val frame = FrameLayout(context).apply {
+            setPadding(Utils.dpToPx(16), Utils.dpToPx(12), Utils.dpToPx(16), 0)
+        }
+        frame.addView(checkbox)
+
+        AlertDialog.Builder(context)
+            .setTitle("Deprecation warning")
+            .setMessage(Html.fromHtml("This sample uses our old UI kit.<br/><br/>Take a look at the new UI Components implementation in the <b>ui-components</b> and <b>ui-components-sample</b> modules instead!"))
+            .setView(frame)
+            .setPositiveButton("Ok") { _, _ ->
+                if (checkbox.isChecked) {
+                    setWarningShown(context)
+                }
+            }
+            .show()
+    }
+
+    private fun warningShown(context: Context): Boolean {
+        return PreferenceManager.getDefaultSharedPreferences(context)
+            .getBoolean(OLD_SAMPLE_WARNING_SHOWN_KEY, false)
+    }
+
+    private fun setWarningShown(context: Context) {
+        PreferenceManager.getDefaultSharedPreferences(context).edit {
+            putBoolean(OLD_SAMPLE_WARNING_SHOWN_KEY, true)
+        }
+    }
+
+    private companion object {
+        private const val OLD_SAMPLE_WARNING_SHOWN_KEY = "old_sample_warning_shown"
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Making sure that nobody accidentally runs the old sample instead of the new one.

### 🛠 Implementation details

Self-explanatory code.

### 🎨 UI Changes

<img width="400" src=https://user-images.githubusercontent.com/12054216/115873865-c16f6800-a443-11eb-8d83-f63b52497c87.png />

### 🧪 Testing

Open old sample.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/3o6Mb2WBUzb7PGcgj6/giphy.gif)