### PR TITLE
[CAS-993] Fix channel sorting

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
-
+- Fixed channel list sorting
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2005,6 +2005,7 @@ public final class io/getstream/chat/android/client/models/Channel : io/getstrea
 	public fun getExtraData ()Ljava/util/Map;
 	public fun getExtraValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getFrozen ()Z
+	public final fun getHasUnread ()Z
 	public final fun getHidden ()Ljava/lang/Boolean;
 	public final fun getHiddenMessagesBefore ()Ljava/util/Date;
 	public final fun getId ()Ljava/lang/String;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
@@ -62,4 +62,7 @@ public data class Channel(
 
     val lastUpdated: Date?
         get() = lastMessageAt?.takeIf { createdAt == null || it.after(createdAt) } ?: createdAt
+
+    val hasUnread: Boolean
+        get() = unreadCount?.let { it > 0 } ?: false
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
@@ -1,0 +1,289 @@
+package io.getstream.chat.android.offline.querychannels
+
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.CustomObject
+import io.getstream.chat.android.client.models.name
+import io.getstream.chat.android.offline.randomChannel
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.util.Date
+
+internal class QueryChannelsSortTest {
+
+    /** [sortArguments] */
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("sortArguments")
+    fun `Given shuffled channels When sorting the list Should return sorted channels`(
+        testName: String,
+        channelList: List<Channel>,
+        querySort: QuerySort<Channel>,
+        expectedChannelList: List<CustomObject>,
+    ) {
+        val result = channelList.sortedWith(querySort.comparator)
+
+        result `should be equal to` expectedChannelList
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun sortArguments() = lastUpdatedSortArguments() +
+            lastMessageAtSortArguments() +
+            updatedAtSortArguments() +
+            createdAtSortArguments() +
+            memberCountSortArguments() +
+            unreadCountSortArguments() +
+            hasUnreadSortArguments() +
+            nameSortArguments() +
+            multiSortArguments()
+
+        @JvmStatic
+        fun lastUpdatedSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by lastUpdated field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::lastUpdated)
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by lastUpdated field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::lastUpdated)
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+            },
+            sortArguments(
+                testName = "Sorting by last_updated field name in ascending order",
+                querySort = QuerySort<Channel>().asc("last_updated")
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by last_updated field name in descending order",
+                querySort = QuerySort<Channel>().desc("last_updated")
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+            },
+        )
+
+        @JvmStatic
+        fun lastMessageAtSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by lastMessageAt field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::lastMessageAt)
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by lastMessageAt field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::lastMessageAt)
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+            },
+            sortArguments(
+                testName = "Sorting by last_message_at field name in ascending order",
+                querySort = QuerySort<Channel>().asc("last_message_at")
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by last_message_at field name in descending order",
+                querySort = QuerySort<Channel>().desc("last_message_at")
+            ) {
+                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+            },
+        )
+
+        @JvmStatic
+        fun updatedAtSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by updatedAt field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::updatedAt)
+            ) {
+                randomChannel(updatedAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by updatedAt field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::updatedAt)
+            ) {
+                randomChannel(updatedAt = dateWithOffset(offsetSeconds = -it))
+            },
+            sortArguments(
+                testName = "Sorting by updated_at field name in ascending order",
+                querySort = QuerySort<Channel>().asc("updated_at")
+            ) {
+                randomChannel(updatedAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by updated_at field name in descending order",
+                querySort = QuerySort<Channel>().desc("updated_at")
+            ) {
+                randomChannel(updatedAt = dateWithOffset(offsetSeconds = -it))
+            },
+        )
+
+        @JvmStatic
+        fun createdAtSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by createdAt field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::createdAt)
+            ) {
+                randomChannel(createdAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by createdAt field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::createdAt)
+            ) {
+                randomChannel(createdAt = dateWithOffset(offsetSeconds = -it))
+            },
+            sortArguments(
+                testName = "Sorting by created_at field name in ascending order",
+                querySort = QuerySort<Channel>().asc("created_at")
+            ) {
+                randomChannel(createdAt = dateWithOffset(offsetSeconds = it))
+            },
+            sortArguments(
+                testName = "Sorting by created_at field name in descending order",
+                querySort = QuerySort<Channel>().desc("created_at")
+            ) {
+                randomChannel(createdAt = dateWithOffset(offsetSeconds = -it))
+            }
+        )
+
+        @JvmStatic
+        fun memberCountSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by memberCount field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::memberCount)
+            ) {
+                randomChannel(memberCount = it)
+            },
+            sortArguments(
+                testName = "Sorting by memberCount field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::memberCount)
+            ) {
+                randomChannel(memberCount = 10 - it)
+            },
+            sortArguments(
+                testName = "Sorting by member_count field name in ascending order",
+                querySort = QuerySort<Channel>().asc("member_count")
+            ) {
+                randomChannel(memberCount = it)
+            },
+            sortArguments(
+                testName = "Sorting by member_count field name in descending order",
+                querySort = QuerySort<Channel>().desc("member_count")
+            ) {
+                randomChannel(memberCount = 10 - it)
+            },
+        )
+
+        @JvmStatic
+        fun unreadCountSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by unreadCount field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::unreadCount)
+            ) {
+                randomChannel(unreadCount = it)
+            },
+            sortArguments(
+                testName = "Sorting by unreadCount field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::unreadCount)
+            ) {
+                randomChannel(unreadCount = 10 - it)
+            },
+            sortArguments(
+                testName = "Sorting by unread_count field name in ascending order",
+                querySort = QuerySort<Channel>().asc("unread_count")
+            ) {
+                randomChannel(unreadCount = it)
+            },
+            sortArguments(
+                testName = "Sorting by unread_count field name in descending order",
+                querySort = QuerySort<Channel>().desc("unread_count")
+            ) {
+                randomChannel(unreadCount = 10 - it)
+            },
+        )
+
+        @JvmStatic
+        fun hasUnreadSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by hasUnread field reference in ascending order",
+                querySort = QuerySort<Channel>().asc(Channel::hasUnread)
+            ) {
+                randomChannel(unreadCount = if (it < 5) 0 else it)
+            },
+            sortArguments(
+                testName = "Sorting by hasUnread field reference in descending order",
+                querySort = QuerySort<Channel>().desc(Channel::hasUnread)
+            ) {
+                randomChannel(unreadCount = if (it < 5) 10 - it else 0)
+            },
+            sortArguments(
+                testName = "Sorting by has_unread field name in ascending order",
+                querySort = QuerySort<Channel>().asc("has_unread")
+            ) {
+                randomChannel(unreadCount = if (it < 5) 0 else it)
+            },
+            sortArguments(
+                testName = "Sorting by has_unread field name in descending order",
+                querySort = QuerySort<Channel>().desc("has_unread")
+            ) {
+                randomChannel(unreadCount = if (it < 5) 10 - it else 0)
+            }
+        )
+
+        @JvmStatic
+        fun nameSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by name extra data field in ascending order",
+                querySort = QuerySort<Channel>().asc("name")
+            ) {
+                randomChannel().apply { name = "$it" }
+            },
+            sortArguments(
+                testName = "Sorting by name extra data field in descending order",
+                querySort = QuerySort<Channel>().desc("name")
+            ) {
+                randomChannel().apply { name = "${10 - it}" }
+            }
+        )
+
+        @JvmStatic
+        fun multiSortArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by unread_count in ascending order and by name extra data field in ascending order",
+                querySort = QuerySort<Channel>()
+                    .desc("unread_count")
+                    .asc("name")
+            ) {
+                randomChannel().apply {
+                    name = "$it"
+                    unreadCount = if (it < 5) 10 - it else 0
+                }
+            },
+        )
+
+        private fun sortArguments(
+            testName: String,
+            querySort: QuerySort<Channel>,
+            channelFactory: (Int) -> Channel,
+        ): Arguments {
+            return List(10, channelFactory).let { expectedList ->
+                Arguments.of(
+                    testName,
+                    expectedList.shuffled(),
+                    querySort,
+                    expectedList,
+                )
+            }
+        }
+
+        private fun dateWithOffset(offsetSeconds: Int): Date {
+            return Date(System.currentTimeMillis() + offsetSeconds * 1000)
+        }
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
@@ -24,9 +24,6 @@ internal class QueryChannelsSortTest {
     ) {
         val result = channelList.sortedWith(querySort.comparator)
 
-        println("-----")
-        println(result.joinToString(separator = "\n") { it.unreadCount.toString() })
-
         result `should be equal to` expectedChannelList
     }
 
@@ -42,7 +39,8 @@ internal class QueryChannelsSortTest {
             hasUnreadSortArguments() +
             nameSortArguments() +
             multiSortByFieldReferencesArguments() +
-            multiSortByFieldNamesArguments()
+            multiSortByFieldNamesArguments() +
+            unreadCountWithNullsSortArguments()
 
         @JvmStatic
         fun lastUpdatedSortArguments() = listOf(
@@ -342,15 +340,84 @@ internal class QueryChannelsSortTest {
             },
         )
 
+        @JvmStatic
+        fun unreadCountWithNullsSortArguments() = listOf(
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) null else it)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by nullable hasUnread field reference in ascending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().asc(Channel::hasUnread),
+                    expectedList,
+                )
+            },
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 6 - it else null)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by nullable hasUnread field reference in descending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().desc(Channel::hasUnread),
+                    expectedList,
+                )
+            },
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) null else it)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by nullable has_unread field name in descending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().asc("unread_count"),
+                    expectedList,
+                )
+            },
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 6 - it else null)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by nullable has_unread field name in descending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().desc("unread_count"),
+                    expectedList,
+                )
+            }
+        )
+
         private fun sortArguments(
             testName: String,
             querySort: QuerySort<Channel>,
             channelFactory: (Int) -> Channel,
         ): Arguments {
             return List(10, channelFactory).let { expectedList ->
-
-                println(expectedList.joinToString(separator = "\n") { it.unreadCount.toString() })
-
                 Arguments.of(
                     testName,
                     expectedList.shuffled(),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
@@ -38,9 +38,9 @@ internal class QueryChannelsSortTest {
             unreadCountSortArguments() +
             hasUnreadSortArguments() +
             nameSortArguments() +
+            unsupportedSortArguments() +
             multiSortByFieldReferencesArguments() +
-            multiSortByFieldNamesArguments() +
-            unreadCountWithNullsSortArguments()
+            multiSortByFieldNamesArguments()
 
         @JvmStatic
         fun lastUpdatedSortArguments() = listOf(
@@ -178,7 +178,7 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by memberCount field reference in descending order",
                 querySort = QuerySort<Channel>().desc(Channel::memberCount)
             ) {
-                randomChannel(memberCount = 10 - it)
+                randomChannel(memberCount = 9 - it)
             },
             sortArguments(
                 testName = "Sorting by member_count field name in ascending order",
@@ -190,7 +190,7 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by member_count field name in descending order",
                 querySort = QuerySort<Channel>().desc("member_count")
             ) {
-                randomChannel(memberCount = 10 - it)
+                randomChannel(memberCount = 9 - it)
             },
         )
 
@@ -206,7 +206,7 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by unreadCount field reference in descending order",
                 querySort = QuerySort<Channel>().desc(Channel::unreadCount)
             ) {
-                randomChannel(unreadCount = 10 - it)
+                randomChannel(unreadCount = 9 - it)
             },
             sortArguments(
                 testName = "Sorting by unread_count field name in ascending order",
@@ -218,7 +218,7 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by unread_count field name in descending order",
                 querySort = QuerySort<Channel>().desc("unread_count")
             ) {
-                randomChannel(unreadCount = 10 - it)
+                randomChannel(unreadCount = 9 - it)
             },
         )
 
@@ -306,8 +306,28 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by name extra data field in descending order",
                 querySort = QuerySort<Channel>().desc("name")
             ) {
-                randomChannel().apply { name = "${10 - it}" }
+                randomChannel().apply { name = "${9 - it}" }
             }
+        )
+
+        @JvmStatic
+        fun unsupportedSortArguments() = listOf(
+            List(10) { randomChannel() }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by unsupported field in ascending order",
+                    expectedList,
+                    QuerySort<Channel>().asc("unsupported_field"),
+                    expectedList,
+                )
+            },
+            List(10) { randomChannel() }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by unsupported field in descending order",
+                    expectedList,
+                    QuerySort<Channel>().desc("unsupported_field"),
+                    expectedList,
+                )
+            },
         )
 
         @JvmStatic
@@ -335,81 +355,9 @@ internal class QueryChannelsSortTest {
             ) {
                 randomChannel().apply {
                     name = "$it"
-                    unreadCount = if (it < 5) 10 - it else 0
+                    unreadCount = if (it < 5) 9 - it else 0
                 }
             },
-        )
-
-        @JvmStatic
-        fun unreadCountWithNullsSortArguments() = listOf(
-            List(6) {
-                randomChannel(unreadCount = if (it < 3) null else it)
-            }.let { expectedList ->
-                Arguments.of(
-                    "Sorting by nullable hasUnread field reference in ascending order",
-                    listOf(
-                        expectedList[0],
-                        expectedList[3],
-                        expectedList[1],
-                        expectedList[4],
-                        expectedList[2],
-                        expectedList[5]
-                    ),
-                    QuerySort<Channel>().asc(Channel::hasUnread),
-                    expectedList,
-                )
-            },
-            List(6) {
-                randomChannel(unreadCount = if (it < 3) 6 - it else null)
-            }.let { expectedList ->
-                Arguments.of(
-                    "Sorting by nullable hasUnread field reference in descending order",
-                    listOf(
-                        expectedList[0],
-                        expectedList[3],
-                        expectedList[1],
-                        expectedList[4],
-                        expectedList[2],
-                        expectedList[5]
-                    ),
-                    QuerySort<Channel>().desc(Channel::hasUnread),
-                    expectedList,
-                )
-            },
-            List(6) {
-                randomChannel(unreadCount = if (it < 3) null else it)
-            }.let { expectedList ->
-                Arguments.of(
-                    "Sorting by nullable has_unread field name in descending order",
-                    listOf(
-                        expectedList[0],
-                        expectedList[3],
-                        expectedList[1],
-                        expectedList[4],
-                        expectedList[2],
-                        expectedList[5]
-                    ),
-                    QuerySort<Channel>().asc("unread_count"),
-                    expectedList,
-                )
-            },
-            List(6) {
-                randomChannel(unreadCount = if (it < 3) 6 - it else null)
-            }.let { expectedList ->
-                Arguments.of(
-                    "Sorting by nullable has_unread field name in descending order",
-                    listOf(
-                        expectedList[0],
-                        expectedList[3],
-                        expectedList[1],
-                        expectedList[4],
-                        expectedList[2],
-                        expectedList[5]
-                    ),
-                    QuerySort<Channel>().desc("unread_count"),
-                    expectedList,
-                )
-            }
         )
 
         private fun sortArguments(

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
@@ -24,6 +24,9 @@ internal class QueryChannelsSortTest {
     ) {
         val result = channelList.sortedWith(querySort.comparator)
 
+        println("-----")
+        println(result.joinToString(separator = "\n") { it.unreadCount.toString() })
+
         result `should be equal to` expectedChannelList
     }
 
@@ -38,7 +41,8 @@ internal class QueryChannelsSortTest {
             unreadCountSortArguments() +
             hasUnreadSortArguments() +
             nameSortArguments() +
-            multiSortArguments()
+            multiSortByFieldReferencesArguments() +
+            multiSortByFieldNamesArguments()
 
         @JvmStatic
         fun lastUpdatedSortArguments() = listOf(
@@ -46,25 +50,37 @@ internal class QueryChannelsSortTest {
                 testName = "Sorting by lastUpdated field reference in ascending order",
                 querySort = QuerySort<Channel>().asc(Channel::lastUpdated)
             ) {
-                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+                randomChannel(
+                    createdAt = dateWithOffset(offsetSeconds = -100),
+                    lastMessageAt = dateWithOffset(offsetSeconds = it)
+                )
             },
             sortArguments(
                 testName = "Sorting by lastUpdated field reference in descending order",
                 querySort = QuerySort<Channel>().desc(Channel::lastUpdated)
             ) {
-                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+                randomChannel(
+                    createdAt = dateWithOffset(offsetSeconds = -100),
+                    lastMessageAt = dateWithOffset(offsetSeconds = -it)
+                )
             },
             sortArguments(
                 testName = "Sorting by last_updated field name in ascending order",
                 querySort = QuerySort<Channel>().asc("last_updated")
             ) {
-                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
+                randomChannel(
+                    createdAt = dateWithOffset(offsetSeconds = -100),
+                    lastMessageAt = dateWithOffset(offsetSeconds = it)
+                )
             },
             sortArguments(
                 testName = "Sorting by last_updated field name in descending order",
                 querySort = QuerySort<Channel>().desc("last_updated")
             ) {
-                randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
+                randomChannel(
+                    createdAt = dateWithOffset(offsetSeconds = -100),
+                    lastMessageAt = dateWithOffset(offsetSeconds = -it)
+                )
             },
         )
 
@@ -210,29 +226,73 @@ internal class QueryChannelsSortTest {
 
         @JvmStatic
         fun hasUnreadSortArguments() = listOf(
-            sortArguments(
-                testName = "Sorting by hasUnread field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::hasUnread)
-            ) {
-                randomChannel(unreadCount = if (it < 5) 0 else it)
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 0 else it)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by hasUnread field reference in ascending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().asc(Channel::hasUnread),
+                    expectedList,
+                )
             },
-            sortArguments(
-                testName = "Sorting by hasUnread field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::hasUnread)
-            ) {
-                randomChannel(unreadCount = if (it < 5) 10 - it else 0)
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 6 - it else 0)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by hasUnread field reference in descending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().desc(Channel::hasUnread),
+                    expectedList,
+                )
             },
-            sortArguments(
-                testName = "Sorting by has_unread field name in ascending order",
-                querySort = QuerySort<Channel>().asc("has_unread")
-            ) {
-                randomChannel(unreadCount = if (it < 5) 0 else it)
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 0 else it)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by has_unread field name in ascending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().asc("has_unread"),
+                    expectedList,
+                )
             },
-            sortArguments(
-                testName = "Sorting by has_unread field name in descending order",
-                querySort = QuerySort<Channel>().desc("has_unread")
-            ) {
-                randomChannel(unreadCount = if (it < 5) 10 - it else 0)
+            List(6) {
+                randomChannel(unreadCount = if (it < 3) 6 - it else 0)
+            }.let { expectedList ->
+                Arguments.of(
+                    "Sorting by has_unread field name in descending order",
+                    listOf(
+                        expectedList[0],
+                        expectedList[3],
+                        expectedList[1],
+                        expectedList[4],
+                        expectedList[2],
+                        expectedList[5]
+                    ),
+                    QuerySort<Channel>().desc("has_unread"),
+                    expectedList,
+                )
             }
         )
 
@@ -253,9 +313,24 @@ internal class QueryChannelsSortTest {
         )
 
         @JvmStatic
-        fun multiSortArguments() = listOf(
+        fun multiSortByFieldReferencesArguments() = listOf(
             sortArguments(
-                testName = "Sorting by unread_count in ascending order and by name extra data field in ascending order",
+                testName = "Sorting by unreadCount field reference in descending order and by memberCount field reference in ascending order",
+                querySort = QuerySort<Channel>()
+                    .desc(Channel::unreadCount)
+                    .asc(Channel::memberCount)
+            ) {
+                randomChannel(
+                    memberCount = it,
+                    unreadCount = if (it < 3) 6 - it else 0
+                )
+            },
+        )
+
+        @JvmStatic
+        fun multiSortByFieldNamesArguments() = listOf(
+            sortArguments(
+                testName = "Sorting by unread_count field name in descending order and by name extra data field in ascending order",
                 querySort = QuerySort<Channel>()
                     .desc("unread_count")
                     .asc("name")
@@ -273,6 +348,9 @@ internal class QueryChannelsSortTest {
             channelFactory: (Int) -> Channel,
         ): Arguments {
             return List(10, channelFactory).let { expectedList ->
+
+                println(expectedList.joinToString(separator = "\n") { it.unreadCount.toString() })
+
                 Arguments.of(
                     testName,
                     expectedList.shuffled(),


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-993
https://getstream.zendesk.com/agent/tickets/11634

### 🎯 Goal

Fix channel list sorting

### 🎨 UI Changes

The following screenshots were taken with this query sort:

```
private val sort: QuerySort<Channel> = QuerySort<Channel>()
        .desc("has_unread")
        .asc("name"),
```

| Before | After |
| --- | --- |
| ![photo_2021-05-17 19 02 03](https://user-images.githubusercontent.com/9600921/118520145-772b8f00-b742-11eb-9f25-e4e0ddd06aa8.jpeg) | ![photo_2021-05-17 19 02 06](https://user-images.githubusercontent.com/9600921/118520107-6aa73680-b742-11eb-8859-09e340ffc622.jpeg) |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/9600921/118521185-72b3a600-b743-11eb-8e6f-157717cba53d.gif)
