### PR TITLE
Ensure channel loading view has no parent

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
 import android.view.View
+import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.annotation.DrawableRes
 import androidx.core.view.isVisible
@@ -116,6 +117,11 @@ public class ChannelListView : FrameLayout {
      */
     @JvmOverloads
     public fun setLoadingView(view: View, layoutParams: LayoutParams = defaultChildLayoutParams) {
+        // Make sure the loading view has no parent.
+        view.parent?.let { parent ->
+            (parent as ViewGroup).removeView(view)
+        }
+
         removeView(this.loadingView)
         this.loadingView = view
         addView(loadingView, layoutParams)


### PR DESCRIPTION
### 🎯 Goal

It is done to ensure that the loading view set by the user has no parent to avoid crashes at runtime. 

### 🛠 Implementation details

Simply, remove the view from the parent if it has any parent. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
