### PR TITLE
Fix/show attachment media activity for video mime type

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -87,6 +87,7 @@ It should be used now to fetch Firebase token in the following way: `handler.get
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 Fixing filter for draft channels. Those channels were not showing in the results, even when the user asked for them. Now this is fixed and the draft channels can be included in the `ChannelListView`.
+Fixed bug when for some video attachments activity with media player wasn't shown.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/AttachmentDestination.kt
@@ -25,15 +25,18 @@ public open class AttachmentDestination(
     }
 
     public fun showAttachment(message: Message, attachment: Attachment) {
+        if (attachment.type == ModelType.attach_file ||
+            attachment.type == ModelType.attach_video ||
+            attachment.mimeType?.contains(VIDEO_MIME_TYPE_PREFIX) == true
+        ) {
+            loadFile(attachment)
+            return
+        }
+
         var url: String? = null
         var type: String? = attachment.type
 
         when (attachment.type) {
-            ModelType.attach_file,
-            ModelType.attach_video -> {
-                loadFile(attachment)
-                return
-            }
             ModelType.attach_image -> {
                 when {
                     attachment.ogUrl != null -> {
@@ -83,7 +86,7 @@ public open class AttachmentDestination(
 
         // Media
         when {
-            mimeType.contains("audio") || mimeType.contains("video") -> {
+            mimeType.contains("audio") || mimeType.contains(VIDEO_MIME_TYPE_PREFIX) -> {
                 val intent = Intent(context, AttachmentMediaActivity::class.java).apply {
                     putExtra(AttachmentMediaActivity.TYPE_KEY, mimeType)
                     putExtra(AttachmentMediaActivity.URL_KEY, url)
@@ -126,4 +129,8 @@ public open class AttachmentDestination(
     }
 
     private fun Attachment.isGif() = mimeType?.contains("gif") ?: false
+
+    private companion object {
+        private const val VIDEO_MIME_TYPE_PREFIX = "video"
+    }
 }


### PR DESCRIPTION
Related issue [here](https://github.com/GetStream/stream-chat-android/issues/1889)

### 🎯 Goal
Added new case for attachment when we should show AttachmentMediaActivity (activity with video player). It's for case when `type != "video"` but mime-type is video type

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF
![](https://media4.giphy.com/media/AeUcmWquAI8tW/giphy.gif)
