### PR TITLE
[CAS-1090] Hide suggestion list popup when keyboard is hidden

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -68,8 +68,10 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Hide suggestion list popup when keyboard is hidden.
 
 ### ✅ Added
+- Added the `MessageInputView::hideSuggestionList` method to hide the suggestion list popup.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -955,6 +955,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun enableSendButton ()V
 	public final fun getChatMode ()Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
 	public final fun getInputMode ()Lio/getstream/chat/android/ui/message/input/MessageInputView$InputMode;
+	public final fun hideSuggestionList ()V
 	public final fun listenForBigAttachments (Lio/getstream/chat/android/ui/message/input/MessageInputView$BigFileSelectionListener;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun setChatMode (Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;)V
 	public final fun setCommands (Ljava/util/List;)V

--- a/stream-chat-android-ui-components/build.gradle
+++ b/stream-chat-android-ui-components/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation Dependencies.androidxStartup
     implementation Dependencies.stfalconImageViewer
     implementation Dependencies.androidxLifecycleLiveDataKtx
+    implementation Dependencies.keyboardVisibilityEvent
 
     // Markdown
     implementation Dependencies.markwonCore

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -116,6 +116,10 @@ internal class MessageInputFieldView : FrameLayout {
         binding.messageEditText.textCursorDrawable = cursor
     }
 
+    fun clearMessageInputFocus() {
+        binding.messageEditText.clearFocus()
+    }
+
     fun setContentChangeListener(contentChangeListener: ContentChangeListener) {
         this.contentChangeListener = contentChangeListener
     }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1090

### 🎯 Goal

Hide suggestion list popup when keyboard is hidden

### 🛠 Implementation details

Currently, the popup window is dismissed 
- When the user makes a touch outside
- When the anchor view is detached from the view hierarchy

But there are certain cases when this is not enough. Therefore, hiding the popup window when a keyboard is hidden. As the last resort, this PR makes it possible to hide the suggestion list popup manually with the help of `MessageInputView::hideSuggestionList` method.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/122950342-0bfa5b80-d385-11eb-8a93-b6dd494b9758.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/122950364-10267900-d385-11eb-929d-365efab7b7ef.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![giphy (3)](https://user-images.githubusercontent.com/9600921/122957595-c345a100-d38a-11eb-9775-c5675ddf6694.gif)

