### PR TITLE
[CAS-1136] Fix FileAttachmentsView memory leaks

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -66,6 +66,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Added a fix for default view for empty state of ChannelListView.
+- Fixed memory leaks for FileAttachmentsView.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1675,6 +1675,8 @@ public abstract class io/getstream/chat/android/ui/message/list/adapter/BaseMess
 	public abstract fun bindData (Lcom/getstream/sdk/chat/adapter/MessageListItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;)V
 	protected final fun getContext ()Landroid/content/Context;
 	protected final fun getData ()Lcom/getstream/sdk/chat/adapter/MessageListItem;
+	public fun onAttachedToWindow ()V
+	public fun onDetachedFromWindow ()V
 	public fun unbind ()V
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/RecyclerView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/RecyclerView.kt
@@ -1,0 +1,12 @@
+package io.getstream.chat.android.ui.common.extensions.internal
+
+import androidx.recyclerview.widget.RecyclerView
+
+internal fun <VH : RecyclerView.ViewHolder, A : RecyclerView.Adapter<VH>> A.doForAllViewHolders(
+    recyclerView: RecyclerView,
+    action: (VH) -> Unit,
+) {
+    for (i in 0 until itemCount) {
+        (recyclerView.findViewHolderForAdapterPosition(i) as? VH)?.let(action)
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AttachmentUtils.kt
@@ -1,10 +1,7 @@
 package io.getstream.chat.android.ui.common.internal
 
-import android.content.Context
 import android.webkit.MimeTypeMap
 import android.widget.ImageView
-import android.widget.TextView
-import androidx.core.view.isVisible
 import com.getstream.sdk.chat.StreamFileUtil
 import com.getstream.sdk.chat.images.StreamImageLoader.ImageTransformation.RoundedCorners
 import com.getstream.sdk.chat.images.load
@@ -13,13 +10,8 @@ import com.getstream.sdk.chat.model.AttachmentMetaData
 import com.getstream.sdk.chat.model.ModelType
 import com.getstream.sdk.chat.utils.extensions.getDisplayableName
 import io.getstream.chat.android.client.models.Attachment
-import io.getstream.chat.android.client.uploader.ProgressTrackerFactory
 import io.getstream.chat.android.ui.ChatUI
-import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.dpToPxPrecise
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
 
 private val FILE_THUMB_TRANSFORMATION = RoundedCorners(3.dpToPxPrecise())
 
@@ -58,30 +50,6 @@ internal fun ImageView.loadAttachmentThumb(attachment: AttachmentMetaData) {
             )
             ModelType.attach_image -> load(data = uri, transformation = FILE_THUMB_TRANSFORMATION)
             else -> load(data = ChatUI.mimeTypeIconProvider.getIconRes(mimeType))
-        }
-    }
-}
-
-internal object AttachmentUtils {
-    internal suspend fun trackFilesSent(context: Context, uploadIdList: List<String>, sentFilesView: TextView) {
-        val filesSent = 0
-        val totalFiles = uploadIdList.size
-
-        sentFilesView.isVisible = true
-        sentFilesView.text = context.getString(R.string.stream_ui_message_list_attachment_uploading, filesSent, totalFiles)
-
-        val completionFlows: List<Flow<Boolean>> = uploadIdList.map { uploadId ->
-            ProgressTrackerFactory.getOrCreate(uploadId).isComplete()
-        }
-
-        combine(completionFlows) { isCompleteArray ->
-            isCompleteArray.count { isComplete -> isComplete }
-        }.collect { completedCount ->
-            if (completedCount == totalFiles) {
-                sentFilesView.text = context.getString(R.string.stream_ui_message_list_attachment_upload_complete)
-            } else {
-                sentFilesView.text = context.getString(R.string.stream_ui_message_list_attachment_uploading, completedCount, totalFiles)
-            }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -522,8 +522,9 @@ public class MessageListView : ConstraintLayout {
     }
 
     override fun onDetachedFromWindow() {
-        super.onDetachedFromWindow()
+        adapter.onDetachedFromRecyclerView(binding.chatMessagesRV)
         attachmentGalleryDestination.unregister()
+        super.onDetachedFromWindow()
     }
 
     public fun setLoadingMore(loadingMore: Boolean) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/BaseMessageItemViewHolder.kt
@@ -50,4 +50,14 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
     }
 
     protected val context: Context = itemView.context
+
+    /**
+     * Called when this view holder and its' view were detached from window.
+     */
+    public open fun onDetachedFromWindow() { }
+
+    /**
+     * Called when this view holder and its' view were attached to window.
+     */
+    public open fun onAttachedToWindow() { }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemAdapter.kt
@@ -2,7 +2,9 @@ package io.getstream.chat.android.ui.message.list.adapter.internal
 
 import android.view.ViewGroup
 import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.adapter.MessageListItem
+import io.getstream.chat.android.ui.common.extensions.internal.doForAllViewHolders
 import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
@@ -51,6 +53,26 @@ internal class MessageListItemAdapter(
     override fun onViewRecycled(holder: BaseMessageItemViewHolder<out MessageListItem>) {
         super.onViewRecycled(holder)
         holder.unbind()
+    }
+
+    override fun onViewAttachedToWindow(holder: BaseMessageItemViewHolder<out MessageListItem>) {
+        super.onViewAttachedToWindow(holder)
+        holder.onAttachedToWindow()
+    }
+
+    override fun onViewDetachedFromWindow(holder: BaseMessageItemViewHolder<out MessageListItem>) {
+        holder.onDetachedFromWindow()
+        super.onViewDetachedFromWindow(holder)
+    }
+
+    override fun onAttachedToRecyclerView(recyclerView: RecyclerView) {
+        super.onAttachedToRecyclerView(recyclerView)
+        doForAllViewHolders(recyclerView) { it.onAttachedToWindow() }
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        doForAllViewHolders(recyclerView) { it.onDetachedFromWindow() }
+        super.onDetachedFromRecyclerView(recyclerView)
     }
 
     companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
@@ -6,6 +6,7 @@ import android.graphics.Rect
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.content.ContextCompat
 import androidx.core.view.isVisible
@@ -22,6 +23,7 @@ import io.getstream.chat.android.client.uploader.ProgressTrackerFactory
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.createStreamThemeWrapper
+import io.getstream.chat.android.ui.common.extensions.internal.doForAllViewHolders
 import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
 import io.getstream.chat.android.ui.common.extensions.internal.dpToPxPrecise
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
@@ -76,6 +78,11 @@ internal class FileAttachmentsView : RecyclerView {
     fun setAttachments(attachments: List<Attachment>) {
         fileAttachmentsAdapter.setItems(attachments)
     }
+
+    override fun onDetachedFromWindow() {
+        adapter?.onDetachedFromRecyclerView(this)
+        super.onDetachedFromWindow()
+    }
 }
 
 private class VerticalSpaceItemDecorator(private val marginPx: Int) : RecyclerView.ItemDecoration() {
@@ -108,6 +115,21 @@ private class FileAttachmentsAdapter(
                 )
             }
     }
+
+    override fun onViewAttachedToWindow(holder: FileAttachmentViewHolder) {
+        super.onViewAttachedToWindow(holder)
+        holder.restartJob()
+    }
+
+    override fun onViewDetachedFromWindow(holder: FileAttachmentViewHolder) {
+        holder.clearScope()
+        super.onViewDetachedFromWindow(holder)
+    }
+
+    override fun onDetachedFromRecyclerView(recyclerView: RecyclerView) {
+        doForAllViewHolders(recyclerView) { it.clearScope() }
+        super.onDetachedFromRecyclerView(recyclerView)
+    }
 }
 
 private class FileAttachmentViewHolder(
@@ -117,25 +139,25 @@ private class FileAttachmentViewHolder(
     private val attachmentDownloadClickListener: AttachmentDownloadClickListener,
     private val style: FileAttachmentViewStyle,
 ) : SimpleListAdapter.ViewHolder<Attachment>(binding.root) {
-    private lateinit var attachment: Attachment
+    private var attachment: Attachment? = null
 
     private var scope: CoroutineScope? = null
 
-    private fun clearScope() {
+    fun clearScope() {
         scope?.cancel()
         scope = null
     }
 
     init {
         binding.root.setOnClickListener {
-            attachmentClickListener.onAttachmentClick(attachment)
+            attachment?.let(attachmentClickListener::onAttachmentClick)
         }
         binding.root.setOnLongClickListener {
             attachmentLongClickListener.onAttachmentLongClick()
             true
         }
         binding.actionButton.setOnClickListener {
-            attachmentDownloadClickListener.onAttachmentDownloadClick(attachment)
+            attachment?.let(attachmentDownloadClickListener::onAttachmentDownloadClick)
         }
     }
 
@@ -167,6 +189,16 @@ private class FileAttachmentViewHolder(
             }
     }
 
+    fun restartJob() {
+        attachment?.let(::subscribeForProgressIfNeeded)
+    }
+
+    private fun subscribeForProgressIfNeeded(attachment: Attachment) {
+        if (attachment.uploadState is Attachment.UploadState.InProgress) {
+            handleInProgressAttachment(binding.fileSize)
+        }
+    }
+
     override fun bind(item: Attachment) {
         this.attachment = item
 
@@ -174,80 +206,92 @@ private class FileAttachmentViewHolder(
             fileTitle.setTextStyle(style.titleTextStyle)
             fileSize.setTextStyle(style.fileSizeTextStyle)
 
-            fileTypeIcon.loadAttachmentThumb(attachment)
-            fileTitle.text = attachment.getDisplayableName()
+            fileTypeIcon.loadAttachmentThumb(item)
+            fileTitle.text = item.getDisplayableName()
 
-            if (attachment.uploadState == Attachment.UploadState.InProgress) {
+            if (item.uploadState == Attachment.UploadState.InProgress) {
                 actionButton.setImageDrawable(null)
-                fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0L)
-            } else if (attachment.uploadState is Attachment.UploadState.Failed || attachment.fileSize == 0) {
+                fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
+            } else if (item.uploadState is Attachment.UploadState.Failed || item.fileSize == 0) {
                 actionButton.setImageDrawable(style.failedAttachmentIcon)
-                fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0L)
+                fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
             } else {
                 actionButton.setImageDrawable(style.actionButtonIcon)
-                fileSize.text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong())
+                fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.fileSize.toLong())
             }
 
             binding.progressBar.indeterminateDrawable = style.progressBarDrawable
-            binding.progressBar.isVisible = attachment.uploadState is Attachment.UploadState.InProgress
+            binding.progressBar.isVisible = item.uploadState is Attachment.UploadState.InProgress
 
-            if (attachment.uploadState is Attachment.UploadState.InProgress) {
-                handleInProgressAttachment(fileSize)
-            }
+            subscribeForProgressIfNeeded(item)
             setupBackground()
         }
     }
 
     private fun handleInProgressAttachment(fileSizeView: TextView) {
-        attachment.uploadId?.let(ProgressTrackerFactory::getOrCreate)?.let { tracker ->
-            val progress = tracker.currentProgress()
-            val completion = tracker.isComplete()
-            val totalValue = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0)
-            val progressCorrection = tracker.maxValue / 100F
+        attachment?.let { attachment ->
+            attachment.uploadId?.let(ProgressTrackerFactory::getOrCreate)?.let { tracker ->
+                val progress = tracker.currentProgress()
+                val completion = tracker.isComplete()
+                val totalValue = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0)
+                val progressCorrection = tracker.maxValue / 100F
 
-            val fileProgress = progress.combine(completion, ::Pair)
+                val fileProgress = progress.combine(completion, ::Pair)
 
-            clearScope()
-            scope = CoroutineScope(DispatcherProvider.Main)
+                clearScope()
+                scope = CoroutineScope(DispatcherProvider.Main)
 
-            scope!!.launch {
-                fileProgress.collect { (progress, isComplete) ->
-                    updateProgress(context, fileSizeView, progress, isComplete, progressCorrection, totalValue)
+                scope?.launch {
+                    fileProgress.collect { (progress, isComplete) ->
+                        updateProgress(
+                            context,
+                            fileSizeView,
+                            binding.progressBar,
+                            attachment,
+                            progress,
+                            isComplete,
+                            progressCorrection,
+                            totalValue
+                        )
+                    }
                 }
             }
         }
     }
 
-    private fun updateProgress(
-        context: Context,
-        fileSizeView: TextView,
-        progress: Int,
-        isComplete: Boolean,
-        progressCorrection: Float,
-        targetValue: String,
-    ) {
-        if (!isComplete) {
-            val nominalProgress = MediaStringUtil.convertFileSizeByteCount((progress * progressCorrection).toLong())
-
-            fileSizeView.text =
-                context.getString(
-                    R.string.stream_ui_message_list_attachment_upload_progress,
-                    nominalProgress,
-                    targetValue
-                )
-        } else {
-            binding.progressBar.isVisible = false
-            fileSizeView.text = attachment.upload?.length()?.let(MediaStringUtil::convertFileSizeByteCount)
-        }
-    }
-
     override fun unbind() {
-        super.unbind()
         clearScope()
+        super.unbind()
     }
 
-    companion object {
+    private companion object {
         private val CORNER_SIZE_PX = 12.dpToPxPrecise()
         private val STROKE_WIDTH_PX = 1.dpToPxPrecise()
+
+        private fun updateProgress(
+            context: Context,
+            fileSizeView: TextView,
+            progressBar: ProgressBar,
+            attachment: Attachment,
+            progress: Int,
+            isComplete: Boolean,
+            progressCorrection: Float,
+            targetValue: String,
+        ) {
+            if (!isComplete) {
+                val nominalProgress = MediaStringUtil.convertFileSizeByteCount((progress * progressCorrection).toLong())
+
+                fileSizeView.text =
+                    context.getString(
+                        R.string.stream_ui_message_list_attachment_upload_progress,
+                        nominalProgress,
+                        targetValue
+                    )
+            } else {
+                progressBar.isVisible = false
+                fileSizeView.text =
+                    attachment.upload?.length()?.let(MediaStringUtil::convertFileSizeByteCount)
+            }
+        }
     }
 }


### PR DESCRIPTION
[Issue on github](https://github.com/GetStream/stream-chat-android/issues/1936)
### 🎯 Goal

Fix memory leaks when using `FileAttachmentsView`

### 🛠 Implementation details

We called `VH::unbind` when `Adapter::onViewRecycled`, but when whole `RecyclerView` was detached from window we didn't get this invocation. So Idea is calling callback for VHs when recycler is detached

### 🧪 Testing

1. Add dependency of canary leak
2. Go to `ChatFragment`
3. Upload heavy files (e.g. video)
4. Go back to `ChannelList` immediately

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media3.giphy.com/media/4EF5LwiRfpBKQUOsoF/giphy.gif)
