### PR TITLE
[CAS-1154] [CAS-1183] Use target version 30

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -2,6 +2,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Updated Target API Level to 30
 - Updated dependency versions
   - Coil 1.3.2
   - AndroidX Activity 1.3.1
@@ -9,7 +10,6 @@
   - AndroidX ConstraintLayout 2.1.0
   - Dokka 1.5.0
   - Lottie 4.0.0
-
 ### ✅ Added
 
 ### ⚠️ Changed

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -2,7 +2,7 @@ package io.getstream.chat.android
 
 object Configuration {
     const val compileSdkVersion = 30
-    const val targetSdkVersion = 29
+    const val targetSdkVersion = 30
     const val minSdkVersion = 21
     const val versionName = "4.16.0"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-ui-common/src/main/AndroidManifest.xml
+++ b/stream-chat-android-ui-common/src/main/AndroidManifest.xml
@@ -4,10 +4,17 @@
     package="io.getstream.chat.android.ui.common"
     >
 
+    <queries>
+        <intent>
+            <action android:name="android.media.action.VIDEO_CAPTURE" />
+        </intent>
+        <intent>
+            <action android:name="android.media.action.IMAGE_CAPTURE" />
+        </intent>
+    </queries>
+
     <application>
-        <activity android:name="com.getstream.sdk.chat.view.activity.AttachmentMediaActivity" />
         <activity android:name="com.getstream.sdk.chat.view.activity.AttachmentDocumentActivity" />
-        <activity android:name="com.getstream.sdk.chat.view.activity.AttachmentActivity" />
 
         <provider
             android:name="com.getstream.sdk.chat.StreamFileProvider"


### PR DESCRIPTION
### 🎯 Goal
Update to Targect SDK Version 30 and check that all our integrations with the new version keep working

### 🛠 Implementation details
Android 11 [added some new rules](https://developer.android.com/training/package-visibility/use-cases) to improve user privacy and if you want to query about apps installed into the device, you need to declare the query into your manifest, in other case you will get an empty list of get an exception when you query is run 

### 🧪 Testing
You will need to use a device/emulator running Android 11
-. Try to send pictures
-. Try to send Videos
-. Try to send files
-. Try to take a picture
-. Try to record a Video
-. Try to share an attachment
-. Try to open a file
-. Try to open a link

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF
![](https://media.giphy.com/media/qfridHRcLlMLMtWueu/giphy.gif)
