### PR TITLE
[CAS-1233] Configure S3 Build Cache

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,6 +2,12 @@ name: Pull request CI checks
 
 on: [pull_request]
 
+env:
+  BUILD_CACHE_AWS_REGION: ${{ secrets.BUILD_CACHE_AWS_REGION }}
+  BUILD_CACHE_AWS_BUCKET: ${{ secrets.BUILD_CACHE_AWS_BUCKET }}
+  BUILD_CACHE_AWS_ACCESS_KEY_ID: ${{ secrets.BUILD_CACHE_AWS_ACCESS_KEY_ID }}
+  BUILD_CACHE_AWS_SECRET_KEY: ${{ secrets.BUILD_CACHE_AWS_SECRET_KEY }}
+
 jobs:
   lint:
     name: ktlint

--- a/settings.gradle
+++ b/settings.gradle
@@ -31,7 +31,9 @@ buildCache {
 	String streamAWSBucket = localProperties.get("buildCache.AWSBucket") ?: System.getenv("BUILD_CACHE_AWS_BUCKET") ?: ""
 	String streamAWSAccessKeyId = localProperties.get("buildCache.AWSAccessKeyId") ?: System.getenv("BUILD_CACHE_AWS_ACCESS_KEY_ID") ?: ""
 	String streamAWSSecretKey = localProperties.get("buildCache.AWSSecretKey") ?: System.getenv("BUILD_CACHE_AWS_SECRET_KEY") ?: ""
-	if (!streamAWSRegion.isBlank() &&
+	Boolean streamBuildCacheDisabled = Boolean.parseBoolean(localProperties.get("buildCache.disabled"))
+	if (!streamBuildCacheDisabled &&
+			!streamAWSRegion.isBlank() &&
 			!streamAWSBucket.isBlank() &&
 			!streamAWSAccessKeyId.isBlank() &&
 			!streamAWSSecretKey.isBlank()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,3 +1,6 @@
+plugins {
+	id("com.github.burrunan.s3-build-cache") version "1.2"
+}
 include (
 		':stream-chat-android',
 		':stream-chat-android-sample',
@@ -18,5 +21,29 @@ buildCache {
 	local {
 		enabled = true
 		removeUnusedEntriesAfterDays = 7
+	}
+	Properties localProperties = new Properties()
+	File file = new File("local.properties")
+	if (file.exists()) {
+		localProperties.load(file.newDataInputStream())
+	}
+	String streamAWSRegion = localProperties.get("buildCache.AWSRegion") ?: System.getenv("BUILD_CACHE_AWS_REGION") ?: ""
+	String streamAWSBucket = localProperties.get("buildCache.AWSBucket") ?: System.getenv("BUILD_CACHE_AWS_BUCKET") ?: ""
+	String streamAWSAccessKeyId = localProperties.get("buildCache.AWSAccessKeyId") ?: System.getenv("BUILD_CACHE_AWS_ACCESS_KEY_ID") ?: ""
+	String streamAWSSecretKey = localProperties.get("buildCache.AWSSecretKey") ?: System.getenv("BUILD_CACHE_AWS_SECRET_KEY") ?: ""
+	if (!streamAWSRegion.isBlank() &&
+			!streamAWSBucket.isBlank() &&
+			!streamAWSAccessKeyId.isBlank() &&
+			!streamAWSSecretKey.isBlank()
+	) {
+		remote(com.github.burrunan.s3cache.AwsS3BuildCache) {
+			region = streamAWSRegion
+			bucket = streamAWSBucket
+			prefix = 'cache/'
+			awsAccessKeyId = streamAWSAccessKeyId
+			awsSecretKey = streamAWSSecretKey
+			push = System.getenv().containsKey("CI")
+
+		}
 	}
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -25,7 +25,7 @@ buildCache {
 	Properties localProperties = new Properties()
 	File file = new File("local.properties")
 	if (file.exists()) {
-		localProperties.load(file.newDataInputStream())
+		file.newDataInputStream().withCloseable { localProperties.load(it) }
 	}
 	String streamAWSRegion = localProperties.get("buildCache.AWSRegion") ?: System.getenv("BUILD_CACHE_AWS_REGION") ?: ""
 	String streamAWSBucket = localProperties.get("buildCache.AWSBucket") ?: System.getenv("BUILD_CACHE_AWS_BUCKET") ?: ""


### PR DESCRIPTION
### 🎯 Goal
Add Gradle Remote Build Cache to improve buil-time on our PR pipeline

### 🛠 Implementation details
We are using a [custom implementation](https://github.com/burrunan/gradle-s3-build-cache) of Remote Build Cache that uses an AWS S3 Bucket to store the cache. The access to it should be really fast and it needs less maintaining

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF
![](https://media.giphy.com/media/3MgJW1FGPus2GaSmdV/giphy.gif)
