### PR TITLE
Fix auto scroll not pushing if first element was visible

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/SnapToTopDataObserver.kt
@@ -30,8 +30,7 @@ internal class SnapToTopDataObserver(
         if (
             itemPosition != 0 ||
             recyclerView.scrollState != RecyclerView.SCROLL_STATE_IDLE ||
-            recyclerView.canScrollVertically(-1) ||
-            layoutManager.findFirstVisibleItemPosition() == 0
+            recyclerView.canScrollVertically(-1)
         ) {
             return
         }


### PR DESCRIPTION
### 🎯 Goal

When the first element was visible the auto-scroll didn't push the list down, making the new updated first element not visible.

### 🛠 Implementation details

Delete the first element visible condition

### 🎨 UI Changes

_ Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

### 🧪 Testing

Don't scroll, make a change on a chat, now the chat is visible on the top

### ☑️ Checklist

- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [X] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [ ] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
