### PR TITLE
CAS-1117 Deleted message visibility customization

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -64,8 +64,14 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `MessageListView::setDeletedMessageListItemPredicate` function. It's responsible for adjusting visibility of the deleted `MessageListItem.MessageItem` elements.
 
 ### ⚠️ Changed
+- 🚨 Breaking change: the deleted `MessageListItem.MessageItem` elements are now displayed by default to all the users. This default behavior can be customized using `MessageListView::setDeletedMessageListItemPredicate` function. This function takes an instance of `MessageListItemPredicate`. You can pass one of the following objects:
+    * `DeletedMessageListItemPredicate.VisibleToEveryone`
+    * `DeletedMessageListItemPredicate.NotVisibleToAnyone`
+    * or `DeletedMessageListItemPredicate.VisibleToAuthorOnly`
+    Alternatively you can pass your custom implementation by implementing the `MessageListItemPredicate` interface if you need to customize it more deeply.
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.utils.EventObserver
 import io.getstream.chat.android.ui.message.input.MessageInputView
 import io.getstream.chat.android.ui.message.input.viewmodel.bindView
+import io.getstream.chat.android.ui.message.list.DeletedMessageListItemPredicate
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.bindView
@@ -64,6 +65,7 @@ class ChatFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         headerViewModel.bindView(binding.messagesHeaderView, viewLifecycleOwner)
+        binding.messageListView.setDeletedMessageListItemPredicate(DeletedMessageListItemPredicate.VisibleToAuthorOnly)
         initChatViewModel()
         initMessagesViewModel()
         configureMessageInputView()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1195,6 +1195,24 @@ public final class io/getstream/chat/android/ui/message/input/viewmodel/MessageI
 	public static final fun bind (Lcom/getstream/sdk/chat/viewmodel/MessageInputViewModel;Lio/getstream/chat/android/ui/message/input/MessageInputView;Landroidx/lifecycle/LifecycleOwner;)V
 }
 
+public abstract class io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate : io/getstream/chat/android/ui/message/list/MessageListView$MessageListItemPredicate {
+}
+
+public final class io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$NotVisibleToAnyone : io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate {
+	public static final field INSTANCE Lio/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$NotVisibleToAnyone;
+	public fun predicate (Lcom/getstream/sdk/chat/adapter/MessageListItem;)Z
+}
+
+public final class io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$VisibleToAuthorOnly : io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate {
+	public static final field INSTANCE Lio/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$VisibleToAuthorOnly;
+	public fun predicate (Lcom/getstream/sdk/chat/adapter/MessageListItem;)Z
+}
+
+public final class io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$VisibleToEveryone : io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate {
+	public static final field INSTANCE Lio/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate$VisibleToEveryone;
+	public fun predicate (Lcom/getstream/sdk/chat/adapter/MessageListItem;)Z
+}
+
 public final class io/getstream/chat/android/ui/message/list/FileAttachmentViewStyle {
 	public fun <init> (IIIILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;)V
 	public final fun component1 ()I
@@ -1348,6 +1366,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListView : a
 	public final fun setCopyMessageEnabled (Z)V
 	public final fun setDeleteMessageConfirmationEnabled (Z)V
 	public final fun setDeleteMessageEnabled (Z)V
+	public final fun setDeletedMessageListItemPredicate (Lio/getstream/chat/android/ui/message/list/MessageListView$MessageListItemPredicate;)V
 	public final fun setDownloadOptionHandler (Lio/getstream/chat/android/ui/gallery/AttachmentGalleryActivity$AttachmentDownloadOptionHandler;)V
 	public final fun setEditMessageEnabled (Z)V
 	public final fun setEmptyStateView (Landroid/view/View;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/DeletedMessageListItemPredicate.kt
@@ -1,0 +1,35 @@
+package io.getstream.chat.android.ui.message.list
+
+import com.getstream.sdk.chat.adapter.MessageListItem
+
+/**
+ * Predicate class used to filter [MessageListItem.MessageItem] items which are deleted. Used by [MessageListView.setDeletedMessageListItemPredicate].
+ */
+public sealed class DeletedMessageListItemPredicate : MessageListView.MessageListItemPredicate {
+    /**
+     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone.
+     */
+    public object NotVisibleToAnyone : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return false
+        }
+    }
+
+    /**
+     * Predicate object used to show deleted [MessageListItem.MessageItem] items to everyone.
+     */
+    public object VisibleToEveryone : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return true
+        }
+    }
+
+    /**
+     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone except for the author of the message.
+     */
+    public object VisibleToAuthorOnly : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return true
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -42,6 +42,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.isCurrentUser
 import io.getstream.chat.android.ui.common.extensions.internal.isMedia
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
 import io.getstream.chat.android.ui.common.extensions.internal.use
+import io.getstream.chat.android.ui.common.extensions.isDeleted
 import io.getstream.chat.android.ui.common.extensions.isInThread
 import io.getstream.chat.android.ui.common.navigation.destinations.AttachmentDestination
 import io.getstream.chat.android.ui.common.navigation.destinations.WebLinkDestination
@@ -247,6 +248,7 @@ public class MessageListView : ConstraintLayout {
     }
 
     private var messageListItemPredicate: MessageListItemPredicate = HiddenMessageListItemPredicate
+    private var deletedMessageListItemPredicate: MessageListItemPredicate = DeletedMessageListItemPredicate.VisibleToEveryone
     private lateinit var loadMoreListener: EndlessScrollListener
 
     private lateinit var channel: Channel
@@ -758,6 +760,17 @@ public class MessageListView : ConstraintLayout {
         this.messageListItemPredicate = messageListItemPredicate
     }
 
+    /**
+     * Used to specify visibility of the deleted
+     * @param deletedMessageListItemPredicate An instance of [MessageListItemPredicate]. You can pass one of the following objects:
+     * [DeletedMessageListItemPredicate.VisibleToEveryone], [DeletedMessageListItemPredicate.NotVisibleToAnyone], or [DeletedMessageListItemPredicate.VisibleToAuthorOnly].
+     * Alternatively you can pass your custom implementation by implementing the [MessageListItemPredicate] interface.
+     */
+    public fun setDeletedMessageListItemPredicate(deletedMessageListItemPredicate: MessageListItemPredicate) {
+        check(::adapter.isInitialized.not()) { "Adapter was already initialized, please set MessageListItemPredicate first" }
+        this.deletedMessageListItemPredicate = deletedMessageListItemPredicate
+    }
+
     public fun setAttachmentViewFactory(attachmentViewFactory: AttachmentViewFactory) {
         check(::adapter.isInitialized.not()) { "Adapter was already initialized, please set AttachmentViewFactory first" }
         this.attachmentViewFactory = attachmentViewFactory
@@ -782,7 +795,16 @@ public class MessageListView : ConstraintLayout {
 
     private fun handleNewWrapper(listItem: MessageListItemWrapper) {
         CoroutineScope(DispatcherProvider.IO).launch {
-            val filteredList = listItem.items.filter(messageListItemPredicate::predicate)
+            val filteredList = listItem.items
+                .filter(messageListItemPredicate::predicate)
+                .filter { item ->
+                    if (item is MessageListItem.MessageItem && item.message.isDeleted()) {
+                        deletedMessageListItemPredicate.predicate(item)
+                    } else {
+                        true
+                    }
+                }
+
             withContext(DispatcherProvider.Main) {
                 buffer.hold()
 
@@ -1178,6 +1200,38 @@ public class MessageListView : ConstraintLayout {
                 return values().find { behaviour -> behaviour.value == value }
                     ?: throw IllegalArgumentException("Unknown messages start type. It must be either BOTTOM (int 0) or TOP (int 1)")
             }
+        }
+    }
+}
+
+/**
+ * Predicate class used to filter [MessageListItem.MessageItem] items which are deleted.
+ */
+public sealed class DeletedMessageListItemPredicate : MessageListView.MessageListItemPredicate {
+    /**
+     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone.
+     */
+    public object NotVisibleToAnyone : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return false
+        }
+    }
+
+    /**
+     * Predicate object used to show deleted [MessageListItem.MessageItem] items to everyone.
+     */
+    public object VisibleToEveryone : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return true
+        }
+    }
+
+    /**
+     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone except for the author of the message.
+     */
+    public object VisibleToAuthorOnly : DeletedMessageListItemPredicate() {
+        override fun predicate(item: MessageListItem): Boolean {
+            return true
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -795,7 +795,7 @@ public class MessageListView : ConstraintLayout {
 
     private fun handleNewWrapper(listItem: MessageListItemWrapper) {
         CoroutineScope(DispatcherProvider.IO).launch {
-            val filteredList = listItem.items
+            val filteredList = listItem.items.asSequence()
                 .filter(messageListItemPredicate::predicate)
                 .filter { item ->
                     if (item is MessageListItem.MessageItem && item.message.isDeleted()) {
@@ -804,6 +804,7 @@ public class MessageListView : ConstraintLayout {
                         true
                     }
                 }
+                .toList()
 
             withContext(DispatcherProvider.Main) {
                 buffer.hold()
@@ -1200,38 +1201,6 @@ public class MessageListView : ConstraintLayout {
                 return values().find { behaviour -> behaviour.value == value }
                     ?: throw IllegalArgumentException("Unknown messages start type. It must be either BOTTOM (int 0) or TOP (int 1)")
             }
-        }
-    }
-}
-
-/**
- * Predicate class used to filter [MessageListItem.MessageItem] items which are deleted.
- */
-public sealed class DeletedMessageListItemPredicate : MessageListView.MessageListItemPredicate {
-    /**
-     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone.
-     */
-    public object NotVisibleToAnyone : DeletedMessageListItemPredicate() {
-        override fun predicate(item: MessageListItem): Boolean {
-            return false
-        }
-    }
-
-    /**
-     * Predicate object used to show deleted [MessageListItem.MessageItem] items to everyone.
-     */
-    public object VisibleToEveryone : DeletedMessageListItemPredicate() {
-        override fun predicate(item: MessageListItem): Boolean {
-            return true
-        }
-    }
-
-    /**
-     * Predicate object used to hide deleted [MessageListItem.MessageItem] items from everyone except for the author of the message.
-     */
-    public object VisibleToAuthorOnly : DeletedMessageListItemPredicate() {
-        override fun predicate(item: MessageListItem): Boolean {
-            return true
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -761,7 +761,8 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
-     * Used to specify visibility of the deleted
+     * Used to specify visibility of the deleted [MessageListItem.MessageItem] elements.
+     *
      * @param deletedMessageListItemPredicate An instance of [MessageListItemPredicate]. You can pass one of the following objects:
      * [DeletedMessageListItemPredicate.VisibleToEveryone], [DeletedMessageListItemPredicate.NotVisibleToAnyone], or [DeletedMessageListItemPredicate.VisibleToAuthorOnly].
      * Alternatively you can pass your custom implementation by implementing the [MessageListItemPredicate] interface.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/HiddenMessageListItemPredicate.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/HiddenMessageListItemPredicate.kt
@@ -1,21 +1,16 @@
 package io.getstream.chat.android.ui.message.list.internal
 
 import com.getstream.sdk.chat.adapter.MessageListItem
-import io.getstream.chat.android.ui.common.extensions.isDeleted
 import io.getstream.chat.android.ui.common.extensions.isGiphyEphemeral
 import io.getstream.chat.android.ui.message.list.MessageListView
 
 internal object HiddenMessageListItemPredicate : MessageListView.MessageListItemPredicate {
-
-    private val theirDeletedMessagePredicate: (MessageListItem) -> Boolean = { item ->
-        item is MessageListItem.MessageItem && item.message.isDeleted() && item.isTheirs
-    }
 
     private val theirGiphyEphemeralMessagePredicate: (MessageListItem) -> Boolean = { item ->
         item is MessageListItem.MessageItem && item.message.isGiphyEphemeral() && item.isTheirs
     }
 
     override fun predicate(item: MessageListItem): Boolean {
-        return theirDeletedMessagePredicate(item).not() && theirGiphyEphemeralMessagePredicate(item).not()
+        return theirGiphyEphemeralMessagePredicate(item).not()
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1117

### 🎯 Goal

Allow customization of deleted `MessageListItem.MessageItem` visibility. 
1. It should be possible to choose from predefined parameters
2. By default deleted `MessageListItem.MessageItem` should be visible for everyone. This is how other SDKs behave so we needed to change this for consistency (breaking change).
3. It should be possible to define a custom condition for the visibility of the deleted `MessageListItem.MessageItem`

### 🛠 Implementation details
* `MessageListView::setDeletedMessageListItemPredicate` is introduced, by default set to `DeletedMessageListItemPredicate.VisibleToEveryone`
* `MessageListView` filters messages which are deleted based on the `MessageListView.deletedMessageListItemPredicate` property inside `MessageListView::handleNewWrapper` method.
* There are the following ready to use implementations of `DeletedMessageListItemPredicate`: `VisibleToEveryone`, `VisibleToAuthor`, and `NotVisibleToAnyone`
* Custom `DeletedMessageVisibility` can be implemented and set to `MessageListView` by implementing `MessageListView.MessageListItemPredicate` interface

### 🧪 Testing

Adjust `MessageListView` behavior in sample app's `ChatFragment`:
```kotlin
override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
    binding.messageListView.setDeletedMessageListItemPredicate(DeletedMessageListItemPredicate.VisibleToAuthorOnly)
}
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

