### PR TITLE
Do not cache current user as a class field in VM

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/AddChannelViewModel.kt
@@ -76,12 +76,11 @@ class AddChannelViewModel : ViewModel() {
             return
         }
         viewModelScope.launch(Dispatchers.IO) {
+            val currentUserId = chatDomain.user.value?.id ?: error("User must be set before create new channel!")
             val result = chatDomain
                 .createDistinctChannel(
                     channelType = CHANNEL_MESSAGING_TYPE,
-                    members = members.map { it.id }.let { members ->
-                        chatDomain.user.value?.id?.let(members::plus) ?: members
-                    },
+                    members = members.map(User::id) + currentUserId,
                     extraData = mapOf(CHANNEL_ARG_DRAFT to true)
                 ).await()
             if (result.isSuccess) {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/group/select_name/AddGroupChannelSelectNameViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/add/group/select_name/AddGroupChannelSelectNameViewModel.kt
@@ -15,7 +15,6 @@ import io.getstream.chat.android.livedata.utils.Event as EventWrapper
 
 class AddGroupChannelSelectNameViewModel : ViewModel() {
 
-    private val currentUserId: String? = ChatDomain.instance().user.value?.id
     private val _state: MutableLiveData<State> = MutableLiveData()
     private val _errorEvents: MutableLiveData<EventWrapper<ErrorEvent>> = MutableLiveData()
     val state: LiveData<State> = _state
@@ -30,13 +29,13 @@ class AddGroupChannelSelectNameViewModel : ViewModel() {
     private fun createChannel(name: String, members: List<User>) {
         _state.value = State.Loading
         viewModelScope.launch(Dispatchers.Main) {
+            val currentUserId =
+                ChatDomain.instance().user.value?.id ?: error("User must be set before create new channel!")
             val result = ChatClient.instance()
                 .createChannel(
                     channelType = CHANNEL_TYPE_MESSAGING,
                     channelId = UUID.randomUUID().toString(),
-                    members = members.map { it.id }.let { members ->
-                        currentUserId?.let(members::plus) ?: members
-                    },
+                    members = members.map(User::id) + currentUserId,
                     extraData = mapOf(EXTRA_DATA_CHANNEL_NAME to name)
                 ).await()
             if (result.isSuccess) {


### PR DESCRIPTION
### 🎯 Goal

Prevent cases when current user isn't initialized yet in ChatDoman when VM got initialized

### 🛠 Implementation details

User current user in the point of logic, do not cache it

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![](https://media2.giphy.com/media/l2QEgWxqxI2WJCXpC/giphy.gif)
