### PR TITLE
[CAS-1170] Add support for French

### DIFF
--- a/stream-chat-android-client/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-fr/strings.xml
@@ -1,0 +1,15 @@
+<resources>
+
+    <!--Notification-->
+    <string name="stream_chat_notification_title">Message de discussion</string>
+    <string name="stream_chat_notification_content">Vous avez reçu un nouveau message</string>
+    <string name="stream_chat_notification_reply">Réponse</string>
+    <string name="stream_chat_notification_type_hint">Tapez le message</string>
+    <string name="stream_chat_notification_read">Marquer comme lu</string>
+    <string name="stream_chat_notification_channel_id">stream_GetStreamClient</string>
+    <string name="stream_chat_notification_channel_name">Nouveaux messages de discussion</string>
+    <string name="stream_chat_load_notification_data_title">Chargement des données de notification</string>
+    <string name="stream_chat_notification_group_summary_content_text">Vous avez reçu de nouveaux messages</string>
+    <string name="stream_chat_error_notification_group_summary_title">Messages de discussion</string>
+    <string name="stream_chat_error_notification_group_summary_content_text">Vous avez reçu de nouveaux messages</string>
+</resources>

--- a/stream-chat-android-client/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <string name="stream_chat_notification_title">Message de discussion</string>
     <string name="stream_chat_notification_content">Vous avez reçu un nouveau message</string>
     <string name="stream_chat_notification_reply">Répondre</string>
-    <string name="stream_chat_notification_type_hint">Tapez le message</string>
+    <string name="stream_chat_notification_type_hint">Tapez votre message</string>
     <string name="stream_chat_notification_read">Marquer comme lu</string>
     <string name="stream_chat_notification_channel_id">stream_GetStreamClient</string>
     <string name="stream_chat_notification_channel_name">Nouveaux messages de discussion</string>

--- a/stream-chat-android-client/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-fr/strings.xml
@@ -3,7 +3,7 @@
     <!--Notification-->
     <string name="stream_chat_notification_title">Message de discussion</string>
     <string name="stream_chat_notification_content">Vous avez reçu un nouveau message</string>
-    <string name="stream_chat_notification_reply">Réponse</string>
+    <string name="stream_chat_notification_reply">Répondre</string>
     <string name="stream_chat_notification_type_hint">Tapez le message</string>
     <string name="stream_chat_notification_read">Marquer comme lu</string>
     <string name="stream_chat_notification_channel_id">stream_GetStreamClient</string>

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!--Message Date-->
+    <string name="stream_ui_yesterday">Hier</string>
+
+    <!-- Media capture -->
+    <string name="stream_ui_message_input_capture_media">Capture d\'image ou vidéo</string>
+
+    <!-- Permissions -->
+    <string name="stream_ui_message_input_permission_camera_title">Caméra et stockage Autorisation d\'accès</string>
+    <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
+    <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
+    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et enregistrer des photos, des vidéos, de la musique et les autres fichiers</string>
+    <string name="stream_ui_message_input_permission_setting_message">Activer les autorisations sur Paramètres de l\'application</string>
+    <string name="stream_ui_message_input_permissions_setting_button">Paramètres</string>
+
+    <!--Attachment View-->
+    <string name="stream_ui_message_list_attachment_load_failed">Le chargement a échoué en raison d\'une erreur inconnue.</string>
+    <string name="stream_ui_message_list_attachment_invalid_url">Le chargement a échoué en raison d\'une URL non valide.</string>
+    <string name="stream_ui_message_list_attachment_invalid_mime_type">Quelque chose s\'est mal passé. Impossible d\'ouvrir la pièce jointe: %s</string>
+    <string name="stream_ui_message_list_attachment_display_error">Erreur. Le fichier ne peut pas être affiché</string>
+</resources>

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -11,7 +11,7 @@
     <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
     <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
     <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et sauvegarder des photos, des vidéos, de la musique et d\'autres fichiers.</string>
-    <string name="stream_ui_message_input_permission_setting_message">Activer les autorisations sur Paramètres de l\'application</string>
+    <string name="stream_ui_message_input_permission_setting_message">Activez les autorisations dans les paramètres de l\'application</string>
     <string name="stream_ui_message_input_permissions_setting_button">Paramètres</string>
 
     <!--Attachment View-->

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -10,7 +10,7 @@
     <string name="stream_ui_message_input_permission_camera_title">Permission d\'accès aux caméras et au stockage</string>
     <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
     <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
-    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et enregistrer des photos, des vidéos, de la musique et les autres fichiers</string>
+    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et sauvegarder des photos, des vidéos, de la musique et d\'autres fichiers.</string>
     <string name="stream_ui_message_input_permission_setting_message">Activer les autorisations sur Paramètres de l\'application</string>
     <string name="stream_ui_message_input_permissions_setting_button">Paramètres</string>
 

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -7,7 +7,7 @@
     <string name="stream_ui_message_input_capture_media">Capture d\'image ou de vidéo</string>
 
     <!-- Permissions -->
-    <string name="stream_ui_message_input_permission_camera_title">Caméra et stockage Autorisation d\'accès</string>
+    <string name="stream_ui_message_input_permission_camera_title">Permission d\'accès aux caméras et au stockage</string>
     <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
     <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
     <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et enregistrer des photos, des vidéos, de la musique et les autres fichiers</string>

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -4,7 +4,7 @@
     <string name="stream_ui_yesterday">Hier</string>
 
     <!-- Media capture -->
-    <string name="stream_ui_message_input_capture_media">Capture d\'image ou vidéo</string>
+    <string name="stream_ui_message_input_capture_media">Capture d\'image ou de vidéo</string>
 
     <!-- Permissions -->
     <string name="stream_ui_message_input_permission_camera_title">Caméra et stockage Autorisation d\'accès</string>

--- a/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values-fr/strings.xml
@@ -17,6 +17,6 @@
     <!--Attachment View-->
     <string name="stream_ui_message_list_attachment_load_failed">Le chargement a échoué en raison d\'une erreur inconnue.</string>
     <string name="stream_ui_message_list_attachment_invalid_url">Le chargement a échoué en raison d\'une URL non valide.</string>
-    <string name="stream_ui_message_list_attachment_invalid_mime_type">Quelque chose s\'est mal passé. Impossible d\'ouvrir la pièce jointe: %s</string>
+    <string name="stream_ui_message_list_attachment_invalid_mime_type">Un problème est survenu. Impossible d\'ouvrir la pièce jointe: %s</string>
     <string name="stream_ui_message_list_attachment_display_error">Erreur. Le fichier ne peut pas être affiché</string>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_attachment_gallery.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_attachment_gallery.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_attachment_gallery_count">%d de %d</string>
+    <string name="stream_ui_attachment_gallery_date">Envoyé %s à %s</string>
+    <string name="stream_ui_attachment_gallery_reply">Réponse</string>
+    <string name="stream_ui_attachment_gallery_delete">Supprimer</string>
+    <string name="stream_ui_attachment_gallery_show_in_chat">Montrer dans le Chat</string>
+    <string name="stream_ui_attachment_gallery_save_image">Sauvegarder l\'image</string>
+    <string name="stream_ui_attachment_gallery_share">Partager l\'image</string>
+
+    <!-- Gallery Overview Dialog -->
+    <string name="stream_ui_attachment_gallery_overview_title">Photos</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="stream_ui_channel_list_empty">Aucune canaux disponible</string>
+    <string name="stream_ui_channel_list_empty">Aucun canal disponible</string>
     <string name="stream_ui_channel_list_you">Toi</string>
     <string name="stream_ui_channel_list_untitled_channel">Le canal sans nom</string>
 

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
@@ -6,7 +6,7 @@
 
     <!-- Channel Actions Dialog -->
     <string name="stream_ui_channel_list_view_info">Voir les informations</string>
-    <string name="stream_ui_channel_list_leave_channel">Quitter le Group</string>
+    <string name="stream_ui_channel_list_leave_channel">Quitter le Groupe</string>
     <string name="stream_ui_channel_list_dismiss_dialog">Annuler</string>
     <string name="stream_ui_channel_list_delete_channel">Supprimer la conversation</string>
     <plurals name="stream_ui_channel_list_member_info">
@@ -15,12 +15,12 @@
     </plurals>
 
     <string name="stream_ui_channel_list_delete_confirmation_title">Supprimer la canal</string>
-    <string name="stream_ui_channel_list_delete_confirmation_message">Êtes-vous sûr de vouloir supprimer définitivement ce\nmessage?</string>
+    <string name="stream_ui_channel_list_delete_confirmation_message">Êtes-vous sûr de vouloir supprimer définitivement cette conversation?</string>
     <string name="stream_ui_channel_list_delete_confirmation_positive_button">Supprimer</string>
     <string name="stream_ui_channel_list_delete_confirmation_negative_button">Annuler</string>
 
     <!-- Errors -->
-    <string name="stream_ui_channel_list_error_hide_channel">Échec de la masquer la canal</string>
-    <string name="stream_ui_channel_list_error_delete_channel">Échec de la suppression de la canal</string>
-    <string name="stream_ui_channel_list_error_leave_channel">Échec de la sortie de la canal</string>
+    <string name="stream_ui_channel_list_error_hide_channel">Echec du masquage du canal</string>
+    <string name="stream_ui_channel_list_error_delete_channel">Échec de la suppression du canal</string>
+    <string name="stream_ui_channel_list_error_leave_channel">Échec de sortie du canal</string>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_channel_list_empty">Aucune canaux disponible</string>
+    <string name="stream_ui_channel_list_you">Toi</string>
+    <string name="stream_ui_channel_list_untitled_channel">Le canal sans nom</string>
+
+    <!-- Channel Actions Dialog -->
+    <string name="stream_ui_channel_list_view_info">Voir les informations</string>
+    <string name="stream_ui_channel_list_leave_channel">Quitter le Group</string>
+    <string name="stream_ui_channel_list_dismiss_dialog">Annuler</string>
+    <string name="stream_ui_channel_list_delete_channel">Supprimer la conversation</string>
+    <plurals name="stream_ui_channel_list_member_info">
+        <item quantity="one">%1d Membre, %2d En ligne</item>
+        <item quantity="other">%1d Membres, %2d En ligne</item>
+    </plurals>
+
+    <string name="stream_ui_channel_list_delete_confirmation_title">Supprimer la canal</string>
+    <string name="stream_ui_channel_list_delete_confirmation_message">Êtes-vous sûr de vouloir supprimer définitivement ce\nmessage?</string>
+    <string name="stream_ui_channel_list_delete_confirmation_positive_button">Supprimer</string>
+    <string name="stream_ui_channel_list_delete_confirmation_negative_button">Annuler</string>
+
+    <!-- Errors -->
+    <string name="stream_ui_channel_list_error_hide_channel">Échec de la masquer la canal</string>
+    <string name="stream_ui_channel_list_error_delete_channel">Échec de la suppression de la canal</string>
+    <string name="stream_ui_channel_list_error_leave_channel">Échec de la sortie de la canal</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="stream_ui_channel_list_empty">Aucun canal disponible</string>
     <string name="stream_ui_channel_list_you">Vous</string>
-    <string name="stream_ui_channel_list_untitled_channel">Le canal sans nom</string>
+    <string name="stream_ui_channel_list_untitled_channel">Canal sans nom</string>
 
     <!-- Channel Actions Dialog -->
     <string name="stream_ui_channel_list_view_info">Voir les informations</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="stream_ui_channel_list_empty">Aucun canal disponible</string>
-    <string name="stream_ui_channel_list_you">Toi</string>
+    <string name="stream_ui_channel_list_you">Vous</string>
     <string name="stream_ui_channel_list_untitled_channel">Le canal sans nom</string>
 
     <!-- Channel Actions Dialog -->

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list_header.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_channel_list_header.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_channel_list_header_connected">Stream Chat</string>
+    <string name="stream_ui_channel_list_header_disconnected">En attente de réseau</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
@@ -6,7 +6,7 @@
     <!-- User Status (Used in Channel Actions Dialog and Message List Header) -->
     <string name="stream_ui_user_status_online">En ligne</string>
     <string name="stream_ui_user_status_last_seen">Vu pour la dernière fois %s</string>
-    <string name="stream_ui_user_status_last_seen_just_now">Dernière vue à l'instant</string>
+    <string name="stream_ui_user_status_last_seen_just_now">Dernière vue à l\'instant</string>
 
     <!-- Message Preview (User in Mention List and Search Result List) -->
     <string name="stream_ui_message_preview_file">Fichier: %s</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_mention">\@%s</string>
+    <string name="stream_ui_yesterday">Hier</string>
+
+    <!-- User Status (Used in Channel Actions Dialog and Message List Header) -->
+    <string name="stream_ui_user_status_online">En ligne</string>
+    <string name="stream_ui_user_status_last_seen">Vu pour la dernière fois %s</string>
+    <string name="stream_ui_user_status_last_seen_just_now">Last seen just now</string>
+
+    <!-- Message Preview (User in Mention List and Search Result List) -->
+    <string name="stream_ui_message_preview_file">Fichier: %s</string>
+    <string name="stream_ui_message_preview_sender">&lt;b&gt;%1$s&lt;/b&gt; dans &lt;b&gt;%2$s&lt;/b&gt;</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_common.xml
@@ -6,7 +6,7 @@
     <!-- User Status (Used in Channel Actions Dialog and Message List Header) -->
     <string name="stream_ui_user_status_online">En ligne</string>
     <string name="stream_ui_user_status_last_seen">Vu pour la dernière fois %s</string>
-    <string name="stream_ui_user_status_last_seen_just_now">Last seen just now</string>
+    <string name="stream_ui_user_status_last_seen_just_now">Dernière vue à l'instant</string>
 
     <!-- Message Preview (User in Mention List and Search Result List) -->
     <string name="stream_ui_message_preview_file">Fichier: %s</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_mention_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_mention_list.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_mention_list_empty">Aucune mention n\'existe encore…</string>
+    <string name="stream_ui_mention_list_error">Une erreur est survenue</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_input.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_input.xml
@@ -22,11 +22,11 @@
     <string name="stream_ui_message_input_permission_camera_title">Caméra et stockage Autorisation d\'accès</string>
     <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
     <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
-    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et enregistrer des photos, des vidéos, de la musique et les autres fichiers</string>
-    <string name="stream_ui_message_input_permission_setting_message">Activer les autorisations sur Paramètres de l\'application</string>
+    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et sauvegarder des photos, des vidéos, de la musique et d\'autres fichiers.</string>
+    <string name="stream_ui_message_input_permission_setting_message">Activez les autorisations dans les Paramètres de l\'application</string>
     <string name="stream_ui_message_input_permissions_setting_button">Paramètres</string>
 
     <!-- Errors -->
-    <string name="stream_ui_message_input_error_file_size">Fichier trop gros</string>
+    <string name="stream_ui_message_input_error_file_size">Fichier trop volumineux</string>
     <string name="stream_ui_message_input_error_max_length">"Longueur maximale du message (%d) dépassée."</string>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_input.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_input.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_message_input_send_to_channel">Envoyer également au canal</string>
+    <string name="stream_ui_message_input_send_as_direct_message">Envoyer aussi comme message direct</string>
+    <string name="stream_ui_message_input_reply">Répondre au Message</string>
+    <string name="stream_ui_message_input_hint">Écrivez quelque chose ici</string>
+    <string name="stream_ui_message_input_only_attachments_hint">Ajouter un commentaire ou envoyer</string>
+
+    <!-- Commands Popup -->
+    <string name="stream_ui_message_input_instant_commands">Commandes instantanées</string>
+    <string name="stream_ui_message_input_command_template">/%1$s %2$s</string>
+
+    <!-- File Picker Dialog -->
+    <string name="stream_ui_message_input_camera_access">Autoriser l\'accès à votre appareil photo</string>
+    <string name="stream_ui_message_input_files_access">Autoriser l\'accès à vos fichiers</string>
+    <string name="stream_ui_message_input_gallery_access">Autoriser l\'accès à votre galerie</string>
+    <string name="stream_ui_message_input_recent_files">Fichiers récents</string>
+    <string name="stream_ui_message_input_no_files">Il n\'y a ni photo ni vidéo.</string>
+    <string name="stream_ui_message_input_capture_media">Capture d\'image ou vidéo</string>
+
+    <!-- System Permission Dialog -->
+    <string name="stream_ui_message_input_permission_camera_title">Caméra et stockage Autorisation d\'accès</string>
+    <string name="stream_ui_message_input_permission_camera_message">Des autorisations d\'accès à l\'appareil photo et au stockage sont nécessaires pour pouvoir prendre des photos et des vidéos</string>
+    <string name="stream_ui_message_input_permission_storage_title">Autorisations d\'accès au stockage</string>
+    <string name="stream_ui_message_input_permission_storage_message">Des autorisations d\'accès au stockage sont nécessaires pour pouvoir envoyer et enregistrer des photos, des vidéos, de la musique et les autres fichiers</string>
+    <string name="stream_ui_message_input_permission_setting_message">Activer les autorisations sur Paramètres de l\'application</string>
+    <string name="stream_ui_message_input_permissions_setting_button">Paramètres</string>
+
+    <!-- Errors -->
+    <string name="stream_ui_message_input_error_file_size">Fichier trop gros</string>
+    <string name="stream_ui_message_input_error_max_length">"Longueur maximale du message (%d) dépassée."</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list.xml
@@ -12,7 +12,7 @@
     <string name="stream_ui_message_list_deleted_message">Message supprimé</string>
     <string name="stream_ui_message_list_attachment_more_count">+%d</string>
     <string name="stream_ui_message_list_attachment_uploading">Téléchargement %d / %d …</string>
-    <string name="stream_ui_message_list_attachment_upload_complete">Téléchargement terminé, traitement…</string>
+    <string name="stream_ui_message_list_attachment_upload_complete">Transfert terminé, traitement…</string>
     <string name="stream_ui_message_list_attachment_upload_progress">%s / %s</string>
     <plurals name="stream_ui_message_list_thread_reply">
         <item quantity="one">%d Réponse au fil de discussion</item>
@@ -30,9 +30,9 @@
     <string name="stream_ui_message_list_copy_message">Copier le message</string>
     <string name="stream_ui_message_list_edit_message">Modifier le message</string>
     <string name="stream_ui_message_list_flag_message">Signaler un message</string>
-    <string name="stream_ui_message_list_mute_user">Utilisateur muter</string>
-    <string name="stream_ui_message_list_unmute_user">Utilisateur unmute</string>
-    <string name="stream_ui_message_list_block_user">Bloquer un utilisateur</string>
+    <string name="stream_ui_message_list_mute_user">Mettre en sourdine l\'utilisateur</string>
+    <string name="stream_ui_message_list_unmute_user">Désactiver la mise en sourdine de l\'utilisateur</string>
+    <string name="stream_ui_message_list_block_user">Bloquer l\'utilisateur</string>
     <string name="stream_ui_message_list_delete_message">Supprimer le message</string>
     <plurals name="stream_ui_message_list_message_reactions">
         <item quantity="one">%d Réaction aux messages</item>
@@ -41,7 +41,7 @@
 
     <!-- Message Action Confirmations -->
     <string name="stream_ui_message_list_delete_confirmation_title">Supprimer le message</string>
-    <string name="stream_ui_message_list_delete_confirmation_message">Voulez-vous vraiment supprimer définitivement ce message ?</string>
+    <string name="stream_ui_message_list_delete_confirmation_message">Êtes-vous sûr de vouloir supprimer définitivement ce message ?</string>
     <string name="stream_ui_message_list_delete_confirmation_positive_button">Supprimer</string>
     <string name="stream_ui_message_list_delete_confirmation_negative_button">Annuler</string>
     <string name="stream_ui_message_list_flag_confirmation_title">Signaler un message</string>
@@ -52,11 +52,11 @@
     <!-- Attachment Viewer -->
     <string name="stream_ui_message_list_attachment_load_failed">Le chargement a échoué en raison d\'une erreur inconnue.</string>
     <string name="stream_ui_message_list_attachment_invalid_url">Le chargement a échoué en raison d\'une URL non valide.</string>
-    <string name="stream_ui_message_list_attachment_invalid_mime_type">Quelque chose s\'est mal passé. Impossible d\'ouvrir la pièce jointe: %s</string>
+    <string name="stream_ui_message_list_attachment_invalid_mime_type">Un problème est survenu. Impossible d\'ouvrir la pièce jointe: %s</string>
     <string name="stream_ui_message_list_attachment_display_error">Erreur. Le fichier ne peut pas être affiché</string>
 
     <!-- Errors -->
-    <string name="stream_ui_message_list_error_mute_user">Échec à l\'utilisateur muet</string>
+    <string name="stream_ui_message_list_error_mute_user">Échec de la mise en sourdine de l\'utilisateur</string>
     <string name="stream_ui_message_list_error_unmute_user">Échec à l\'utilisateur unmute</string>
     <string name="stream_ui_message_list_error_block_user">Échec du blocage de l\'utilisateur</string>
     <string name="stream_ui_message_list_error_flag_message">Échec du signalement du message</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="stream_ui_message_list_empty">Pas de messages</string>
+    <string name="stream_ui_message_list_download_started">Téléchargement commencé</string>
+
+    <!-- Message List Item -->
+    <string name="stream_ui_message_list_giphy_title">Giphy</string>
+    <string name="stream_ui_message_list_giphy_send">Envoyer</string>
+    <string name="stream_ui_message_list_giphy_cancel">Annuler</string>
+    <string name="stream_ui_message_list_giphy_shuffle">Mélanger</string>
+    <string name="stream_ui_message_list_ephemeral_message">Seulement visible par vous</string>
+    <string name="stream_ui_message_list_deleted_message">Message supprimé</string>
+    <string name="stream_ui_message_list_attachment_more_count">+%d</string>
+    <string name="stream_ui_message_list_attachment_uploading">Téléchargement %d / %d …</string>
+    <string name="stream_ui_message_list_attachment_upload_complete">Téléchargement terminé, traitement…</string>
+    <string name="stream_ui_message_list_attachment_upload_progress">%s / %s</string>
+    <plurals name="stream_ui_message_list_thread_reply">
+        <item quantity="one">%d Réponse au fil de discussion</item>
+        <item quantity="other">%d Réponses au fil de discussion</item>
+    </plurals>
+    <plurals name="stream_ui_message_list_thread_separator">
+        <item quantity="one">%d Réponse</item>
+        <item quantity="other">%d Réponses</item>
+    </plurals>
+
+    <!-- Message Actions Dialog -->
+    <string name="stream_ui_message_list_reply">Réponse</string>
+    <string name="stream_ui_message_list_thread_reply">Réponse au fil de discussion</string>
+    <string name="stream_ui_message_list_resend_message">Renvoyer</string>
+    <string name="stream_ui_message_list_copy_message">Copier le message</string>
+    <string name="stream_ui_message_list_edit_message">Modifier le message</string>
+    <string name="stream_ui_message_list_flag_message">Signaler un message</string>
+    <string name="stream_ui_message_list_mute_user">Utilisateur muter</string>
+    <string name="stream_ui_message_list_unmute_user">Utilisateur unmute</string>
+    <string name="stream_ui_message_list_block_user">Bloquer un utilisateur</string>
+    <string name="stream_ui_message_list_delete_message">Supprimer le message</string>
+    <plurals name="stream_ui_message_list_message_reactions">
+        <item quantity="one">%d Réaction aux messages</item>
+        <item quantity="other">%d Réactions aux messages</item>
+    </plurals>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_ui_message_list_delete_confirmation_title">Supprimer le message</string>
+    <string name="stream_ui_message_list_delete_confirmation_message">Voulez-vous vraiment supprimer définitivement ce message ?</string>
+    <string name="stream_ui_message_list_delete_confirmation_positive_button">Supprimer</string>
+    <string name="stream_ui_message_list_delete_confirmation_negative_button">Annuler</string>
+    <string name="stream_ui_message_list_flag_confirmation_title">Signaler un message</string>
+    <string name="stream_ui_message_list_flag_confirmation_message">Voulez-vous envoyer une copie de ce message à un nmodérateur pour une enquête plus approfondie?</string>
+    <string name="stream_ui_message_list_flag_confirmation_positive_button">Signaler</string>
+    <string name="stream_ui_message_list_flag_confirmation_negative_button">Annuler</string>
+
+    <!-- Attachment Viewer -->
+    <string name="stream_ui_message_list_attachment_load_failed">Le chargement a échoué en raison d\'une erreur inconnue.</string>
+    <string name="stream_ui_message_list_attachment_invalid_url">Le chargement a échoué en raison d\'une URL non valide.</string>
+    <string name="stream_ui_message_list_attachment_invalid_mime_type">Quelque chose s\'est mal passé. Impossible d\'ouvrir la pièce jointe: %s</string>
+    <string name="stream_ui_message_list_attachment_display_error">Erreur. Le fichier ne peut pas être affiché</string>
+
+    <!-- Errors -->
+    <string name="stream_ui_message_list_error_mute_user">Échec à l\'utilisateur muet</string>
+    <string name="stream_ui_message_list_error_unmute_user">Échec à l\'utilisateur unmute</string>
+    <string name="stream_ui_message_list_error_block_user">Échec du blocage de l\'utilisateur</string>
+    <string name="stream_ui_message_list_error_flag_message">Échec du signalement du message</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
@@ -15,8 +15,8 @@
         <item quantity="other">%1d Membres</item>
     </plurals>
     <plurals name="stream_ui_message_list_header_typing_users">
-        <item quantity="one">%s est en train d'écrire</item>
-        <item quantity="other">%s et %d sont entrain d'écrire</item>
+        <item quantity="one">%s est en train d\'écrire</item>
+        <item quantity="other">%s et %d sont entrain d\'écrire</item>
     </plurals>
 
     <string name="stream_ui_message_list_header_back_button_content_description">Bouton Retour</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Header Title -->
+    <string name="stream_ui_message_list_header_thread_title">Réponse au fil de discussion</string>
+    <string name="stream_ui_message_list_header_untitled_channel">Le canal sans nom</string>
+
+    <!-- Header Subtitle -->
+    <string name="stream_ui_message_list_header_thread_subtitle">avec %s</string>
+    <string name="stream_ui_message_list_header_disconnected">Recherche de réseau</string>
+    <string name="stream_ui_message_list_header_offline">Hors ligne…</string>
+    <string name="stream_ui_message_list_header_retry">Essayer à nouveau</string>
+    <string name="stream_ui_message_list_header_member_count_online">%s, %d En ligne</string>
+    <plurals name="stream_ui_message_list_header_member_count">
+        <item quantity="one">%1d Membre</item>
+        <item quantity="other">%1d Membres</item>
+    </plurals>
+    <plurals name="stream_ui_message_list_header_typing_users">
+        <item quantity="one">%s est en train d'écrire</item>
+        <item quantity="other">%s et %d sont entrain d'écrire</item>
+    </plurals>
+
+    <string name="stream_ui_message_list_header_back_button_content_description">Bouton Retour</string>
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_message_list_header.xml
@@ -2,7 +2,7 @@
 <resources>
     <!-- Header Title -->
     <string name="stream_ui_message_list_header_thread_title">Réponse au fil de discussion</string>
-    <string name="stream_ui_message_list_header_untitled_channel">Le canal sans nom</string>
+    <string name="stream_ui_message_list_header_untitled_channel">Canal sans nom</string>
 
     <!-- Header Subtitle -->
     <string name="stream_ui_message_list_header_thread_subtitle">avec %s</string>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_search.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_search.xml
@@ -12,5 +12,5 @@
     </plurals>
 
     <string name="stream_ui_search_input_search_icon_content_description">Recherche</string>
-    <string name="stream_ui_search_input_clear_icon_content_description">Dégager</string>
+    <string name="stream_ui_search_input_clear_icon_content_description">Effacer</string>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values-fr/strings_search.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-fr/strings_search.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Search Input -->
+    <string name="stream_ui_search_input_hint">Recherche</string>
+
+    <!-- Search Result List -->
+    <string name="stream_ui_search_results_empty">Aucun résultat pour \"%s\"</string>
+    <string name="stream_ui_search_results_error">Une erreur s\'est produite</string>
+    <plurals name="stream_ui_search_results_count">
+        <item quantity="one">1 résultat</item>
+        <item quantity="other">%d résultats</item>
+    </plurals>
+
+    <string name="stream_ui_search_input_search_icon_content_description">Recherche</string>
+    <string name="stream_ui_search_input_clear_icon_content_description">Dégager</string>
+</resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1170

### 🎯 Goal

Add French translations

### 🛠 Implementation details

Added French translations based on Flutter SDK and Google Translate.
You can find English strings here:
- [Client](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-client/src/main/res/values/strings.xml)
- [Common](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-ui-common/src/main/res/values/strings.xml)
- [UI Components](https://github.com/GetStream/stream-chat-android/tree/develop/stream-chat-android-ui-components/src/main/res/values)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
