### PR TITLE
[CAS-1075] Add possibility to configure channel actions background

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -82,6 +82,7 @@ permission is not granted, now it asks for it.
   - `streamUiChannelActionsDeleteConversationEnabled` attribute to hide/show "Delete Conversation" action item
   - `streamUiChannelActionsCancelIcon` attribute to customize "Cancel" action icon
   - `streamUiChannelActionsCancelEnabled` attribute to hide/show "Cancel" action item
+  - `streamUiChannelActionsBackground` attribute for dialog's background
 - Added `streamUiIconOnlyVisibleToYou` attribute to `MessageListView` to allow customizing "Only visible to you" icon placed in messages footer
 - Added `GiphyViewHolderStyle` to `MessageListViewStyle` to allow customizing `GiphyViewHolder`. The new style comes together with following `MessageListView` attributes:
   - `streamUiGiphyCardBackgroundColor` attribute to customize card's background color

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -180,11 +180,12 @@ public final class io/getstream/chat/android/ui/avatar/AvatarView$OnlineIndicato
 
 public final class io/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Z)V
+	public fun <init> (Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component10 ()Z
 	public final fun component11 ()Landroid/graphics/drawable/Drawable;
 	public final fun component12 ()Z
+	public final fun component13 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component3 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component4 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
@@ -193,9 +194,10 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelActionsDialo
 	public final fun component7 ()Landroid/graphics/drawable/Drawable;
 	public final fun component8 ()Z
 	public final fun component9 ()Landroid/graphics/drawable/Drawable;
-	public final fun copy (Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Z)Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackground ()Landroid/graphics/drawable/Drawable;
 	public final fun getCancelEnabled ()Z
 	public final fun getCancelIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getDeleteConversationEnabled ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/actions/internal/ChannelActionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/actions/internal/ChannelActionsDialogFragment.kt
@@ -50,6 +50,7 @@ internal class ChannelActionsDialogFragment : BottomSheetDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         consumeStyleArg()
 
+        binding.channelActionsContainer.background = style.background
         binding.recyclerView.adapter = membersAdapter
         configureViewInfoAction()
         configureLeaveGroupButton()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.ui.common.style.TextStyle
  * @property deleteConversationEnabled - shows/hides delete conversation action. Shown by default
  * @property cancelIcon - icon for dismiss dialog action. Default - [R.drawable.stream_ui_ic_clear]
  * @property cancelEnabled - shows/hides dismiss dialog action. Shown by default
+ * @property background - dialog's background
  */
 public data class ChannelActionsDialogViewStyle(
     public val memberNamesTextStyle: TextStyle,
@@ -43,6 +44,7 @@ public data class ChannelActionsDialogViewStyle(
     public val deleteConversationEnabled: Boolean,
     public val cancelIcon: Drawable,
     public val cancelEnabled: Boolean,
+    public val background: Drawable,
 ) {
     internal companion object {
         operator fun invoke(context: Context, attrs: AttributeSet?): ChannelActionsDialogViewStyle {
@@ -171,6 +173,9 @@ public data class ChannelActionsDialogViewStyle(
                     true
                 )
 
+                val background = a.getDrawable(R.styleable.ChannelActionsDialog_streamUiChannelActionsBackground)
+                    ?: context.getDrawableCompat(R.drawable.stream_ui_round_bottom_sheet)!!
+
                 return ChannelActionsDialogViewStyle(
                     memberNamesTextStyle = memberNamesTextStyle,
                     memberInfoTextStyle = memberInfoTextStyle,
@@ -184,6 +189,7 @@ public data class ChannelActionsDialogViewStyle(
                     deleteConversationEnabled = deleteConversationEnabled,
                     cancelIcon = cancelIcon,
                     cancelEnabled = cancelEnabled,
+                    background = background,
                 ).let(TransformStyle.channelActionsDialogStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_channel_actions.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_channel_actions.xml
@@ -2,12 +2,13 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/channelActionsContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:background="@drawable/stream_ui_round_bottom_sheet"
     android:divider="@drawable/stream_ui_divider"
     android:orientation="vertical"
     android:showDividers="middle"
+    tools:background="@drawable/stream_ui_round_bottom_sheet"
     >
 
     <LinearLayout

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_channel_actions_dialog.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_channel_actions_dialog.xml
@@ -52,5 +52,6 @@
         <attr name="streamUiChannelActionsDeleteConversationEnabled" format="boolean" />
         <attr name="streamUiChannelActionsCancelIcon" format="reference" />
         <attr name="streamUiChannelActionsCancelEnabled" format="boolean" />
+        <attr name="streamUiChannelActionsBackground" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
#1935 

### 🎯 Goal

Add possibility to configure `ChannelActionsDialogFragment` background

### 🎨 UI Changes

| Before | After |
| --- | --- |
|<img width="271" alt="Screenshot 2021-06-14 at 13 12 17" src="https://user-images.githubusercontent.com/17440581/121907868-9d2d5a80-cd13-11eb-9575-59a591d35b77.png">|<img width="273" alt="Screenshot 2021-06-14 at 13 16 48" src="https://user-images.githubusercontent.com/17440581/121907897-a3233b80-cd13-11eb-8948-0d16da21a95d.png">|


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

