### PR TITLE
[CAS-975] Provide error description if upload fails

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -39,6 +39,7 @@ Fixing filter for draft channels. Those channels were not showing in the results
     - Deprecated `ChatNotificationHandler.getFirebaseMessageIdKey`
     - Deprecated `ChatNotificationHandler.getFirebaseChannelIdKey`
     - Deprecated `ChatNotificationHandler.getFirebaseChannelTypeKey`
+- Improved error description provided by `ChatClient::sendImage`, `ChatClient::sendFile`, `ChannelClient::sendImage` and `ChannelClient::sendFile` methods if upload fails. 
 
 ### ✅ Added
 - Added `ChatClient::truncateChannel` and `ChannelClient::truncate` methods to remove messages from a channel.
@@ -46,6 +47,7 @@ Fixing filter for draft channels. Those channels were not showing in the results
 - Added method `SocketListener::onDisconnected(cause: DisconnectCause)`
 
 ### ⚠️ Changed
+- Changed the return type of `FileUploader` methods from nullable string to `Result<String>`.
 
 ### ❌ Removed
 

--- a/docusaurus/docs/Android/client/uploading_files.md
+++ b/docusaurus/docs/Android/client/uploading_files.md
@@ -61,9 +61,30 @@ The SDK allows you to use your own CDN by creating your own implementation of th
 The example below show how to change where files are uploaded:
 
 ```kotlin
+// Create a custom FileUploader
+class MyFileUploader : FileUploader {
+    override fun sendFile(
+        channelType: String,
+        channelId: String,
+        userId: String,
+        connectionId: String,
+        file: File,
+    ): Result<String> {
+        return try {
+            // Send the file to your own CDN
+            val url = ...
+            // Return a Result object with file url
+            Result.success(url)
+        } catch (e: Exception) {
+            // Return a Result object with exception in case upload failed
+            Result.error(e)
+        }
+    }
+    ...
+}
+
 // Set a custom FileUploader implementation when building your client
 val client = ChatClient.Builder("39mr6a3z4tem", context)
     .fileUploader(MyFileUploader())
     .build()
-}
 ```

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2809,12 +2809,12 @@ public abstract interface class io/getstream/chat/android/client/token/TokenProv
 }
 
 public abstract interface class io/getstream/chat/android/client/uploader/FileUploader {
-	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/lang/String;
-	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Ljava/lang/String;
-	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Ljava/lang/String;
-	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Ljava/lang/String;
+	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/utils/Result;
+	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/utils/Result;
+	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/chat/android/client/utils/Result;
+	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/chat/android/client/utils/Result;
+	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/chat/android/client/utils/Result;
+	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/chat/android/client/utils/Result;
 }
 
 public final class io/getstream/chat/android/client/uploader/ProgressTrackerKt {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -52,7 +52,6 @@ import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.ProgressCallback
-import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.UuidGenerator
 import kotlinx.coroutines.CoroutineScope
 import java.io.File
@@ -82,7 +81,7 @@ internal class GsonChatApi(
         callback: ProgressCallback?,
     ): Call<String> {
         return CoroutineCall(coroutineScope) {
-            val result = if (callback != null) {
+            if (callback != null) {
                 fileUploader.sendFile(
                     channelType = channelType,
                     channelId = channelId,
@@ -100,12 +99,6 @@ internal class GsonChatApi(
                     file = file,
                 )
             }
-
-            if (result != null) {
-                Result(result)
-            } else {
-                Result(ChatError("Upload failed"))
-            }
         }
     }
 
@@ -116,7 +109,7 @@ internal class GsonChatApi(
         callback: ProgressCallback?,
     ): Call<String> {
         return CoroutineCall(coroutineScope) {
-            val result = if (callback != null) {
+            if (callback != null) {
                 fileUploader.sendImage(
                     channelType = channelType,
                     channelId = channelId,
@@ -134,12 +127,6 @@ internal class GsonChatApi(
                     file = file
                 )
             }
-
-            if (result != null) {
-                Result(result)
-            } else {
-                Result(ChatError("Upload failed"))
-            }
         }
     }
 
@@ -152,7 +139,6 @@ internal class GsonChatApi(
                 connectionId = connectionId,
                 url = url
             )
-            Result(Unit)
         }
     }
 
@@ -165,7 +151,6 @@ internal class GsonChatApi(
                 connectionId = connectionId,
                 url = url
             )
-            Result(Unit)
         }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -233,7 +233,7 @@ internal class MoshiChatApi(
         callback: ProgressCallback?,
     ): Call<String> {
         return CoroutineCall(coroutineScope) {
-            val result = if (callback != null) {
+            if (callback != null) {
                 fileUploader.sendFile(
                     channelType = channelType,
                     channelId = channelId,
@@ -251,12 +251,6 @@ internal class MoshiChatApi(
                     file = file,
                 )
             }
-
-            if (result != null) {
-                Result(result)
-            } else {
-                Result(ChatError("Upload failed"))
-            }
         }
     }
 
@@ -267,7 +261,7 @@ internal class MoshiChatApi(
         callback: ProgressCallback?,
     ): Call<String> {
         return CoroutineCall(coroutineScope) {
-            val result = if (callback != null) {
+            if (callback != null) {
                 fileUploader.sendImage(
                     channelType = channelType,
                     channelId = channelId,
@@ -284,12 +278,6 @@ internal class MoshiChatApi(
                     connectionId = connectionId,
                     file = file
                 )
-            }
-
-            if (result != null) {
-                Result(result)
-            } else {
-                Result(ChatError("Upload failed"))
             }
         }
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.client.uploader
 
 import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.client.utils.Result
 import java.io.File
 
 /**
@@ -11,7 +12,10 @@ public interface FileUploader {
     /**
      * Uploads a file for the given channel. Progress can be accessed via [callback].
      *
-     * @return The URL of the uploaded file, or null if the upload failed.
+     * @return The [Result] object with the URL of the uploaded file, or [Result] object with exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun sendFile(
         channelType: String,
@@ -20,12 +24,15 @@ public interface FileUploader {
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String?
+    ): Result<String>
 
     /**
      * Uploads a file for the given channel.
      *
-     * @return The URL of the uploaded file, or null if the upload failed.
+     * @return The [Result] object with the URL of the uploaded file, or [Result] object with exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun sendFile(
         channelType: String,
@@ -33,12 +40,15 @@ public interface FileUploader {
         userId: String,
         connectionId: String,
         file: File,
-    ): String?
+    ): Result<String>
 
     /**
      * Uploads an image for the given channel. Progress can be accessed via [callback].
      *
-     * @return The URL of the uploaded image, or null if the upload failed.
+     * @return The [Result] object with the URL of the uploaded image, or [Result] object with exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun sendImage(
         channelType: String,
@@ -47,12 +57,15 @@ public interface FileUploader {
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String?
+    ): Result<String>
 
     /**
      * Uploads an image for the given channel.
      *
-     * @return The URL of the uploaded image, or null if the upload failed.
+     * @return The [Result] object with the URL of the uploaded image, or [Result] object with exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun sendImage(
         channelType: String,
@@ -60,10 +73,15 @@ public interface FileUploader {
         userId: String,
         connectionId: String,
         file: File,
-    ): String?
+    ): Result<String>
 
     /**
      * Deletes the file represented by [url] from the given channel.
+     *
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun deleteFile(
         channelType: String,
@@ -71,10 +89,15 @@ public interface FileUploader {
         userId: String,
         connectionId: String,
         url: String,
-    )
+    ): Result<Unit>
 
     /**
      * Deletes the image represented by [url] from the given channel.
+     *
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @see [Result.success]
+     * @see [Result.error]
      */
     public fun deleteImage(
         channelType: String,
@@ -82,5 +105,5 @@ public interface FileUploader {
         userId: String,
         connectionId: String,
         url: String,
-    )
+    ): Result<Unit>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
@@ -4,6 +4,9 @@ import io.getstream.chat.android.client.api.RetrofitCdnApi
 import io.getstream.chat.android.client.api.models.ProgressRequestBody
 import io.getstream.chat.android.client.extensions.getMediaType
 import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.client.utils.map
+import io.getstream.chat.android.client.utils.toUnitResult
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
 import java.io.File
@@ -19,22 +22,16 @@ internal class StreamFileUploader(
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String? {
+    ): Result<String> {
         val body = ProgressRequestBody(file, callback)
         val part = MultipartBody.Part.createFormData("file", file.name, body)
 
-        val result = retrofitCdnApi.sendFile(
+        return retrofitCdnApi.sendFile(
             channelType,
             channelId,
             part,
             connectionId
-        ).execute()
-
-        return if (result.isSuccess) {
-            result.data().file
-        } else {
-            null
-        }
+        ).execute().map { it.file }
     }
 
     override fun sendFile(
@@ -43,25 +40,19 @@ internal class StreamFileUploader(
         userId: String,
         connectionId: String,
         file: File,
-    ): String? {
+    ): Result<String> {
         val part = MultipartBody.Part.createFormData(
             "file",
             file.name,
             file.asRequestBody(file.getMediaType())
         )
 
-        val result = retrofitCdnApi.sendFile(
+        return retrofitCdnApi.sendFile(
             channelType,
             channelId,
             part,
             connectionId
-        ).execute()
-
-        return if (result.isSuccess) {
-            result.data().file
-        } else {
-            null
-        }
+        ).execute().map { it.file }
     }
 
     override fun sendImage(
@@ -71,23 +62,17 @@ internal class StreamFileUploader(
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String? {
+    ): Result<String> {
         val body = ProgressRequestBody(file, callback)
         val part = MultipartBody.Part.createFormData("file", file.name, body)
 
-        val result = retrofitCdnApi
+        return retrofitCdnApi
             .sendImage(
                 channelType,
                 channelId,
                 part,
                 connectionId
-            ).execute()
-
-        return if (result.isSuccess) {
-            result.data().file
-        } else {
-            null
-        }
+            ).execute().map { it.file }
     }
 
     override fun sendImage(
@@ -96,25 +81,19 @@ internal class StreamFileUploader(
         userId: String,
         connectionId: String,
         file: File,
-    ): String? {
+    ): Result<String> {
         val part = MultipartBody.Part.createFormData(
             "file",
             file.name,
             file.asRequestBody(file.getMediaType())
         )
 
-        val result = retrofitCdnApi.sendImage(
+        return retrofitCdnApi.sendImage(
             channelType,
             channelId,
             part,
             connectionId
-        ).execute()
-
-        return if (result.isSuccess) {
-            result.data().file
-        } else {
-            null
-        }
+        ).execute().map { it.file }
     }
 
     override fun deleteFile(
@@ -123,8 +102,10 @@ internal class StreamFileUploader(
         userId: String,
         connectionId: String,
         url: String,
-    ) {
-        retrofitCdnApi.deleteFile(channelType, channelId, connectionId, url).execute()
+    ): Result<Unit> {
+        return retrofitCdnApi.deleteFile(channelType, channelId, connectionId, url)
+            .execute()
+            .toUnitResult()
     }
 
     override fun deleteImage(
@@ -133,7 +114,9 @@ internal class StreamFileUploader(
         userId: String,
         connectionId: String,
         url: String,
-    ) {
-        retrofitCdnApi.deleteImage(channelType, channelId, connectionId, url).execute()
+    ): Result<Unit> {
+        return retrofitCdnApi.deleteImage(channelType, channelId, connectionId, url)
+            .execute()
+            .toUnitResult()
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
@@ -15,7 +15,7 @@ import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import org.amshove.kluent.shouldBeEqualTo
-import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldBeTrue
 import org.junit.Before
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -66,28 +66,26 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should return file when successfully sent file without progress callback`() {
+    fun `Should return result containing file when successfully sent file without progress callback`() {
         val file = "file"
         whenever(retrofitCdnApi.sendFile(any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse(file)).toRetrofitCall()
         )
 
-        val result =
-            streamFileUploader.sendFile(channelType, channelId, userId, connectionId, File(""))
+        val result = streamFileUploader.sendFile(channelType, channelId, userId, connectionId, File(""))
 
-        result shouldBeEqualTo file
+        result.data() shouldBeEqualTo file
     }
 
     @Test
-    fun `Should return null when sending file without progress callback failed`() {
+    fun `Should return result containing error when sending file without progress callback failed`() {
         whenever(retrofitCdnApi.sendFile(any(), any(), any(), any())).thenReturn(
             RetroError<UploadFileResponse>(500).toRetrofitCall()
         )
 
-        val result =
-            streamFileUploader.sendFile(channelType, channelId, userId, connectionId, File(""))
+        val result = streamFileUploader.sendFile(channelType, channelId, userId, connectionId, File(""))
 
-        result.shouldBeNull()
+        result.isError.shouldBeTrue()
     }
 
     @Test
@@ -130,28 +128,26 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should return file when successfully sent image without progress callback`() {
+    fun `Should return result containing file when successfully sent image without progress callback`() {
         val file = "file"
         whenever(retrofitCdnApi.sendImage(any(), any(), any(), any())).thenReturn(
             RetroSuccess(UploadFileResponse(file)).toRetrofitCall()
         )
 
-        val result =
-            streamFileUploader.sendImage(channelType, channelId, userId, connectionId, File(""))
+        val result = streamFileUploader.sendImage(channelType, channelId, userId, connectionId, File(""))
 
-        result shouldBeEqualTo file
+        result.data() shouldBeEqualTo file
     }
 
     @Test
-    fun `Should return null when sending image without progress callback failed`() {
+    fun `Should return containing error when sending image without progress callback failed`() {
         whenever(retrofitCdnApi.sendImage(any(), any(), any(), any())).thenReturn(
             RetroError<UploadFileResponse>(500).toRetrofitCall()
         )
 
-        val result =
-            streamFileUploader.sendImage(channelType, channelId, userId, connectionId, File(""))
+        val result = streamFileUploader.sendImage(channelType, channelId, userId, connectionId, File(""))
 
-        result.shouldBeNull()
+        result.isError.shouldBeTrue()
     }
 
     @Test

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -26,14 +26,26 @@ public class io/getstream/chat/android/client/errors/ChatError {
 }
 
 public final class io/getstream/chat/android/client/utils/Result {
+	public static final field Companion Lio/getstream/chat/android/client/utils/Result$Companion;
 	public fun <init> (Lio/getstream/chat/android/client/errors/ChatError;)V
 	public fun <init> (Ljava/lang/Object;)V
+	public synthetic fun <init> (Ljava/lang/Object;Lio/getstream/chat/android/client/errors/ChatError;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun data ()Ljava/lang/Object;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun error ()Lio/getstream/chat/android/client/errors/ChatError;
+	public static final fun error (Ljava/lang/Throwable;)Lio/getstream/chat/android/client/utils/Result;
 	public fun hashCode ()I
 	public final fun isError ()Z
 	public final fun isSuccess ()Z
+	public static final fun success (Ljava/lang/Object;)Lio/getstream/chat/android/client/utils/Result;
+}
+
+public final class io/getstream/chat/android/client/utils/Result$Companion {
+	public final fun error (Ljava/lang/Throwable;)Lio/getstream/chat/android/client/utils/Result;
+	public final fun success (Ljava/lang/Object;)Lio/getstream/chat/android/client/utils/Result;
+}
+
+public final class io/getstream/chat/android/client/utils/ResultKt {
 }
 
 public abstract interface annotation class io/getstream/chat/android/core/ExperimentalStreamChatApi : java/lang/annotation/Annotation {

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/utils/Result.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/utils/Result.kt
@@ -1,17 +1,21 @@
 package io.getstream.chat.android.client.utils
 
 import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
+/**
+ *  A class which encapsulates a successful outcome with a value of type [T] or a failure with [ChatError].
+ */
 public class Result<T : Any> private constructor(
     private val data: T?,
-    private val error: ChatError?
+    private val error: ChatError?,
 ) {
 
     @Suppress("DEPRECATION")
     public constructor(data: T) : this(data, null)
 
     @Suppress("DEPRECATION")
-    public constructor(error: ChatError)  : this(null, error)
+    public constructor(error: ChatError) : this(null, error)
 
     public val isSuccess: Boolean
         get() = data != null
@@ -44,4 +48,35 @@ public class Result<T : Any> private constructor(
         result = 31 * result + (error?.hashCode() ?: 0)
         return result
     }
+
+    public companion object {
+
+        /**
+         * Creates a [Result] object with [data] payload
+         */
+        @JvmStatic
+        public fun <T : Any> success(data: T): Result<T> {
+            return Result(data)
+        }
+
+        /**
+         * Creates a [Result] object with error payload
+         */
+        @JvmStatic
+        public fun <T : Any> error(t: Throwable): Result<T> {
+            return Result(null, ChatError(t.message, t))
+        }
+    }
 }
+
+@InternalStreamChatApi
+public fun <T : Any, K : Any> Result<T>.map(mapper: (T) -> K): Result<K> {
+    return if (isSuccess) {
+        Result(mapper(data()))
+    } else {
+        Result(error())
+    }
+}
+
+@InternalStreamChatApi
+public fun Result<*>.toUnitResult(): Result<Unit> = map {}

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/helpers/MyFileUploader.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/helpers/MyFileUploader.java
@@ -8,39 +8,65 @@ import java.io.File;
 
 import io.getstream.chat.android.client.uploader.FileUploader;
 import io.getstream.chat.android.client.utils.ProgressCallback;
+import io.getstream.chat.android.client.utils.Result;
+import kotlin.Unit;
 
 public class MyFileUploader implements FileUploader {
     @Nullable
     @Override
-    public String sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file, @NotNull ProgressCallback callback) {
-        return null;
+    public Result<String> sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file, @NotNull ProgressCallback callback) {
+         try {
+            return Result.success("url");
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 
     @Nullable
     @Override
-    public String sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file) {
-        return null;
+    public Result<String> sendFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file) {
+        try {
+            return Result.success("url");
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 
     @Nullable
     @Override
-    public String sendImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file, @NotNull ProgressCallback callback) {
-        return null;
+    public Result<String> sendImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file, @NotNull ProgressCallback callback) {
+        try {
+            return Result.success("url");
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 
     @Nullable
     @Override
-    public String sendImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file) {
-        return null;
+    public Result<String> sendImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull File file) {
+        try {
+            return Result.success("url");
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 
     @Override
-    public void deleteFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull String url) {
-
+    public Result<Unit> deleteFile(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull String url) {
+        try {
+            return Result.success(Unit.INSTANCE);
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 
     @Override
-    public void deleteImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull String url) {
-
+    public Result<Unit> deleteImage(@NotNull String channelType, @NotNull String channelId, @NotNull String userId, @NotNull String connectionId, @NotNull String url) {
+        try {
+            return Result.success(Unit.INSTANCE);
+        } catch (Exception e) {
+            return Result.error(e);
+        }
     }
 }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/helpers/MyFileUploader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/helpers/MyFileUploader.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.docs.kotlin.helpers
 
 import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.client.utils.Result
 import java.io.File
 
 class MyFileUploader : FileUploader {
@@ -12,8 +13,12 @@ class MyFileUploader : FileUploader {
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String? {
-        TODO("Not yet implemented")
+    ): Result<String> {
+        return try {
+            Result.success("url")
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 
     override fun sendFile(
@@ -22,8 +27,12 @@ class MyFileUploader : FileUploader {
         userId: String,
         connectionId: String,
         file: File,
-    ): String? {
-        TODO("Not yet implemented")
+    ): Result<String> {
+        return try {
+            Result.success("url")
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 
     override fun sendImage(
@@ -33,8 +42,12 @@ class MyFileUploader : FileUploader {
         connectionId: String,
         file: File,
         callback: ProgressCallback,
-    ): String? {
-        TODO("Not yet implemented")
+    ): Result<String> {
+        return try {
+            Result.success("url")
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 
     override fun sendImage(
@@ -43,8 +56,12 @@ class MyFileUploader : FileUploader {
         userId: String,
         connectionId: String,
         file: File,
-    ): String? {
-        TODO("Not yet implemented")
+    ): Result<String> {
+        return try {
+            Result.success("url")
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 
     override fun deleteFile(
@@ -53,8 +70,12 @@ class MyFileUploader : FileUploader {
         userId: String,
         connectionId: String,
         url: String,
-    ) {
-        TODO("Not yet implemented")
+    ): Result<Unit> {
+        return try {
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 
     override fun deleteImage(
@@ -63,7 +84,11 @@ class MyFileUploader : FileUploader {
         userId: String,
         connectionId: String,
         url: String,
-    ) {
-        TODO("Not yet implemented")
+    ): Result<Unit> {
+        return try {
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.error(e)
+        }
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-975

### 🎯 Goal

Allow clients to receive meaningful information about the cause of the failure when calling `ChatClient::sendImage` and `ChatClient::sendFile` methods.

### 🛠 Implementation details

According to the poll in Slack, the solution with `Result` got more votes. Therefore, changed `FileUploader` methods to return `Result` objects instead of nullable strings. 

### 🧪 Testing

1. Update `ChannelController` to send every attachment as images (`client.sendImage(channelType, channelId, file)`)
2. Try to upload a file
3. Observe that the `Result` object contains meaningful error (`Result<String> = sendImage(file)`)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/9600921/119083427-96f3d900-ba08-11eb-8d5e-91350e3a8199.gif)

