### PR TITLE
[CAS-955] Fix - Only admins or owner can delete users

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoFragment.kt
@@ -92,7 +92,8 @@ class GroupChatInfoFragment : Fragment() {
                         GroupChatInfoMemberOptionsDialogFragment.newInstance(
                             args.cid,
                             it.channelName,
-                            it.member.user
+                            it.member.user,
+                            viewModel.state.value?.isCurrentUserOwnerOrAdmin == true
                         )
                             .show(parentFragmentManager, GroupChatInfoMemberOptionsDialogFragment.TAG)
                     GroupChatInfoViewModel.UiEvent.RedirectToHome -> findNavController().popBackStack(

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoViewModel.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.launch
 class GroupChatInfoViewModel(
     private val cid: String,
     private val chatDomain: ChatDomain = ChatDomain.instance(),
-    chatClient: ChatClient = ChatClient.instance()
+    chatClient: ChatClient = ChatClient.instance(),
 ) : ViewModel() {
 
     private val channelClient: ChannelClient = chatClient.channel(cid)
@@ -52,7 +52,7 @@ class GroupChatInfoViewModel(
         }
     }
 
-    private fun getOwnerOrAdmin(members: List<Member>?) : Member? {
+    private fun getOwnerOrAdmin(members: List<Member>?): Member? {
         return members?.firstOrNull { member ->
             member.isOwnerOrAdmin
         }
@@ -130,7 +130,7 @@ class GroupChatInfoViewModel(
         val channelMuted: Boolean,
         val shouldExpandMembers: Boolean?,
         val membersToShowCount: Int,
-        val isCurrentUserOwnerOrAdmin: Boolean
+        val isCurrentUserOwnerOrAdmin: Boolean,
     )
 
     sealed class Action {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/GroupChatInfoViewModel.kt
@@ -156,7 +156,7 @@ class GroupChatInfoViewModel(
             channelMuted = false,
             shouldExpandMembers = null,
             membersToShowCount = 0,
-            false
+            false,
         )
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
@@ -36,6 +36,10 @@ class GroupChatInfoMemberOptionsDialogFragment : BottomSheetDialogFragment() {
     private val user: User by lazy {
         userData.toUser()
     }
+    private val isOwnerOrAdmin: Boolean by lazy {
+        requireArguments().getBoolean(ARG_IS_OWNER_OR_ADMIN)
+    }
+
     private val viewModel: GroupChatInfoMemberOptionsViewModel by viewModels {
         GroupChatInfoMemberOptionsViewModelFactory(cid, user.id)
     }
@@ -73,7 +77,7 @@ class GroupChatInfoMemberOptionsDialogFragment : BottomSheetDialogFragment() {
                 viewModel.onAction(GroupChatInfoMemberOptionsViewModel.Action.MessageClicked)
             }
 
-            if (isAnonymousChannel(cid)) {
+            if (isAnonymousChannel(cid) || !isOwnerOrAdmin) {
                 optionRemove.isVisible = false
             } else {
                 optionRemove.setOnClickListener {
@@ -144,11 +148,17 @@ class GroupChatInfoMemberOptionsDialogFragment : BottomSheetDialogFragment() {
         private const val ARG_CID = "cid"
         private const val ARG_CHANNEL_NAME = "channel_name"
         private const val ARG_USER_DATA = "user_data"
+        private const val ARG_IS_OWNER_OR_ADMIN = "is_owner_or_admin"
 
-        fun newInstance(cid: String, channelName: String, user: User) =
+        fun newInstance(cid: String, channelName: String, user: User, isOwnerOrAdmin: Boolean) =
             GroupChatInfoMemberOptionsDialogFragment().apply {
                 arguments =
-                    bundleOf(ARG_CID to cid, ARG_CHANNEL_NAME to channelName, ARG_USER_DATA to user.toUserData())
+                    bundleOf(
+                        ARG_CID to cid,
+                        ARG_CHANNEL_NAME to channelName,
+                        ARG_USER_DATA to user.toUserData(),
+                        ARG_IS_OWNER_OR_ADMIN to isOwnerOrAdmin
+                    )
             }
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
@@ -157,7 +157,7 @@ class GroupChatInfoMemberOptionsDialogFragment : BottomSheetDialogFragment() {
                         ARG_CID to cid,
                         ARG_CHANNEL_NAME to channelName,
                         ARG_USER_DATA to user.toUserData(),
-                        ARG_IS_OWNER_OR_ADMIN to isOwnerOrAdmin
+                        ARG_IS_OWNER_OR_ADMIN to isOwnerOrAdmin,
                     )
             }
     }


### PR DESCRIPTION
[CAS-955](https://stream-io.atlassian.net/browse/CAS-955)

### 🎯 Goal

Remove the option to remove users when a member is not an admin of the channel

### 🛠 Implementation details

I added the field `isOwnerOrAdmin` to the `state` of `GroupChatInfoViewModel`

### 🎨 UI Changes

_ Add relevant screenshots_

| Before | After |
| --- | --- |
| ![Screenshot_20210423-104304](https://user-images.githubusercontent.com/10619102/115880462-249bd300-a421-11eb-8eb2-2bb42d4cd0da.png) | ![Screenshot_20210423-104326](https://user-images.githubusercontent.com/10619102/115880523-341b1c00-a421-11eb-982f-f931552304f7.png) |

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/115880806-7fcdc580-a421-11eb-8770-c3222ec0ecd9.gif)
