### PR TITLE
[CAS-1133] Improve API to check if the channel is muted

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -28,6 +28,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `Channel::isMutedFor` extension function which might be used to check if the Channel is muted for User
 
 ### ⚠️ Changed
 
@@ -36,6 +37,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed updating `ChannelController::muted` value
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1756,6 +1756,7 @@ public final class io/getstream/chat/android/client/extensions/AttachmentExtensi
 
 public final class io/getstream/chat/android/client/extensions/ChannelExtensionKt {
 	public static final fun isAnonymousChannel (Lio/getstream/chat/android/client/models/Channel;)Z
+	public static final fun isMutedFor (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;)Z
 }
 
 public final class io/getstream/chat/android/client/extensions/MessageExtensionsKt {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
@@ -1,5 +1,13 @@
 package io.getstream.chat.android.client.extensions
 
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.User
 
 public fun Channel.isAnonymousChannel(): Boolean = id.isAnonymousChannelId()
+
+/**
+ * Checks if [Channel] is muted for [user]
+ *
+ * @return true if the channel is muted for [user]
+ */
+public fun Channel.isMutedFor(user: User): Boolean = user.channelMutes.any { mute -> mute.channel.cid == cid }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.client.events.MessageReadEvent
 import io.getstream.chat.android.client.events.MessageUpdatedEvent
 import io.getstream.chat.android.client.events.NewMessageEvent
 import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
+import io.getstream.chat.android.client.events.NotificationChannelMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationChannelTruncatedEvent
 import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
 import io.getstream.chat.android.client.events.NotificationInviteRejectedEvent
@@ -1113,6 +1114,11 @@ public class ChannelController internal constructor(
             is NotificationInviteRejectedEvent -> {
                 upsertMember(event.member)
                 updateChannelData(event.channel)
+            }
+            is NotificationChannelMutesUpdatedEvent -> {
+                _muted.value = event.me.channelMutes.any { mute ->
+                    mute.channel.cid == cid
+                }
             }
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -410,6 +410,13 @@ internal class EventHandlerImpl(
             }
         }
 
+        // mutes are user related, so they have to be propagated to all channels
+        sortedEvents.filterIsInstance<NotificationChannelMutesUpdatedEvent>().lastOrNull()?.let { event ->
+            domainImpl.allActiveChannels().forEach { channelController ->
+                channelController.handleEvent(event)
+            }
+        }
+
         // User presence change applies to all active channels with that user
         sortedEvents.find { it is UserPresenceChangedEvent }?.let { userPresenceChanged ->
             val event = userPresenceChanged as UserPresenceChangedEvent


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1133

### 🎯 Goal

Improve API to check if the channel is muted

### 🛠 Implementation details

- Added `Channel::isMutedFor` extension function
- Fixed `ChannelController::muted` value

### 🧪 Testing

Check if `ChannelController::muted` and new function work as expected

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

