### PR TITLE
Docusaurus - Removing merge script

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -21,8 +21,6 @@ jobs:
           ./gradlew stream-chat-android-client:dokkaDokkasaurus \
             stream-chat-android-offline:dokkaDokkasaurus \
             stream-chat-android-ui-components:dokkaDokkasaurus
-      - name: Move dokkasaurus files
-        run: ./scripts/merge-dokkasaurus-outputs.sh
       - name: Update Dokka Sidebar
         run: ./gradlew docusaurusSidebar
       - name: push

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ task clean(type: Delete) {
 
 // Use the default greeting
 tasks.register('docusaurusSidebar', GenerateSidebar) {
-    inputDir = file("build/dokka/dokkasaurusMultiModule")
+    inputDir = file("build/dokka/docusaurus")
     outputDir = file("docusaurus/docs/Android/Dokka")
     modulesFilterInput = [
             'stream-chat-android-client',

--- a/scripts/merge-dokkasaurus-outputs.sh
+++ b/scripts/merge-dokkasaurus-outputs.sh
@@ -1,3 +1,0 @@
-cp -R stream-chat-android-client/build/dokka/dokkasaurus/ build/dokka/dokkasaurusMultiModule/
-cp -R stream-chat-android-offline/build/dokka/dokkasaurus/ build/dokka/dokkasaurusMultiModule/
-cp -R stream-chat-android-ui-components/build/dokka/dokkasaurus/ build/dokka/dokkasaurusMultiModule/

--- a/stream-chat-android-client/build.gradle
+++ b/stream-chat-android-client/build.gradle
@@ -113,4 +113,6 @@ tasks.register('dokkaDokkasaurus', DokkaTask) {
     dependencies {
         dokkaPlugin(Dependencies.dokkasaurus)
     }
+
+    outputDirectory = file("../build/dokka/docusaurus")
 }

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -124,4 +124,6 @@ tasks.register('dokkaDokkasaurus', DokkaTask) {
     dependencies {
         dokkaPlugin(Dependencies.dokkasaurus)
     }
+
+    outputDirectory = file("../build/dokka/docusaurus")
 }

--- a/stream-chat-android-ui-components/build.gradle
+++ b/stream-chat-android-ui-components/build.gradle
@@ -106,4 +106,6 @@ tasks.register('dokkaDokkasaurus', DokkaTask) {
     dependencies {
         dokkaPlugin(Dependencies.dokkasaurus)
     }
+
+    outputDirectory = file("../build/dokka/docusaurus")
 }


### PR DESCRIPTION
### 🎯 Goal

I saw a way to customize the output folder for each dokkasaurus task. This way we don't need an extra script just to move the files to correct place. 

### 🛠 Implementation details

The output folder was added to the configuration of dokka tasks.

### 🧪 Testing

run: 

```
./gradlew stream-chat-android-client:dokkaDokkasaurus \
            stream-chat-android-offline:dokkaDokkasaurus \
            stream-chat-android-ui-components:dokkaDokkasaurus
```

And see where the files were generated. 
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy (2)](https://user-images.githubusercontent.com/10619102/120690887-2921c580-c47c-11eb-82e4-b02237e7fa69.gif)
