### PR TITLE
[CAS-960] Hotfix/delete message

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -345,12 +345,7 @@ public class ChannelController internal constructor(
     }
 
     private fun removeMessagesBefore(date: Date) {
-        val copy = _messages.value
-        // start off empty
-        _messages.value = mutableMapOf()
-        // call upsert with the messages that are recent
-        val recentMessages = copy.values.filter { it.wasCreatedAfter(date) }
-        upsertMessages(recentMessages)
+        _messages.value = _messages.value.filter { it.value.wasCreatedAfter(date) }
     }
 
     internal suspend fun hide(clearHistory: Boolean): Result<Unit> {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplEventTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/controller/ChannelControllerImplEventTest.kt
@@ -30,6 +30,9 @@ import io.getstream.chat.android.livedata.randomUser
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.test.InstantTaskExecutorExtension
+import io.getstream.chat.android.test.randomDate
+import io.getstream.chat.android.test.randomDateAfter
+import io.getstream.chat.android.test.randomDateBefore
 import io.getstream.chat.android.test.randomInt
 import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -162,17 +165,29 @@ internal class ChannelControllerEventNewTest {
     @Test
     fun `when a message update event is outdated, it should be ignored`() {
         val messageId = randomString()
+        val createdAt = randomDate()
+        val createdLocallyAt = randomDateBefore(createdAt.time)
+        val updatedAt = randomDateAfter(createdAt.time)
+        val oldUpdatedAt = randomDateBefore(updatedAt.time)
         val recentMessage = randomMessage(
             id = messageId,
             user = User(id = "otherUserId"),
-            updatedAt = Date(),
+            createdAt = createdAt,
+            createdLocallyAt = createdLocallyAt,
+            updatedAt = updatedAt,
+            updatedLocallyAt = updatedAt,
+            deletedAt = null,
             silent = false,
             showInChannel = true
         )
         val oldMessage = randomMessage(
             id = messageId,
             user = User(id = "otherUserId"),
-            updatedAt = Date(Long.MIN_VALUE),
+            createdAt = createdAt,
+            createdLocallyAt = createdLocallyAt,
+            updatedAt = oldUpdatedAt,
+            updatedLocallyAt = oldUpdatedAt,
+            deletedAt = null,
             silent = false,
             showInChannel = true
         )

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/Mother.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/Mother.kt
@@ -16,7 +16,7 @@ public fun positiveRandomLong(maxLong: Long = Long.MAX_VALUE - 1): Long =
 public fun randomInt(): Int = Random.nextInt()
 public fun randomIntBetween(min: Int, max: Int): Int = Random.nextInt(min, max + 1)
 public fun randomLong(): Long = Random.nextLong()
-public fun randomLongBetween(min: Long, max: Long): Long = Random.nextLong(min, max + 1)
+public fun randomLongBetween(min: Long, max: Long = Long.MAX_VALUE - 1): Long = Random.nextLong(min, max + 1)
 public fun randomBoolean(): Boolean = Random.nextBoolean()
 public fun randomString(size: Int = 20): String = buildString(capacity = size) {
     repeat(size) {
@@ -36,9 +36,9 @@ public fun randomFiles(
     creationFunction: (Int) -> File = { randomFile() }
 ): List<File> = (1..size).map(creationFunction)
 
-public fun randomDate(): Date = Date(randomLong())
-
+public fun randomDate(): Date = Date(positiveRandomLong())
 public fun randomDateBefore(date: Long): Date = Date(date - positiveRandomInt())
+public fun randomDateAfter(date: Long): Date = Date(randomLongBetween(date))
 
 public fun createDate(
     year: Int = positiveRandomInt(),


### PR DESCRIPTION
### 🎯 Goal
The message looked like it wasn't removed because it wasn't refreshed on the recyclerView. After debuged the DiffUtil I could see it was working fine and at the end I found the issue was taht we were mutating the same `Message` instance and because that the recyclerView didn't get update.
The different methods where a message was updated has been refactored to not mutate the same instance but a copy of it

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF
![gif](https://images.ctfassets.net/s600jj41gsex/68DOjhOzEbuPdmzvpTngxp/fea1881f52463120d600ec254f17017c/blob_giphy.gif)
