### PR TITLE
Fixing position of default empty view

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-
+- Added a fix for default view for empty state of ChannelListView.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -83,7 +83,7 @@ public class ChannelListView : FrameLayout {
         addView(simpleChannelListView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
 
         emptyStateView = streamThemeInflater.inflate(style.emptyStateView, this, false).apply {
-            isVisible = true
+            isVisible = false
             addView(this)
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
-import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -82,14 +82,9 @@ public class ChannelListView : FrameLayout {
 
         addView(simpleChannelListView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
 
-        emptyStateView = streamThemeInflater.inflate(style.emptyStateView, null).apply {
+        emptyStateView = streamThemeInflater.inflate(style.emptyStateView, this, false).apply {
             isVisible = true
-            addView(
-                this,
-                LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
-                    gravity = Gravity.CENTER
-                }
-            )
+            addView(this)
         }
 
         loadingView = streamThemeInflater.inflate(style.loadingView, null).apply {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -84,7 +84,8 @@ public class ChannelListView : FrameLayout {
 
         emptyStateView = streamThemeInflater.inflate(style.emptyStateView, null).apply {
             isVisible = true
-            addView(this,
+            addView(
+                this,
                 LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
                     gravity = Gravity.CENTER
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
@@ -82,8 +83,12 @@ public class ChannelListView : FrameLayout {
         addView(simpleChannelListView, LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT))
 
         emptyStateView = streamThemeInflater.inflate(style.emptyStateView, null).apply {
-            isVisible = false
-            addView(this)
+            isVisible = true
+            addView(this,
+                LayoutParams(ViewGroup.LayoutParams.WRAP_CONTENT, ViewGroup.LayoutParams.WRAP_CONTENT).apply {
+                    gravity = Gravity.CENTER
+                }
+            )
         }
 
         loadingView = streamThemeInflater.inflate(style.loadingView, null).apply {


### PR DESCRIPTION
### 🎯 Goal

Fix the position of the default view of empty state for ChannelListView. 


### 🛠 Implementation details

I just added the `LayoutParams` =].

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_20210804-114409](https://user-images.githubusercontent.com/10619102/128202573-f4b224e5-4586-4e34-b559-44253fd33911.png) | ![Screenshot_20210804-114046](https://user-images.githubusercontent.com/10619102/128202469-fb94d478-1d5c-455b-8599-c21a60d82b3b.png) |

Much better, right? =]

### 🧪 Testing

Comment this: 
```
val emptyView = layoutInflater.inflate(
    R.layout.channels_empty_view,
    view,
    false,
)
emptyView.findViewById<TextView>(R.id.startChatButton).setOnClickListener {
    requireActivity().findNavController(R.id.hostFragmentContainer)
        .navigateSafely(HomeFragmentDirections.actionHomeFragmentToAddChannelFragment())
}
setEmptyStateView(emptyView, FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT))
```

Inside `ChannelListFragment` in our sample app to see the default version of our empty state. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
