### PR TITLE
[CAS-1210] Add doc note about autolink property in case of markdown text

### DIFF
--- a/docusaurus/docs/Android/03-ui/03-chatui.md
+++ b/docusaurus/docs/Android/03-ui/03-chatui.md
@@ -161,6 +161,10 @@ Then the SDK will parse Markdown automatically:
 
 ![Markdown messages](../assets/markdown_support.png)
 
+:::note
+If you are using default `ChatMarkdown` implementation provided by Stream, do not set `android:autoLink` attribute on the message text view. It prevents markdown links from being formatted and clickable.
+:::
+
 ### Navigator
 
 The SDK performs navigation in certain cases:

--- a/docusaurus/docs/Android/03-ui/03-chatui.md
+++ b/docusaurus/docs/Android/03-ui/03-chatui.md
@@ -161,10 +161,6 @@ Then the SDK will parse Markdown automatically:
 
 ![Markdown messages](../assets/markdown_support.png)
 
-:::note
-If you are using default `ChatMarkdown` implementation provided by Stream, do not set `android:autoLink` attribute on the message text view. It prevents markdown links from being formatted and clickable.
-:::
-
 ### Navigator
 
 The SDK performs navigation in certain cases:

--- a/docusaurus/docs/Android/03-ui/04-components/03-message-list.md
+++ b/docusaurus/docs/Android/03-ui/04-components/03-message-list.md
@@ -408,6 +408,8 @@ class CustomMessageViewHolderFactory : MessageListItemViewHolderFactory() {
 messageListView.setMessageViewHolderFactory(CustomMessageViewHolderFactory())
 ```
 
+Additionally, you can also use `ChatUI.markdown` for Markdown support. If you do that, don't use `android:autoLink` attribute because it'll break the markdown [Linkify](https://noties.io/Markwon/docs/v4/linkify/) implementation.
+
 ## Custom Empty State
 
 `MessageListView` handles loading and empty states out-of-box. If you want to customize these, you can do it at runtime.


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1210

### 🎯 Goal
If the user sets `autolink` property on textview, android internal implementation of Linkify removes markdown link URLSpan. So it should be specified in the docs to not use the autolink property. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added