### PR TITLE
[CAS-1056] Fix - Mime type fix

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
-
+Fixed but where files without extension in its name lost the mime type.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -47,7 +47,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
-Fixed but where files without extension in its name lost the mime type.
+Fixed bug where files without extension in their name lost the mime type.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/attachment/AttachmentUploader.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/attachment/AttachmentUploader.kt
@@ -23,8 +23,8 @@ internal class AttachmentUploader(
     ): Result<Attachment> {
         val file = checkNotNull(attachment.upload) { "An attachment needs to have a non null attachment.upload value" }
 
-        val mimeType: String? = MimeTypeMap.getSingleton()
-            .getMimeTypeFromExtension(file.extension)
+        val mimeType: String? = MimeTypeMap.getSingleton().getMimeTypeFromExtension(file.extension)
+            ?: attachment.mimeType
         val attachmentType = mimeType.toAttachmentType()
 
         val progressTracker = attachment.uploadId?.let {

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -98,11 +98,11 @@ public class MessageInputViewModel @JvmOverloads constructor(
 
     public fun sendMessageWithAttachments(
         messageText: String,
-        attachmentFiles: List<Pair<File, String?>>,
+        attachmentsWithMimeTypes: List<Pair<File, String?>>,
         messageTransformer: Message.() -> Unit = { }
     ) {
         // Send message should not be cancelled when viewModel.onCleared is called
-        val attachments = attachmentFiles.map { (file, mimeType) ->
+        val attachments = attachmentsWithMimeTypes.map { (file, mimeType) ->
             Attachment(upload = file, mimeType = mimeType)
         }.toMutableList()
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -98,11 +98,14 @@ public class MessageInputViewModel @JvmOverloads constructor(
 
     public fun sendMessageWithAttachments(
         messageText: String,
-        attachmentFiles: List<File>,
+        attachmentFiles: List<Pair<File, String?>>,
         messageTransformer: Message.() -> Unit = { }
     ) {
         // Send message should not be cancelled when viewModel.onCleared is called
-        val attachments = attachmentFiles.map { Attachment(upload = it) }.toMutableList()
+        val attachments = attachmentFiles.map { (file, mimeType) ->
+            Attachment(upload = file, mimeType = mimeType)
+        }.toMutableList()
+
         val message = Message(cid = cid, text = messageText, attachments = attachments).apply(messageTransformer)
         chatDomain.sendMessage(message).enqueue()
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -490,7 +490,7 @@ public class MessageInputView : ConstraintLayout {
 
             override fun sendMessageWithAttachments(
                 message: String,
-                attachmentsFiles: List<File>,
+                attachmentsFiles: List<Pair<File, String?>>,
                 messageReplyTo: Message?,
             ) {
                 throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
@@ -508,7 +508,7 @@ public class MessageInputView : ConstraintLayout {
                 parentMessage: Message,
                 message: String,
                 alsoSendToChannel: Boolean,
-                attachmentsFiles: List<File>,
+                attachmentsFiles: List<Pair<File, String?>>,
             ) {
                 throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
             }
@@ -543,7 +543,7 @@ public class MessageInputView : ConstraintLayout {
 
         public fun sendMessageWithAttachments(
             message: String,
-            attachmentsFiles: List<File>,
+            attachmentsFiles: List<Pair<File, String?>>,
             messageReplyTo: Message? = null,
         )
 
@@ -557,7 +557,7 @@ public class MessageInputView : ConstraintLayout {
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>,
+            attachmentsFiles: List<Pair<File, String?>>,
         )
 
         public fun editMessage(oldMessage: Message, newMessageText: String)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -490,7 +490,7 @@ public class MessageInputView : ConstraintLayout {
 
             override fun sendMessageWithAttachments(
                 message: String,
-                attachmentsFiles: List<Pair<File, String?>>,
+                attachmentsWithMimeTypes: List<Pair<File, String?>>,
                 messageReplyTo: Message?,
             ) {
                 throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
@@ -508,7 +508,7 @@ public class MessageInputView : ConstraintLayout {
                 parentMessage: Message,
                 message: String,
                 alsoSendToChannel: Boolean,
-                attachmentsFiles: List<Pair<File, String?>>,
+                attachmentsWithMimeTypes: List<Pair<File, String?>>,
             ) {
                 throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
             }
@@ -543,7 +543,7 @@ public class MessageInputView : ConstraintLayout {
 
         public fun sendMessageWithAttachments(
             message: String,
-            attachmentsFiles: List<Pair<File, String?>>,
+            attachmentsWithMimeTypes: List<Pair<File, String?>>,
             messageReplyTo: Message? = null,
         )
 
@@ -557,7 +557,7 @@ public class MessageInputView : ConstraintLayout {
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<Pair<File, String?>>,
+            attachmentsWithMimeTypes: List<Pair<File, String?>>,
         )
 
         public fun editMessage(oldMessage: Message, newMessageText: String)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -166,9 +166,9 @@ internal class MessageInputFieldView : FrameLayout {
         messageText = "${messageText.substringBeforeLast("@")}@${user.name} "
     }
 
-    fun getAttachedFiles(): List<File> {
-        return selectedAttachments.map {
-            storageHelper.getCachedFileFromUri(context, it)
+    fun getAttachedFiles(): List<Pair<File, String?>> {
+        return selectedAttachments.map { metaData ->
+            storageHelper.getCachedFileFromUri(context, metaData) to metaData.mimeType
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
@@ -57,19 +57,21 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
 
             override fun sendMessageWithAttachments(
                 message: String,
-                attachmentsFiles: List<Pair<File, String?>>,
+                attachmentsWithMimeTypes: List<Pair<File, String?>>,
                 messageReplyTo: Message?,
             ) {
-                viewModel.sendMessageWithAttachments(message, attachmentsFiles) { replyMessageId = messageReplyTo?.id }
+                viewModel.sendMessageWithAttachments(message, attachmentsWithMimeTypes) {
+                    replyMessageId = messageReplyTo?.id
+                }
             }
 
             override fun sendToThreadWithAttachments(
                 parentMessage: Message,
                 message: String,
                 alsoSendToChannel: Boolean,
-                attachmentsFiles: List<Pair<File, String?>>,
+                attachmentsWithMimeTypes: List<Pair<File, String?>>,
             ) {
-                viewModel.sendMessageWithAttachments(message, attachmentsFiles) {
+                viewModel.sendMessageWithAttachments(message, attachmentsWithMimeTypes) {
                     this.parentId = parentMessage.id
                     this.showInChannel = alsoSendToChannel
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
@@ -57,26 +57,26 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
 
             override fun sendMessageWithAttachments(
                 message: String,
-                attachmentsFiles: List<File>,
+                attachmentsFiles: List<Pair<File, String?>>,
                 messageReplyTo: Message?,
             ) {
                 viewModel.sendMessageWithAttachments(message, attachmentsFiles) { replyMessageId = messageReplyTo?.id }
-            }
-
-            override fun sendToThread(parentMessage: Message, messageText: String, alsoSendToChannel: Boolean) {
-                viewModel.sendMessage(messageText) {
-                    this.parentId = parentMessage.id
-                    this.showInChannel = alsoSendToChannel
-                }
             }
 
             override fun sendToThreadWithAttachments(
                 parentMessage: Message,
                 message: String,
                 alsoSendToChannel: Boolean,
-                attachmentsFiles: List<File>,
+                attachmentsFiles: List<Pair<File, String?>>,
             ) {
                 viewModel.sendMessageWithAttachments(message, attachmentsFiles) {
+                    this.parentId = parentMessage.id
+                    this.showInChannel = alsoSendToChannel
+                }
+            }
+
+            override fun sendToThread(parentMessage: Message, messageText: String, alsoSendToChannel: Boolean) {
+                viewModel.sendMessage(messageText) {
                     this.parentId = parentMessage.id
                     this.showInChannel = alsoSendToChannel
                 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
@@ -112,11 +112,11 @@ internal class MessageInputController(
                 parentMessage,
                 message,
                 binding.cbSendAlsoToChannel.isChecked,
-                attachmentsController.selectedAttachments.map {
+                attachmentsController.selectedAttachments.map { metaData ->
                     storageHelper.getCachedFileFromUri(
                         view.context,
-                        it
-                    )
+                        metaData
+                    ) to metaData.mimeType
                 }
             )
         }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputController.kt
@@ -96,11 +96,11 @@ internal class MessageInputController(
             true -> view.sendTextMessage(message)
             false -> view.sendAttachments(
                 message,
-                attachmentsController.selectedAttachments.map {
+                attachmentsController.selectedAttachments.map { metaData ->
                     storageHelper.getCachedFileFromUri(
                         view.context,
-                        it
-                    )
+                        metaData
+                    ) to metaData.mimeType
                 }
             )
         }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -73,7 +73,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
 
-        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<File>) {
+        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
 
@@ -228,7 +228,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
 
     private fun configSendButtonEnableState() {
         val attachments = messageInputController.getSelectedAttachments()
-        val notEmptyMessage = !messageText.isNullOrBlank() || attachments.isNotEmpty()
+        val notEmptyMessage = messageText.isNotBlank() || attachments.isNotEmpty()
         binding.sendButton.isVisible = notEmptyMessage && !isMessageTooLong()
     }
 
@@ -286,7 +286,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         messageSendHandler.sendMessage(message)
     }
 
-    internal fun sendAttachments(message: String, attachmentFiles: List<File>) {
+    internal fun sendAttachments(message: String, attachmentFiles: List<Pair<File, String?>>) {
         messageSendHandler.sendMessageWithAttachments(message, attachmentFiles)
     }
 
@@ -442,7 +442,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
 
     public interface MessageSendHandler {
         public fun sendMessage(messageText: String)
-        public fun sendMessageWithAttachments(message: String, attachmentsFiles: List<File>)
+        public fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>)
         public fun sendToThread(parentMessage: Message, messageText: String, alsoSendToChannel: Boolean)
         public fun sendToThreadWithAttachments(
             parentMessage: Message,

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -73,7 +73,10 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
 
-        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>) {
+        override fun sendMessageWithAttachments(
+            message: String,
+            attachmentsFilesWithMimeType: List<Pair<File, String?>>
+        ) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
 
@@ -286,8 +289,8 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         messageSendHandler.sendMessage(message)
     }
 
-    internal fun sendAttachments(message: String, attachmentFiles: List<Pair<File, String?>>) {
-        messageSendHandler.sendMessageWithAttachments(message, attachmentFiles)
+    internal fun sendAttachments(message: String, attachmentFilesWithMimeType: List<Pair<File, String?>>) {
+        messageSendHandler.sendMessageWithAttachments(message, attachmentFilesWithMimeType)
     }
 
     internal fun sendToThread(parentMessage: Message, message: String, alsoSendToChannel: Boolean) {
@@ -298,13 +301,13 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         parentMessage: Message,
         message: String,
         alsoSendToChannel: Boolean,
-        attachmentFiles: List<Pair<File, String?>>,
+        attachmentFilesWithMimeType: List<Pair<File, String?>>,
     ) {
         messageSendHandler.sendToThreadWithAttachments(
             parentMessage,
             message,
             alsoSendToChannel,
-            attachmentFiles
+            attachmentFilesWithMimeType
         )
     }
 
@@ -442,13 +445,13 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
 
     public interface MessageSendHandler {
         public fun sendMessage(messageText: String)
-        public fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>)
+        public fun sendMessageWithAttachments(message: String, attachmentsFilesWithMimeType: List<Pair<File, String?>>)
         public fun sendToThread(parentMessage: Message, messageText: String, alsoSendToChannel: Boolean)
         public fun sendToThreadWithAttachments(
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<Pair<File, String?>>,
+            attachmentsFilesWithMimeType: List<Pair<File, String?>>,
         )
 
         public fun editMessage(oldMessage: Message, newMessageText: String)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/messageinput/MessageInputView.kt
@@ -89,7 +89,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>,
+            attachmentsFiles: List<Pair<File, String?>>,
         ) {
             throw IllegalStateException("MessageInputView#messageSendHandler needs to be configured to send messages")
         }
@@ -298,7 +298,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
         parentMessage: Message,
         message: String,
         alsoSendToChannel: Boolean,
-        attachmentFiles: List<File>,
+        attachmentFiles: List<Pair<File, String?>>,
     ) {
         messageSendHandler.sendToThreadWithAttachments(
             parentMessage,
@@ -448,7 +448,7 @@ public class MessageInputView(context: Context, attrs: AttributeSet?) : Relative
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>,
+            attachmentsFiles: List<Pair<File, String?>>,
         )
 
         public fun editMessage(oldMessage: Message, newMessageText: String)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
@@ -19,8 +19,11 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
             this@bindView.sendMessage(messageText)
         }
 
-        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>) {
-            this@bindView.sendMessageWithAttachments(message, attachmentsFiles)
+        override fun sendMessageWithAttachments(
+            message: String,
+            attachmentsFilesWithMimeType: List<Pair<File, String?>>
+        ) {
+            this@bindView.sendMessageWithAttachments(message, attachmentsFilesWithMimeType)
         }
 
         override fun sendToThread(
@@ -38,9 +41,9 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<Pair<File, String?>>,
+            attachmentsFilesWithMimeType: List<Pair<File, String?>>,
         ) {
-            this@bindView.sendMessageWithAttachments(message, attachmentsFiles) {
+            this@bindView.sendMessageWithAttachments(message, attachmentsFilesWithMimeType) {
                 this.parentId = parentMessage.id
                 this.showInChannel = alsoSendToChannel
             }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
@@ -19,7 +19,7 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
             this@bindView.sendMessage(messageText)
         }
 
-        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<File>) {
+        override fun sendMessageWithAttachments(message: String, attachmentsFiles: List<Pair<File, String?>>) {
             this@bindView.sendMessageWithAttachments(message, attachmentsFiles)
         }
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/viewmodel/MessageInputViewModelBinding.kt
@@ -38,7 +38,7 @@ public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner
             parentMessage: Message,
             message: String,
             alsoSendToChannel: Boolean,
-            attachmentsFiles: List<File>,
+            attachmentsFiles: List<Pair<File, String?>>,
         ) {
             this@bindView.sendMessageWithAttachments(message, attachmentsFiles) {
                 this.parentId = parentMessage.id


### PR DESCRIPTION
[CAS-1056](https://stream-io.atlassian.net/browse/CAS-1056)

### 🎯 Goal

Fixing mime type for files when they don't have file extension in its name. 

### 🛠 Implementation details

Propagating mime type from AttachmentMetaData instead of throwing it away and then relying in the name to figure out the mime type. Some files may not have the extension in its name, so we can't rely om that (some audio files may be only "track 8" without .mp3 in the end)

### 🎨 UI Changes

Before:

https://user-images.githubusercontent.com/10619102/120698199-12cc3780-c485-11eb-9b57-25e0f5b8bcb3.mov

After: 

https://user-images.githubusercontent.com/10619102/120698417-6a6aa300-c485-11eb-91a6-bded2ad495cd.mov

### 🧪 Testing

Upload an audio file without extension in its name.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes todo~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added todo

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/120698695-c6cdc280-c485-11eb-96b0-8b003b3284c7.gif)
_Let the music play!!_