### PR TITLE
Unique worker for attachment upload

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/UploadAttachmentsAndroidWorker.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/UploadAttachmentsAndroidWorker.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.offline.message.attachment
 import android.content.Context
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
@@ -55,8 +56,11 @@ internal class UploadAttachmentsAndroidWorker(
                 )
                 .build()
 
-            WorkManager.getInstance(context)
-                .enqueue(uploadAttachmentsWorRequest)
+            WorkManager.getInstance(context).enqueueUniqueWork(
+                "$channelId$messageId",
+                ExistingWorkPolicy.KEEP,
+                uploadAttachmentsWorRequest
+            )
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Avoid the creation of a second Worker if the attachments for a certain message are being uploaded already

### 🛠 Implementation details

Enqueueing a unique a unique worker instead of simply enqueueing a worker. 

### 🧪 Testing

Use the attachments upload feature

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[] Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/124292188-ae57d300-db2b-11eb-9142-1cc5ba1ee936.gif)
