### PR TITLE
2223 - Added SDK-specific version header

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -55,7 +55,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun getReplies (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun getRepliesMore (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun getSyncHistory (Ljava/util/List;Ljava/util/Date;)Lio/getstream/chat/android/client/call/Call;
-	public final fun getVersion ()Ljava/lang/String;
+	public static final fun getVERSION_PREFIX ()Ljava/lang/String;
 	public static final fun handlePushMessage (Lio/getstream/chat/android/client/models/PushMessage;)V
 	public final fun hideChannel (Ljava/lang/String;Ljava/lang/String;Z)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun hideChannel$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
@@ -118,6 +118,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun setUser (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Lio/getstream/chat/android/client/socket/InitConnectionListener;)V
 	public static synthetic fun setUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;Lio/getstream/chat/android/client/socket/InitConnectionListener;ILjava/lang/Object;)V
 	public static synthetic fun setUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Lio/getstream/chat/android/client/socket/InitConnectionListener;ILjava/lang/Object;)V
+	public static final fun setVERSION_PREFIX (Ljava/lang/String;)V
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
 	public final fun showChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun stopWatching (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
@@ -163,10 +164,12 @@ public final class io/getstream/chat/android/client/ChatClient$Builder {
 }
 
 public final class io/getstream/chat/android/client/ChatClient$Companion {
+	public final fun getVERSION_PREFIX ()Ljava/lang/String;
 	public final fun handlePushMessage (Lio/getstream/chat/android/client/models/PushMessage;)V
 	public final fun instance ()Lio/getstream/chat/android/client/ChatClient;
 	public final fun isInitialized ()Z
 	public final fun setDevice (Lio/getstream/chat/android/client/models/Device;)V
+	public final fun setVERSION_PREFIX (Ljava/lang/String;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/ChatEventListener {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -55,7 +55,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun getReplies (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun getRepliesMore (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun getSyncHistory (Ljava/util/List;Ljava/util/Date;)Lio/getstream/chat/android/client/call/Call;
-	public static final fun getVERSION_PREFIX ()Ljava/lang/String;
+	public static final fun getVERSION_PREFIX_HEADER ()Lio/getstream/chat/android/client/header/VersionPrefixHeader;
+	public final fun getVersion ()Ljava/lang/String;
 	public static final fun handlePushMessage (Lio/getstream/chat/android/client/models/PushMessage;)V
 	public final fun hideChannel (Ljava/lang/String;Ljava/lang/String;Z)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun hideChannel$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
@@ -118,7 +119,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun setUser (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Lio/getstream/chat/android/client/socket/InitConnectionListener;)V
 	public static synthetic fun setUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;Lio/getstream/chat/android/client/socket/InitConnectionListener;ILjava/lang/Object;)V
 	public static synthetic fun setUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Lio/getstream/chat/android/client/socket/InitConnectionListener;ILjava/lang/Object;)V
-	public static final fun setVERSION_PREFIX (Ljava/lang/String;)V
+	public static final fun setVERSION_PREFIX_HEADER (Lio/getstream/chat/android/client/header/VersionPrefixHeader;)V
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
 	public final fun showChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun stopWatching (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
@@ -164,12 +165,12 @@ public final class io/getstream/chat/android/client/ChatClient$Builder {
 }
 
 public final class io/getstream/chat/android/client/ChatClient$Companion {
-	public final fun getVERSION_PREFIX ()Ljava/lang/String;
+	public final fun getVERSION_PREFIX_HEADER ()Lio/getstream/chat/android/client/header/VersionPrefixHeader;
 	public final fun handlePushMessage (Lio/getstream/chat/android/client/models/PushMessage;)V
 	public final fun instance ()Lio/getstream/chat/android/client/ChatClient;
 	public final fun isInitialized ()Z
 	public final fun setDevice (Lio/getstream/chat/android/client/models/Device;)V
-	public final fun setVERSION_PREFIX (Ljava/lang/String;)V
+	public final fun setVERSION_PREFIX_HEADER (Lio/getstream/chat/android/client/header/VersionPrefixHeader;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/ChatEventListener {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.DisconnectedEvent
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_FILE
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_IMAGE
+import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.client.helpers.QueryChannelsPostponeHelper
 import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.logger.ChatLogger
@@ -84,7 +85,7 @@ import java.nio.charset.StandardCharsets
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.Executor
-import kotlin.jvm.Throws
+import kotlin.properties.Delegates
 
 /**
  * The ChatClient is the main entry point for all low-level operations on chat
@@ -1082,6 +1083,7 @@ public class ChatClient internal constructor(
         return api.sendEvent(eventType, channelType, channelId, extraData)
     }
 
+    @InternalStreamChatApi
     public fun getVersion(): String = VERSION_PREFIX + BuildConfig.STREAM_CHAT_VERSION
 
     @CheckResult
@@ -1576,7 +1578,12 @@ public class ChatClient internal constructor(
     }
 
     public companion object {
-        private const val VERSION_PREFIX = "stream-chat-android-"
+        @InternalStreamChatApi
+        @JvmStatic
+        public var VERSION_PREFIX: String by Delegates.vetoable(VersionPrefixHeader.CORE_ANDROID.prefix) { _, _, new ->
+            VersionPrefixHeader.values().any { it.prefix == new }
+        }
+
         private var instance: ChatClient? = null
 
         @JvmField

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -85,7 +85,6 @@ import java.nio.charset.StandardCharsets
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.Executor
-import kotlin.properties.Delegates
 
 /**
  * The ChatClient is the main entry point for all low-level operations on chat
@@ -1083,8 +1082,7 @@ public class ChatClient internal constructor(
         return api.sendEvent(eventType, channelType, channelId, extraData)
     }
 
-    @InternalStreamChatApi
-    public fun getVersion(): String = VERSION_PREFIX + BuildConfig.STREAM_CHAT_VERSION
+    public fun getVersion(): String = VERSION_PREFIX_HEADER.prefix + BuildConfig.STREAM_CHAT_VERSION
 
     @CheckResult
     public fun acceptInvite(
@@ -1580,9 +1578,7 @@ public class ChatClient internal constructor(
     public companion object {
         @InternalStreamChatApi
         @JvmStatic
-        public var VERSION_PREFIX: String by Delegates.vetoable(VersionPrefixHeader.DEFAULT.prefix) { _, _, new ->
-            VersionPrefixHeader.values().any { it.prefix == new }
-        }
+        public var VERSION_PREFIX_HEADER: VersionPrefixHeader = VersionPrefixHeader.DEFAULT
 
         private var instance: ChatClient? = null
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1580,7 +1580,7 @@ public class ChatClient internal constructor(
     public companion object {
         @InternalStreamChatApi
         @JvmStatic
-        public var VERSION_PREFIX: String by Delegates.vetoable(VersionPrefixHeader.CORE_ANDROID.prefix) { _, _, new ->
+        public var VERSION_PREFIX: String by Delegates.vetoable(VersionPrefixHeader.DEFAULT.prefix) { _, _, new ->
             VersionPrefixHeader.values().any { it.prefix == new }
         }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
@@ -4,7 +4,8 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 @InternalStreamChatApi
 public enum class VersionPrefixHeader(public val prefix: String) {
-    CORE_ANDROID("stream-chat-android-"),
-    COMPOSE("stream-chat-compose-")
-    // TODO - @Rafal - we'll need to add a value for the old UI component too
+    DEFAULT("stream-chat-android-"),
+    OLD_UI_COMPONENTS("stream-chat-android-old-ui-"),
+    UI_COMPONENTS("stream-chat-android-ui-components-"),
+    COMPOSE("stream-chat-android-compose-")
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
@@ -1,0 +1,10 @@
+package io.getstream.chat.android.client.header
+
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
+@InternalStreamChatApi
+public enum class VersionPrefixHeader(public val prefix: String) {
+    CORE_ANDROID("stream-chat-android-"),
+    COMPOSE("stream-chat-compose-")
+    // TODO - @Rafal - we'll need to add a value for the old UI component too
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
@@ -67,7 +67,6 @@ class ChannelActivity : AppCompatActivity() {
          * */
         setContent {
             ChatTheme {
-                ChatTheme.colors.appBackground
                 ChannelsScreen(
                     title = stringResource(id = R.string.app_name),
                     isShowingHeader = true,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
@@ -67,6 +67,7 @@ class ChannelActivity : AppCompatActivity() {
          * */
         setContent {
             ChatTheme {
+                ChatTheme.colors.appBackground
                 ChannelsScreen(
                     title = stringResource(id = R.string.app_name),
                     isShowingHeader = true,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.compose.sample
 
 import android.app.Application
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.offline.ChatDomain
 
@@ -11,6 +12,7 @@ class ChatApp : Application() {
         super.onCreate()
 
         val client = ChatClient.Builder("qx5us2v6xvmh", applicationContext)
+            .logLevel(ChatLogLevel.ALL)
             .build()
         ChatDomain.Builder(client, applicationContext).build()
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -3,8 +3,11 @@ package io.getstream.chat.android.compose.ui.theme
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.runtime.compositionLocalOf
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.compose.ui.util.DefaultReactionTypes.defaultReactionTypes
 
 /**
@@ -47,6 +50,10 @@ public fun ChatTheme(
     reactionTypes: Map<String, Int> = defaultReactionTypes,
     content: @Composable () -> Unit,
 ) {
+    LaunchedEffect(Unit) {
+        ChatClient.VERSION_PREFIX = VersionPrefixHeader.COMPOSE.prefix
+    }
+
     CompositionLocalProvider(
         LocalColors provides colors,
         LocalTypography provides typography,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -51,7 +51,7 @@ public fun ChatTheme(
     content: @Composable () -> Unit,
 ) {
     LaunchedEffect(Unit) {
-        ChatClient.VERSION_PREFIX = VersionPrefixHeader.COMPOSE.prefix
+        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.COMPOSE
     }
 
     CompositionLocalProvider(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ChatUIInitializer.kt
@@ -2,10 +2,13 @@ package io.getstream.chat.android.ui.common.internal
 
 import android.content.Context
 import androidx.startup.Initializer
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.ui.ChatUI
 
 public class ChatUIInitializer : Initializer<ChatUI> {
     override fun create(context: Context): ChatUI {
+        ChatClient.VERSION_PREFIX = VersionPrefixHeader.UI_COMPONENTS.prefix
         ChatUI.appContext = context
         return ChatUI
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/ChatUIInitializer.kt
@@ -8,9 +8,10 @@ import io.getstream.chat.android.ui.ChatUI
 
 public class ChatUIInitializer : Initializer<ChatUI> {
     override fun create(context: Context): ChatUI {
-        ChatClient.VERSION_PREFIX = VersionPrefixHeader.UI_COMPONENTS.prefix
+        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.UI_COMPONENTS
         ChatUI.appContext = context
         return ChatUI
     }
+
     override fun dependencies(): MutableList<Class<out Initializer<*>>> = mutableListOf()
 }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatUI.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatUI.kt
@@ -13,6 +13,7 @@ import com.getstream.sdk.chat.utils.strings.ChatStrings
 import com.getstream.sdk.chat.utils.strings.ChatStringsImpl
 import io.getstream.chat.android.client.BuildConfig.STREAM_CHAT_VERSION
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.ui.common.BuildConfig
 
@@ -35,7 +36,7 @@ public class ChatUI internal constructor(
     public val strings: ChatStrings,
     public val navigator: ChatNavigator,
     public val markdown: ChatMarkdown,
-    public val urlSigner: UrlSigner
+    public val urlSigner: UrlSigner,
 ) {
     public val version: String
         get() = BuildConfig.BUILD_TYPE + ":" + STREAM_CHAT_VERSION
@@ -52,7 +53,7 @@ public class ChatUI internal constructor(
         public constructor(
             client: ChatClient,
             chatDomain: ChatDomain,
-            appContext: Context
+            appContext: Context,
         ) : this(appContext)
 
         private var style: ChatStyle? = null
@@ -102,6 +103,7 @@ public class ChatUI internal constructor(
                 markdown ?: ChatMarkdownImpl(appContext),
                 urlSigner ?: UrlSigner.DefaultUrlSigner()
             )
+            ChatClient.VERSION_PREFIX = VersionPrefixHeader.OLD_UI_COMPONENTS.prefix
             return instance()
         }
     }

--- a/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatUI.kt
+++ b/stream-chat-android/src/main/java/com/getstream/sdk/chat/ChatUI.kt
@@ -103,7 +103,7 @@ public class ChatUI internal constructor(
                 markdown ?: ChatMarkdownImpl(appContext),
                 urlSigner ?: UrlSigner.DefaultUrlSigner()
             )
-            ChatClient.VERSION_PREFIX = VersionPrefixHeader.OLD_UI_COMPONENTS.prefix
+            ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.OLD_UI_COMPONENTS
             return instance()
         }
     }


### PR DESCRIPTION
Closes #2223.

### 🎯 Goal

We need a way to track if our customers use the Compose SDK or the core SDK to keep tabs on how many people use which SDK.

### 🛠 Implementation details

Exposed the `VERSION_PREFIX` property as public, but `@InternalStreamChatApi`. Also added an enum that describes which version headers we support.

Internally, we don't allow for header changes to values that we don't support - using `Delegates.vetoable()`.

### 🧪 Testing

We can test it by tracking out headers and using the Compose SDK. We should have the `X-Stream-Client` show up as `stream-chat-compose-4.16.0`

### ☑️ Checklist

- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF
![header](https://user-images.githubusercontent.com/17215808/129724074-bb0f18cd-a36b-4cdd-a6cd-83e7c6a863be.gif)