### PR TITLE
Move internal annotation to ViewModel constructor

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -363,6 +363,17 @@ public final class com/getstream/sdk/chat/view/messages/MessageListItemWrapper {
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel : androidx/lifecycle/ViewModel {
+	public final fun getActiveThread ()Landroidx/lifecycle/LiveData;
+	public final fun getAnyOtherUsersOnline ()Landroidx/lifecycle/LiveData;
+	public final fun getChannelState ()Landroidx/lifecycle/LiveData;
+	public final fun getMembers ()Landroidx/lifecycle/LiveData;
+	public final fun getOnline ()Landroidx/lifecycle/LiveData;
+	public final fun getTypingUsers ()Landroidx/lifecycle/LiveData;
+	public final fun resetThread ()V
+	public final fun setActiveThread (Lio/getstream/chat/android/client/models/Message;)V
+}
+
 public final class com/getstream/sdk/chat/viewmodel/MessageInputViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lio/getstream/chat/android/livedata/ChatDomain;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
@@ -12,8 +12,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomain
 
-@InternalStreamChatApi
-public abstract class BaseMessageListHeaderViewModel constructor(
+public abstract class BaseMessageListHeaderViewModel @InternalStreamChatApi constructor(
     cid: String,
     private val chatDomain: ChatDomain,
 ) : ViewModel() {


### PR DESCRIPTION
### 🎯 Goal

Remove warnings when clients use the `setActiveThread` and `resetThread` methods of this ViewModel via its subclasses.

### 🛠 Implementation details

Moving the warning to the constructor will still show the warning if someone attempts to create their own subclass of the base ViewModel.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
