### PR TITLE
[CAS-965] Fix click listener in the header view

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -116,15 +116,17 @@ class ChatFragment : Fragment() {
     }
 
     private fun initChatViewModel() {
-        binding.messagesHeaderView.apply {
-            setAvatarClickListener {
-                chatViewModel.onAction(ChatViewModel.Action.HeaderClicked)
-            }
-            setTitleClickListener {
-                chatViewModel.onAction(ChatViewModel.Action.HeaderClicked)
-            }
-            setSubtitleClickListener {
-                chatViewModel.onAction(ChatViewModel.Action.HeaderClicked)
+        chatViewModel.members.observe(viewLifecycleOwner) { members ->
+            binding.messagesHeaderView.apply {
+                setAvatarClickListener {
+                    chatViewModel.onAction(ChatViewModel.Action.HeaderClicked(members))
+                }
+                setTitleClickListener {
+                    chatViewModel.onAction(ChatViewModel.Action.HeaderClicked(members))
+                }
+                setSubtitleClickListener {
+                    chatViewModel.onAction(ChatViewModel.Action.HeaderClicked(members))
+                }
             }
         }
         chatViewModel.navigationEvent.observe(

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
@@ -1,8 +1,10 @@
 package io.getstream.chat.ui.sample.feature.chat
 
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
 import io.getstream.chat.android.livedata.utils.Event
@@ -13,36 +15,38 @@ class ChatViewModel(private val cid: String, private val chatDomain: ChatDomain 
     private val _navigationEvent: MutableLiveData<Event<NavigationEvent>> = MutableLiveData()
     private var channelController: ChannelController? = null
     val navigationEvent: LiveData<Event<NavigationEvent>> = _navigationEvent
+    private val _members: MediatorLiveData<List<Member>> = MediatorLiveData()
+    val members: LiveData<List<Member>> = _members
 
     init {
         chatDomain.getChannelController(cid).enqueue { result ->
             if (result.isSuccess) {
-                channelController = result.data()
+                channelController = result.data().also {
+                    _members.addSource(it.members) { members -> _members.value = members }
+                }
             }
         }
     }
 
     fun onAction(action: Action) {
         when (action) {
-            Action.HeaderClicked -> {
+            is Action.HeaderClicked -> {
                 val controller = requireNotNull(channelController)
-                controller.members.value?.let { members ->
-                    _navigationEvent.value = Event(
-                        if (members.size > 2 ||
-                            controller.channelData.value?.isAnonymousChannel() == false
-                        ) {
-                            NavigationEvent.NavigateToGroupChatInfo(cid)
-                        } else {
-                            NavigationEvent.NavigateToChatInfo(cid)
-                        }
-                    )
-                }
+                _navigationEvent.value = Event(
+                    if (action.members.size > 2 ||
+                        controller.channelData.value?.isAnonymousChannel() == false
+                    ) {
+                        NavigationEvent.NavigateToGroupChatInfo(cid)
+                    } else {
+                        NavigationEvent.NavigateToChatInfo(cid)
+                    }
+                )
             }
         }
     }
 
     sealed class Action {
-        object HeaderClicked : Action()
+        class HeaderClicked(val members: List<Member>) : Action()
     }
 
     sealed class NavigationEvent {


### PR DESCRIPTION
### 🎯 Goal

New offline chat domain converts flow to livedata. But livedata doesn't get any values until it is active (has at least one observer). We used the member live data value inappropriate before, we invoke `LiveData::value` without setting any observer. It leads to null default live data value with new `Flow::asLiveData`.

### 🛠 Implementation details

Fix this issue as observing changes in livedata and setup listener every time when members get changed

### 🧪 Testing

1. Open chat group screen
2. Click on users' avatar

Expected behaviour: should open the group chat info screen.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF
 ![](https://media1.giphy.com/media/G7Pc0fNwuVzYk/giphy.gif)
