### PR TITLE
Fix publishing of jar artifacts

### DIFF
--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -42,7 +42,7 @@ afterEvaluate {
                 if (project.plugins.findPlugin("com.android.library")) {
                     from components.release
                 } else {
-                    artifact("$buildDir/libs/${project.getName()}-${version}.jar")
+                    from components.java
                 }
 
                 artifact androidSourcesJar


### PR DESCRIPTION
The original publishing script gave me good pom.xml for aar artifacts, but jar ones had no `<dependencies>` blocks. So here's a fix borrowed from Gradle docs.