### PR TITLE
[CAS-1247] Fix attachment url validator logic 

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1778,6 +1778,7 @@ public final class io/getstream/chat/android/client/helpers/AttachmentHelper {
 	public fun <init> ()V
 	public fun <init> (Lio/getstream/chat/android/client/utils/SystemTimeProvider;)V
 	public synthetic fun <init> (Lio/getstream/chat/android/client/utils/SystemTimeProvider;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun hasStreamImageUrl (Lio/getstream/chat/android/client/models/Attachment;)Z
 	public final fun hasValidImageUrl (Lio/getstream/chat/android/client/models/Attachment;)Z
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/helpers/AttachmentHelper.kt
@@ -15,7 +15,12 @@ public class AttachmentHelper(private val systemTimeProvider: SystemTimeProvider
         return timestamp > systemTimeProvider.provideCurrentTimeInSeconds()
     }
 
+    public fun hasStreamImageUrl(attachment: Attachment): Boolean {
+        return attachment.imageUrl?.toHttpUrlOrNull()?.host?.contains(STREAM_CDN_HOST_PART, ignoreCase = true) ?: false
+    }
+
     private companion object {
         private const val QUERY_KEY_NAME_EXPIRES = "Expires"
+        private const val STREAM_CDN_HOST_PART = "stream-chat"
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUrlValidator.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUrlValidator.kt
@@ -43,14 +43,32 @@ internal class AttachmentUrlValidator(private val attachmentHelper: AttachmentHe
             oldAttachment == null -> newAttachment
             oldAttachment.imageUrl.isNullOrEmpty() -> newAttachment
             oldAttachment.imageUrl == newAttachment.imageUrl -> newAttachment
+            attachmentHelper.hasStreamImageUrl(oldAttachment).not() -> newAttachment
             attachmentHelper.hasValidImageUrl(oldAttachment).not() -> newAttachment
             else -> newAttachment.copy(imageUrl = oldAttachment.imageUrl)
         }
     }
 
     private fun Attachment.partialEquality(other: Attachment): Boolean {
-        return authorName == other.authorName && titleLink == other.titleLink && mimeType == other.mimeType &&
-            fileSize == other.fileSize && title == other.title && text == other.text && type == other.type &&
-            name == other.name && fallback == other.fallback
+        return authorName == other.authorName &&
+            titleLink == other.titleLink &&
+            mimeType == other.mimeType &&
+            fileSize == other.fileSize &&
+            title == other.title &&
+            text == other.text &&
+            type == other.type &&
+            name == other.name &&
+            fallback == other.fallback &&
+            isDefault().not()
+    }
+
+    private fun Attachment.isDefault(): Boolean {
+        return authorName.isNullOrBlank() &&
+            titleLink.isNullOrBlank() &&
+            fileSize == 0 &&
+            title.isNullOrBlank() &&
+            text.isNullOrBlank() &&
+            name.isNullOrBlank() &&
+            fallback.isNullOrBlank()
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/AttachmentUrlValidatorTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/AttachmentUrlValidatorTests.kt
@@ -4,9 +4,11 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import io.getstream.chat.android.client.helpers.AttachmentHelper
+import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.offline.message.attachment.AttachmentUrlValidator
 import io.getstream.chat.android.offline.randomAttachment
 import io.getstream.chat.android.offline.randomMessage
+import junit.framework.Assert.assertTrue
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -107,5 +109,22 @@ internal class AttachmentUrlValidatorTests {
             message.cid == message.cid && message.updatedAt!!.time == 2000L &&
                 message.attachments.first().imageUrl == "oldValidUrl"
         } shouldBeEqualTo true
+    }
+
+    @Test
+    fun `Given attachments with only imageUrls Should not update different attachments`() {
+        sut = AttachmentUrlValidator(AttachmentHelper())
+        val url1 = "https://community.dev.whoop.com/chat/stream/573570/team:community-770-general/2021-08-23T15:06:06.415904Z.png"
+        val url2 = "https://community.dev.whoop.com/chat/stream/573570/team:community-770-general/2021-08-23T15:06:27.941762Z.png"
+        val attachment1 = Attachment(imageUrl = url1)
+        val attachment2 = Attachment(imageUrl = url2)
+        val message = randomMessage(attachments = mutableListOf(attachment1, attachment2))
+
+        val result = sut.updateValidAttachmentsUrl(listOf(message.copy(updatedAt = Date())), mapOf(message.id to message))
+
+        result.first().attachments.let { attachments ->
+            assertTrue(attachments.any { it.imageUrl == url1 })
+            assertTrue(attachments.any { it.imageUrl == url2 })
+        }
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/AttachmentUrlValidatorTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/AttachmentUrlValidatorTests.kt
@@ -1,5 +1,7 @@
 package io.getstream.chat.android.offline.channel
 
+import com.google.common.truth.Truth
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -21,7 +23,9 @@ internal class AttachmentUrlValidatorTests {
 
     @BeforeEach
     fun setup() {
-        attachmentHelper = mock()
+        attachmentHelper = mock {
+            on { it.hasStreamImageUrl(any()) } doReturn true
+        }
         sut = AttachmentUrlValidator(attachmentHelper)
     }
 
@@ -36,7 +40,7 @@ internal class AttachmentUrlValidatorTests {
     }
 
     @Test
-    fun `If old messages contains the same id and old url is null to new url Should return list with new message`() {
+    fun `Given old messages contains the same id and old url is null Should return list with new message`() {
         val oldAttachment = randomAttachment { imageUrl = null }
         val newAttachment = oldAttachment.copy(imageUrl = "imageUrl")
         val oldMessage = randomMessage(attachments = mutableListOf(oldAttachment), updatedAt = Date(1000L))
@@ -55,7 +59,7 @@ internal class AttachmentUrlValidatorTests {
     }
 
     @Test
-    fun `If old messages contains the same id and old url is equal to new url Should return list with new message`() {
+    fun `Given old messages contains the same id and old url is equal to new url Should return list with new message`() {
         val oldAttachment = randomAttachment { imageUrl = "imageUrl" }
         val newAttachment = oldAttachment.copy(name = "otherName")
         val oldMessage = randomMessage(attachments = mutableListOf(oldAttachment), updatedAt = Date(1000L))
@@ -112,12 +116,12 @@ internal class AttachmentUrlValidatorTests {
     }
 
     @Test
-    fun `Given attachments with only imageUrls Should not update different attachments`() {
-        sut = AttachmentUrlValidator(AttachmentHelper())
-        val url1 = "https://community.dev.whoop.com/chat/stream/573570/team:community-770-general/2021-08-23T15:06:06.415904Z.png"
-        val url2 = "https://community.dev.whoop.com/chat/stream/573570/team:community-770-general/2021-08-23T15:06:27.941762Z.png"
+    fun `Given attachments with only imageUrls and they are valid Should not update different attachments`() {
+        val url1 = "url1"
+        val url2 = "url2"
         val attachment1 = Attachment(imageUrl = url1)
         val attachment2 = Attachment(imageUrl = url2)
+        whenever(attachmentHelper.hasValidImageUrl(any())) doReturn true
         val message = randomMessage(attachments = mutableListOf(attachment1, attachment2))
 
         val result = sut.updateValidAttachmentsUrl(listOf(message.copy(updatedAt = Date())), mapOf(message.id to message))
@@ -126,5 +130,19 @@ internal class AttachmentUrlValidatorTests {
             assertTrue(attachments.any { it.imageUrl == url1 })
             assertTrue(attachments.any { it.imageUrl == url2 })
         }
+    }
+
+    @Test
+    fun `Given attachments with not stream imageUrls and valid old urls Should Not return attachment with old url`() {
+        val oldAttachment = randomAttachment { imageUrl = "oldUrl" }
+        val newAttachment = oldAttachment.copy(imageUrl = "newUrl")
+        val oldMessage = randomMessage(attachments = mutableListOf(oldAttachment))
+        val newMessage = oldMessage.copy(attachments = mutableListOf(newAttachment))
+        whenever(attachmentHelper.hasStreamImageUrl(oldAttachment)) doReturn false
+        whenever(attachmentHelper.hasValidImageUrl(any())) doReturn true
+
+        val result = sut.updateValidAttachmentsUrl(listOf(newMessage), mapOf(oldMessage.id to oldMessage))
+
+        Truth.assertThat(result.first().attachments.first()).isEqualTo(newAttachment)
     }
 }


### PR DESCRIPTION
One of our customers complained that he got messages where all attachments had the same image URL. They used custom attachment uploading to their own CDN. This spotted one problem in our `AttachmentUrlValidator`

### 🎯 Goal
Our `AttachmentUrlValidator` was implemented according to the requirements of stream CDN usage. And customers who had a custom one got this bug.

### 🛠 Implementation details
1. Do not run this logic for non-stream URLs 
2. Fix `partialEquality`. It shouldn't found attachments with all default fields (nulls or blank) as equal


### 🧪 Testing

Run tests and see. You can comment new lines in `AttachmentUrlValidator` and run unit tests for this class

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media4.giphy.com/media/x47mB95aUV3RGwB6x8/giphy.gif)
