### PR TITLE
Hotfix/increase default timeout

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1345,8 +1345,8 @@ public class ChatClient internal constructor(
 
         private var baseUrl: String = "chat-us-east-1.stream-io-api.com"
         private var cdnUrl: String = baseUrl
-        private var baseTimeout = 10000L
-        private var cdnTimeout = 10000L
+        private var baseTimeout = 30_000L
+        private var cdnTimeout = 30_000L
         private var enableMoshi = false
         private var logLevel = ChatLogLevel.NOTHING
         private var warmUp: Boolean = true

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
@@ -140,7 +140,6 @@ internal open class BaseChatModule(
     ): OkHttpClient.Builder {
         return baseClientBuilder()
             // timeouts
-            .callTimeout(timeout, TimeUnit.MILLISECONDS)
             .connectTimeout(timeout, TimeUnit.MILLISECONDS)
             .writeTimeout(timeout, TimeUnit.MILLISECONDS)
             .readTimeout(timeout, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
### 🎯 Goal
The default timout into our SDK is exceded sometimes when querying for channels, and it causes that our ChannelList shows an empty list.
The `callTimeout` has been removed, it limited the "full call time" to this time and the rest of timetouts (connection/write/read) doesn't apply on that case.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![gif](https://media.giphy.com/media/xUA7b5CJFboJa7zw0E/giphy.gif)
