### PR TITLE
[CAS-1195] Fix setting SuggestionListView's style when using it as a standalone component

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -71,7 +71,8 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-Fixed attachments of camera. Now multiple videos and pictures can be taken from the camera. 
+- Fixed attachments of camera. Now multiple videos and pictures can be taken from the camera.
+- Fixed applying style to `SuggestionListView` when using it as a standalone component. You can modify the style using `suggestionListViewTheme` or `TransformStyle::suggestionListStyleTransformer`
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
@@ -32,7 +32,7 @@ public class SuggestionListView : FrameLayout, SuggestionListUi {
         suggestionClickListener?.onCommandClick(it)
     }
 
-    private var style: SuggestionListViewStyle? = null
+    private lateinit var style: SuggestionListViewStyle
     private var suggestionClickListener: OnSuggestionClickListener? = null
 
     public constructor(context: Context) : this(context, null, 0)
@@ -46,6 +46,7 @@ public class SuggestionListView : FrameLayout, SuggestionListUi {
     )
 
     init {
+        setSuggestionListViewStyle(SuggestionListViewStyle.createDefault(context))
         binding.suggestionsRecyclerView.apply {
             itemAnimator = null
             adapter = ConcatAdapter(mentionListAdapter, commandListAdapter)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListViewStyle.kt
@@ -173,5 +173,7 @@ public data class SuggestionListViewStyle(
                 ).let(TransformStyle.suggestionListStyleTransformer::transform)
             }
         }
+
+        fun createDefault(context: Context) = invoke(context, null)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/SuggestionListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/SuggestionListItemViewHolderFactory.kt
@@ -7,16 +7,16 @@ import io.getstream.chat.android.ui.suggestion.list.adapter.viewholder.internal.
 import io.getstream.chat.android.ui.suggestion.list.adapter.viewholder.internal.MentionViewHolder
 
 public open class SuggestionListItemViewHolderFactory {
-    internal var style: SuggestionListViewStyle? = null
+    internal lateinit var style: SuggestionListViewStyle
 
     public open fun createMentionViewHolder(
         parentView: ViewGroup,
     ): BaseSuggestionItemViewHolder<SuggestionListItem.MentionItem> {
         return MentionViewHolder(
             parent = parentView,
-            usernameStyle = style?.mentionsUsernameTextStyle,
-            mentionNameStyle = style?.mentionsNameTextStyle,
-            mentionIcon = style?.mentionIcon,
+            usernameStyle = style.mentionsUsernameTextStyle,
+            mentionNameStyle = style.mentionsNameTextStyle,
+            mentionIcon = style.mentionIcon,
         )
     }
 
@@ -25,9 +25,9 @@ public open class SuggestionListItemViewHolderFactory {
     ): BaseSuggestionItemViewHolder<SuggestionListItem.CommandItem> {
         return CommandViewHolder(
             parent = parentView,
-            commandsNameStyle = style?.commandsNameTextStyle,
-            commandsDescriptionStyle = style?.commandsDescriptionTextStyle,
-            commandIcon = style?.commandIcon
+            commandsNameStyle = style.commandsNameTextStyle,
+            commandsDescriptionStyle = style.commandsDescriptionTextStyle,
+            commandIcon = style.commandIcon,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/viewholder/internal/CommandViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/viewholder/internal/CommandViewHolder.kt
@@ -11,17 +11,17 @@ import io.getstream.chat.android.ui.suggestion.list.adapter.viewholder.BaseSugge
 
 internal class CommandViewHolder(
     parent: ViewGroup,
-    commandsNameStyle: TextStyle? = null,
-    commandsDescriptionStyle: TextStyle? = null,
-    commandIcon: Drawable? = null,
+    commandsNameStyle: TextStyle,
+    commandsDescriptionStyle: TextStyle,
+    commandIcon: Drawable,
     private val binding: StreamUiItemCommandBinding = StreamUiItemCommandBinding
         .inflate(parent.streamThemeInflater, parent, false),
 ) : BaseSuggestionItemViewHolder<SuggestionListItem.CommandItem>(binding.root) {
 
     init {
-        commandsNameStyle?.apply(binding.commandNameTextView)
-        commandsDescriptionStyle?.apply(binding.commandQueryTextView)
-        commandIcon?.let(binding.instantCommandImageView::setImageDrawable)
+        commandsNameStyle.apply(binding.commandNameTextView)
+        commandsDescriptionStyle.apply(binding.commandQueryTextView)
+        binding.instantCommandImageView.setImageDrawable(commandIcon)
     }
 
     override fun bindItem(item: SuggestionListItem.CommandItem) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/viewholder/internal/MentionViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/adapter/viewholder/internal/MentionViewHolder.kt
@@ -12,19 +12,17 @@ import io.getstream.chat.android.ui.suggestion.list.adapter.viewholder.BaseSugge
 
 internal class MentionViewHolder(
     parent: ViewGroup,
-    usernameStyle: TextStyle? = null,
-    mentionNameStyle: TextStyle? = null,
-    mentionIcon: Drawable? = null,
+    usernameStyle: TextStyle,
+    mentionNameStyle: TextStyle,
+    mentionIcon: Drawable,
     private val binding: StreamUiItemMentionBinding = StreamUiItemMentionBinding
         .inflate(parent.streamThemeInflater, parent, false),
 ) : BaseSuggestionItemViewHolder<SuggestionListItem.MentionItem>(binding.root) {
 
     init {
-        usernameStyle?.apply(binding.usernameTextView)
-        mentionNameStyle?.apply(binding.mentionNameTextView)
-        mentionIcon?.let { icon ->
-            binding.mentionsIcon.setImageDrawable(icon)
-        }
+        usernameStyle.apply(binding.usernameTextView)
+        mentionNameStyle.apply(binding.mentionNameTextView)
+        binding.mentionsIcon.setImageDrawable(mentionIcon)
     }
 
     override fun bindItem(item: SuggestionListItem.MentionItem) {


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1195

### 🎯 Goal

Fix setting SuggestionListView's style when using it as a standalone component

### 🛠 Implementation details
`SuggestionListViewStyle` resolves attributes based on `MessageInputView` attrs. That's why `SuggestionListViewStyle` was nullable and set only when we were creating it inside `MessageInputView`.
I've changed that and created a `default` style during view initialization that allows overriding different attributes either by using `suggestionListViewTheme` or `suggestionListStyleTransformer `


### 🧪 Testing

1. Create a sample that uses `SuggestionListView` as a standalone components
2. Override `suggestionListViewTheme` and check if the style is applied

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
