### PR TITLE
Replace ne operator with eq for custom fields filtering

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -69,6 +69,7 @@ in your Manifest file:
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed "operator $ne is not supported for custom fields" error when querying channels
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt
@@ -13,7 +13,7 @@ public fun Filters.defaultChannelListFilter(user: User?): FilterObject? {
         and(
             eq("type", "messaging"),
             `in`("members", listOf(user.id)),
-            or(notExists("draft"), ne("draft", true)),
+            or(notExists("draft"), eq("draft", false)),
         )
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsFragment.kt
@@ -32,7 +32,7 @@ class ChatInfoSharedGroupsFragment : Fragment() {
                         ChatDomain.instance().user.value?.id?.let(members::plus) ?: members
                     }
                 ),
-                Filters.or(Filters.notExists("draft"), Filters.ne("draft", true)),
+                Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
                 Filters.greaterThan("member_count", 2),
             ),
         )


### PR DESCRIPTION


### 🎯 Goal

Fix "operator $ne is not supported for custom fields" error when querying channels in new apps

### 🛠 Implementation details

$ne operator shouldn't be used for custom fields and it was deprecated in new apps. 


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

