### PR TITLE
Add unsubscribing from channelData when first value is received

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -89,6 +89,8 @@ public class MessageListViewModel @JvmOverloads constructor(
                 val channelController = channelControllerResult.data()
                 _channel.addSource(channelController.channelData) {
                     _channel.value = channelController.toChannel()
+                    // Channel should be propagated only once because it's used to initialize MessageListView
+                    _channel.removeSource(channelController.channelData)
                 }
                 val typingIds = Transformations.map(channelController.typing) { (_, idList) -> idList }
 


### PR DESCRIPTION
### 🎯 Goal

Fix _MessageListView_ initialization.

### 🛠 Implementation details
#1767 introduced a _MessageListView_ initialization bug. The view was reinitialized every time when `channelData` changes. This PR fixes it by unsubscribing from `channelData` after receiving the first value.


### 🧪 Testing

1. Open a channel
2. Send a message
3. Send a message to this channel from another device
4. Chat shouldn't flash and auto-scroll should be working

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

