### PR TITLE
[CAS-1121] Add possibility to configure ChannelListView's edge effect color

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -67,6 +67,7 @@
 - Now you can configure the style of `AttachmentMediaActivity`
 - Added `streamUiLoadingView`, `streamUiEmptyStateView` and `streamUiLoadingMoreView` attributes to `ChannelListView` and `ChannelListViewStyle`
 - Added possibility to customize `ChannelListView` using `streamUiChannelListViewStyle`. Check `StreamUi.ChannelListView` style.
+- Added `edgeEffectColor` attribute to `ChannelListView` and `ChannelListViewStyle` to allow configuring edge effect color.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -293,7 +293,7 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListView$Use
 
 public final class io/getstream/chat/android/ui/channel/list/ChannelListViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle$Companion;
-	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;III)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component10 ()Landroid/graphics/drawable/Drawable;
 	public final fun component11 ()Landroid/graphics/drawable/Drawable;
@@ -308,6 +308,7 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListViewStyl
 	public final fun component2 ()Landroid/graphics/drawable/Drawable;
 	public final fun component20 ()I
 	public final fun component21 ()I
+	public final fun component22 ()Ljava/lang/Integer;
 	public final fun component3 ()Z
 	public final fun component4 ()Z
 	public final fun component5 ()Z
@@ -315,13 +316,14 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListViewStyl
 	public final fun component7 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component8 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component9 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;III)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;IIIILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZILio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/ChannelListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundLayoutColor ()I
 	public final fun getChannelTitleText ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getDeleteEnabled ()Z
 	public final fun getDeleteIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getEdgeEffectColor ()Ljava/lang/Integer;
 	public final fun getEmptyStateView ()I
 	public final fun getForegroundLayoutColor ()I
 	public final fun getIndicatorPendingSyncIcon ()Landroid/graphics/drawable/Drawable;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
@@ -65,6 +65,7 @@ public data class ChannelListViewStyle(
     @LayoutRes public val loadingView: Int,
     @LayoutRes public val emptyStateView: Int,
     @LayoutRes public val loadingMoreView: Int,
+    @ColorInt public val edgeEffectColor: Int?,
 ) {
 
     internal companion object {
@@ -224,6 +225,8 @@ public data class ChannelListViewStyle(
                     R.layout.stream_ui_channel_list_loading_more_view,
                 )
 
+                val edgeEffectColor = a.getColorOrNull(R.styleable.ChannelListView_streamUiEdgeEffectColor)
+
                 return ChannelListViewStyle(
                     optionsIcon = optionsIcon,
                     deleteIcon = deleteIcon,
@@ -246,6 +249,7 @@ public data class ChannelListViewStyle(
                     loadingView = loadingView,
                     emptyStateView = emptyStateView,
                     loadingMoreView = loadingMoreView,
+                    edgeEffectColor = edgeEffectColor,
                 ).let(TransformStyle.channelListStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
@@ -41,6 +41,7 @@ import io.getstream.chat.android.ui.common.style.TextStyle
  * @property loadingView - loading view. Default - [R.layout.stream_ui_channel_list_loading_view]
  * @property emptyStateView - empty state view. Default - [R.layout.stream_ui_channel_list_empty_state_view]
  * @property loadingMoreView - loading more view. Default - [R.layout.stream_ui_channel_list_loading_more_view]
+ * @property edgeEffectColor - color applied to the [ChannelListView] edge effect. Pass null if you want to use default [android.R.attr.colorEdgeEffect]. Default - null.
  */
 public data class ChannelListViewStyle(
     public val optionsIcon: Drawable,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
@@ -3,6 +3,8 @@ package io.getstream.chat.android.ui.channel.list.internal
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
+import android.widget.EdgeEffect
+import androidx.annotation.ColorInt
 import androidx.annotation.DrawableRes
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -51,6 +53,17 @@ internal class SimpleChannelListView @JvmOverloads constructor(
         this.style = style
 
         dividerDecoration.drawable = style.itemSeparator
+        style.edgeEffectColor?.let(::setEdgeEffectColor)
+    }
+
+    private fun setEdgeEffectColor(@ColorInt edgeEffectColor: Int) {
+        edgeEffectFactory = object : EdgeEffectFactory() {
+            override fun createEdgeEffect(view: RecyclerView, direction: Int): EdgeEffect {
+                return super.createEdgeEffect(view, direction).apply {
+                    color = edgeEffectColor
+                }
+            }
+        }
     }
 
     private fun requireAdapter(): ChannelListItemAdapter {

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
@@ -68,6 +68,8 @@
         <attr name="streamUiEmptyStateView" format="reference" />
         <attr name="streamUiLoadingMoreView" format="reference" />
 
+        <attr name="streamUiEdgeEffectColor" format="color|reference" />
+
         <attr name="streamUiChannelActionsDialogStyle" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1121

### 🎯 Goal

Add possibility to configure ChannelListView's edge effect color

### 🛠 Implementation details

Added attribute and nullable `edgeEffectColor` property to `ChannelListViewStyle`. By default (when `edgeEffectColor` is null), `ChannelListView` applies `android.R.attr.colorEdgeEffect` as edge effect color.

### 🧪 Testing

Try to apply custom `edgeEffectColor`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

