### PR TITLE
Adding context in constructor for ImageDecoderDecoder

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/coil/StreamImageLoaderFactory.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/coil/StreamImageLoaderFactory.kt
@@ -38,7 +38,7 @@ public class StreamImageLoaderFactory(
             }
             .componentRegistry {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder())
+                    add(ImageDecoderDecoder(context))
                 } else {
                     add(GifDecoder())
                 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
@@ -21,7 +21,7 @@ class App : Application() {
         Coil.setImageLoader(
             ImageLoader.Builder(this).componentRegistry {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder())
+                    add(ImageDecoderDecoder(this@App))
                 } else {
                     add(GifDecoder())
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ImageLoaderFactoryInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ImageLoaderFactoryInitializer.kt
@@ -17,7 +17,7 @@ internal class ImageLoaderFactoryInitializer : Initializer<ImageLoaderFactory> {
                 // duplicated as we can not extend component
                 // registry of existing image loader builder
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder())
+                    add(ImageDecoderDecoder(context))
                 } else {
                     add(GifDecoder())
                 }


### PR DESCRIPTION
### 🎯 Goal

Stop using a constructor that deprecated. A small change that I saw while reading our code. 

### 🛠 Implementation details

Just adding the context to the constructor of that `ImageDecoderDecoder` 

### 🧪 Testing

Just use a image are vefiry that nothing gets broken. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/118505519-dec1ea00-b702-11eb-8b8d-666d715a1a44.gif)
_Tiny change_