### PR TITLE
[CAS-1046] Increasing message limit to 3

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
@@ -28,7 +28,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
     ),
     private val sort: QuerySort<Channel> = ChannelListViewModel.DEFAULT_SORT,
     private val limit: Int = 30,
-    private val messageLimit: Int = 1,
+    private val messageLimit: Int = 3,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass == ChannelListViewModel::class.java) {


### PR DESCRIPTION
[CAS-1046](https://stream-io.atlassian.net/browse/CAS-1046)

### 🎯 Goal

Recude the change to show an empty message.

### 🛠 Implementation details

The message limit our the Channels that we request in the ChannelListView is now 3, then we will show the last not deleted message even when the last and second last messages are deleted. 

### 🎨 UI Changes

Before: In the last channel the message show as empty, because the last message is deleted. 
After: The last non deleted message is not shown. 

| Before | After |
| --- | --- |
| ![Screenshot_20210602-175231](https://user-images.githubusercontent.com/10619102/120550666-8c9fea80-c3cb-11eb-94ed-ab5a1fc74c23.png) | ![Screenshot_20210602-175250](https://user-images.githubusercontent.com/10619102/120550710-99bcd980-c3cb-11eb-9fe4-146c92cb4c18.png) |

### 🧪 Testing

Delete the last message and notice that you won't see it without the PR in a fresh install of the app. 
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/120551169-194aa880-c3cc-11eb-81f1-00754e1a6e43.gif)
