### PR TITLE
[CAS-1073] Use Docusaurus admonitions

### DIFF
--- a/docusaurus/docs/Android/01-basics/02-dependencies.md
+++ b/docusaurus/docs/Android/01-basics/02-dependencies.md
@@ -37,7 +37,9 @@ The offline library exposes easy to use LiveData/StateFlow objects for messages,
 It also adds support for offline chat. This means you can send messages, reactions and even create channels while you're offline. When the user comes back online, the library will automatically recover lost events and retry sending messages.
 The offline storage also provides support for implementing optimistic UI updates.
 
-> **Optimistic UI Updates explained**: If you send a message using the offline support lib it will immediately update the underlying LiveData objects and the connected UI. The actual API call happens in the background. This tends to improve a user's perceived performance of the chat interface. This is especially for applications running in high latency or unreliable network conditions such as mobile applications.
+:::note Optimistic UI Updates explained
+If you send a message using the offline support lib it will immediately update the underlying LiveData objects and the connected UI. The actual API call happens in the background. This tends to improve a user's perceived performance of the chat interface. This is especially for applications running in high latency or unreliable network conditions such as mobile applications.
+:::
 
 Offline package is built on top of the Client package. You need to add the following dependency to use the Offline package:
 

--- a/docusaurus/docs/Android/01-basics/03-initializing-sdk.md
+++ b/docusaurus/docs/Android/01-basics/03-initializing-sdk.md
@@ -17,7 +17,9 @@ A best practice is to initialize `ChatClient` in the `Application` class:
 
 The _Builder_ for `ChatClient` exposes configuration options for features such as [Logging](./05-logging.md).
 
-> You can access your apiKey in the [Dashboard](https://getstream.io/dashboard).
+:::note
+You can access your apiKey in the [Dashboard](https://getstream.io/dashboard).
+:::
 
 If you create the `ChatClient` instance following the pattern in the previous example, you will be able to access that instance from any part of your application using the `instance()` method:
 
@@ -68,7 +70,8 @@ ChatClient.instance().connectUser(user = user, token = "userToken") // Replace w
     }
 ```
 
-> To learn more about how to create a token and different user types, see [Connecting a User](../02-client/01-users.md#connecting-a-user).
-
+:::note
+To learn more about how to create a token and different user types, see [Connecting a User](../02-client/01-users.md#connecting-a-user).
+:::
 
 If the `connectUser` call was successful, you are now ready to use the SDK!

--- a/docusaurus/docs/Android/02-client/01-users.md
+++ b/docusaurus/docs/Android/02-client/01-users.md
@@ -94,7 +94,9 @@ Guest sessions can be created client-side and do not require any server-side aut
 
 Guest users are not available to application using multi-tenancy (teams).
 
-> Unlike anonymous users, guest users are counted towards your MAU usage.
+:::note
+Unlike anonymous users, guest users are counted towards your MAU usage.
+:::
 
 Guest users have a limited set of permissions. You can create a guest user session by using `connectGuestUser` instead of `connectUser`.
 
@@ -132,8 +134,9 @@ When you connect to chat using anonymously you receive a special user back with 
 	"language": ""
 }
 ```
-> Anonymous users are not counted toward your MAU number and only have an impact on the number of concurrent connected clients.
-
+:::note
+Anonymous users are not counted toward your MAU number and only have an impact on the number of concurrent connected clients.
+:::
 
 ## Querying Users
 
@@ -228,7 +231,9 @@ User presence allows you to show when a user was last active and if they are onl
 
 <!-- TODO: Check if this status field is actuallz used anywhere -->
 
-> The online field indicates if the user is online. The status field stores text indicating the current user status.
+:::note
+The online field indicates if the user is online. The status field stores text indicating the current user status.
+:::
 
 ### Marking a User Invisible
 
@@ -250,7 +255,9 @@ client.connectUser(user, "user-token").enqueue { result ->
 }
 ```
 
-> **Note**: a User's invisible status can be only set while calling `connectUser` method.
+:::note
+User's invisible status can be only set while calling `connectUser` method.
+:::
 
 ### Listening to User Presence Changes
 

--- a/docusaurus/docs/Android/02-client/02-channels.md
+++ b/docusaurus/docs/Android/02-client/02-channels.md
@@ -33,7 +33,9 @@ client.queryChannels(request).enqueue { result ->
 }
 ```
 
-> At a minimum, the filter should include members: { $in: [userID] }.
+:::note
+At a minimum, the filter should include members: { $in: [userID] }.
+:::
 
 On messaging and team applications you normally have users added to channels as a member. A good starting point is to use this filter to show the channels the user is participating.
 
@@ -122,7 +124,9 @@ channelClient.query(request).enqueue { result ->
 
 For members and watchers, we use limit and offset parameters.
 
-> The maximum number of messages that can be retrieved at once from the API is 300.
+:::note
+The maximum number of messages that can be retrieved at once from the API is 300.
+:::
 
 ## Watching Channels
 
@@ -147,7 +151,9 @@ channelClient.watch().enqueue { result ->
     }
 }
 ```
-> **NOTE:** Watching a channel only works if you have connected as a user to the chat API
+:::note
+Watching a channel only works if you have connected as a user to the chat API
+:::
 
 The default `queryChannels` API returns channels and starts watching them. There is no need to also use `channel.watch` on the channels returned from `queryChannels`.
 
@@ -272,7 +278,9 @@ Channels can be used to conversations between users. In most cases, you want con
 
 You can achieve this by leaving the channel ID empty and provide channel type and members. When you do so, the API will ensure that only one channel for the members you specified exists (the order of the members does not matter).
 
-> You cannot add/remove members for channels created this way.
+:::note
+You cannot add/remove members for channels created this way.
+:::
 
 ```kotlin
 client.createChannel(
@@ -354,9 +362,13 @@ channelClient.update(
 
 Sometimes channels will have many hundreds (or thousands) of members and it is important to be able to access ID's and information on all of these members. The `queryMembers` endpoint queries the channel members and allows the user to paginate through a full list of users in channels with very large member counts. The endpoint supports filtering on numerous criteria to efficiently return member information.
 
-> The members are sorted by _created_at_ in ascending order.
+:::note
+The members are sorted by _created_at_ in ascending order.
+:::
 
-> _Stream Chat_ does not run MongoDB on the backend, only a subset of the query options are available.
+:::note
+_Stream Chat_ does not run MongoDB on the backend, only a subset of the query options are available.
+:::
 
 Here’s some example of how you can query the list of members:
 
@@ -580,7 +592,9 @@ client
     }
 ```
 
-> Messages added to muted channels do not increase the unread messages count.
+:::note
+Messages added to muted channels do not increase the unread messages count.
+:::
 
 Muted channels can be filtered or excluded by using the `muted` in your query channels filter.
 

--- a/docusaurus/docs/Android/02-client/03-messages.md
+++ b/docusaurus/docs/Android/02-client/03-messages.md
@@ -121,7 +121,9 @@ channelClient.sendImage(imageFile).enqueue { result->
 }
 ```
 
-> **NOTE**: Attachments need to be linked to the message after the upload is completed.
+:::note
+Attachments need to be linked to the message after the upload is completed.
+:::
 
 ### Uploading a File
 
@@ -212,7 +214,9 @@ channelClient.sendReaction(reaction).enqueue { result ->
 | reaction.score | Int | Score of the reaction for cumulative reactions (see example below) | 1 | &check; |
 | enforceUnique | Boolean | If set to true, new reaction will replace all reactions the user has (if any) on this message | false | &check; |
 
-> Custom data for reactions is limited to 1KB.
+:::note
+Custom data for reactions is limited to 1KB.
+:::
 
 ### Replacing a Reaction
 
@@ -319,7 +323,9 @@ channelClient.sendMessage(message).enqueue { result ->
 
 <!-- TODO: show_in_channel is not Android API -->
 
-> If you specify `show_in_channel`, the message will be visible both in a thread of replies as well as the main channel.
+:::note
+If you specify `show_in_channel`, the message will be visible both in a thread of replies as well as the main channel.
+:::
 
 Messages inside a thread can also have reactions, attachments and mentions as any other message.
 
@@ -407,7 +413,9 @@ client.searchMessages(
 
 Pagination works via the standard `limit` and `offset` parameters. The first argument, `filter`, uses a MongoDB style query expression.
 
-> We do not run MongoDB on the backend, so only a subset of the standard MongoDB filters are supported.
+:::note
+We do not run MongoDB on the backend, so only a subset of the standard MongoDB filters are supported.
+:::
 
 ### Searching for Messages with Attachments
 
@@ -446,12 +454,14 @@ val message = Message(
 channelClient.sendMessage(message).enqueue { /* ... */ }
 ```
 
-> Existing messages cannot be turned into a silent message or vice versa.
+:::note
+Existing messages cannot be turned into a silent message or vice versa.
+:::
 
 <!-- TODO: What's the Android API for skip_push? -->
-
-> Silent messages do send push notifications by default. To skip our push notification service, mark the message with `skip_push: true`
-
+:::note
+Silent messages do send push notifications by default. To skip our push notification service, mark the message with `skip_push: true`
+:::
 
 ## Pinned Messages
 

--- a/docusaurus/docs/Android/02-client/05-moderation-tools.md
+++ b/docusaurus/docs/Android/02-client/05-moderation-tools.md
@@ -49,20 +49,26 @@ client.unmuteUser("user-id").enqueue { result ->
 
 After muting a user messages will still be delivered via web-socket. Implementing business logic such as hiding messages from muted users or display them differently is left to the developer to implement.
 
-> Messages from muted users are not delivered via push (APN/Firebase)
+:::note
+Messages from muted users are not delivered via push (APN/Firebase)
+:::
 
 ## Banning Users
 
 Users can be banned from an app entirely or just from a single channel. When a user is banned, they will not be allowed to post messages until the ban is removed or expired but they will be able to connect to Chat and to channels as before.
 
-> In most cases, only admins or moderators are allowed to ban other users from a channel.
+:::note
+In most cases, only admins or moderators are allowed to ban other users from a channel.
+:::
 
 | Name | Type | Description | Default | Optional |
 | :--- | :--- | :--- | :--- | :--- |
 | timeout | Int | The timeout in minutes until the ban is automatically expired. | 	no limit | &check; |
 | reason | String | The reason that the ban was created. | | &check; |
 
-> Banning a user from all channels can only be done using server-side auth.
+:::note
+Banning a user from all channels can only be done using server-side auth.
+:::
 
 ```kotlin
 // Ban user for 60 minutes from a channel 
@@ -87,7 +93,9 @@ channelClient.unBanUser(targetId = "user-id").enqueue { result ->
 
 Users can be shadow banned from an app entirely or just from a single channel. When a user is shadow banned, they will still be allowed to post messages, but any message sent during, will have `shadowed: true` field.
 
-> It's up to the client-side implementation to handle `shadowed` messages appropriately.
+:::note
+It's up to the client-side implementation to handle `shadowed` messages appropriately.
+:::
 
 ```kotlin
 // Shadow ban user for 60 minutes from a channel 
@@ -108,7 +116,9 @@ channelClient.removeShadowBan("user-id").enqueue { result ->
 }
 ```
 
-> Administrators can view shadow banned user status in `queryChannels()`, `queryMembers()` and `queryUsers()`.
+:::note
+Administrators can view shadow banned user status in `queryChannels()`, `queryMembers()` and `queryUsers()`.
+:::
 
 ### Retrieving Banned Users
 

--- a/docusaurus/docs/Android/02-client/06-push-notifications.md
+++ b/docusaurus/docs/Android/02-client/06-push-notifications.md
@@ -10,7 +10,9 @@ The Android SDK handles push notifications by default, including:
 
 See [Customizing Push Notifications](#customizing-push-notifications) for customization options.
 
-> **NOTE:** Make sure _ChatClient_ is initialized before handling push notifications. We highly recommend initializing it in the `Application` class.
+:::note
+Make sure _ChatClient_ is initialized before handling push notifications. We highly recommend initializing it in the `Application` class.
+:::
 
 In order to configure push notifications on Android devices, you need to:
 
@@ -34,7 +36,9 @@ Enable _Android & Firebase_ push notifications and upload the _Server Key_ to th
 Save the push notification settings changes:
 ![notifications step 5](../assets/notifications_firebase_setup_step_5.jpeg)
 
-> **NOTE:** Remember to add _google-services.json_ file to your project source directory. For more information take a look at [Firebase setup tutorial](https://firebase.google.com/docs/android/setup).
+:::note
+Remember to add _google-services.json_ file to your project source directory. For more information take a look at [Firebase setup tutorial](https://firebase.google.com/docs/android/setup).
+:::
 
 #### Step 6
 Setup the following push notification data payload at Stream Dashboard:
@@ -99,7 +103,9 @@ In order to redirect from notification to the specific _Activity_ in your app, y
     }
 ```
 
-> **NOTE**: Consider overriding _ChatNotificationHandler#getErrorCaseIntent_ for error case notifications
+:::note
+Consider overriding _ChatNotificationHandler#getErrorCaseIntent_ for error case notifications
+:::
 
 ## Handling Push Notifications From Multiple Providers
 
@@ -108,7 +114,9 @@ _ChatClient_ provides following static methods that might be helpful for push no
 * `ChatClient.handleRemoteMessage` - handles remote message internally
 * `ChatClient.setFirebaseToken` - sets Firebase token
 
-> **NOTE**: Each method should be called after initializing _ChatClient_
+:::note
+Each method should be called after initializing _ChatClient_
+:::
 
 Push notifications from multiple providers can be handled in two different ways:
 
@@ -155,5 +163,6 @@ class CustomFirebaseMessagingService : FirebaseMessagingService() {
 }
 ```
 
-> **NOTE**: Make sure that CustomMessageFirebaseService's priority is higher than -1 to override the default service
-
+:::note
+Make sure that CustomMessageFirebaseService's priority is higher than -1 to override the default service
+:::

--- a/docusaurus/docs/Android/03-ui/02-global-styling.md
+++ b/docusaurus/docs/Android/03-ui/02-global-styling.md
@@ -2,8 +2,9 @@
 
 If you want to customize view styles programmatically you can override the corresponding `StyleTransformer` in the `TransformStyle` class.
 
-> **Important: This doesn't apply the changes instantly, the view must be recreated for the
-changes to take effect.**
+:::caution
+This doesn't apply the changes instantly, the view must be recreated for the changes to take effect.
+:::
 
 Here are some examples of styling you can perform here:
 

--- a/docusaurus/docs/Android/03-ui/04-components/01-channel-list.md
+++ b/docusaurus/docs/Android/03-ui/04-components/01-channel-list.md
@@ -67,7 +67,9 @@ TransformStyle.channelListStyleTransformer = StyleTransformer { defaultStyle ->
     )
 }
 ```
-> **NOTE**: The transformer should be set before the view is rendered to make sure that the new style was applied.
+:::note
+The transformer should be set before the view is rendered to make sure that the new style was applied.
+:::
 
 ## Creating a Custom ViewHolder Factory
 

--- a/docusaurus/docs/Android/03-ui/04-components/06-mention-list-view.md
+++ b/docusaurus/docs/Android/03-ui/04-components/06-mention-list-view.md
@@ -49,7 +49,9 @@ override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
 From that point, you should be able to see messages which contain current user mention.
 
-> `bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::note
+`bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::
 
 ## Handling Mention List View Actions
 

--- a/docusaurus/docs/Android/03-ui/04-components/07-search-view.md
+++ b/docusaurus/docs/Android/03-ui/04-components/07-search-view.md
@@ -75,4 +75,6 @@ searchResultView.setSearchResultSelectedListener { message ->
 }
 ```
 
-> `bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::note
+`bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::

--- a/docusaurus/docs/Android/04-guides/01-building-channel-list-screen.md
+++ b/docusaurus/docs/Android/04-guides/01-building-channel-list-screen.md
@@ -65,7 +65,9 @@ channelListHeaderViewModel.bindView(channelListHeaderView, viewLifecycleOwner)
 channelListViewModel.bindView(channelListView, viewLifecycleOwner)
 ```
 
-> Note that `bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::note
+`bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::
 
 From that point, `ChannelListHeaderView` will be able to display the current user avatar as well as online status, while `ChannelListView` will display different channels view states, as well as the channel’s pagination, which will be handled automatically.
 

--- a/docusaurus/docs/Android/04-guides/02-building-message-list-screen.md
+++ b/docusaurus/docs/Android/04-guides/02-building-message-list-screen.md
@@ -98,6 +98,8 @@ messageListHeaderView.setBackButtonClickListener(backHandler)
 // You should also consider overriding default Activity's back button behaviour
 ```
 
-> `bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::note
+`bindView` sets listeners on the view and the ViewModel. Any additional listeners should be set _after_ calling `bindView`.
+:::
 
 From that point, you will be able to display and send messages, conduct different actions, as well as view different channel info.

--- a/docusaurus/docs/Android/04-guides/03-custom-message-input.md
+++ b/docusaurus/docs/Android/04-guides/03-custom-message-input.md
@@ -13,7 +13,9 @@ Note that the UI Components Input View supports many advanced features that you'
 
 With that, let's see how you can build an Input View from scratch.
 
-> Note that this sample is meant to be as simple as possible. You might want to architect your actual custom views in more advanced ways than shown here.
+:::note
+This sample is meant to be as simple as possible. You might want to architect your actual custom views in more advanced ways than shown here.
+:::
 
 ### Creating a layout
 
@@ -159,7 +161,9 @@ val stopTyping: Runnable = Runnable {
 
 Note that `enqueue` is called without a callback, so you're not checking whether or not the operation succeeded or what its result was. This is simplification as these events are not usually high priority.
 
-> The `parentId` here would be the ID of the parent message in case you're typing in a thread (see below about supporting threading).
+:::note
+The `parentId` here would be the ID of the parent message in case you're typing in a thread (see below about supporting threading).
+:::
 
 Then, inside the `init` block, add a `TextWatcher` to the `inputField` that will detect changes in the text input:
 
@@ -209,7 +213,9 @@ fun editMessage(message: Message) {
 
 The input field is also updated here to reflect the original text of the message.
 
-> You might want to add additional UI and listeners to cancel a pending edit and clear this value. You could also update the text / icon of the _Send_ button when a message is being edited.
+:::note
+You might want to add additional UI and listeners to cancel a pending edit and clear this value. You could also update the text / icon of the _Send_ button when a message is being edited.
+:::
 
 Next, the listener of the _Send_ button has to be updated:
 
@@ -290,7 +296,9 @@ chatDomain.sendMessage(message).enqueue { /* ... */ }
 
 This sets the `parentId` value on the newly created message if there is a parent message available.
 
-> Another message property related to threading is `showInChannel`. Setting this to `true` will show a message sent to a thread in the main channel as well. You can add additional UI to let users choose this option, for example, the UI Components message input implementation shows a checkbox for this.
+:::note
+Another message property related to threading is `showInChannel`. Setting this to `true` will show a message sent to a thread in the main channel as well. You can add additional UI to let users choose this option, for example, the UI Components message input implementation shows a checkbox for this.
+:::
 
 To connect this with the thread handling of the Message List View, add the following calls in your screen's implementation (this assumes that you're also using the default Message List Header View):
 


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1073

### 🎯 Goal

Use Docusaurus admonitions https://docusaurus.io/docs/next/markdown-features/admonitions

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot 2021-06-11 at 16 24 28](https://user-images.githubusercontent.com/9600921/121693174-8c8da200-cad1-11eb-935e-2ee5946e8c2f.png) | <img width="1041" alt="Screenshot 2021-06-11 at 16 19 36" src="https://user-images.githubusercontent.com/9600921/121692891-3b7dae00-cad1-11eb-86a7-74bf92e2412b.png"> |

### 🧪 Testing

`npx stream-chat-docusaurus -i -s `

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

