### PR TITLE
Move streamUiMessageListHeaderBackButtonIcon attribute next to other back button related attrs

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_header_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_header_view.xml
@@ -37,6 +37,7 @@
         <attr name="streamUiMessageListHeaderShowSearchingForNetworkProgressBar" format="boolean" />
         <attr name="streamUiMessageListHeaderSearchingForNetworkProgressBarTint" format="color|reference" />
 
+        <attr name="streamUiMessageListHeaderBackButtonIcon" format="reference" />
         <attr name="streamUiMessageListHeaderShowBackButton" format="boolean" />
         <attr name="streamUiMessageListHeaderShowBackButtonBadge" format="boolean" />
         <attr name="streamUiMessageListHeaderBackButtonBadgeBackgroundColor" format="color" />
@@ -50,6 +51,5 @@
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
-        <attr name="streamUiMessageListHeaderBackButtonIcon" format="reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### 🎯 Goal

To keep similar attributes together for better clarity.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added