### PR TITLE
Fix crash in old MessageListView::onScrolled

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
+- Fix scroll bug in the `MessageListView` that produces an exception related to index out of bounds.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
@@ -393,7 +393,7 @@ public class MessageListView : ConstraintLayout {
                     firstVisiblePosition = currentFirstVisible
 
                     val realLastVisibleMessage =
-                        min(max(currentLastVisible, getLastSeenMessagePosition()), currentList.size)
+                        min(max(currentLastVisible, getLastSeenMessagePosition()), currentList.lastIndex)
                     updateLastSeen(currentList[realLastVisibleMessage])
 
                     val unseenItems = adapter.itemCount - 1 - realLastVisibleMessage


### PR DESCRIPTION
### 🎯 Goal

Scroll listener in the old MessageListView produces an exception related to index out of bound.

### 🛠 Implementation details

Use lastIndex instead of List::size


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![](https://media3.giphy.com/media/xUPGcqaVH1cDeKZTBS/giphy.gif)
