### PR TITLE
Use in memory GPG key for signing artifacts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,13 +15,6 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Prepare environment
-        env:
-          GPG_KEY_CONTENTS: ${{ secrets.GPG_KEY_CONTENTS }}
-          SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
-        run: |
-          git fetch --unshallow
-          sudo bash -c "echo '$GPG_KEY_CONTENTS' | base64 -d > '$SIGNING_SECRET_KEY_RING_FILE'"
       - name: Release build
         # assembleRelease for all modules, excluding non-library modules: sample, ui-components sample, docs
         run: ./gradlew assembleRelease -x :stream-chat-android-sample:assembleRelease -x :stream-chat-android-ui-components-sample:assembleRelease -x :stream-chat-android-docs:assembleRelease
@@ -34,5 +27,5 @@ jobs:
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
           SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-          SIGNING_SECRET_KEY_RING_FILE: ${{ secrets.SIGNING_SECRET_KEY_RING_FILE }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}

--- a/scripts/publish-module.gradle
+++ b/scripts/publish-module.gradle
@@ -111,10 +111,11 @@ afterEvaluate {
     }
 }
 
-ext["signing.keyId"] = rootProject.ext["signing.keyId"]
-ext["signing.password"] = rootProject.ext["signing.password"]
-ext["signing.secretKeyRingFile"] = rootProject.ext["signing.secretKeyRingFile"]
-
 signing {
+    useInMemoryPgpKeys(
+            rootProject.ext["signing.keyId"],
+            rootProject.ext["signing.key"],
+            rootProject.ext["signing.password"],
+    )
     sign publishing.publications
 }

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -4,7 +4,7 @@ ext["ossrhPassword"] = ''
 ext["sonatypeStagingProfileId"] = ''
 ext["signing.keyId"] = ''
 ext["signing.password"] = ''
-ext["signing.secretKeyRingFile"] = ''
+ext["signing.key"] = ''
 
 File secretPropsFile = project.rootProject.file('local.properties')
 if (secretPropsFile.exists()) {
@@ -19,7 +19,7 @@ if (secretPropsFile.exists()) {
     ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
     ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
     ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
-    ext["signing.secretKeyRingFile"] = System.getenv('SIGNING_SECRET_KEY_RING_FILE')
+    ext["signing.key"] = System.getenv('SIGNING_KEY')
 }
 
 // Set up Sonatype repository


### PR DESCRIPTION
### 🎯 Goal

Simplify publishing setup.

### 🛠 Implementation details

Eliminate the need for creating a separate file in CI to contain the GPG key, use an in-memory key instead.

⚠ Our GitHub CI secrets need to be updated:

- We can remove `SIGNING_SECRET_KEY_RING_FILE ` 
- We can remove `GPG_KEY_CONTENTS ` and have to add `SIGNING_KEY ` instead that contains the base64 encoded key contents (can be generated with `gpg --armor --export-secret-keys GPGKEYID | base64`)

### 🧪 Testing

Merge this and then create a release 😉

... or run `publishReleasePublicationToMavenLocal` locally with values set up in `local.properties`.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/de0AlLgV7XTRhEudoL/giphy.gif)
