### PR TITLE
Configure jitpack with JDK11

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,3 @@
+jdk: openjdk11
+before_install:
+  - echo "signing.key=$SIGNING_KEY" >> local.properties && echo "signing.password=$SIGNING_PASSWORD" >> local.properties && echo "signing.keyId=$SIGNING_KEY_ID" >> local.properties


### PR DESCRIPTION
### 🎯 Goal
Fix Jitpack compilation.
We don't officially deploy our artifacts by this server, but sometimes we ask our customers to use a concreted version from a commit, and it is the easier way to provide it, so keep it working would help them

### 🛠 Implementation details
Some stuff have been updated on our SDK and Jitpack didn't use them.
As an example the JDK version or the configuration to sign the artifact.
All of that has been configured on the `jitpack.yml` file that is loaded by jitpack before the compilation is done.

### 🧪 Testing

You can check build result [here](https://jitpack.io/com/github/getStream/stream-chat-android/c133dd0b35/build.log)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/vMNoKKznOrUJi/giphy-downsized.gif)