### PR TITLE
Revert "Merge pull request #2168 from GetStream/refac/CAS-1164/TitleLinkInsteadOfOgUrl

### DIFF
--- a/docusaurus/docs/Android/04-compose/02-general-customization/02-attachment-factory.md
+++ b/docusaurus/docs/Android/04-compose/02-general-customization/02-attachment-factory.md
@@ -23,7 +23,7 @@ There are three examples of default attachment factory implementations, in the [
 public val defaultFactories: List<AttachmentFactory> = listOf(
     AttachmentFactory(
         { state -> LinkAttachmentFactory(state) },
-        { message -> message.attachments.any { it.titleLink != null } }
+        { message -> message.attachments.any { it.ogUrl != null } }
     ),
     AttachmentFactory(
         { state -> ImageAttachmentFactory(state) },

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextMessagesComponentBrowserFragment.kt
@@ -13,7 +13,7 @@ class PlainTextMessagesComponentBrowserFragment : BaseMessagesComponentBrowserFr
     override fun getItems(): List<MessageListItem.MessageItem> {
         val date = Date()
         val attachmentLink = Attachment(
-            titleLink = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
+            ogUrl = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
             title = "Title",
             text = "Some description",
             authorName = "Stream",

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithFileAttachmentsMessagesComponentBrowserFragment.kt
@@ -14,7 +14,7 @@ class PlainTextWithFileAttachmentsMessagesComponentBrowserFragment : BaseMessage
     @OptIn(InternalStreamChatApi::class)
     override fun getItems(): List<MessageListItem.MessageItem> {
         val attachmentLink = Attachment(
-            titleLink = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
+            ogUrl = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
             title = "Title",
             text = "Some description",
             authorName = "Stream",

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/component_browser/messages/viewholder/PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment.kt
@@ -15,7 +15,7 @@ class PlainTextWithMediaAttachmentsMessagesComponentBrowserFragment : BaseMessag
         val uri2 = drawableResToUri(context, R.drawable.stream_ui_sample_image_2)
         val uri3 = drawableResToUri(context, R.drawable.stream_ui_sample_image_3)
         val attachmentLink = Attachment(
-            titleLink = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
+            ogUrl = drawableResToUri(requireContext(), R.drawable.stream_ui_sample_image_1),
             title = "Title",
             text = "Some description",
             authorName = "Stream",

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Attachment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Attachment.kt
@@ -7,4 +7,4 @@ private val MEDIA_ATTACHMENT_TYPES: Collection<String> = listOf(ModelType.attach
 
 internal fun Attachment.isMedia(): Boolean = type in MEDIA_ATTACHMENT_TYPES
 
-internal fun Attachment.hasLink(): Boolean = titleLink != null || ogUrl != null
+internal fun Attachment.hasLink(): Boolean = ogUrl != null

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/AttachmentDestination.kt
@@ -41,8 +41,8 @@ public open class AttachmentDestination(
         when (attachment.type) {
             ModelType.attach_image -> {
                 when {
-                    attachment.titleLink != null || attachment.ogUrl != null -> {
-                        url = attachment.titleLink ?: attachment.ogUrl
+                    attachment.ogUrl != null -> {
+                        url = attachment.ogUrl
                         type = ModelType.attach_link
                     }
                     attachment.isGif() -> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/LinkAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/LinkAttachmentView.kt
@@ -31,7 +31,7 @@ internal class LinkAttachmentView : FrameLayout {
     )
 
     fun showLinkAttachment(attachment: Attachment, style: MessageListItemStyle) {
-        previewUrl = attachment.titleLink ?: attachment.ogUrl
+        previewUrl = attachment.ogUrl
 
         val title = attachment.title
         if (title != null) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MediaAttachmentView.kt
@@ -59,7 +59,7 @@ internal class MediaAttachmentView : ConstraintLayout {
     }
 
     fun showAttachment(attachment: Attachment, andMoreCount: Int = NO_MORE_COUNT) {
-        val url = attachment.imagePreviewUrl ?: attachment.titleLink ?: attachment.ogUrl ?: return
+        val url = attachment.imagePreviewUrl ?: attachment.ogUrl ?: return
         val showMore = {
             if (andMoreCount > NO_MORE_COUNT) {
                 showMoreCount(andMoreCount)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MessageReplyView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MessageReplyView.kt
@@ -167,7 +167,7 @@ internal class MessageReplyView : FrameLayout {
         } else {
             val type = attachment.type
             if (type == ModelType.attach_link) {
-                attachment.titleLink ?: attachment.ogUrl
+                attachment.ogUrl
             } else {
                 attachment.title ?: attachment.name
             }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/navigation/destinations/AttachmentDestination.kt
@@ -37,8 +37,8 @@ public open class AttachmentDestination(
             }
             ModelType.attach_image -> {
                 when {
-                    attachment.titleLink != null || attachment.ogUrl != null -> {
-                        url = attachment.titleLink ?: attachment.ogUrl
+                    attachment.ogUrl != null -> {
+                        url = attachment.ogUrl
                         type = ModelType.attach_link
                     }
                     attachment.isGif() -> {


### PR DESCRIPTION
This reverts commit 8fa897245bdcbb3da4e1143192cf96ec218399ba, reversing
changes made to 61660c6373af901ef5d0529077093ebd859e3a23.

### 🎯 Goal

Fix Giphy

### 🛠 Implementation details

Giphy attachments don't work with this change

### 🧪 Testing

Try to send Giphy 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

