### PR TITLE
[CAS-1148] Fix adding typing item to message list

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
+- Fixed adding `MessageListItem.TypingItem` to message list
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -108,7 +108,7 @@ internal class MessageListItemLiveData(
             typingUser.id != currentUser?.id
         }
 
-        return if (newTypingUsers != typingUsers) {
+        return if (newTypingUsers != this.typingUsers) {
             typingChanged(newTypingUsers)
         } else {
             null


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1148

### 🎯 Goal

Fix adding typing item to message list

### 🛠 Implementation details

We were comparing the wrong `typingUsers` list

### 🧪 Testing

1. Add custom typing indicator view holder
2. It should be visible when someone is typing in the channel

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

