### PR TITLE
[CAS-1189] Use Map instead of SparseArray for fonts

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/ChatFontsImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/style/ChatFontsImpl.kt
@@ -2,11 +2,9 @@ package io.getstream.chat.android.ui.common.style
 
 import android.content.Context
 import android.graphics.Typeface
-import android.util.SparseArray
 import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.util.contains
 import io.getstream.chat.android.client.logger.ChatLogger
 import java.util.HashMap
 
@@ -15,7 +13,7 @@ internal class ChatFontsImpl(
     private val context: Context,
 ) : ChatFonts {
 
-    private val resourceMap = SparseArray<Typeface>()
+    private val resourceMap: MutableMap<Int, Typeface> = HashMap()
     private val pathMap: MutableMap<String, Typeface> = HashMap()
 
     private val logger = ChatLogger.get(ChatFonts::class.java.simpleName)

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/style/ChatFontsImpl.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/style/ChatFontsImpl.kt
@@ -2,11 +2,9 @@ package com.getstream.sdk.chat.style
 
 import android.content.Context
 import android.graphics.Typeface
-import android.util.SparseArray
 import android.widget.TextView
 import androidx.annotation.FontRes
 import androidx.core.content.res.ResourcesCompat
-import androidx.core.util.contains
 import io.getstream.chat.android.client.logger.ChatLogger
 import java.util.HashMap
 
@@ -15,7 +13,7 @@ public class ChatFontsImpl(
     private val context: Context
 ) : ChatFonts {
 
-    private val resourceMap = SparseArray<Typeface>()
+    private val resourceMap: MutableMap<Int, Typeface> = HashMap()
     private val pathMap: MutableMap<String, Typeface> = HashMap()
 
     private val logger = ChatLogger.get(ChatFonts::class.java.simpleName)


### PR DESCRIPTION
Fix #2171 
### 🎯 Goal
Remove usage of SparseArray into our `ChatFontsImpl`, the benefits are only involved on the memory efficiency, but it is almost despicable compared with a `HashMap`, and this one is faster

https://developer.android.com/reference/android/util/SparseArray.html
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/IdcPofFGvr8pW/giphy.gif)
