### PR TITLE
Fix enriching channel with messages

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
@@ -68,7 +68,7 @@ internal class RepositoryFacade constructor(
         config = selectChannelConfig(type)?.config ?: defaultConfig
         messages = if (messageMap.containsKey(cid)) {
             val fullList = (messageMap[cid] ?: error("Messages must be in the map")) + messages
-            fullList.distinct()
+            fullList.distinctBy(Message::id)
         } else {
             messages
         }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/WhenEnrichChannel.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/WhenEnrichChannel.kt
@@ -77,6 +77,26 @@ internal class WhenEnrichChannel : BaseRepositoryFacadeTest() {
     }
 
     @Test
+    fun `Given messages for channel in the map And channel messages are not empty And contain message with the same id but different data Should update channel with distinct set of messages`() {
+        sut.run {
+            val commonMessageId = "commonMessage"
+            val commonMessage = randomMessage(id = commonMessageId)
+            val message2 = randomMessage()
+            val message3 = randomMessage()
+            val channel = randomChannel(cid = "cid1", messages = listOf(randomMessage(id = commonMessageId), message3))
+            val messageMap = mapOf("cid1" to listOf(commonMessage, message2))
+
+            channel.enrichChannel(messageMap, Config())
+
+            val channelMessages = channel.messages
+            channelMessages.size `should be equal to` 3
+            channelMessages[0] `should be equal to` commonMessage
+            channelMessages[1] `should be equal to` message2
+            channelMessages[2] `should be equal to` message3
+        }
+    }
+
+    @Test
     fun `Given no messages for channel in the map Should not update channel messages`() {
         sut.run {
             val message1 = randomMessage()


### PR DESCRIPTION
### 🎯 Goal

Fix displaying messages in the channel

### 🛠 Implementation details
`Channel.messages` and `messageMap` can contain messages with the same id but different data.
We should distinct concatenated list by `Message::id` in order to remove duplicated messages.

### 🧪 Testing

1. Send `?!@@$$^^$$` - you should see "Automod blocked your message"
2. Press back and open the channel again
3. You should see the same message

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
