### PR TITLE
Fix - Stop filtering messages with sent attachments

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.offline
 
 import android.content.Context
 import android.os.Handler
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.getstream.chat.android.client.BuildConfig.STREAM_CHAT_VERSION
 import io.getstream.chat.android.client.ChatClient

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.offline
 
 import android.content.Context
 import android.os.Handler
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.getstream.chat.android.client.BuildConfig.STREAM_CHAT_VERSION
 import io.getstream.chat.android.client.ChatClient
@@ -730,7 +731,7 @@ internal class ChatDomainImpl internal constructor(
 
     private suspend fun retryMessagesWithAttachments(): List<Message> {
         val retriedMessages = repos.selectMessagesWaitForAttachments()
-            .filter { message -> message.attachments.any { it.uploadState == Attachment.UploadState.InProgress } }
+
         val (failedMessages, needToBeSync) = retriedMessages.partition { message ->
             message.attachments.any { it.uploadState is Attachment.UploadState.Failed }
         }


### PR DESCRIPTION
### 🎯 Goal

Fix the attachment sending in the background.

### 🛠 Implementation details

Removing the filter for only `InProgress` attachments. It is possible that the attachment is sent, but the message still wasn't sent. This is the case of this bug, the attachments were send by out Worker, but the message is not sent yet.

### 🧪 Testing

Case 1  - 
Send the attachment without internet.
Enabled the internet
Check that the message it sent.

Case 2 - 
Send the attachment without internet.
Close and kill the app
Enabled the internet
Come back to the app and the same channel.
Check that the message it sent.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/10619102/124185665-9e8bb080-da91-11eb-8152-c3a23d6f874f.gif)

