### PR TITLE
Remove hardcoded Dokkasaurus plugin from offline and UI Components co…

### DIFF
--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -115,9 +115,6 @@ dependencies {
     androidTestImplementation Dependencies.kluent
     androidTestImplementation Dependencies.mockito
     androidTestImplementation Dependencies.mockitoKotlin
-
-    dokkaHtmlPlugin(Dependencies.dokkasaurus)
-    dokkaHtmlPartialPlugin(Dependencies.dokkasaurus)
 }
 
 tasks.register('dokkaDokkasaurus', DokkaTask) {

--- a/stream-chat-android-ui-components/build.gradle
+++ b/stream-chat-android-ui-components/build.gradle
@@ -97,9 +97,6 @@ dependencies {
     testImplementation Dependencies.kluent
     testImplementation Dependencies.mockitoKotlin
     testImplementation Dependencies.truth
-
-    dokkaHtmlPlugin(Dependencies.dokkasaurus)
-    dokkaHtmlPartialPlugin(Dependencies.dokkasaurus)
 }
 
 tasks.register('dokkaDokkasaurus', DokkaTask) {


### PR DESCRIPTION
Quick follow-up to https://github.com/GetStream/stream-chat-android/pull/1927

Removes Dokkasaurus plugin from offline and UI Component modules, as we only removed it from the client module in the PR above

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

