### PR TITLE
[CAS-1124] Only show Copy Message option if the message contains text

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -64,6 +64,7 @@
 - Fixed crash caused by missing `streamUiReplyAvatarStyle`
 
 ### ⬆️ Improved
+- "Copy Message" option is now hidden when the message contains no text to copy.
 
 ### ✅ Added
 - Now you can configure the style of `AttachmentMediaActivity`.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -269,7 +269,8 @@ public class MessageListView : ConstraintLayout {
                         MessageOptionsView.Configuration(
                             viewStyle = requireStyle(),
                             channelConfig = channel.config,
-                            suppressThreads = adapter.isThread || message.isInThread()
+                            hasTextToCopy = message.text.isNotBlank(),
+                            suppressThreads = adapter.isThread || message.isInThread(),
                         ),
                         requireStyle()
                     )
@@ -366,6 +367,8 @@ public class MessageListView : ConstraintLayout {
                     MessageOptionsView.Configuration(
                         viewStyle = requireStyle(),
                         channelConfig = channel.config,
+                        hasTextToCopy = false, // No effect when displaying reactions
+                        suppressThreads = false, // No effect when displaying reactions
                     ),
                     requireStyle()
                 ).apply {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -220,14 +220,15 @@ internal class MessageOptionsView : FrameLayout {
             operator fun invoke(
                 viewStyle: MessageListViewStyle,
                 channelConfig: Config,
-                suppressThreads: Boolean = false,
+                hasTextToCopy: Boolean,
+                suppressThreads: Boolean,
             ) =
                 Configuration(
                     replyEnabled = viewStyle.replyEnabled && channelConfig.isRepliesEnabled,
                     threadsEnabled = if (suppressThreads) false else viewStyle.threadsEnabled && channelConfig.isRepliesEnabled,
                     editMessageEnabled = viewStyle.editMessageEnabled,
                     deleteMessageEnabled = viewStyle.deleteMessageEnabled,
-                    copyTextEnabled = viewStyle.copyTextEnabled,
+                    copyTextEnabled = viewStyle.copyTextEnabled && hasTextToCopy,
                     deleteConfirmationEnabled = viewStyle.deleteConfirmationEnabled,
                     reactionsEnabled = viewStyle.reactionsEnabled && channelConfig.isReactionsEnabled,
                     flagEnabled = viewStyle.flagEnabled,


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1124

### 🎯 Goal

Hide the copy option on messages only containing attachments or gifs.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1626683648](https://user-images.githubusercontent.com/12054216/126129319-cdfa7377-ebf5-4619-9939-99d551528438.png) | ![Screenshot_1626683559](https://user-images.githubusercontent.com/12054216/126129323-75adb7bd-88be-4149-8e9f-b579daf4f7ca.png)|

### 🧪 Testing

Send messages with attachments only. Open message options dialog.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![gif](https://media.giphy.com/media/26FfdPdmHehBsRb0s/giphy.gif)