### PR TITLE
[CAS-1224] Muting a channel with timeout

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -35,6 +35,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added the `expiration` parameter to `ChatClient::muteChannel`, `ChannelClient:mute` methods
+- Added the `timeout` parameter to `ChatClient::muteUser`, `ChannelClient:mute::muteUser` methods
 
 ### ⚠️ Changed
 

--- a/docusaurus/docs/Android/02-client/02-channels.md
+++ b/docusaurus/docs/Android/02-client/02-channels.md
@@ -567,9 +567,23 @@ By default, mutes stay in place indefinitely until the user removes it; however,
 client.muteChannel(channelType, channelId)
     .enqueue { result: Result<Unit> ->
         if (result.isSuccess) {
-            //channel is muted
+            // Channel muted
         } else {
-            result.error().printStackTrace()
+            // Handle result.error()
+        }
+    }
+```
+
+### Muting a Channel with Expiration Time
+
+```kotlin
+// Mute a channel for 60 minutes
+client.muteChannel(channelType, channelId, expiration = 60 * 60 * 1000)
+    .enqueue { result: Result<Unit> ->
+        if (result.isSuccess) {
+            // Channel muted
+        } else {
+            // Handle result.error() 
         }
     }
 ```

--- a/docusaurus/docs/Android/02-client/05-moderation-tools.md
+++ b/docusaurus/docs/Android/02-client/05-moderation-tools.md
@@ -43,6 +43,17 @@ client.muteUser("user-id").enqueue { result ->
         // Handle result.error() 
     } 
 } 
+
+// Mute user for 60 minutes
+client.muteUser("user-id", timeout = 60)
+    .enqueue { result: Result<Unit> ->
+        if (result.isSuccess) {
+            // User was muted
+            val mute: Mute = result.data() 
+        } else {
+            // Handle result.error() 
+        }
+    }
  
 client.unmuteUser("user-id").enqueue { result -> 
     if (result.isSuccess) { 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -65,8 +65,12 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun markMessageRead (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun markRead (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun muteChannel$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun muteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public final fun muteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun muteUser (Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun muteUser$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun partialUpdateMessage (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun partialUpdateMessage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/util/Map;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun partialUpdateUser (Ljava/lang/String;Ljava/util/Map;Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
@@ -613,8 +617,12 @@ public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public final fun markMessageRead (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun markRead ()Lio/getstream/chat/android/client/call/Call;
 	public final fun mute ()Lio/getstream/chat/android/client/call/Call;
+	public final fun mute (Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun mute$default (Lio/getstream/chat/android/client/channel/ChannelClient;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun muteCurrentUser ()Lio/getstream/chat/android/client/call/Call;
 	public final fun muteUser (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun muteUser (Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun muteUser$default (Lio/getstream/chat/android/client/channel/ChannelClient;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun pinMessage (Lio/getstream/chat/android/client/models/Message;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun pinMessage (Lio/getstream/chat/android/client/models/Message;Ljava/util/Date;)Lio/getstream/chat/android/client/call/Call;
 	public final fun query (Lio/getstream/chat/android/client/api/models/QueryChannelRequest;)Lio/getstream/chat/android/client/call/Call;
@@ -2058,17 +2066,22 @@ public final class io/getstream/chat/android/client/models/Channel : io/getstrea
 }
 
 public final class io/getstream/chat/android/client/models/ChannelMute {
-	public fun <init> (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component2 ()Lio/getstream/chat/android/client/models/Channel;
 	public final fun component3 ()Ljava/util/Date;
-	public final fun copy (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;)Lio/getstream/chat/android/client/models/ChannelMute;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/models/ChannelMute;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/ChannelMute;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;)Lio/getstream/chat/android/client/models/ChannelMute;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/models/ChannelMute;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Channel;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/ChannelMute;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Lio/getstream/chat/android/client/models/Channel;
 	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getExpires ()Ljava/util/Date;
+	public final fun getUpdatedAt ()Ljava/util/Date;
 	public final fun getUser ()Lio/getstream/chat/android/client/models/User;
 	public fun hashCode ()I
+	public final fun setUpdatedAt (Ljava/util/Date;)V
 	public fun toString ()Ljava/lang/String;
 }
 
@@ -2492,15 +2505,17 @@ public final class io/getstream/chat/android/client/models/Message$Companion {
 }
 
 public final class io/getstream/chat/android/client/models/Mute {
-	public fun <init> (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component2 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component3 ()Ljava/util/Date;
 	public final fun component4 ()Ljava/util/Date;
-	public final fun copy (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;)Lio/getstream/chat/android/client/models/Mute;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/models/Mute;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/Mute;
+	public final fun component5 ()Ljava/util/Date;
+	public final fun copy (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;)Lio/getstream/chat/android/client/models/Mute;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/models/Mute;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/Mute;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCreatedAt ()Ljava/util/Date;
+	public final fun getExpires ()Ljava/util/Date;
 	public final fun getTarget ()Lio/getstream/chat/android/client/models/User;
 	public final fun getUpdatedAt ()Ljava/util/Date;
 	public final fun getUser ()Lio/getstream/chat/android/client/models/User;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -35,6 +35,8 @@ import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.DisconnectedEvent
+import io.getstream.chat.android.client.events.NotificationChannelMutesUpdatedEvent
+import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_FILE
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_IMAGE
 import io.getstream.chat.android.client.helpers.QueryChannelsPostponeHelper
@@ -1169,21 +1171,88 @@ public class ChatClient internal constructor(
         members
     )
 
+    /**
+     * Mutes a channel for the current user. Messages added to the channel will not trigger
+     * push notifications, and will not change the unread count for the users that muted it.
+     * By default, mutes stay in place indefinitely until the user removes it. However, you
+     * can optionally set an expiration time. Triggers `notification.channel_mutes_updated`
+     * event.
+     *
+     * @param channelType the channel type. ie messaging
+     * @param channelId the channel id. ie 123
+     * @param expiration the duration of mute in **millis**
+     *
+     * @return executable async [Call] responsible for muting a channel
+     *
+     * @see [NotificationChannelMutesUpdatedEvent]
+     */
+    @JvmOverloads
     @CheckResult
-    public fun muteUser(userId: String): Call<Mute> = api.muteUser(userId)
-
-    @CheckResult
-    public fun muteChannel(channelType: String, channelId: String): Call<Unit> {
-        return api.muteChannel(channelType, channelId)
+    public fun muteChannel(
+        channelType: String,
+        channelId: String,
+        expiration: Int? = null,
+    ): Call<Unit> {
+        return api.muteChannel(
+            channelType = channelType,
+            channelId = channelId,
+            expiration = expiration
+        )
     }
 
+    /**
+     * Unmutes a channel for the current user. Triggers `notification.channel_mutes_updated`
+     * event.
+     *
+     * @param channelType the channel type. ie messaging
+     * @param channelId the channel id. ie 123
+     *
+     * @return executable async [Call] responsible for unmuting a channel
+     *
+     * @see [NotificationChannelMutesUpdatedEvent]
+     */
     @CheckResult
-    public fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+    public fun unmuteChannel(
+        channelType: String,
+        channelId: String,
+    ): Call<Unit> {
         return api.unmuteChannel(channelType, channelId)
     }
 
+    /**
+     * Mutes a user. Messages from muted users will not trigger push notifications. By default,
+     * mutes stay in place indefinitely until the user removes it. However, you can optionally
+     * set a mute timeout. Triggers `notification.mutes_updated` event.
+     *
+     * @param userId the user id to mute
+     * @param timeout the timeout in **minutes** until the mute is expired
+     *
+     * @return executable async [Call] responsible for muting a user
+     *
+     * @see [NotificationMutesUpdatedEvent]
+     */
+    @JvmOverloads
     @CheckResult
-    public fun unmuteUser(userId: String): Call<Unit> = api.unmuteUser(userId)
+    public fun muteUser(
+        userId: String,
+        timeout: Int? = null,
+    ): Call<Mute> {
+        return api.muteUser(userId, timeout)
+    }
+
+    /**
+     * Unmutes a previously muted user. Triggers `notification.mutes_updated` event.
+     *
+     * @param userId the user id to unmute
+     *
+     * @return executable async [Call] responsible for unmuting a user
+     *
+     * @see [NotificationMutesUpdatedEvent]
+     */
+    @CheckResult
+    public fun unmuteUser(userId: String): Call<Unit> {
+        return api.unmuteUser(userId)
+    }
 
     @CheckResult
     public fun unmuteCurrentUser(): Call<Unit> = api.unmuteCurrentUser()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -109,10 +109,17 @@ internal interface ChatApi {
     ): Call<Message>
 
     @CheckResult
-    fun muteChannel(channelType: String, channelId: String): Call<Unit>
+    fun muteChannel(
+        channelType: String,
+        channelId: String,
+        expiration: Int?,
+    ): Call<Unit>
 
     @CheckResult
-    fun unmuteChannel(channelType: String, channelId: String): Call<Unit>
+    fun unmuteChannel(
+        channelType: String,
+        channelId: String,
+    ): Call<Unit>
 
     @CheckResult
     fun updateMessage(
@@ -259,6 +266,7 @@ internal interface ChatApi {
     @CheckResult
     fun muteUser(
         userId: String,
+        timeout: Int?,
     ): Call<Mute>
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/GsonChatApi.kt
@@ -290,17 +290,30 @@ internal class GsonChatApi(
         ).map { it.message }
     }
 
-    override fun muteChannel(channelType: String, channelId: String): Call<Unit> {
+    override fun muteChannel(
+        channelType: String,
+        channelId: String,
+        expiration: Int?,
+    ): Call<Unit> {
         return retrofitApi.muteChannel(
             connectionId = connectionId,
-            body = MuteChannelRequest("$channelType:$channelId")
+            body = MuteChannelRequest(
+                channel_cid = "$channelType:$channelId",
+                expiration = expiration,
+            )
         ).toUnitCall()
     }
 
-    override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+    override fun unmuteChannel(
+        channelType: String,
+        channelId: String,
+    ): Call<Unit> {
         return retrofitApi.unmuteChannel(
             connectionId = connectionId,
-            body = MuteChannelRequest("$channelType:$channelId")
+            body = MuteChannelRequest(
+                "$channelType:$channelId",
+                expiration = null,
+            )
         ).toUnitCall()
     }
 
@@ -317,7 +330,7 @@ internal class GsonChatApi(
     override fun partialUpdateMessage(
         messageId: String,
         set: Map<String, Any>,
-        unset: List<String>
+        unset: List<String>,
     ): Call<Message> {
         return retrofitApi.partialUpdateMessage(
             messageId = messageId,
@@ -512,7 +525,10 @@ internal class GsonChatApi(
     }
 
     override fun muteCurrentUser(): Call<Mute> {
-        return muteUser(userId)
+        return muteUser(
+            userId = userId,
+            timeout = null,
+        )
     }
 
     override fun unmuteCurrentUser(): Call<Unit> {
@@ -613,10 +629,15 @@ internal class GsonChatApi(
 
     override fun muteUser(
         userId: String,
+        timeout: Int?,
     ): Call<Mute> {
         return retrofitApi.muteUser(
             connectionId = connectionId,
-            body = MuteUserRequest(userId, this.userId)
+            body = MuteUserRequest(
+                targetId = userId,
+                userId = this.userId,
+                timeout = timeout
+            )
         ).map { it.mute }
     }
 
@@ -625,7 +646,11 @@ internal class GsonChatApi(
     ): Call<Unit> {
         return retrofitApi.unmuteUser(
             connectionId = connectionId,
-            body = MuteUserRequest(userId, this.userId)
+            body = MuteUserRequest(
+                targetId = userId,
+                userId = this.userId,
+                timeout = null
+            )
         ).toUnitCall()
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/MuteChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/MuteChannelRequest.kt
@@ -1,3 +1,6 @@
 package io.getstream.chat.android.client.api.models
 
-internal data class MuteChannelRequest(val channel_cid: String)
+internal data class MuteChannelRequest(
+    val channel_cid: String,
+    val expiration: Int?,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/MuteUserRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/MuteUserRequest.kt
@@ -6,5 +6,6 @@ internal data class MuteUserRequest(
     @SerializedName("target_id")
     val targetId: String,
     @SerializedName("user_id")
-    val userId: String
+    val userId: String,
+    val timeout: Int?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -205,38 +205,65 @@ internal class MoshiChatApi(
     }
 
     override fun muteCurrentUser(): Call<Mute> {
-        return muteUser(userId)
+        return muteUser(
+            userId = userId,
+            timeout = null,
+        )
     }
 
     override fun unmuteCurrentUser(): Call<Unit> {
         return unmuteUser(userId)
     }
 
-    override fun muteUser(userId: String): Call<Mute> {
+    override fun muteUser(
+        userId: String,
+        timeout: Int?,
+    ): Call<Mute> {
         return moderationApi.muteUser(
             connectionId = connectionId,
-            body = MuteUserRequest(userId, this.userId),
+            body = MuteUserRequest(
+                target_id = userId,
+                user_id = this.userId,
+                timeout = timeout,
+            ),
         ).map { response -> response.mute.toDomain() }
     }
 
     override fun unmuteUser(userId: String): Call<Unit> {
         return moderationApi.unmuteUser(
             connectionId = this.connectionId,
-            body = MuteUserRequest(userId, this.userId),
+            body = MuteUserRequest(
+                target_id = userId,
+                user_id = this.userId,
+                timeout = null
+            ),
         ).toUnitCall()
     }
 
-    override fun muteChannel(channelType: String, channelId: String): Call<Unit> {
+    override fun muteChannel(
+        channelType: String,
+        channelId: String,
+        expiration: Int?,
+    ): Call<Unit> {
         return moderationApi.muteChannel(
             connectionId = connectionId,
-            body = MuteChannelRequest("$channelType:$channelId"),
+            body = MuteChannelRequest(
+                channel_cid = "$channelType:$channelId",
+                expiration = expiration
+            ),
         ).toUnitCall()
     }
 
-    override fun unmuteChannel(channelType: String, channelId: String): Call<Unit> {
+    override fun unmuteChannel(
+        channelType: String,
+        channelId: String,
+    ): Call<Unit> {
         return moderationApi.unmuteChannel(
             connectionId = connectionId,
-            body = MuteChannelRequest("$channelType:$channelId"),
+            body = MuteChannelRequest(
+                channel_cid = "$channelType:$channelId",
+                expiration = null
+            ),
         ).toUnitCall()
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/ChannelMuteMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/ChannelMuteMapping.kt
@@ -8,4 +8,6 @@ internal fun DownstreamChannelMuteDto.toDomain(): ChannelMute =
         user = user.toDomain(),
         channel = channel.toDomain(),
         createdAt = created_at,
+        updatedAt = updated_at,
+        expires = expires,
     )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/MuteMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/MuteMapping.kt
@@ -10,6 +10,7 @@ internal fun Mute.toDto(): UpstreamMuteDto =
         target = target.toDto(),
         created_at = createdAt,
         updated_at = updatedAt,
+        expires = expires,
     )
 
 internal fun DownstreamMuteDto.toDomain(): Mute =
@@ -18,4 +19,5 @@ internal fun DownstreamMuteDto.toDomain(): Mute =
         target = target.toDomain(),
         createdAt = created_at,
         updatedAt = updated_at,
+        expires = expires,
     )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamChannelMuteDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/DownstreamChannelMuteDto.kt
@@ -8,4 +8,6 @@ internal data class DownstreamChannelMuteDto(
     val user: DownstreamUserDto,
     val channel: DownstreamChannelDto,
     val created_at: Date,
+    val updated_at: Date,
+    val expires: Date?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MuteDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MuteDtos.kt
@@ -9,6 +9,7 @@ internal data class UpstreamMuteDto(
     val target: UpstreamUserDto,
     val created_at: Date,
     val updated_at: Date,
+    val expires: Date?,
 )
 
 @JsonClass(generateAdapter = true)
@@ -17,4 +18,5 @@ internal data class DownstreamMuteDto(
     val target: DownstreamUserDto,
     val created_at: Date,
     val updated_at: Date,
+    val expires: Date?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MuteChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MuteChannelRequest.kt
@@ -5,4 +5,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 internal data class MuteChannelRequest(
     val channel_cid: String,
+    val expiration: Int?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MuteUserRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MuteUserRequest.kt
@@ -6,4 +6,5 @@ import com.squareup.moshi.JsonClass
 internal data class MuteUserRequest(
     val target_id: String,
     val user_id: String,
+    val timeout: Int?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -529,29 +529,73 @@ public class ChannelClient internal constructor(
         return client.rejectInvite(channelType, channelId)
     }
 
+    /**
+     * Mutes a channel for the current user. Messages added to the channel will not trigger
+     * push notifications, and will not change the unread count for the users that muted it.
+     * By default, mutes stay in place indefinitely until the user removes it. However, you
+     * can optionally set an expiration time. Triggers `notification.channel_mutes_updated`
+     * event.
+     *
+     * @param expiration the duration of mute in **millis**
+     *
+     * @return executable async [Call] responsible for muting a channel
+     *
+     * @see [NotificationChannelMutesUpdatedEvent]
+     */
+    @JvmOverloads
     @CheckResult
-    public fun muteCurrentUser(): Call<Mute> {
-        return client.muteCurrentUser()
+    public fun mute(expiration: Int? = null): Call<Unit> {
+        return client.muteChannel(channelType, channelId, expiration)
     }
 
-    @CheckResult
-    public fun mute(): Call<Unit> {
-        return client.muteChannel(channelType, channelId)
-    }
-
+    /**
+     * Unmutes a channel for the current user. Triggers `notification.channel_mutes_updated`
+     * event.
+     *
+     * @return executable async [Call] responsible for unmuting a channel
+     *
+     * @see [NotificationChannelMutesUpdatedEvent]
+     */
     @CheckResult
     public fun unmute(): Call<Unit> {
         return client.unmuteChannel(channelType, channelId)
     }
 
+    /**
+     * Mutes a user. Messages from muted users will not trigger push notifications. By default,
+     * mutes stay in place indefinitely until the user removes it. However, you can optionally
+     * set a mute timeout. Triggers `notification.mutes_updated` event.
+     *
+     * @param userId the user id to mute
+     * @param timeout the timeout in **minutes** until the mute is expired
+     *
+     * @return executable async [Call] responsible for muting a user
+     *
+     * @see [NotificationMutesUpdatedEvent]
+     */
+    @JvmOverloads
     @CheckResult
-    public fun muteUser(userId: String): Call<Mute> {
-        return client.muteUser(userId)
+    public fun muteUser(userId: String, timeout: Int? = null): Call<Mute> {
+        return client.muteUser(userId, timeout)
     }
 
+    /**
+     * Unmutes a previously muted user. Triggers `notification.mutes_updated` event.
+     *
+     * @param userId the user id to unmute
+     *
+     * @return executable async [Call] responsible for unmuting a user
+     *
+     * @see [NotificationMutesUpdatedEvent]
+     */
     @CheckResult
     public fun unmuteUser(userId: String): Call<Unit> {
         return client.unmuteUser(userId)
+    }
+
+    @CheckResult
+    public fun muteCurrentUser(): Call<Mute> {
+        return client.muteCurrentUser()
     }
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/ChannelMute.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/ChannelMute.kt
@@ -7,5 +7,8 @@ public data class ChannelMute(
     val user: User,
     val channel: Channel,
     @SerializedName("created_at")
-    val createdAt: Date
+    val createdAt: Date,
+    @SerializedName("updated_at")
+    var updatedAt: Date,
+    val expires: Date?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Mute.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Mute.kt
@@ -9,5 +9,6 @@ public data class Mute(
     @SerializedName("created_at")
     var createdAt: Date,
     @SerializedName("updated_at")
-    var updatedAt: Date
+    var updatedAt: Date,
+    val expires: Date?,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -482,7 +482,7 @@ internal class ChannelsApiCallsTests {
         whenever(
             mock.retrofitApi.muteChannel(
                 mock.connectionId,
-                MuteChannelRequest("${mock.channelType}:${mock.channelId}")
+                MuteChannelRequest("${mock.channelType}:${mock.channelId}", null)
             )
         ) doReturn RetroSuccess(CompletableResponse()).toRetrofitCall()
 
@@ -496,7 +496,7 @@ internal class ChannelsApiCallsTests {
         whenever(
             mock.retrofitApi.unmuteChannel(
                 mock.connectionId,
-                MuteChannelRequest("${mock.channelType}:${mock.channelId}")
+                MuteChannelRequest("${mock.channelType}:${mock.channelId}", null)
             )
         ) doReturn RetroSuccess(CompletableResponse()).toRetrofitCall()
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -232,13 +232,14 @@ internal class UsersApiCallsTests {
             mock.user,
             targetUser,
             Date(1),
-            Date(2)
+            Date(2),
+            null,
         )
 
         Mockito.`when`(
             mock.retrofitApi.muteUser(
                 mock.connectionId,
-                MuteUserRequest(targetUser.id, mock.userId)
+                MuteUserRequest(targetUser.id, mock.userId, null)
             )
         ).thenReturn(RetroSuccess(MuteUserResponse(mute, mock.user)).toRetrofitCall())
 
@@ -254,7 +255,7 @@ internal class UsersApiCallsTests {
         Mockito.`when`(
             mock.retrofitApi.unmuteUser(
                 mock.connectionId,
-                MuteUserRequest(targetUser.id, mock.userId)
+                MuteUserRequest(targetUser.id, mock.userId, null)
             )
         ).thenReturn(RetroSuccess(CompletableResponse()).toRetrofitCall())
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -176,7 +176,7 @@ internal object EventArguments {
         userId = "bender",
         createdAt = date
     )
-    private val channelMute = ChannelMute(user, channel, date)
+    private val channelMute = ChannelMute(user, channel, date, date, null)
     private val channelDeletedEvent = ChannelDeletedEvent(EventType.CHANNEL_DELETED, date, cid, channelType, channelId, channel, user)
     private val channelHiddenEvent = ChannelHiddenEvent(EventType.CHANNEL_HIDDEN, date, cid, channelType, channelId, user, clearHistory = true)
     private val channelTruncatedEvent = ChannelTruncatedEvent(EventType.CHANNEL_TRUNCATED, date, cid, channelType, channelId, user, channel)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
@@ -100,7 +100,8 @@ internal object UserDtoTestData {
                     user = downstreamUserWithoutExtraData,
                     target = downstreamUserWithoutExtraData,
                     created_at = Date(1591787071000),
-                    updated_at = Date(1591787071588)
+                    updated_at = Date(1591787071588),
+                    null,
                 ),
             ),
             teams = listOf("team1", "team2"),

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Channels.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Channels.kt
@@ -564,6 +564,15 @@ class Channels(val client: ChatClient, val channelClient: ChannelClient) {
                 }
             }
 
+            // Mute a channel for 60 minutes
+            channelClient.mute(expiration = 60 * 60 * 1000).enqueue { result ->
+                if (result.isSuccess) {
+                    // Channel is muted
+                } else {
+                    // Handle result.error()
+                }
+            }
+
             // Get list of muted channels when user is connected
             client.connectUser(User("user-id"), "token")
                 .enqueue { result ->

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Moderation.kt
@@ -81,6 +81,17 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
             }
         }
 
+        fun muteUserWithTimeout() {
+            // Mute user for 60 minutes
+            client.muteUser("user-id", timeout = 60).enqueue { result ->
+                if (result.isSuccess) {
+                    // User was muted
+                } else {
+                    // Handle result.error()
+                }
+            }
+        }
+
         fun unmuteUser() {
             client.unmuteUser("user-id").enqueue { result ->
                 if (result.isSuccess) {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
@@ -57,7 +57,7 @@ internal class TestDataHelper {
     val user1 = User("broad-lake-3")
     val user3 = User("user-3")
     val userEvil = User("user-evil")
-    val mute1 = Mute(user1, userEvil, Date(), Date())
+    val mute1 = Mute(user1, userEvil, Date(), Date(), null)
     val me1 = User("broad-lake-3").apply { mutes = listOf(mute1) }
 
     val user1Token = checkNotNull(dotenv["STREAM_USER_1_TOKEN"]) { "Be sure to specify the STREAM_USER_1_TOKEN environment variable" }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1224

### 🎯 Goal

Add an option to mute channel with timeout:
https://getstream.io/chat/docs/react/moderation/?language=javascript#mutes

### 🛠 Implementation details

- Added the `expiration` parameter to `ChatClient::muteChannel`, `ChannelClient:mute` methods
- Added the `timeout` parameter to `ChatClient::muteUser`, `ChannelClient:mute::muteUser` methods

Notes:

- `expiration` is in milliseconds, `timeout` is in minutes
- leaving suspicious `muteCurrentUser` method as is

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![giphy (3)](https://user-images.githubusercontent.com/9600921/129806912-2c549e86-1a80-4a89-9180-4e31df2674a7.gif)

