### PR TITLE
[CAS-1109] Documentation for forcing light mode

### DIFF
--- a/docusaurus/docs/Android/03-ui/02-theming.md
+++ b/docusaurus/docs/Android/03-ui/02-theming.md
@@ -148,3 +148,12 @@ SDK contains following activities: `AttachmentMediaActivity`, `AttachmentActivit
     <item name="android:src">@drawable/stream_ui_ic_audio</item>
 </style>
 ```
+
+####Forcing ligtht mode
+If you prefer to light mode and ignore the dark theme colors of the SDK. Just use:
+
+```
+AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
+```
+
+Otherwise the SDK will follow the system UI mode.


### PR DESCRIPTION
[CAS-1109](https://stream-io.atlassian.net/browse/CAS-1109)

### 🎯 Goal

Document how to for light mode. 

### 🛠 Implementation details

There's no need to implement anything... Our SDK already has support for that, all it takes for force this is to use:
```
AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
```
And everything will light. This PR just adds a documentation to make clear how to use light mode in our SDK. Since this is already documented in the official android documentation, I'm not sure if this is necessary... please @GetStream/android-developers give me your input on this. 

### 🧪 Testing

Use:
```
AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO)
```
Inside our `App` class and see the magic =D

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/128408650-b74258d6-65c0-4053-909d-7c0c167d3192.gif)
_That's what I had to do =|_