### PR TITLE
Fix filtering channels with empty extra data

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsFragment.kt
@@ -29,7 +29,7 @@ class ChatInfoSharedGroupsFragment : Fragment() {
             filter = Filters.and(
                 Filters.eq("type", "messaging"),
                 Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id, args.memberId)),
-                Filters.ne("draft", true),
+                Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
                 Filters.greaterThan("member_count", 2),
             ),
         )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -32,7 +32,7 @@ public class ChannelListViewModel(
     private val filter: FilterObject = Filters.and(
         eq("type", "messaging"),
         Filters.`in`("members", listOf(chatDomain.currentUser.id)),
-        Filters.ne("draft", true)
+        Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
@@ -24,7 +24,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
     private val filter: FilterObject = Filters.and(
         Filters.eq("type", "messaging"),
         Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id)),
-        Filters.ne("draft", true)
+        Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
     ),
     private val sort: QuerySort<Channel> = ChannelListViewModel.DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -31,7 +31,7 @@ public class ChannelsViewModel(
     private val filter: FilterObject = Filters.and(
         eq("type", "messaging"),
         Filters.`in`("members", listOf(chatDomain.currentUser.id)),
-        Filters.ne("draft", true)
+        Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/factory/ChannelsViewModelFactory.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/factory/ChannelsViewModelFactory.kt
@@ -23,7 +23,7 @@ public class ChannelsViewModelFactory @JvmOverloads constructor(
     private val filter: FilterObject = Filters.and(
         Filters.eq("type", "messaging"),
         Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id)),
-        Filters.ne("draft", true)
+        Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
     ),
     private val sort: QuerySort<Channel> = ChannelsViewModel.DEFAULT_SORT,
     private val limit: Int = 30


### PR DESCRIPTION
### 🎯 Goal

Fix filtering channels with empty extra data.

### 🛠 Implementation details

`Filters.ne` doesn't work correctly when `extraData` is null. The issue is already reported to the backend team, but I've updated the filter just to make sure that the channel response contains proper data.

### 🧪 Testing

1. Create a channel that matches the filter but has empty extra data
2. Channel should be visible in the lix

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
