### PR TITLE
[CAS-1159] Use correct color for message reply background

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-night/colors.xml
@@ -22,4 +22,7 @@
     <color name="stream_ui_button_text_color">#005AFF</color>
     <color name="stream_ui_border">#141924</color>
     <color name="stream_ui_highlight">#302D22</color>
+
+    <!-- Message replies -->
+    <color name="stream_ui_bars_background">#121416</color>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/colors.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/colors.xml
@@ -56,4 +56,7 @@
     <color name="stream_ui_literal_transparent">#00000000</color>
     <color name="stream_ui_literal_white">#FFFFFF</color>
     <color name="stream_ui_literal_black">#000000</color>
+
+    <!-- Message replies -->
+    <color name="stream_ui_bars_background">#FFFFFF</color>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -367,8 +367,8 @@
         <item name="streamUiMessageTextStyleThreadSeparator">normal</item>
 
         <!-- Message Reply background color -->
-        <item name="streamUiMessageReplyBackgroundColorMine">@color/stream_ui_grey_gainsboro</item>
-        <item name="streamUiMessageReplyBackgroundColorTheirs">@color/stream_ui_white</item>
+        <item name="streamUiMessageReplyBackgroundColorMine">@color/stream_ui_bars_background</item>
+        <item name="streamUiMessageReplyBackgroundColorTheirs">@color/stream_ui_bars_background</item>
 
         <!-- Message Reply text style mine -->
         <item name="streamUiMessageReplyTextSizeMine">@dimen/stream_ui_text_medium</item>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1159

### 🎯 Goal

To have correct UI as per the mockups

### 🛠 Implementation details

Added correct colors for message reply as mentioned in the mockups 

### 🎨 UI Changes

| Before | After |
| --- | --- |
| <img width="400" src="https://user-images.githubusercontent.com/13432025/128317726-94125436-b1d9-488b-854d-b9b476f9cb71.png"/> | <img width="400" src="https://user-images.githubusercontent.com/13432025/128317775-e4ab9f8c-3593-4a9c-935f-009b9ff785e8.png"/> |
| <img width="400" src="https://user-images.githubusercontent.com/13432025/128318246-efa83003-3d05-43eb-8636-f45e6d68cf82.png" /> | <img width="400" src="https://user-images.githubusercontent.com/13432025/128318258-df081a40-15d0-4c80-a65a-2468424b0013.png" /> |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
