### PR TITLE
Expose MessageListViewStyle

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -75,6 +75,7 @@ https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-u
 ### ⬆️ Improved
 Now you can use the style `streamUiChannelListHeaderStyle` to customize ChannelListHeaderView. 
 ### ✅ Added
+Added `MessageListView::requireStyle` which expose `MessageListViewStyle`. Be sure invoke it when view is initialized already.
 
 ### ⚠️ Changed
 - 🚨 Breaking change: removed `MessageListItemStyle.threadsEnabled` property. You should use only the `MessageListViewStyle.threadsEnabled` instead. E.g. The following code will disable both _Thread reply_ message option and _Thread reply_ footnote view visible below the message list item:

--- a/stream-chat-android/api/stream-chat-android.api
+++ b/stream-chat-android/api/stream-chat-android.api
@@ -475,6 +475,7 @@ public final class com/getstream/sdk/chat/view/MessageListView : androidx/constr
 	public final fun hideEmptyStateView ()V
 	public final fun hideLoadingView ()V
 	public final fun init (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;)V
+	public final fun requireStyle ()Lcom/getstream/sdk/chat/view/MessageListViewStyle;
 	public final fun scrollToBottom ()V
 	public final fun scrollToMessage (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun setAttachmentClickListener (Lcom/getstream/sdk/chat/view/MessageListView$AttachmentClickListener;)V

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
@@ -772,6 +772,13 @@ public class MessageListView : ConstraintLayout {
         this.onStartThreadListener = onStartThreadListener
     }
 
+    /**
+     * Returns an instance of [MessageListViewStyle] associated with this instance of [MessageListView].
+     * Be sure invoke this method after this view laid out on layout and already initialized, otherwise you'll get an
+     * exception.
+     *
+     * @return [MessageListViewStyle] instance associated with this [MessageListView].
+     */
     public fun requireStyle(): MessageListViewStyle {
         return checkNotNull(style) {
             "View must be initialized first to obtain style!"

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/view/MessageListView.kt
@@ -63,7 +63,7 @@ import kotlin.math.min
 public class MessageListView : ConstraintLayout {
     private var firstVisiblePosition = 0
 
-    private lateinit var style: MessageListViewStyle
+    private var style: MessageListViewStyle? = null
 
     private lateinit var binding: StreamMessageListViewBinding
 
@@ -150,7 +150,7 @@ public class MessageListView : ConstraintLayout {
                 channel,
                 message,
                 currentUser,
-                style,
+                requireStyle(),
                 onMessageEditHandler,
                 onMessageDeleteHandler,
                 { m: Message ->
@@ -177,7 +177,7 @@ public class MessageListView : ConstraintLayout {
                 channel,
                 message,
                 currentUser,
-                style,
+                requireStyle(),
                 onMessageEditHandler,
                 onMessageDeleteHandler,
                 onStartThreadHandler,
@@ -456,7 +456,7 @@ public class MessageListView : ConstraintLayout {
         messageViewHolderFactory.bubbleHelper = bubbleHelper
         messageViewHolderFactory.messageDateFormatter = messageDateFormatter
 
-        adapter = MessageListItemAdapter(channel, messageViewHolderFactory, style)
+        adapter = MessageListItemAdapter(channel, messageViewHolderFactory, requireStyle())
         adapter.setHasStableIds(true)
 
         setMessageListItemAdapter(adapter)
@@ -770,6 +770,12 @@ public class MessageListView : ConstraintLayout {
 
     public fun setOnStartThreadListener(onStartThreadListener: (Message) -> Unit) {
         this.onStartThreadListener = onStartThreadListener
+    }
+
+    public fun requireStyle(): MessageListViewStyle {
+        return checkNotNull(style) {
+            "View must be initialized first to obtain style!"
+        }
     }
 
     public fun interface HeaderAvatarGroupClickListener {


### PR DESCRIPTION
### 🎯 Goal

Some of our customers would like to reuse `AttachmentViewFactory` manually.  `AttachmentViewFactory::createAttachmentView` requires `MessageListItemStyle` as an argument. But `MessageListView` doesn't have public method/field for that

### 🛠 Implementation details

1. Make style nullable
2. Expose it via `requireStyle()`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (CMS, cookbooks, tutorial)
- [x] Reviewers added

### 🎉 GIF

![](https://media0.giphy.com/media/l0HU0chahWySQPD8c/giphy.gif)
