### PR TITLE
Make BannedUserResponse::shadow optional

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -23,6 +23,7 @@ Fixing filter for draft channels. Those channels were not showing in the results
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed querying banned users using new serialization.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/BannedUserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/BannedUserMapping.kt
@@ -10,7 +10,7 @@ internal fun BannedUserResponse.toDomain(): BannedUser {
         channel = channel?.toDomain(),
         createdAt = created_at,
         expires = expires,
-        shadow = shadow,
+        shadow = shadow ?: false,
         reason = reason,
     )
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/BannedUserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/BannedUserMapping.kt
@@ -10,7 +10,7 @@ internal fun BannedUserResponse.toDomain(): BannedUser {
         channel = channel?.toDomain(),
         createdAt = created_at,
         expires = expires,
-        shadow = shadow ?: false,
+        shadow = shadow,
         reason = reason,
     )
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BannedUserResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BannedUserResponse.kt
@@ -12,6 +12,6 @@ internal data class BannedUserResponse(
     val channel: DownstreamChannelDto?,
     val created_at: Date?,
     val expires: Date?,
-    val shadow: Boolean?,
+    val shadow: Boolean = false,
     val reason: String?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BannedUserResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BannedUserResponse.kt
@@ -12,6 +12,6 @@ internal data class BannedUserResponse(
     val channel: DownstreamChannelDto?,
     val created_at: Date?,
     val expires: Date?,
-    val shadow: Boolean,
+    val shadow: Boolean?,
     val reason: String?,
 )


### PR DESCRIPTION
#1864 

### 🎯 Goal

Fix `BannedUserResponse` deserialization

### 🛠 Implementation details

### 🧪 Testing

1. Ban user
2. Call `queryBannedUser`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
