### PR TITLE
Quickfix: fix attachment button, remove code pushed by mistake

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -69,7 +69,6 @@ class ChatFragment : Fragment() {
         configureMessageInputView()
         initMessageInputViewModel()
         configureBackButtonHandling()
-        _binding?.messageInputView?.disableView()
     }
 
     private fun configureMessageInputView() {

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -830,9 +830,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public final fun disableSendButton ()V
-	public final fun disableView ()V
 	public final fun enableSendButton ()V
-	public final fun enableView ()V
 	public final fun getChatMode ()Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
 	public final fun getInputMode ()Lio/getstream/chat/android/ui/message/input/MessageInputView$InputMode;
 	public final fun listenForBigAttachments (Lio/getstream/chat/android/ui/message/input/MessageInputView$BigFileSelectionListener;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -167,28 +167,6 @@ public class MessageInputView : ConstraintLayout {
         refreshControlsState()
     }
 
-    public fun disableView() {
-        binding.inputModeIcon.isEnabled = false
-        binding.dismissInputMode.isEnabled = false
-        binding.attachmentsButton.isEnabled = false
-        binding.commandsButton.isEnabled = false
-        binding.messageInputFieldView.isEnabled = false
-        binding.sendMessageButtonDisabled.isEnabled = false
-        binding.sendMessageButtonEnabled.isEnabled = false
-        binding.sendAlsoToChannel.isEnabled = false
-    }
-
-    public fun enableView() {
-        binding.inputModeIcon.isEnabled = true
-        binding.dismissInputMode.isEnabled = true
-        binding.attachmentsButton.isEnabled = true
-        binding.commandsButton.isEnabled = true
-        binding.messageInputFieldView.isEnabled = true
-        binding.sendMessageButtonDisabled.isEnabled = true
-        binding.sendMessageButtonEnabled.isEnabled = true
-        binding.sendAlsoToChannel.isEnabled = true
-    }
-
     /**
      * Enables or disables the handling of mentions in the message input view.
      *


### PR DESCRIPTION
Quickfix: fix attachment button, remove code pushed by mistake

### 🧪 Testing

Attachment button should not be inactive

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF
