### PR TITLE
[CAS-1038] Review theme attribute to customize MediaAttachmentView

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -483,7 +483,7 @@ public class MessageListView : ConstraintLayout {
         context.obtainStyledAttributes(
             attributeSet,
             R.styleable.MessageListView,
-            R.attr.streamUiMentionListStyle,
+            R.attr.streamUiMessageListStyle,
             R.style.StreamUi_MessageList
         ).use { tArray ->
             tArray.getInteger(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
@@ -38,7 +38,7 @@ public data class MediaAttachmentViewStyle(
                 attrs,
                 R.styleable.MediaAttachmentView,
                 R.attr.streamUiMessageListMediaAttachmentStyle,
-                0
+                R.style.StreamUi_MessageList_MediaAttachment
             ).use { a ->
                 val progressIcon = a.getDrawable(R.styleable.MediaAttachmentView_streamUiMediaAttachmentProgressIcon)
                     ?: context.getDrawableCompat(R.drawable.stream_ui_rotating_indeterminate_progress_gradient)!!

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -263,7 +263,6 @@
 
     <style name="StreamUiTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="streamUiValidTheme">true</item>
-        <item name="streamUiMessageListMediaAttachmentStyle">@style/StreamUi.MessageList.MediaAttachment</item>
         <item name="streamUiGlobalAvatarBorderColor">@color/stream_ui_white</item>
         <item name="streamUiGlobalAvatarOnlineIndicatorColor">@color/stream_ui_accent_green</item>
         <item name="streamUiGlobalAvatarTextColor">@color/stream_ui_white</item>
@@ -514,7 +513,7 @@
         <item name="streamUiMediaAttachmentMoreCountOverlayColor">@color/stream_ui_overlay</item>
 
         <item name="streamUiMediaAttachmentMoreCountTextSize">@dimen/stream_ui_message_media_attachment_more_count_text_size</item>
-        <item name="streamUiMediaAttachmentMoreCountTextColor">@color/stream_ui_black</item>
+        <item name="streamUiMediaAttachmentMoreCountTextColor">@color/stream_ui_literal_white</item>
         <item name="streamUiMediaAttachmentMoreCountTextStyle">normal</item>
     </style>
 


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1038

### 🎯 Goal

Review the theme attribute `streamUiMessageListMediaAttachmentStyle` which is used to customize the appearance of `MediaAttachmentView`.

### 🛠 Implementation details

The corresponding theme attribute and the style were already present. Just minor changes.

### 🧪 Testing

Override `streamUiMessageListMediaAttachmentStyle` theme attribute:

```xml
<style name="StreamTheme" parent="@style/StreamUiTheme">
    ...
    <item name="streamUiMessageListMediaAttachmentStyle">@style/MediaAttachmentTheme</item>
</style>
    
<style name="MediaAttachmentTheme" parent="StreamUi.MessageList.MediaAttachment">
    ...
     <item name="streamUiMediaAttachmentMoreCountTextColor">@color/stream_ui_accent_red</item>
</style>
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![giphy (2)](https://user-images.githubusercontent.com/9600921/127229245-971957c9-017a-41e8-8cf6-6e0da08e968e.gif)

