### PR TITLE
Add possibility to run docusaurus workflow manually

### DIFF
--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main # default branch name for each repo that docs should be push from
+  workflow_dispatch:
 jobs:
   push_docusaurus:
     name: Publish docusaurus docs


### PR DESCRIPTION
### 🎯 Goal

Add the possibility to run docusaurus workflow manually so we don't need to do nasty hacks to push docs to staging without making a release.

### 🛠 Implementation details

Added `workflow_dispatch` as described [here](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow#configuring-a-workflow-to-run-manually)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

