### PR TITLE
2221 - Added missing MessageList loading and empty views from public API

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -79,6 +79,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Added missing `emptyContent` and `loadingContent` parameters to `MessageList` inner components.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
@@ -81,7 +81,9 @@ public fun MessageList(
         onMessagesStartReached = onMessagesStartReached,
         onLongItemClick = onLongItemClick,
         onScrollToBottom = onScrollToBottom,
-        itemContent = itemContent
+        itemContent = itemContent,
+        loadingContent = loadingContent,
+        emptyContent = emptyContent
     )
 }
 


### PR DESCRIPTION
Fixes #2221 

### 🎯 Goal

We had missed consuming `loading` and `empty` composable view's from the `MessageList`  into the inner child components, this MR fixes it.


### ☑️ Checklist

- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ x Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF
![](https://media.giphy.com/media/dtBUUa0dEvFgiL1OVx/giphy.gif)
