### PR TITLE
[CAS-1197] Add missing attributes to AttachmentSelectionDialogStyle

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -79,6 +79,8 @@
 
 ### ✅ Added
 - Added `MessageListView::setDeletedMessageListItemPredicate` function. It's responsible for adjusting visibility of the deleted `MessageListItem.MessageItem` elements.
+- Added `streamUiAttachmentSelectionBackgroundColor` for configuring attachment's icon background in `AttachmentSelectionDialogFragment`
+- Added `streamUiAttachmentSelectionAttachIcon` for configuring attach icon in `AttachmentSelectionDialogFragment`
 
 ### ⚠️ Changed
 - 🚨 Breaking change: the deleted `MessageListItem.MessageItem` elements are now displayed by default to all the users. This default behavior can be customized using `MessageListView::setDeletedMessageListItemPredicate` function. This function takes an instance of `MessageListItemPredicate`. You can pass one of the following objects:

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1139,7 +1139,7 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 
 public final class io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle$Companion;
-	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZ)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component10 ()Landroid/graphics/drawable/Drawable;
 	public final fun component11 ()Landroid/graphics/drawable/Drawable;
@@ -1153,6 +1153,8 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun component19 ()Z
 	public final fun component2 ()Landroid/content/res/ColorStateList;
 	public final fun component20 ()Z
+	public final fun component21 ()I
+	public final fun component22 ()Landroid/graphics/drawable/Drawable;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
 	public final fun component4 ()Landroid/content/res/ColorStateList;
 	public final fun component5 ()Landroid/graphics/drawable/Drawable;
@@ -1160,8 +1162,8 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZ)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Landroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowAccessToCameraIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getAllowAccessToCameraText ()Ljava/lang/String;
@@ -1169,6 +1171,8 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun getAllowAccessToFilesText ()Ljava/lang/String;
 	public final fun getAllowAccessToGalleryIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getAllowAccessToGalleryText ()Ljava/lang/String;
+	public final fun getAttachButtonIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getBackgroundColor ()I
 	public final fun getCameraAttachmentIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getCameraAttachmentIconTint ()Landroid/content/res/ColorStateList;
 	public final fun getFileAttachmentIcon ()Landroid/graphics/drawable/Drawable;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -380,8 +380,18 @@ public data class MessageInputViewStyle(
                         Typeface.NORMAL
                     )
                     .build()
-                val videoLengthVisible = a.getBoolean(R.styleable.MessageInputView_streamUiAttachmentVideoLengthVisible, true)
-                val videoIconVisible = a.getBoolean(R.styleable.MessageInputView_streamUiAttachmentVideoIconVisible, true)
+                val videoLengthVisible =
+                    a.getBoolean(R.styleable.MessageInputView_streamUiAttachmentVideoLengthVisible, true)
+                val videoIconVisible =
+                    a.getBoolean(R.styleable.MessageInputView_streamUiAttachmentVideoIconVisible, true)
+                val attachmentSelectionBackgroundColor =
+                    a.getColor(
+                        R.styleable.MessageInputView_streamUiAttachmentSelectionBackgroundColor,
+                        context.getColorCompat(R.color.stream_ui_white_smoke)
+                    )
+                val attachmentSelectionAttachIcon =
+                    a.getDrawable(R.styleable.MessageInputView_streamUiAttachmentSelectionAttachIcon)
+                        ?: context.getDrawableCompat(R.drawable.stream_ui_ic_next)!!
 
                 val attachmentDialogStyle = AttachmentSelectionDialogStyle(
                     pictureAttachmentIcon = pictureAttachmentIcon,
@@ -404,6 +414,8 @@ public data class MessageInputViewStyle(
                     videoDurationTextStyle = videoLengthTextStyle,
                     videoLengthLabelVisible = videoLengthVisible,
                     videoIconVisible = videoIconVisible,
+                    backgroundColor = attachmentSelectionBackgroundColor,
+                    attachButtonIcon = attachmentSelectionAttachIcon,
                 )
 
                 val commandInputCancelIcon = a.getDrawable(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogFragment.kt
@@ -46,12 +46,17 @@ public class AttachmentSelectionDialogFragment : BottomSheetDialogFragment(), At
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         binding.apply {
+            val attachmentSelectionDialogStyle = style.attachmentSelectionDialogStyle
+
+            container.setBackgroundColor(attachmentSelectionDialogStyle.backgroundColor)
+
+            attachButton.setImageDrawable(attachmentSelectionDialogStyle.attachButtonIcon)
             attachButton.isEnabled = false
             attachButton.setOnClickListener {
                 attachmentSelectionListener?.onAttachmentsSelected(selectedAttachments, attachmentSource)
                 dismiss()
             }
-            val attachmentSelectionDialogStyle = style.attachmentSelectionDialogStyle
+
             mediaAttachmentButton.run {
                 background = attachmentSelectionDialogStyle.pictureAttachmentIcon
                 if (attachmentSelectionDialogStyle.pictureAttachmentIconTint != null) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
+import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
@@ -34,6 +35,8 @@ public data class AttachmentSelectionDialogStyle(
     val videoIconDrawable: Drawable,
     val videoIconVisible: Boolean,
     val videoLengthLabelVisible: Boolean,
+    @ColorInt val backgroundColor: Int,
+    val attachButtonIcon: Drawable,
 ) {
     public companion object {
         /**
@@ -72,6 +75,8 @@ public data class AttachmentSelectionDialogStyle(
                 videoIconDrawable = context.getDrawableCompat(R.drawable.stream_ui_ic_video)!!,
                 videoIconVisible = true,
                 videoLengthLabelVisible = true,
+                backgroundColor = context.getColorCompat(R.color.stream_ui_white_smoke),
+                attachButtonIcon = context.getDrawableCompat(R.drawable.stream_ui_ic_next)!!,
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_attachment.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/container"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:background="@color/stream_ui_white_smoke"

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
@@ -181,6 +181,9 @@
         </attr>
         <attr name="streamUiAttachmentVideoLengthVisible" format="boolean" />
         <attr name="streamUiAttachmentVideoIconVisible" format="boolean" />
+        <attr name="streamUiAttachmentSelectionBackgroundColor" format="color|reference" />
+        <attr name="streamUiAttachmentSelectionAttachIcon" format="reference" />
+
         <!-- Attachment permissions -->
         <attr name="streamUiAllowAccessToGalleryText" format="string" />
         <attr name="streamUiAllowAccessToFilesText" format="string" />

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -904,5 +904,7 @@
         <item name="streamUiAttachmentsFilesEmptyStateText">@string/stream_ui_message_input_no_files</item>
         <item name="streamUiAttachmentsMediaEmptyStateText">@string/stream_ui_message_input_no_files</item>
         <item name="streamUiMessageInputCloseButtonIconDrawable">@drawable/stream_ui_ic_clear</item>
+        <item name="streamUiAttachmentSelectionBackgroundColor">@color/stream_ui_white_smoke</item>
+        <item name="streamUiAttachmentSelectionAttachIcon">@drawable/stream_ui_ic_next</item>
     </style>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1197

### 🎯 Goal

Add missing attributes to `AttachmentSelectionDialogStyle`

### 🛠 Implementation details

Added `streamUiAttachmentSelectionBackgroundColor` and `streamUiAttachmentSelectionAttachIcon`

### 🎨 UI Changes

| Before | After |
| --- | --- |
|<img width="323" alt="Screenshot 2021-08-11 at 15 26 39" src="https://user-images.githubusercontent.com/17440581/129039761-85503cd3-732d-460f-a726-ffc3cc5ee924.png">|<img width="323" alt="Screenshot 2021-08-11 at 15 28 34" src="https://user-images.githubusercontent.com/17440581/129039722-4ed67c1f-89a1-40b9-b950-fcc756e16c28.png">|


### 🧪 Testing

Try to use newly created attributes

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

