### PR TITLE
[CAS-991] Fix - Adding all styles to default one

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -264,12 +264,21 @@
     <style name="StreamUiTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="streamUiValidTheme">true</item>
         <item name="streamUiMessageListItemAvatarStyle">@style/StreamUi.MessageList.Item.Avatar</item>
+        <item name="streamUiMessageListHeaderAvatarStyle">@style/StreamUi.MessageList.Header.Avatar</item>
         <item name="streamUiChannelListItemAvatarStyle">@style/StreamUi.ChannelList.Item.Avatar</item>
         <item name="streamUiChannelListHeaderAvatarStyle">@style/StreamUi.ChannelListHeader.Avatar</item>
+        <item name="streamUiChannelListHeaderStyle">@style/StreamUi.ChannelListHeader</item>
+        <item name="streamUiMentionPreviewItemAvatarStyle">@style/StreamUi.MentionPreview.Item.Avatar</item>
+        <item name="streamUiMentionListStyle">@style/StreamUi.MentionPreview.Item.Avatar</item>
+        <item name="streamUiChannelActionsDialogAvatarStyle">@style/StreamUi.ChannelActions.Dialog.Avatar</item>
         <item name="streamUiGlobalAvatarBorderColor">@color/stream_ui_white</item>
         <item name="streamUiGlobalAvatarOnlineIndicatorColor">@color/stream_ui_accent_green</item>
         <item name="streamUiGlobalAvatarTextColor">@color/stream_ui_white</item>
         <item name="streamUiChannelActionsDialogStyle">@style/StreamUi.ChannelList.ActionsDialog</item>
+        <item name="streamUiAttachmentGalleryAvatarStyle">@style/StreamUi.AttachmentGallery.Avatar</item>
+        <item name="streamUiMentionSuggestionAvatarStyle">@style/StreamUi.MentionSuggestion.Avatar</item>
+        <item name="streamUiSearchResultAvatarStyle">@style/StreamUi.SearchResult.Avatar</item>
+        <item name="streamUiThreadAvatarStyle">@style/StreamUi.Thread.Avatar</item>
         <item name="streamUiMessageListHeaderStyle">@style/StreamUi.MessageListHeader</item>
         <item name="streamUiSearchInputViewStyle">@style/StreamUi.SearchInputView</item>
     </style>


### PR DESCRIPTION
[CAS-991](https://stream-io.atlassian.net/browse/CAS-991)

### 🎯 Goal

Add all the styles to the default one so the SDK doesn't crash if a style is not overridden. 

### 🧪 Testing

Delete the themes from sample app and check that nothing crashes.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/10619102/124970302-24fa4200-dffe-11eb-9e3f-bb36d41befdb.gif)
