### PR TITLE
Add default implementation of leave channel click listener

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -60,6 +60,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Added default implementation of "Leave channel" click listener to `ChannelListViewModelBinding`
 
 ### ✅ Added
 - Added `streamUiChannelActionsDialogStyle` attribute to application theme and `ChannelListView` to customize channel actions dialog appearance. The attribute references a style with the following attributes:

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
@@ -100,10 +100,6 @@ class ChannelListFragment : Fragment() {
                     .findNavController(R.id.hostFragmentContainer)
                     .navigateSafely(direction)
             }
-
-            setChannelLeaveClickListener { channel ->
-                viewModel.leaveChannel(channel)
-            }
         }
 
         binding.searchInputView.apply {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModelBinding.kt
@@ -61,6 +61,10 @@ public fun ChannelListViewModel.bindView(
             .show()
     }
 
+    view.setChannelLeaveClickListener { channel ->
+        leaveChannel(channel)
+    }
+
     errorEvents.observe(
         lifecycleOwner,
         EventObserver {


### PR DESCRIPTION
### 🎯 Goal

Add default implementation of "leave channel" click listener so that clients have this functionality working out of the box

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
