### PR TITLE
[CAS-1127] Add missing default streamUiReplyAvatarStyle

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed crash caused by missing `streamUiReplyAvatarStyle`
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components-sample/src/main/res/values-v23/themes.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/values-v23/themes.xml
@@ -10,61 +10,10 @@
     </style>
 
     <style name="StreamTheme" parent="@style/StreamUiTheme">
-        <item name="streamUiMessageListItemAvatarStyle">@style/MessageListAvatarTheme</item>
-        <item name="streamUiMessageListHeaderAvatarStyle">@style/MessageListHeaderAvatarTheme</item>
-        <item name="streamUiChannelListItemAvatarStyle">@style/ChannelListAvatarTheme</item>
-        <item name="streamUiChannelListHeaderStyle">@style/ChannelListHeaderTheme</item>
-        <item name="streamUiChannelListHeaderAvatarStyle">@style/ChannelListHeaderAvatarTheme</item>
-        <item name="streamUiMentionPreviewItemAvatarStyle">@style/MentionPreviewAvatarTheme</item>
-        <item name="streamUiMentionListStyle">@style/MentionListTheme</item>
-        <item name="streamUiChannelActionsDialogAvatarStyle">@style/ChannelActionsDialogAvatarStyle</item>
         <item name="streamUiChannelActionsDialogStyle">@style/ChannelActionsDialogTheme</item>
-        <item name="streamUiAttachmentGalleryAvatarStyle">@style/AttachmentGalleryAvatarStyle</item>
-        <item name="streamUiSuggestionListViewMentionAvatarStyle">@style/SuggestionListViewMentionAvatarStyle</item>
-        <item name="streamUiSearchResultAvatarStyle">@style/SearchResultAvatarStyle</item>
-        <item name="streamUiMessageOptionsAvatarStyle">@style/MessageOptionsAvatarStyle</item>
-        <item name="streamUiReplyAvatarStyle">@style/ReplyAvatarStyle</item>
-        <item name="streamUiThreadAvatarStyle">@style/ThreadAvatarStyle</item>
-        <item name="streamUiMessageListHeaderStyle">@style/MessageListHeaderTheme</item>
-        <item name="streamUiSearchInputViewStyle">@style/SearchInputViewTheme</item>
-        <item name="streamUiSuggestionListViewStyle">@style/SuggestionListViewTheme</item>
     </style>
-
-    <style name="MessageListAvatarTheme" parent="StreamUi.MessageList.Item.Avatar"/>
-
-    <style name="MessageListHeaderAvatarTheme" parent="StreamUi.MessageList.Header.Avatar"/>
-
-    <style name="MentionListTheme" parent="StreamUi.MentionList"/>
-
-    <style name="MentionPreviewAvatarTheme" parent="StreamUi.MentionPreview.Item.Avatar"/>
-
-    <style name="ChannelListAvatarTheme" parent="StreamUi.ChannelList.Item.Avatar"/>
-
-    <style name="ChannelListHeaderTheme" parent="StreamUi.ChannelListHeader"/>
-
-    <style name="ChannelListHeaderAvatarTheme" parent="StreamUi.ChannelListHeader.Avatar"/>
-
-    <style name="ChannelActionsDialogAvatarStyle" parent="StreamUi.ChannelActions.Dialog.Avatar"/>
-
-    <style name="AttachmentGalleryAvatarStyle" parent="StreamUi.AttachmentGallery.Avatar"/>
-
-    <style name="SuggestionListViewMentionAvatarStyle" parent="StreamUi.SuggestionListView.Mention.Avatar"/>
-
-    <style name="SearchResultAvatarStyle" parent="StreamUi.SearchResult.Avatar"/>
-
-    <style name="MessageOptionsAvatarStyle" parent="StreamUi.MessageOptions.Avatar"/>
-
-    <style name="ReplyAvatarStyle" parent="StreamUi.Reply.Avatar"/>
-
-    <style name="ThreadAvatarStyle" parent="StreamUi.Thread.Avatar"/>
 
     <style name="ChannelActionsDialogTheme" parent="StreamUi.ChannelList.ActionsDialog" >
         <item name="streamUiChannelActionsViewInfoEnabled">true</item>
     </style>
-
-    <style name="MessageListHeaderTheme" parent="StreamUi.MessageListHeader" />
-
-    <style name="SearchInputViewTheme" parent="StreamUi.SearchInputView"/>
-  
-    <style name="SuggestionListViewTheme" parent="StreamUi.SuggestionListView" />
 </resources>

--- a/stream-chat-android-ui-components-sample/src/main/res/values-v29/themes.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/values-v29/themes.xml
@@ -11,64 +11,10 @@
     </style>
 
     <style name="StreamTheme" parent="@style/StreamUiTheme">
-        <item name="streamUiMessageListItemAvatarStyle">@style/MessageListAvatarTheme</item>
-        <item name="streamUiMessageListHeaderAvatarStyle">@style/MessageListHeaderAvatarTheme</item>
-        <item name="streamUiChannelListItemAvatarStyle">@style/ChannelListAvatarTheme</item>
-        <item name="streamUiChannelListHeaderStyle">@style/ChannelListHeaderTheme</item>
-        <item name="streamUiChannelListHeaderAvatarStyle">@style/ChannelListHeaderAvatarTheme</item>
-        <item name="streamUiMentionPreviewItemAvatarStyle">@style/MentionPreviewAvatarTheme</item>
-        <item name="streamUiMentionListStyle">@style/MentionListTheme</item>
-        <item name="streamUiChannelActionsDialogAvatarStyle">@style/ChannelActionsDialogAvatarStyle</item>
         <item name="streamUiChannelActionsDialogStyle">@style/ChannelActionsDialogTheme</item>
-        <item name="streamUiAttachmentGalleryAvatarStyle">@style/AttachmentGalleryAvatarStyle</item>
-        <item name="streamUiSuggestionListViewMentionAvatarStyle">@style/SuggestionListViewMentionAvatarStyle</item>
-        <item name="streamUiSearchResultAvatarStyle">@style/SearchResultAvatarStyle</item>
-        <item name="streamUiMessageOptionsAvatarStyle">@style/MessageOptionsAvatarStyle</item>
-        <item name="streamUiReplyAvatarStyle">@style/ReplyAvatarStyle</item>
-        <item name="streamUiThreadAvatarStyle">@style/ThreadAvatarStyle</item>
-        <item name="streamUiMessageListHeaderStyle">@style/MessageListHeaderTheme</item>
-        <item name="streamUiSearchInputViewStyle">@style/SearchInputViewTheme</item>
-        <item name="streamUiSuggestionListViewStyle">@style/SuggestionListViewTheme</item>
     </style>
-
-    <style name="MessageListAvatarTheme" parent="StreamUi.MessageList.Item.Avatar" />
-
-    <style name="MessageListHeaderAvatarTheme" parent="StreamUi.MessageList.Header.Avatar"/>
-
-    <style name="MentionListTheme" parent="StreamUi.MentionList"/>
-
-    <style name="MentionPreviewAvatarTheme" parent="StreamUi.MentionPreview.Item.Avatar"/>
-
-    <style name="ChannelListAvatarTheme" parent="StreamUi.ChannelList.Item.Avatar" />
-
-    <style name="ChannelListHeaderTheme" parent="StreamUi.ChannelListHeader"/>
-
-    <style name="ChannelListHeaderAvatarTheme" parent="StreamUi.ChannelListHeader.Avatar">
-        <item name="android:layout_width">@dimen/stream_ui_avatar_size_medium</item>
-        <item name="android:layout_height">@dimen/stream_ui_avatar_size_medium</item>
-    </style>
-
-    <style name="ChannelActionsDialogAvatarStyle" parent="StreamUi.ChannelActions.Dialog.Avatar"/>
-
-    <style name="AttachmentGalleryAvatarStyle" parent="StreamUi.AttachmentGallery.Avatar"/>
-
-    <style name="SuggestionListViewMentionAvatarStyle" parent="StreamUi.SuggestionListView.Mention.Avatar"/>
-
-    <style name="SearchResultAvatarStyle" parent="StreamUi.SearchResult.Avatar"/>
-
-    <style name="MessageOptionsAvatarStyle" parent="StreamUi.MessageOptions.Avatar"/>
-
-    <style name="ReplyAvatarStyle" parent="StreamUi.Reply.Avatar"/>
-
-    <style name="ThreadAvatarStyle" parent="StreamUi.Thread.Avatar"/>
       
     <style name="ChannelActionsDialogTheme" parent="StreamUi.ChannelList.ActionsDialog">
         <item name="streamUiChannelActionsViewInfoEnabled">true</item>
     </style>
-
-    <style name="MessageListHeaderTheme" parent="StreamUi.MessageListHeader" />
-
-    <style name="SearchInputViewTheme" parent="StreamUi.SearchInputView"/>
-
-    <style name="SuggestionListViewTheme" parent="StreamUi.SuggestionListView" />
 </resources>

--- a/stream-chat-android-ui-components-sample/src/main/res/values/themes.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/values/themes.xml
@@ -7,61 +7,10 @@
     </style>
 
     <style name="StreamTheme" parent="@style/StreamUiTheme">
-        <item name="streamUiMessageListItemAvatarStyle">@style/MessageListAvatarTheme</item>
-        <item name="streamUiMessageListHeaderAvatarStyle">@style/MessageListHeaderAvatarTheme</item>
-        <item name="streamUiChannelListItemAvatarStyle">@style/ChannelListAvatarTheme</item>
-        <item name="streamUiChannelListHeaderAvatarStyle">@style/ChannelListHeaderAvatarTheme</item>
-        <item name="streamUiChannelListHeaderStyle">@style/ChannelListHeaderTheme</item>
-        <item name="streamUiMentionPreviewItemAvatarStyle">@style/MentionPreviewAvatarTheme</item>
-        <item name="streamUiMentionListStyle">@style/MentionListTheme</item>
-        <item name="streamUiChannelActionsDialogAvatarStyle">@style/ChannelActionsDialogAvatarStyle</item>
         <item name="streamUiChannelActionsDialogStyle">@style/ChannelActionsDialogTheme</item>
-        <item name="streamUiAttachmentGalleryAvatarStyle">@style/AttachmentGalleryAvatarStyle</item>
-        <item name="streamUiSuggestionListViewMentionAvatarStyle">@style/SuggestionListViewMentionAvatarStyle</item>
-        <item name="streamUiSearchResultAvatarStyle">@style/SearchResultAvatarStyle</item>
-        <item name="streamUiMessageOptionsAvatarStyle">@style/MessageOptionsAvatarStyle</item>
-        <item name="streamUiReplyAvatarStyle">@style/ReplyAvatarStyle</item>
-        <item name="streamUiThreadAvatarStyle">@style/ThreadAvatarStyle</item>
-        <item name="streamUiMessageListHeaderStyle">@style/MessageListHeaderTheme</item>
-        <item name="streamUiSearchInputViewStyle">@style/SearchInputViewTheme</item>
-        <item name="streamUiSuggestionListViewStyle">@style/SuggestionListViewTheme</item>
     </style>
-
-    <style name="MessageListAvatarTheme" parent="StreamUi.MessageList.Item.Avatar"/>
-
-    <style name="MessageListHeaderAvatarTheme" parent="StreamUi.MessageList.Header.Avatar"/>
-
-    <style name="MentionListTheme" parent="StreamUi.MentionPreview.Item.Avatar"/>
-
-    <style name="MentionPreviewAvatarTheme" parent="StreamUi.MentionPreview.Item.Avatar"/>
-
-    <style name="ChannelListAvatarTheme" parent="StreamUi.ChannelList.Item.Avatar"/>
-
-    <style name="ChannelListHeaderTheme" parent="StreamUi.ChannelListHeader"/>
-
-    <style name="ChannelListHeaderAvatarTheme" parent="StreamUi.ChannelListHeader.Avatar"/>
-
-    <style name="ChannelActionsDialogAvatarStyle" parent="StreamUi.ChannelActions.Dialog.Avatar"/>
-
-    <style name="AttachmentGalleryAvatarStyle" parent="StreamUi.AttachmentGallery.Avatar"/>
-
-    <style name="SuggestionListViewMentionAvatarStyle" parent="StreamUi.SuggestionListView.Mention.Avatar"/>
-
-    <style name="SearchResultAvatarStyle" parent="StreamUi.SearchResult.Avatar"/>
-
-    <style name="MessageOptionsAvatarStyle" parent="StreamUi.MessageOptions.Avatar"/>
-
-    <style name="ReplyAvatarStyle" parent="StreamUi.Reply.Avatar"/>
-
-    <style name="ThreadAvatarStyle" parent="StreamUi.Thread.Avatar"/>
 
     <style name="ChannelActionsDialogTheme" parent="StreamUi.ChannelList.ActionsDialog" >
         <item name="streamUiChannelActionsViewInfoEnabled">true</item>
     </style>
-
-    <style name="MessageListHeaderTheme" parent="StreamUi.MessageListHeader" />
-
-    <style name="SearchInputViewTheme" parent="StreamUi.SearchInputView"/>
-
-    <style name="SuggestionListViewTheme" parent="StreamUi.SuggestionListView" />
 </resources>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarStyle.kt
@@ -29,7 +29,7 @@ public data class AvatarStyle(
                 attrs,
                 R.styleable.AvatarView,
                 0,
-                0
+                0,
             ).use {
                 val avatarBorderWidth = it.getDimensionPixelSize(
                     R.styleable.AvatarView_streamUiAvatarBorderWidth,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelActionsDialogViewStyle.kt
@@ -52,13 +52,13 @@ public data class ChannelActionsDialogViewStyle(
                 attrs,
                 R.styleable.ChannelListView,
                 0,
-                0
+                0,
             ).use {
 
                 val a = context.obtainStyledAttributes(
                     it.getResourceId(
                         R.styleable.ChannelListView_streamUiChannelActionsDialogStyle,
-                        -1
+                        R.style.StreamUi_ChannelList_ActionsDialog,
                     ),
                     R.styleable.ChannelActionsDialog
                 )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/header/ChannelListHeaderView.kt
@@ -52,7 +52,7 @@ public class ChannelListHeaderView : ConstraintLayout {
             attrs,
             R.styleable.ChannelListHeaderView,
             R.attr.streamUiChannelListHeaderStyle,
-            R.style.StreamUi_ChannelListHeader
+            R.style.StreamUi_ChannelListHeader,
         ).use { typedArray ->
             configUserAvatar(typedArray)
             configOnlineTitle(typedArray)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/MessageListHeaderViewStyle.kt
@@ -51,7 +51,7 @@ public data class MessageListHeaderViewStyle(
                 attrs,
                 R.styleable.MessageListHeaderView,
                 R.attr.streamUiMessageListHeaderStyle,
-                R.style.StreamUi_MessageListHeader
+                R.style.StreamUi_MessageListHeader,
             ).use { a ->
                 val showUserAvatar =
                     a.getBoolean(R.styleable.MessageListHeaderView_streamUiMessageListHeaderShowUserAvatar, true)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/SearchInputViewStyle.kt
@@ -34,7 +34,7 @@ public data class SearchInputViewStyle(
                 attrs,
                 R.styleable.SearchInputView,
                 R.attr.streamUiSearchInputViewStyle,
-                R.style.StreamUi_SearchInputView
+                R.style.StreamUi_SearchInputView,
             ).use { a ->
                 val searchIcon = a.getDrawable(R.styleable.SearchInputView_streamUiSearchInputViewSearchIcon)
                     ?: context.getDrawableCompat(R.drawable.stream_ui_ic_search)!!

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -280,6 +280,7 @@
         <item name="streamUiMessageListHeaderStyle">@style/StreamUi.MessageListHeader</item>
         <item name="streamUiSearchInputViewStyle">@style/StreamUi.SearchInputView</item>
         <item name="streamUiSuggestionListViewStyle">@style/StreamUi.SuggestionListView</item>
+        <item name="streamUiReplyAvatarStyle">@style/StreamUi.Reply.Avatar</item>
     </style>
 
     <style name="StreamUi">

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -261,25 +261,20 @@
 
     <style name="StreamUiTheme" parent="Theme.MaterialComponents.DayNight">
         <item name="streamUiValidTheme">true</item>
+        <item name="streamUiGlobalAvatarBorderColor">@color/stream_ui_white</item>
+        <item name="streamUiGlobalAvatarOnlineIndicatorColor">@color/stream_ui_accent_green</item>
+        <item name="streamUiGlobalAvatarTextColor">@color/stream_ui_white</item>
         <item name="streamUiMessageListItemAvatarStyle">@style/StreamUi.MessageList.Item.Avatar</item>
         <item name="streamUiMessageListHeaderAvatarStyle">@style/StreamUi.MessageList.Header.Avatar</item>
         <item name="streamUiChannelListItemAvatarStyle">@style/StreamUi.ChannelList.Item.Avatar</item>
         <item name="streamUiChannelListHeaderAvatarStyle">@style/StreamUi.ChannelListHeader.Avatar</item>
-        <item name="streamUiChannelListHeaderStyle">@style/StreamUi.ChannelListHeader</item>
         <item name="streamUiMentionPreviewItemAvatarStyle">@style/StreamUi.MentionPreview.Item.Avatar</item>
         <item name="streamUiMentionListStyle">@style/StreamUi.MentionPreview.Item.Avatar</item>
         <item name="streamUiChannelActionsDialogAvatarStyle">@style/StreamUi.ChannelActions.Dialog.Avatar</item>
-        <item name="streamUiGlobalAvatarBorderColor">@color/stream_ui_white</item>
-        <item name="streamUiGlobalAvatarOnlineIndicatorColor">@color/stream_ui_accent_green</item>
-        <item name="streamUiGlobalAvatarTextColor">@color/stream_ui_white</item>
-        <item name="streamUiChannelActionsDialogStyle">@style/StreamUi.ChannelList.ActionsDialog</item>
         <item name="streamUiAttachmentGalleryAvatarStyle">@style/StreamUi.AttachmentGallery.Avatar</item>
         <item name="streamUiSuggestionListViewMentionAvatarStyle">@style/StreamUi.SuggestionListView.Mention.Avatar</item>
         <item name="streamUiSearchResultAvatarStyle">@style/StreamUi.SearchResult.Avatar</item>
         <item name="streamUiThreadAvatarStyle">@style/StreamUi.Thread.Avatar</item>
-        <item name="streamUiMessageListHeaderStyle">@style/StreamUi.MessageListHeader</item>
-        <item name="streamUiSearchInputViewStyle">@style/StreamUi.SearchInputView</item>
-        <item name="streamUiSuggestionListViewStyle">@style/StreamUi.SuggestionListView</item>
         <item name="streamUiReplyAvatarStyle">@style/StreamUi.Reply.Avatar</item>
     </style>
 


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1127

### 🎯 Goal
Fix crash caused by missing `streamUiReplyAvatarStyle`

### 🛠 Implementation details
- Removed overriding default styles in the sample app (except for `streamUiChannelActionsDialogStyle ` that is needed) so we can discover such bugs faster
- Added default `streamUiReplyAvatarStyle`
- Removed redundant default styles from `StreamUiTheme `. They are applied when we are obtaining attributes (for example: `            context.obtainStyledAttributes(
                attrs,
                R.styleable.MessageListHeaderView,
                R.attr.streamUiMessageListHeaderStyle,
                R.style.StreamUi_MessageListHeader,
            )`), so there is no need to have them doubled. `AvatarView` is an exception - none of them has the default style

### 🧪 Testing

Play with the app and check everything works fine

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

