### PR TITLE
Fix flaky custom object tests

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/CustomObjectFilteringTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/livedata/utils/CustomObjectFilteringTest.kt
@@ -632,7 +632,7 @@ internal class CustomObjectFilteringTest {
                             }
                         }
                         ),
-                    Filters.greaterThan("someField", randomIntBetween(-100, -80)),
+                    Filters.greaterThan("someField", randomIntBetween(-100, -81)),
                     expectedList,
                 )
             },
@@ -649,7 +649,7 @@ internal class CustomObjectFilteringTest {
                             }
                         }
                         ),
-                    Filters.greaterThan("someField", randomLongBetween(-100, -80)),
+                    Filters.greaterThan("someField", randomLongBetween(-100, -81)),
                     expectedList,
                 )
             },
@@ -677,7 +677,7 @@ internal class CustomObjectFilteringTest {
             }.let { expectedList ->
                 Arguments.of(
                     (expectedList + List(positiveRandomInt(10)) { randomChannel() }),
-                    Filters.greaterThan("someField", randomIntBetween(-100, -80)),
+                    Filters.greaterThan("someField", randomIntBetween(-100, -81)),
                     expectedList,
                 )
             },
@@ -688,7 +688,7 @@ internal class CustomObjectFilteringTest {
             }.let { expectedList ->
                 Arguments.of(
                     (expectedList + List(positiveRandomInt(10)) { randomChannel() }),
-                    Filters.greaterThan("someField", randomLongBetween(-100, -80)),
+                    Filters.greaterThan("someField", randomLongBetween(-100, -81)),
                     expectedList,
                 )
             },
@@ -915,7 +915,7 @@ internal class CustomObjectFilteringTest {
                             }
                         }
                         ),
-                    Filters.lessThan("someField", randomIntBetween(300, 320)),
+                    Filters.lessThan("someField", randomIntBetween(301, 320)),
                     expectedList,
                 )
             },
@@ -932,7 +932,7 @@ internal class CustomObjectFilteringTest {
                             }
                         }
                         ),
-                    Filters.lessThan("someField", randomLongBetween(300, 320)),
+                    Filters.lessThan("someField", randomLongBetween(301, 320)),
                     expectedList,
                 )
             },
@@ -960,7 +960,7 @@ internal class CustomObjectFilteringTest {
             }.let { expectedList ->
                 Arguments.of(
                     (expectedList + List(positiveRandomInt(10)) { randomChannel() }),
-                    Filters.lessThan("someField", randomIntBetween(300, 320)),
+                    Filters.lessThan("someField", randomIntBetween(301, 320)),
                     expectedList,
                 )
             },
@@ -971,7 +971,7 @@ internal class CustomObjectFilteringTest {
             }.let { expectedList ->
                 Arguments.of(
                     (expectedList + List(positiveRandomInt(10)) { randomChannel() }),
-                    Filters.lessThan("someField", randomLongBetween(300, 320)),
+                    Filters.lessThan("someField", randomLongBetween(301, 320)),
                     expectedList,
                 )
             },


### PR DESCRIPTION
### 🎯 Goal

Stop random PR pipeline failures

### 🛠 Implementation details

Our tests for custom object filters use random values. The ranges in which are generated were incorrect for the lesser-than and greater-than filters.

For example, the greater-than filter generated the expected values in the [-80, 300] range, and the value of the filter in the [-100, -80] range. When some values ended up being -80 and the filter also got the -80 random value, the filter would (correctly) filter out the -80 values present in the expected list. The PR adjusts the upper bound of the filter value to -81 to avoid this in the future.

Screenshot of this failure state:
![image](https://user-images.githubusercontent.com/12054216/117265566-a5f95980-ae54-11eb-82e7-4f4b58bb5381.png)


### 🧪 Testing

Verified by running the tests in an endless loop for a while, and no failures happening. Previously a failure would show up every couple seconds.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests ☑️
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/MFClzg5WrAOTEb9Zbu/giphy.gif)