### PR TITLE
[CAS-954] Add refreshing channels after receiving update event

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/Mother.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.NeutralFilterObject
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.events.ChannelDeletedEvent
+import io.getstream.chat.android.client.events.ChannelUpdatedByUserEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MessageReadEvent
@@ -527,6 +528,27 @@ internal fun randomChannelUpdatedEvent(
         channelId = channelId,
         message = message,
         channel = channel,
+    )
+}
+
+internal fun randomChannelUpdatedByUserEvent(
+    createdAt: Date = randomDate(),
+    cid: String = randomString(),
+    channelType: String = randomString(),
+    channelId: String = randomString(),
+    message: Message = randomMessage(),
+    channel: Channel = randomChannel(),
+    user: User = randomUser(),
+): ChannelUpdatedByUserEvent {
+    return ChannelUpdatedByUserEvent(
+        type = EventType.CHANNEL_UPDATED,
+        createdAt = createdAt,
+        cid = cid,
+        channelType = channelType,
+        channelId = channelId,
+        message = message,
+        channel = channel,
+        user = user,
     )
 }
 


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-954

### 🎯 Goal

Fix showing new channels.

### 🛠 Implementation details
There might be a case when a channel is not added to `queryChannelsSpec.cids` when `NotificationAddedToChannelEvent` arrives (because it doesn't match filter) but it should be added after receiving `ChannelUpdated` or `ChannelUpdatedByUser` events (because now it matches the filter).

### 🧪 Testing

1. Create a new channel based on members
2. Go back to the channel's list view
3. New channel should be visible

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/17440581/115887422-35187180-a452-11eb-80d2-7c75bd9dc0f4.gif)

