### PR TITLE
Removing style from some views and letting the global style be applied

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_home.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_home.xml
@@ -14,7 +14,6 @@
 
         <io.getstream.chat.android.ui.channel.list.header.ChannelListHeaderView
             android:id="@+id/channelListHeaderView"
-            style="?attr/streamUiChannelListHeaderStyle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_constraintEnd_toEndOf="parent"

--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_mentions.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_mentions.xml
@@ -7,7 +7,6 @@
 
     <io.getstream.chat.android.ui.mention.list.MentionListView
         android:id="@+id/mentionsListView"
-        style="?attr/streamUiMentionListStyle"
         android:layout_width="0dp"
         android:layout_height="0dp"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -422,6 +422,7 @@ public final class io/getstream/chat/android/ui/channel/list/header/ChannelListH
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;II)V
 	public final fun setOnActionButtonClickListener (Lio/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView$ActionButtonClickListener;)V
 	public final fun setOnUserAvatarClickListener (Lio/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView$UserAvatarClickListener;)V
 	public final fun setUser (Lio/getstream/chat/android/client/models/User;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
@@ -21,11 +21,11 @@ import io.getstream.chat.android.ui.databinding.StreamUiChannelListHeaderViewBin
 public class ChannelListHeaderView : ConstraintLayout {
 
     public constructor(context: Context) : super(context.createStreamThemeWrapper()) {
-        init(context, null)
+        init(null)
     }
 
     public constructor(context: Context, attrs: AttributeSet?) : super(context.createStreamThemeWrapper(), attrs) {
-        init(context, attrs)
+        init(attrs)
     }
 
     public constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
@@ -33,12 +33,20 @@ public class ChannelListHeaderView : ConstraintLayout {
         attrs,
         defStyleAttr
     ) {
-        init(context, attrs)
+        init(attrs)
+    }
+
+    public constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int, defStyleRes: Int) : super(
+        context.createStreamThemeWrapper(),
+        attrs,
+        defStyleAttr,
+        defStyleRes) {
+        init(attrs)
     }
 
     private val binding = StreamUiChannelListHeaderViewBinding.inflate(streamThemeInflater, this, true)
 
-    private fun init(context: Context, attrs: AttributeSet?) {
+    private fun init(attrs: AttributeSet?) {
         context.obtainStyledAttributes(
             attrs,
             R.styleable.ChannelListHeaderView,
@@ -96,7 +104,7 @@ public class ChannelListHeaderView : ConstraintLayout {
             setImageDrawable(drawable)
             backgroundTintList =
                 typedArray.getColorStateList(R.styleable.ChannelListHeaderView_streamUiActionBackgroundTint)
-                ?: ContextCompat.getColorStateList(context, R.color.stream_ui_icon_button_background_selector)
+                    ?: ContextCompat.getColorStateList(context, R.color.stream_ui_icon_button_background_selector)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
@@ -40,7 +40,8 @@ public class ChannelListHeaderView : ConstraintLayout {
         context.createStreamThemeWrapper(),
         attrs,
         defStyleAttr,
-        defStyleRes) {
+        defStyleRes
+    ) {
         init(attrs)
     }
 
@@ -104,7 +105,7 @@ public class ChannelListHeaderView : ConstraintLayout {
             setImageDrawable(drawable)
             backgroundTintList =
                 typedArray.getColorStateList(R.styleable.ChannelListHeaderView_streamUiActionBackgroundTint)
-                    ?: ContextCompat.getColorStateList(context, R.color.stream_ui_icon_button_background_selector)
+                ?: ContextCompat.getColorStateList(context, R.color.stream_ui_icon_button_background_selector)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Removing the application of explicit style from some views so the global style is applied.

### 🧪 Testing

Change the theme and check is gets applied, even thought it is not added to the view.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added



