### PR TITLE
Remove Channel::isMuted extension

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -32,6 +32,7 @@
 ### ⚠️ Changed
 
 ### ❌ Removed
+- Removed `Channel::isMuted` extension. Use `User::channelMutes` or subscribe for `NotificationChannelMutesUpdatedEvent` to get information about muted channels.
 
 
 ## stream-chat-android-offline

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1756,8 +1756,6 @@ public final class io/getstream/chat/android/client/extensions/AttachmentExtensi
 
 public final class io/getstream/chat/android/client/extensions/ChannelExtensionKt {
 	public static final fun isAnonymousChannel (Lio/getstream/chat/android/client/models/Channel;)Z
-	public static final fun isMuted (Lio/getstream/chat/android/client/models/Channel;)Z
-	public static final fun setMuted (Lio/getstream/chat/android/client/models/Channel;Z)V
 }
 
 public final class io/getstream/chat/android/client/extensions/MessageExtensionsKt {
@@ -2053,10 +2051,6 @@ public final class io/getstream/chat/android/client/models/Channel : io/getstrea
 	public final fun setWatcherCount (I)V
 	public final fun setWatchers (Ljava/util/List;)V
 	public fun toString ()Ljava/lang/String;
-}
-
-public final class io/getstream/chat/android/client/models/ChannelKt {
-	public static final field EXTRA_DATA_MUTED Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/client/models/ChannelMute {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
@@ -1,12 +1,5 @@
 package io.getstream.chat.android.client.extensions
 
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.client.models.EXTRA_DATA_MUTED
 
 public fun Channel.isAnonymousChannel(): Boolean = id.isAnonymousChannelId()
-
-public var Channel.isMuted: Boolean
-    get() = extraData[EXTRA_DATA_MUTED] as Boolean? ?: false
-    set(value) {
-        extraData[EXTRA_DATA_MUTED] = value
-    }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
@@ -6,8 +6,6 @@ import io.getstream.chat.android.client.parser.IgnoreSerialisation
 import io.getstream.chat.android.client.utils.SyncStatus
 import java.util.Date
 
-public const val EXTRA_DATA_MUTED: String = "mutedChannel"
-
 public data class Channel(
     var cid: String = "",
     var id: String = "",

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -8,7 +8,6 @@ import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import com.getstream.sdk.chat.utils.formatDate
-import io.getstream.chat.android.client.extensions.isMuted
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -26,6 +25,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.extensions.internal.getLastMessage
 import io.getstream.chat.android.ui.common.extensions.internal.getLastMessagePreviewText
 import io.getstream.chat.android.ui.common.extensions.internal.isMessageRead
+import io.getstream.chat.android.ui.common.extensions.internal.isMuted
 import io.getstream.chat.android.ui.common.extensions.internal.isNotNull
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
 import io.getstream.chat.android.ui.common.extensions.isCurrentUserOwnerOrAdmin

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -11,7 +11,6 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.call.enqueue
 import io.getstream.chat.android.client.errors.ChatError
-import io.getstream.chat.android.client.extensions.isMuted
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.TypingEvent
@@ -20,6 +19,7 @@ import io.getstream.chat.android.core.internal.exhaustive
 import io.getstream.chat.android.livedata.utils.Event
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.querychannels.QueryChannelsController
+import io.getstream.chat.android.ui.common.extensions.internal.isMuted
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -78,6 +78,14 @@ internal fun Channel.getLastMessagePreviewText(
     }
 }
 
+private const val EXTRA_DATA_MUTED: String = "mutedChannel"
+
+internal var Channel.isMuted: Boolean
+    get() = extraData[EXTRA_DATA_MUTED] as Boolean? ?: false
+    set(value) {
+        extraData[EXTRA_DATA_MUTED] = value
+    }
+
 private fun getAttachmentPrefix(attachment: Attachment): String? =
     when (attachment.type) {
         ModelType.attach_giphy -> "/giphy"


### PR DESCRIPTION
### 🎯 Goal

Remove Channel::isMuted extension

### 🛠 Implementation details

We are using `Channel::isMuted` and updating it locally for channels displayed in `ChannelListView`, so it doesn't work well for other channels (for example returned by `chatClient.queryChannels`).
It can be misleading, so I moved the property to ui module and made it internal

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
