### PR TITLE
Fix add users in group chat infinite loader

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
@@ -38,11 +38,9 @@ class ChatInfoViewModel(
                 val channelControllerResult = chatDomain.getChannelController(cid).await()
                 if (channelControllerResult.isSuccess) {
                     val channelController = channelControllerResult.data()
-                    val canDeleteChannel = channelController.members.value.isCurrentUserOwnerOrAdmin()
-                    _state.value = _state.value!!.copy(canDeleteChannel = canDeleteChannel)
-
                     _state.addSource(channelController.members) { memberList ->
                         // Updates only if the user state is already set
+                        _state.value = _state.value!!.copy(canDeleteChannel = memberList.isCurrentUserOwnerOrAdmin())
                         memberList.find { member -> member.user.id == _state.value?.member?.user?.id }?.let { member ->
                             _state.value = _state.value?.copy(member = member)
                         }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.ui.sample.feature.chat.info.group.users
 
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Observer
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
@@ -11,32 +12,42 @@ import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.android.livedata.controller.ChannelController
 import kotlinx.coroutines.launch
 
 class GroupChatInfoAddUsersViewModel(
     cid: String,
     chatDomain: ChatDomain = ChatDomain.instance(),
-    chatClient: ChatClient = ChatClient.instance()
+    chatClient: ChatClient = ChatClient.instance(),
 ) : ViewModel() {
 
     private val channelClient = chatClient.channel(cid)
-    private var members: LiveData<List<Member>> = MutableLiveData(emptyList())
+    private var members: List<Member> = emptyList()
     private val _state: MutableLiveData<State> = MutableLiveData(INITIAL_STATE)
     private val _userAddedState: MutableLiveData<Boolean> = MutableLiveData(false)
     private var isLoadingMore: Boolean = false
     val state: LiveData<State> = _state
     val userAddedState: LiveData<Boolean> = _userAddedState
+    private var channelController: ChannelController? = null
+
+    private val observer = Observer<List<Member>> { members = it }
 
     init {
         viewModelScope.launch {
             val result = chatDomain.getChannelController(cid).await()
             if (result.isSuccess) {
-                members = result.data().members
+                channelController = result.data()
+                channelController?.members?.observeForever(observer)
                 viewModelScope.launch {
                     fetchUsers()
                 }
             }
         }
+    }
+
+    override fun onCleared() {
+        channelController?.members?.removeObserver(observer)
+        super.onCleared()
     }
 
     fun onAction(action: Action) {
@@ -84,7 +95,10 @@ class GroupChatInfoAddUsersViewModel(
     }
 
     private suspend fun fetchUsers() {
-        val currentMembers = members.value ?: return
+        if (members.isEmpty()) {
+            return
+        }
+        val currentMembers = members
         val currentState = _state.value!!
         val filter = if (currentState.query.isEmpty()) {
             Filters.nin("id", currentMembers.map { it.getUserId() })


### PR DESCRIPTION
### 🎯 Goal

In `GroupChatInfoAddUsersViewModel` there was direct invocation of `LiveData::value`. Now it is null by default. 

### 🛠 Implementation details
 I added observer for members in VM which is removed `::onCleared`. It receives all updates propagated to this members value
### 🧪 Testing
1. Open group chat screen
2. Click on users' avatar
3. Click on add member

Expected behaviour: see the list of possible members
Actual: infinite loader

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

