### PR TITLE
Remove companion from StreamFileProvider

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -3,7 +3,6 @@ public abstract interface class com/getstream/sdk/chat/ChatMarkdown {
 }
 
 public final class com/getstream/sdk/chat/StreamFileProvider : androidx/core/content/FileProvider {
-	public static final field Companion Lcom/getstream/sdk/chat/StreamFileProvider$Companion;
 	public fun <init> ()V
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/CaptureMediaContract.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/CaptureMediaContract.kt
@@ -53,7 +53,7 @@ public class CaptureMediaContract : ActivityResultContract<Unit, File>() {
         action: String,
         destinationFile: File
     ): List<Intent> {
-        val destinationUri = StreamFileProvider.getUriForFile(
+        val destinationUri = StreamFileUtil.getUriForFile(
             context,
             destinationFile
         )

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileProvider.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileProvider.kt
@@ -1,44 +1,5 @@
 package com.getstream.sdk.chat
 
-import android.content.ComponentName
-import android.content.Context
-import android.graphics.Bitmap
-import android.net.Uri
-import android.os.Environment
 import androidx.core.content.FileProvider
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
-import java.io.File
-import java.io.IOException
 
-public class StreamFileProvider : FileProvider() {
-
-    @InternalStreamChatApi
-    public companion object {
-
-        private fun getFileProviderAuthority(context: Context): String {
-            val compName = ComponentName(context, StreamFileProvider::class.java.name)
-            val providerInfo = context.packageManager.getProviderInfo(compName, 0)
-            return providerInfo.authority
-        }
-
-        public fun getUriForFile(context: Context, file: File): Uri =
-            getUriForFile(context, getFileProviderAuthority(context), file)
-
-        public fun writeImageToSharableFile(context: Context, bitmap: Bitmap): Uri? {
-            return try {
-                val file = File(
-                    context.getExternalFilesDir(Environment.DIRECTORY_PICTURES) ?: context.cacheDir,
-                    "share_image_${System.currentTimeMillis()}.png"
-                )
-                file.outputStream().use { out ->
-                    bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
-                    out.flush()
-                }
-                getUriForFile(context, file)
-            } catch (e: IOException) {
-                e.printStackTrace()
-                null
-            }
-        }
-    }
-}
+public class StreamFileProvider : FileProvider()

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
@@ -1,0 +1,41 @@
+package com.getstream.sdk.chat
+
+import android.content.ComponentName
+import android.content.Context
+import android.graphics.Bitmap
+import android.net.Uri
+import android.os.Environment
+import androidx.core.content.FileProvider
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import java.io.File
+import java.io.IOException
+
+@InternalStreamChatApi
+public object StreamFileUtil {
+
+    private fun getFileProviderAuthority(context: Context): String {
+        val compName = ComponentName(context, StreamFileProvider::class.java.name)
+        val providerInfo = context.packageManager.getProviderInfo(compName, 0)
+        return providerInfo.authority
+    }
+
+    public fun getUriForFile(context: Context, file: File): Uri =
+        FileProvider.getUriForFile(context, getFileProviderAuthority(context), file)
+
+    public fun writeImageToSharableFile(context: Context, bitmap: Bitmap): Uri? {
+        return try {
+            val file = File(
+                context.getExternalFilesDir(Environment.DIRECTORY_PICTURES) ?: context.cacheDir,
+                "share_image_${System.currentTimeMillis()}.png"
+            )
+            file.outputStream().use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 90, out)
+                out.flush()
+            }
+            getUriForFile(context, file)
+        } catch (e: IOException) {
+            e.printStackTrace()
+            null
+        }
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/model/AttachmentMetaData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/model/AttachmentMetaData.kt
@@ -2,7 +2,7 @@ package com.getstream.sdk.chat.model
 
 import android.content.Context
 import android.net.Uri
-import com.getstream.sdk.chat.StreamFileProvider
+import com.getstream.sdk.chat.StreamFileUtil
 import com.getstream.sdk.chat.utils.Utils
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
@@ -30,7 +30,7 @@ public data class AttachmentMetaData(
     public constructor(
         context: Context,
         file: File
-    ) : this(file = file, uri = StreamFileProvider.getUriForFile(context, file)) {
+    ) : this(file = file, uri = StreamFileUtil.getUriForFile(context, file)) {
         mimeType = Utils.getMimeType(file)
         type = getTypeFromMimeType(mimeType)
         size = file.length()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
@@ -5,7 +5,7 @@ import android.webkit.MimeTypeMap
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.core.view.isVisible
-import com.getstream.sdk.chat.StreamFileProvider
+import com.getstream.sdk.chat.StreamFileUtil
 import com.getstream.sdk.chat.images.StreamImageLoader.ImageTransformation.RoundedCorners
 import com.getstream.sdk.chat.images.load
 import com.getstream.sdk.chat.images.loadVideoThumbnail
@@ -38,7 +38,7 @@ internal fun ImageView.loadAttachmentThumb(attachment: Attachment) {
                 // We don't have icons for image types, but we can load the actual image in this case
                 if (actualMimeType?.startsWith("image") == true && attachment.upload != null) {
                     load(
-                        data = StreamFileProvider.getUriForFile(context, attachment.upload!!),
+                        data = StreamFileUtil.getUriForFile(context, attachment.upload!!),
                         transformation = FILE_THUMB_TRANSFORMATION
                     )
                 } else {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentGalleryActivity.kt
@@ -12,7 +12,7 @@ import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
 import androidx.viewpager2.widget.ViewPager2
-import com.getstream.sdk.chat.StreamFileProvider
+import com.getstream.sdk.chat.StreamFileUtil
 import com.getstream.sdk.chat.images.StreamImageLoader
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.PermissionChecker
@@ -113,7 +113,7 @@ public class AttachmentGalleryActivity : AppCompatActivity() {
                     context = applicationContext,
                     url = adapter.getItem(binding.galleryViewPager.currentItem)
                 )?.let { bitmap ->
-                    StreamFileProvider.writeImageToSharableFile(applicationContext, bitmap)
+                    StreamFileUtil.writeImageToSharableFile(applicationContext, bitmap)
                 }?.let(onSharePictureListener)
 
                 delay(500)


### PR DESCRIPTION

### 🎯 Goal

Simplify our FileProvider class to hopefully make Samsung happy

### 🛠 Implementation details

Removes the companion object, leaving just an empty subclass of `FileProvider`.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

