### PR TITLE
Disable missing translation inspection for sample apps

### DIFF
--- a/stream-chat-android-compose-sample/build.gradle
+++ b/stream-chat-android-compose-sample/build.gradle
@@ -63,6 +63,10 @@ android {
         kotlinCompilerVersion Versions.KOTLIN
         kotlinCompilerExtensionVersion Versions.COMPOSE
     }
+
+    lintOptions {
+        disable 'MissingTranslation'
+    }
 }
 
 dependencies {

--- a/stream-chat-android-ui-components-sample/build.gradle
+++ b/stream-chat-android-ui-components-sample/build.gradle
@@ -88,6 +88,7 @@ android {
         abortOnError false
         xmlReport true
         checkDependencies true
+        disable 'MissingTranslation'
     }
 
     packagingOptions {

--- a/stream-chat-android/build.gradle
+++ b/stream-chat-android/build.gradle
@@ -44,6 +44,10 @@ android {
             it.java.srcDir "src/$it.name/kotlin"
         }
     }
+
+    lintOptions {
+        disable 'MissingTranslation'
+    }
 }
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {


### PR DESCRIPTION
### 🎯 Goal

Disable missing translation inspection for sample apps not to get annoying warnings in the IDE.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/9600921/128874644-c1b08bf4-5d48-4470-b4e8-2e2c83e65a94.gif)

