### PR TITLE
CAS-926 Move `client/invites` cookbook to docusaurus

### DIFF
--- a/documentation/docs/client/invites/_category_.json
+++ b/documentation/docs/client/invites/_category_.json
@@ -1,0 +1,4 @@
+{
+  "label": "Invites",
+  "position": 11
+}

--- a/documentation/docs/client/invites/accepting_invite.md
+++ b/documentation/docs/client/invites/accepting_invite.md
@@ -1,0 +1,18 @@
+---
+id: AcceptingInvite
+title: Accepting an invite
+sidebar_position: 2
+---
+In order to accept an invite, you must use call the `acceptInvite` method. The `acceptInvite` method accepts and object with an optional message property. Please see below for an example of how to call `acceptInvite`:
+
+```kotlin
+channelClient.acceptInvite( 
+    message = "Nick joined this channel!" 
+).enqueue { result -> 
+    if (result.isSuccess) { 
+        val channel = result.data() 
+    } else { 
+        // Handle result.error() 
+    } 
+}
+```

--- a/documentation/docs/client/invites/inviting_user.md
+++ b/documentation/docs/client/invites/inviting_user.md
@@ -1,0 +1,26 @@
+---
+id: Invites
+title: Inviting a user
+sidebar_position: 1
+---
+Stream Chat provides the ability to invite users to a channel via the `channel` method with the `invites` array. Upon invitation, the end-user will receive a notification that they were invited to the specified channel.
+
+#### Inviting a User
+
+See the following for an example on how to invite a user by adding an `invites` array containing the user ID:
+
+```kotlin
+val channelClient = client.channel("messaging", "general") 
+val data = mapOf( 
+    "members" to listOf("thierry", "tommaso"), 
+    "invites" to listOf("nick") 
+) 
+ 
+channelClient.create(data).enqueue { result -> 
+    if (result.isSuccess) { 
+        val channel = result.data() 
+    } else { 
+        // Handle result.error() 
+    } 
+}
+```

--- a/documentation/docs/client/invites/querying_accepted_invites.md
+++ b/documentation/docs/client/invites/querying_accepted_invites.md
@@ -1,0 +1,21 @@
+---
+id: QueryingAcceptedInvites
+title: Accepting for Accepted Invites
+sidebar_position: 4
+---
+Querying for accepted invites is done via the `queryChannels` method. This allows you to return a list of accepted invites with a single call. See below for an example:
+
+```kotlin
+val request = QueryChannelsRequest( 
+    filter = Filters.eq("invite", "accepted"), 
+    offset = 0, 
+    limit = 10 
+) 
+client.queryChannels(request).enqueue { result -> 
+    if (result.isSuccess) { 
+        val channels: List<Channel> = result.data() 
+    } else { 
+        // Handle result.error() 
+    } 
+}
+```

--- a/documentation/docs/client/invites/querying_rejected_invites.md
+++ b/documentation/docs/client/invites/querying_rejected_invites.md
@@ -1,0 +1,21 @@
+---
+id: QueryingRejectedInvites
+title: Accepting for Rejected Invites
+sidebar_position: 5
+---
+Similar to querying for accepted invites, you can query for rejected invites with `queryChannels`. See below for an example:
+
+```kotlin
+val request = QueryChannelsRequest( 
+    filter = Filters.eq("invite", "rejected"), 
+    offset = 0, 
+    limit = 10 
+) 
+client.queryChannels(request).enqueue { result -> 
+    if (result.isSuccess) { 
+        val channels: List<Channel> = result.data() 
+    } else { 
+        // Handle result.error() 
+    } 
+}
+```

--- a/documentation/docs/client/invites/rejecting_invite.md
+++ b/documentation/docs/client/invites/rejecting_invite.md
@@ -1,0 +1,16 @@
+---
+id: RejectingInvite
+title: Rejecting an invite
+sidebar_position: 3
+---
+To reject an invite, call the `rejectInvite` method. This method does not require a user ID as it pulls the user ID from the current session in store from the `connectUser` call.
+
+```kotlin
+channelClient.rejectInvite().enqueue { result ->  
+    if (result.isSuccess) {  
+        // Invite rejected  
+    } else {  
+        // Handle result.error()  
+    }  
+}
+```


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-926

### 🎯 Goal

Move `client/invites` cookbook to docusaurus

### 🧪 Testing

1. Go to `documentation` folder
2. Run `yarn run start`
3. Check out Client -> Invites section

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

