### PR TITLE
Fix header alignment when MessageListHeaderView avatar is hidden

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -72,11 +72,13 @@ https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-u
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed the alignment of the titles in `MessageListHeaderView` when the avatar is hidden.
 
 ### ⬆️ Improved
-Now you can use the style `streamUiChannelListHeaderStyle` to customize ChannelListHeaderView. 
+- Now you can use the style `streamUiChannelListHeaderStyle` to customize ChannelListHeaderView.
+
 ### ✅ Added
-Added `MessageListView::requireStyle` which expose `MessageListViewStyle`. Be sure invoke it when view is initialized already.
+- Added `MessageListView::requireStyle` which expose `MessageListViewStyle`. Be sure invoke it when view is initialized already.
 
 ### ⚠️ Changed
 - 🚨 Breaking change: removed `MessageListItemStyle.threadsEnabled` property. You should use only the `MessageListViewStyle.threadsEnabled` instead. E.g. The following code will disable both _Thread reply_ message option and _Thread reply_ footnote view visible below the message list item:

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderView.kt
@@ -47,7 +47,7 @@ public class MessageListHeaderView : FrameLayout {
     }
 
     public fun hideAvatar() {
-        binding.avatarView.isVisible = false
+        binding.avatarView.isInvisible = true
     }
 
     public fun showBackButtonBadge(text: String) {


### PR DESCRIPTION
### 🎯 Goal

Fix title/subtitle alignment

Follow-up on https://github.com/GetStream/stream-chat-android/pull/1731

### 🛠 Implementation details

Set the view to invisible instead of gone (same as when it's hidden via attributes).

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_20210712-194502](https://user-images.githubusercontent.com/12054216/125333263-5189c300-e34a-11eb-9200-5c5bfb57ff54.jpg) | ![Screenshot_20210712-194608](https://user-images.githubusercontent.com/12054216/125333262-50f12c80-e34a-11eb-8432-1156e92747b0.jpg) |

### 🧪 Testing

Call `hideAvatar` on a message list header.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (CMS, cookbooks, tutorial)~
- [x] Reviewers added
