### PR TITLE
Fix thrown exception type while checking if ChatClient is initialized

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed thrown exception type while checking if `ChatClient` is initialized
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1705,7 +1705,7 @@ public class ChatClient internal constructor(
 
         @Throws(IllegalStateException::class)
         private fun ensureClientInitialized(): ChatClient {
-            require(isInitialized) { "ChatClient should be initialized first!" }
+            check(isInitialized) { "ChatClient should be initialized first!" }
             return instance()
         }
     }


### PR DESCRIPTION
#1943 

### 🎯 Goal

Fix crash when the push notification is received or token is updated and `ChatClient` is not initialized yet

### 🛠 Implementation details

Replaced `require` (which throws `IllegalArgumentException`) with `check` (which throws `IllegalStateException`)

### 🧪 Testing

1. Check that app doesn't crash after opening for the first time
2. Check that app doesn't crash after receiving push notification without initialized ChatClient

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

