### PR TITLE
[CAS-1021] Allow horizontal alignment of online indicator

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,8 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `AvatarView.OnlineIndicatorPosition.TOP`<br/>*ui-components* | 2021.06.01 | 2021.07.01⌛ | 2021.08.01⌛ | Use the `OnlineIndicatorPosition.TOP_RIGHT` constant instead |
+| `AvatarView.OnlineIndicatorPosition.BOTTOM`<br/>*ui-components* | 2021.06.01 | 2021.07.01⌛ | 2021.08.01⌛ | Use the `OnlineIndicatorPosition.BOTTOM_RIGHT` constant instead |
 | `SocketListener::onDisconnected` <br/>*client* | 2021.05.17 | 2021.06.17⌛ | 2021.07.17⌛ | Use method with DisconnectCause instead of it |
 | `ChatClient#handleRemoteMessage`<br/>*client* | 2021.05.14<br/>4.11.0 | 2021.06.14<br/>⌛ | 2021.07.14 ⌛ | Use the `ChatClient.handleRemoteMessage` method instead |
 | `ChatClient#onNewTokenReceived`<br/>*client* | 2021.05.14<br/>4.11.0 | 2021.06.14<br/>⌛ | 2021.07.14 ⌛ | Use the `ChatClient.setFirebaseToken` method instead |

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -96,6 +96,7 @@ Fixed bug when for some video attachments activity with media player wasn't show
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `topLeft`, `topRight`, `bottomLeft`, `bottomRight` options to the `streamUiAvatarOnlineIndicatorPosition` attribute of `AvatarView` and corresponding constants to `AvatarView.OnlineIndicatorPosition` enum.
 
 ### ⚠️ Changed
 - Swipe options of `ChannelListView` component:

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/avatarview/ComponentBrowserAvatarViewFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/avatarview/ComponentBrowserAvatarViewFragment.kt
@@ -117,7 +117,18 @@ class ComponentBrowserAvatarViewFragment : Fragment() {
         binding.avatarViewLargeIndicator.apply {
             setUserData(user3)
         }
-
+        binding.avatarViewIndicatorTopLeft.apply {
+            setUserData(user2)
+        }
+        binding.avatarViewIndicatorBottomLeft.apply {
+            setUserData(user2)
+        }
+        binding.avatarViewIndicatorTopRight.apply {
+            setUserData(user2)
+        }
+        binding.avatarViewIndicatorBottomRight.apply {
+            setUserData(user2)
+        }
         binding.avatarViewSmallIndicatorBorder.apply {
             setUserData(user1)
         }

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_avatar_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_avatar_view.xml
@@ -112,7 +112,7 @@
 
             <TextView
                 style="@style/ComponentBrowserLabel"
-                android:text="Read indicator"
+                android:text="Online indicator"
                 />
 
             <io.getstream.chat.android.ui.avatar.AvatarView
@@ -131,6 +131,43 @@
                 android:id="@+id/avatarViewLargeIndicator"
                 style="@style/StreamUiGroupActionsAvatarStyle"
                 />
+
+            <View style="@style/ComponentBrowserSeparator" />
+
+            <TextView
+                style="@style/ComponentBrowserLabel"
+                android:text="Online indicator position"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                android:id="@+id/avatarViewIndicatorTopLeft"
+                style="@style/StreamUiUserAvatarStyle"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarOnlineIndicatorPosition="topLeft"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                android:id="@+id/avatarViewIndicatorBottomLeft"
+                style="@style/StreamUiUserAvatarStyle"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarOnlineIndicatorPosition="bottomLeft"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                android:id="@+id/avatarViewIndicatorTopRight"
+                style="@style/StreamUiUserAvatarStyle"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarOnlineIndicatorPosition="topRight"
+                />
+
+            <io.getstream.chat.android.ui.avatar.AvatarView
+                android:id="@+id/avatarViewIndicatorBottomRight"
+                style="@style/StreamUiUserAvatarStyle"
+                app:streamUiAvatarOnlineIndicatorEnabled="true"
+                app:streamUiAvatarOnlineIndicatorPosition="bottomRight"
+                />
+
+            <View style="@style/ComponentBrowserSeparator" />
 
             <TextView
                 style="@style/ComponentBrowserLabel"
@@ -159,6 +196,8 @@
                 app:streamUiAvatarBorderWidth="4dp"
                 app:streamUiAvatarBorderColor="@color/grey_dark"
                 />
+
+            <View style="@style/ComponentBrowserSeparator" />
 
             <TextView
                 style="@style/ComponentBrowserLabel"
@@ -193,6 +232,9 @@
                 app:streamUiAvatarOnlineIndicatorColor="@color/stream_ui_accent_blue"
                 app:streamUiAvatarOnlineIndicatorBorderColor="@color/stream_ui_avatar_gradient_yellow"
                 />
+
         </LinearLayout>
+
     </ScrollView>
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -161,7 +161,11 @@ public final class io/getstream/chat/android/ui/avatar/AvatarView : androidx/app
 
 public final class io/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition : java/lang/Enum {
 	public static final field BOTTOM Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
+	public static final field BOTTOM_LEFT Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
+	public static final field BOTTOM_RIGHT Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
 	public static final field TOP Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
+	public static final field TOP_LEFT Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
+	public static final field TOP_RIGHT Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
 	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
 	public static fun values ()[Lio/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicatorPosition;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
@@ -62,7 +62,7 @@ public data class AvatarStyle(
                 )
                 val onlineIndicatorPosition = it.getEnum(
                     R.styleable.AvatarView_streamUiAvatarOnlineIndicatorPosition,
-                    AvatarView.OnlineIndicatorPosition.TOP
+                    AvatarView.OnlineIndicatorPosition.TOP_RIGHT
                 )
                 val onlineIndicatorColor = it.getColor(R.styleable.AvatarView_streamUiAvatarOnlineIndicatorColor, Color.GREEN)
                 val onlineIndicatorBorderColor = it.getColor(R.styleable.AvatarView_streamUiAvatarOnlineIndicatorBorderColor, Color.WHITE)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
@@ -92,10 +92,26 @@ public class AvatarView : AppCompatImageView {
 
     private fun drawOnlineStatus(canvas: Canvas) {
         if (isOnline && avatarStyle.onlineIndicatorEnabled) {
-            val cx = width - (width / 8f)
+            val cx: Float = when (avatarStyle.onlineIndicatorPosition) {
+                OnlineIndicatorPosition.TOP_LEFT,
+                OnlineIndicatorPosition.BOTTOM_LEFT,
+                -> width / 8f
+                OnlineIndicatorPosition.TOP,
+                OnlineIndicatorPosition.BOTTOM,
+                OnlineIndicatorPosition.TOP_RIGHT,
+                OnlineIndicatorPosition.BOTTOM_RIGHT,
+                -> width - (width / 8f)
+            }
+
             val cy: Float = when (avatarStyle.onlineIndicatorPosition) {
-                OnlineIndicatorPosition.TOP -> height / 8f
-                OnlineIndicatorPosition.BOTTOM -> height - height / 8f
+                OnlineIndicatorPosition.TOP_LEFT,
+                OnlineIndicatorPosition.TOP_RIGHT,
+                OnlineIndicatorPosition.TOP,
+                -> height / 8f
+                OnlineIndicatorPosition.BOTTOM_LEFT,
+                OnlineIndicatorPosition.BOTTOM_RIGHT,
+                OnlineIndicatorPosition.BOTTOM,
+                -> height - height / 8f
             }
             canvas.drawCircle(cx, cy, width / 8f, onlineIndicatorOutlinePaint)
             canvas.drawCircle(cx, cy, width / 10f, onlineIndicatorPaint)
@@ -114,8 +130,21 @@ public class AvatarView : AppCompatImageView {
     }
 
     public enum class OnlineIndicatorPosition {
+        @Deprecated(
+            message = "Use OnlineIndicatorPosition.TOP_RIGHT instead",
+            level = DeprecationLevel.WARNING,
+        )
         TOP,
-        BOTTOM
+
+        @Deprecated(
+            message = "Use OnlineIndicatorPosition.BOTTOM_RIGHT instead",
+            level = DeprecationLevel.WARNING,
+        )
+        BOTTOM,
+        TOP_LEFT,
+        TOP_RIGHT,
+        BOTTOM_LEFT,
+        BOTTOM_RIGHT
     }
 
     internal companion object {

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_avatar_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_avatar_view.xml
@@ -14,8 +14,14 @@
         </attr>
         <attr name="streamUiAvatarOnlineIndicatorEnabled" format="boolean" />
         <attr name="streamUiAvatarOnlineIndicatorPosition" format="enum">
+            <!-- {@deprecated Use topRight instead.} -->
             <enum name="top" value="0" />
+            <!-- {@deprecated Use bottomRight instead.} -->
             <enum name="bottom" value="1" />
+            <enum name="topLeft" value="2" />
+            <enum name="topRight" value="3" />
+            <enum name="bottomLeft" value="4" />
+            <enum name="bottomRight" value="5" />
         </attr>
         <attr name="streamUiAvatarOnlineIndicatorColor" format="color|reference" />
         <attr name="streamUiAvatarOnlineIndicatorBorderColor" format="color|reference" />

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -48,7 +48,7 @@
         <item name="android:layout_height">@dimen/stream_ui_avatar_size_large</item>
         <item name="streamUiAvatarTextSize">@dimen/stream_ui_avatar_text_size_large</item>
         <item name="streamUiAvatarOnlineIndicatorEnabled">true</item>
-        <item name="streamUiAvatarOnlineIndicatorPosition">bottom</item>
+        <item name="streamUiAvatarOnlineIndicatorPosition">bottomRight</item>
     </style>
 
     <style name="StreamUiChatInfoAvatarStyle" parent="StreamUiBaseAvatarStyle">
@@ -281,7 +281,7 @@
         <item name="streamUiAvatarBorderColor">?attr/streamUiGlobalAvatarBorderColor</item>
         <item name="streamUiAvatarTextColor">?attr/streamUiGlobalAvatarTextColor</item>
         <item name="streamUiAvatarOnlineIndicatorEnabled">true</item>
-        <item name="streamUiAvatarOnlineIndicatorPosition">top</item>
+        <item name="streamUiAvatarOnlineIndicatorPosition">topRight</item>
         <item name="streamUiAvatarBorderWidth">0dp</item>
         <item name="streamUiAvatarOnlineIndicatorColor">?attr/streamUiGlobalAvatarOnlineIndicatorColor</item>
         <item name="streamUiAvatarOnlineIndicatorBorderColor">@color/stream_ui_white</item>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1021

### 🎯 Goal

Allow horizontal alignment of online indicator

### 🛠 Implementation details

Using separate constants for each case: `topLeft`, `topRight`, `bottomLeft` and `bottomRight`. Alternative solution was to use a bit mask for that (e.g. `top|left`), but this approach increases the complexity of handling online indicator alignment programmatically.

### 🎨 UI Changes

![device-2021-06-01-082135](https://user-images.githubusercontent.com/9600921/120270533-76523b80-c2b2-11eb-97e8-bcaa9cc016f6.png)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (3)](https://user-images.githubusercontent.com/9600921/120269555-b7e1e700-c2b0-11eb-8e6f-3a0e184b4fba.gif)
