### PR TITLE
Fixing filter for draft and hidden channels

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -12,7 +12,9 @@
 
 ## stream-chat-android
 ### 🐞 Fixed
-
+Fixing filter for hidden and draft channels. Those channels were not showing in the results,
+even when the user asked for then. Now this is fixed and the draft and hidden channels can be included
+in the ChannelsView
 ### ⬆️ Improved
 
 ### ✅ Added
@@ -56,7 +58,9 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-
+Fixing filter for hidden and draft channels. Those channels were not showing in the results,
+even when the user asked for then. Now this is fixed and the draft and hidden channels can be included
+in the ChannelListView.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -35,7 +35,7 @@ public class ChannelListViewModel(
         eq("type", "messaging"),
         `in`("members", listOf(chatDomain.currentUser.id)),
         or(Filters.notExists("draft"), ne("draft", true)),
-        eq("hidden", false)
+        or(Filters.notExists("hidden"), Filters.ne("hidden", true)),
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -5,13 +5,15 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.Transformations.map
 import androidx.lifecycle.ViewModel
-import com.getstream.sdk.chat.utils.extensions.isDraft
 import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.extensions.isMuted
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
+import io.getstream.chat.android.client.models.Filters.`in`
 import io.getstream.chat.android.client.models.Filters.eq
+import io.getstream.chat.android.client.models.Filters.ne
+import io.getstream.chat.android.client.models.Filters.or
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.core.internal.exhaustive
 import io.getstream.chat.android.livedata.ChatDomain
@@ -31,8 +33,9 @@ public class ChannelListViewModel(
     private val chatDomain: ChatDomain = ChatDomain.instance(),
     private val filter: FilterObject = Filters.and(
         eq("type", "messaging"),
-        Filters.`in`("members", listOf(chatDomain.currentUser.id)),
-        Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
+        `in`("members", listOf(chatDomain.currentUser.id)),
+        or(Filters.notExists("draft"), ne("draft", true)),
+        ne("hidden", false)
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30,
@@ -65,7 +68,7 @@ public class ChannelListViewModel(
                             is QueryChannelsController.ChannelsState.Result -> currentState.copy(
                                 isLoading = false,
                                 channels = parseMutedChannels(
-                                    channelState.channels.filterNot { it.hidden == true || it.isDraft },
+                                    channelState.channels,
                                     chatDomain.currentUser.channelMutes.map { channelMute -> channelMute.channel.id }
                                 ),
                             )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -35,7 +35,7 @@ public class ChannelListViewModel(
         eq("type", "messaging"),
         `in`("members", listOf(chatDomain.currentUser.id)),
         or(Filters.notExists("draft"), ne("draft", true)),
-        ne("hidden", false)
+        eq("hidden", false)
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -35,7 +35,7 @@ public class ChannelListViewModel(
         eq("type", "messaging"),
         `in`("members", listOf(chatDomain.currentUser.id)),
         or(Filters.notExists("draft"), ne("draft", true)),
-        or(Filters.notExists("hidden"), Filters.ne("hidden", true)),
+        or(Filters.notExists("hidden"), ne("hidden", true)),
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
@@ -25,6 +25,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         Filters.eq("type", "messaging"),
         Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id)),
         Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
+        Filters.or(Filters.notExists("hidden"), Filters.ne("hidden", true)),
     ),
     private val sort: QuerySort<Channel> = ChannelListViewModel.DEFAULT_SORT,
     private val limit: Int = 30,

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -5,7 +5,6 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.Transformations
 import androidx.lifecycle.Transformations.map
 import androidx.lifecycle.ViewModel
-import com.getstream.sdk.chat.utils.extensions.isDraft
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QuerySort

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -32,6 +32,7 @@ public class ChannelsViewModel(
         eq("type", "messaging"),
         Filters.`in`("members", listOf(chatDomain.currentUser.id)),
         Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
+        Filters.ne("hidden", false)
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30
@@ -56,7 +57,7 @@ public class ChannelsViewModel(
                             is QueryChannelsController.ChannelsState.Loading -> State.Loading
                             is QueryChannelsController.ChannelsState.OfflineNoResults -> State.NoChannelsAvailable
                             is QueryChannelsController.ChannelsState.Result ->
-                                State.Result(channelState.channels.filterNot { it.hidden == true || it.isDraft })
+                                State.Result(channelState.channels)
                         }
                     }
                 ) { state -> stateMerger.value = state }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -32,7 +32,7 @@ public class ChannelsViewModel(
         eq("type", "messaging"),
         Filters.`in`("members", listOf(chatDomain.currentUser.id)),
         Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
-        Filters.ne("hidden", false)
+        eq("hidden", false)
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/channels/ChannelsViewModel.kt
@@ -31,7 +31,7 @@ public class ChannelsViewModel(
         eq("type", "messaging"),
         Filters.`in`("members", listOf(chatDomain.currentUser.id)),
         Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
-        eq("hidden", false)
+        Filters.or(Filters.notExists("hidden"), Filters.ne("hidden", true)),
     ),
     private val sort: QuerySort<Channel> = DEFAULT_SORT,
     private val limit: Int = 30

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/factory/ChannelsViewModelFactory.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/factory/ChannelsViewModelFactory.kt
@@ -24,6 +24,7 @@ public class ChannelsViewModelFactory @JvmOverloads constructor(
         Filters.eq("type", "messaging"),
         Filters.`in`("members", listOf(ChatDomain.instance().currentUser.id)),
         Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
+        Filters.or(Filters.notExists("hidden"), Filters.ne("hidden", true)),
     ),
     private val sort: QuerySort<Channel> = ChannelsViewModel.DEFAULT_SORT,
     private val limit: Int = 30


### PR DESCRIPTION
### 🎯 Goal

Fix the filter for hidden and draft channels. Until so far, it was not possible to make those channels appear. Now if the users don't use our default filter and don't ask for hidden and draft channels to be removed, they will appear. 

This will fix the filter problem of issue #1773.

**Important: This may cause some apps to include many channels that they may not want to, although this fixes a wrong behaviour.**

### 🛠 Implementation details

Removing the filter of those channels from `queryChannelsController.channelsState` and adding then in the default filter of `ChannelsViewModel` and `ChannelListViewModel`.

### 🧪 Testing

Ask for draft and hidden channels with and without this PR, you will see the difference =P.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/118001451-1ef92500-b31d-11eb-8efc-a00494524793.gif)