### PR TITLE
[CAS-1113] Add ChatClient::partialUserUpdate for partial user updates

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -29,6 +29,7 @@
 - Improved `ChatClient::enableSlowMode`, `ChatClient::disableSlowMode`, `ChannelClient::enableSlowMode`, `ChannelClient::disableSlowMode` methods. Now the methods do partial channel updates so that other channel fields are not affected.
 
 ### ✅ Added
+- Added `ChatClient::partialUpdateUser` method for user partial updates.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -70,6 +70,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun muteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun onMessageReceived (Lcom/google/firebase/messaging/RemoteMessage;)V
 	public final fun onNewTokenReceived (Ljava/lang/String;)V
+	public final fun partialUpdateUser (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun partialUpdateUser$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun pinMessage (Lio/getstream/chat/android/client/models/Message;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun pinMessage (Lio/getstream/chat/android/client/models/Message;Ljava/util/Date;)Lio/getstream/chat/android/client/call/Call;
 	public final fun queryBannedUsers (Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1084,6 +1084,11 @@ public class ChatClient internal constructor(
         set: Map<String, Any> = emptyMap(),
         unset: List<String> = emptyList(),
     ): Call<User> {
+        if (id != getCurrentUser()?.id) {
+            logger.logE("The client-side partial update allows you to update only the current user. Make sure the user is set before updating it.")
+            return ErrorCall(ChatError("The client-side partial update allows you to update only the current user. Make sure the user is set before updating it."))
+        }
+
         return api.partialUpdateUser(
             id = id,
             set = set,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1069,6 +1069,28 @@ public class ChatClient internal constructor(
         return updateUsers(listOf(user)).map { it.first() }
     }
 
+    /**
+     * Updates specific user fields retaining the custom data fields which were set previously.
+     *
+     * @param id user ids
+     * @param set the key-value data which will be added to the existing user object
+     * @param unset the list of fields which will be removed from the existing user object
+     *
+     * @return executable async [Call]
+     */
+    @CheckResult
+    public fun partialUpdateUser(
+        id: String,
+        set: Map<String, Any> = emptyMap(),
+        unset: List<String> = emptyList(),
+    ): Call<User> {
+        return api.partialUpdateUser(
+            id = id,
+            set = set,
+            unset = unset,
+        )
+    }
+
     @CheckResult
     public fun queryUsers(query: QueryUsersRequest): Call<List<User>> {
         return api.queryUsers(query)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -131,6 +131,13 @@ internal interface ChatApi {
     @CheckResult
     fun updateUsers(users: List<User>): Call<List<User>>
 
+    @CheckResult
+    fun partialUpdateUser(
+        id: String,
+        set: Map<String, Any>,
+        unset: List<String>,
+    ): Call<User>
+
     fun queryChannel(
         channelType: String,
         channelId: String = "",

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -14,6 +14,8 @@ import io.getstream.chat.android.client.api.models.MarkReadRequest
 import io.getstream.chat.android.client.api.models.MessageRequest
 import io.getstream.chat.android.client.api.models.MuteChannelRequest
 import io.getstream.chat.android.client.api.models.MuteUserRequest
+import io.getstream.chat.android.client.api.models.PartialUpdateUser
+import io.getstream.chat.android.client.api.models.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api.models.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
@@ -335,6 +337,15 @@ internal class GsonChatApi(
                     listOf(it.value)
                 }
             }
+    }
+
+    override fun partialUpdateUser(id: String, set: Map<String, Any>, unset: List<String>): Call<User> {
+        return retrofitApi.partialUpdateUsers(
+            connectionId = connectionId,
+            body = PartialUpdateUsersRequest(
+                users = listOf(PartialUpdateUser(id = id, set = set, unset = unset)),
+            )
+        ).map { response -> response.users[id]!! }
     }
 
     override fun queryChannel(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitApi.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.api.models.MessageResponse
 import io.getstream.chat.android.client.api.models.MuteChannelRequest
 import io.getstream.chat.android.client.api.models.MuteUserRequest
 import io.getstream.chat.android.client.api.models.MuteUserResponse
+import io.getstream.chat.android.client.api.models.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api.models.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api.models.QueryBannedUsersResponse
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
@@ -204,6 +205,13 @@ internal interface RetrofitApi {
     fun updateUsers(
         @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateUsersRequest,
+    ): RetrofitCall<UpdateUsersResponse>
+
+    @PATCH("/users")
+    @JvmSuppressWildcards // See issue: https://github.com/square/retrofit/issues/3275
+    fun partialUpdateUsers(
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
+        @Body body: PartialUpdateUsersRequest,
     ): RetrofitCall<UpdateUsersResponse>
 
     @GET("/users")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/PartialUpdateUsersRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/PartialUpdateUsersRequest.kt
@@ -1,0 +1,9 @@
+package io.getstream.chat.android.client.api.models
+
+internal data class PartialUpdateUsersRequest(val users: List<PartialUpdateUser>)
+
+internal data class PartialUpdateUser(
+    val id: String,
+    val set: Map<String, Any>,
+    val unset: List<String>,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -17,6 +17,7 @@ import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamReactionDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserDto
+import io.getstream.chat.android.client.api2.model.dto.PartialUpdateUserDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamUserDto
 import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddDeviceRequest
@@ -28,6 +29,7 @@ import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
 import io.getstream.chat.android.client.api2.model.requests.MessageRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
+import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.ReactionRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
@@ -621,6 +623,17 @@ internal class MoshiChatApi(
             body = UpdateUsersRequest(map),
         ).map { response ->
             response.users.values.map(DownstreamUserDto::toDomain)
+        }
+    }
+
+    override fun partialUpdateUser(id: String, set: Map<String, Any>, unset: List<String>): Call<User> {
+        return userApi.partialUpdateUsers(
+            connectionId = connectionId,
+            body = PartialUpdateUsersRequest(
+                listOf(PartialUpdateUserDto(id = id, set = set, unset = unset)),
+            ),
+        ).map { response ->
+            response.users[id]!!.toDomain()
         }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/UserApi.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api.QueryParams
+import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.UpdateUsersRequest
 import io.getstream.chat.android.client.api2.model.response.UpdateUsersResponse
@@ -9,6 +10,7 @@ import io.getstream.chat.android.client.api2.model.response.UsersResponse
 import io.getstream.chat.android.client.call.RetrofitCall
 import retrofit2.http.Body
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Query
 
@@ -19,6 +21,13 @@ internal interface UserApi {
     fun updateUsers(
         @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: UpdateUsersRequest,
+    ): RetrofitCall<UpdateUsersResponse>
+
+    @PATCH("/users")
+    @JvmSuppressWildcards // See issue: https://github.com/square/retrofit/issues/3275
+    fun partialUpdateUsers(
+        @Query(QueryParams.CONNECTION_ID) connectionId: String,
+        @Body body: PartialUpdateUsersRequest,
     ): RetrofitCall<UpdateUsersResponse>
 
     @GET("/users")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -43,3 +43,10 @@ internal data class DownstreamUserDto(
 
     val extraData: Map<String, Any>,
 )
+
+@JsonClass(generateAdapter = true)
+internal data class PartialUpdateUserDto(
+    val id: String,
+    val set: Map<String, Any>,
+    val unset: List<String>,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PartialUpdateUsersRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PartialUpdateUsersRequest.kt
@@ -1,0 +1,7 @@
+package io.getstream.chat.android.client.api2.model.requests
+
+import com.squareup.moshi.JsonClass
+import io.getstream.chat.android.client.api2.model.dto.PartialUpdateUserDto
+
+@JsonClass(generateAdapter = true)
+internal data class PartialUpdateUsersRequest(val users: List<PartialUpdateUserDto>)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1113

### 🎯 Goal

Add possibility for partial user updates

### 🛠 Implementation details

Added `ChatClient::partialUserUpdate`.
NOTE: You can only partially update `currentUser` using client-side API.

### 🧪 Testing
Try to partially update a user.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added
