### PR TITLE
[CAS-1262] Deprecate ChatDomain::removeMembers

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,7 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `ChatDomain#removeMembers` <br/>*offline* | 2021.09.14<br/>4.18.0 | 2021.10.14⌛ | 2021.11.14 ⌛ | Use class member instead |
+| `ChatDomain#removeMembers` <br/>*offline* | 2021.09.14<br/>4.18.0 | 2021.10.14⌛ | 2021.11.14 ⌛ | Use ChatClient::removeMembers directly |
 | `User#name` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |
 | `User#image` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |
 | `Channel#name` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `ChatDomain#removeMembers` <br/>*offline* | 2021.09.14<br/>4.18.0 | 2021.10.14⌛ | 2021.11.14 ⌛ | Use class member instead |
 | `User#name` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |
 | `User#image` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |
 | `Channel#name` extension<br/>*client* | 2021.09.14<br/>4.18.0 | 2021.09.14<br/>4.18.0 | 2021.10.14 ⌛ | Use class member instead |

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1835,6 +1835,7 @@ public final class io/getstream/chat/android/client/extensions/SharedPreferences
 }
 
 public final class io/getstream/chat/android/client/extensions/StringExtensionsKt {
+	public static final fun cidToTypeAndId (Ljava/lang/String;)Lkotlin/Pair;
 }
 
 public final class io/getstream/chat/android/client/logger/ChatLogLevel : java/lang/Enum {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
@@ -34,7 +34,7 @@ internal fun String.isAnonymousChannelId(): Boolean = contains("!members")
  */
 @Throws(IllegalStateException::class)
 public fun String.cidToTypeAndId(): Pair<String, String> {
-    require(isNotEmpty()) { "cid can not be empty" }
-    require(':' in this) { "cid needs to be in the format channelType:channelId. For example, messaging:123" }
-    return requireNotNull(split(":").takeIf { it.size >= 2 }?.let { it.first() to it.last() })
+    check(isNotEmpty()) { "cid can not be empty" }
+    check(':' in this) { "cid needs to be in the format channelType:channelId. For example, messaging:123" }
+    return checkNotNull(split(":").takeIf { it.size >= 2 }?.let { it.first() to it.last() })
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/StringExtensions.kt
@@ -25,3 +25,16 @@ internal fun String.camelCaseToSnakeCase(): String {
 }
 
 internal fun String.isAnonymousChannelId(): Boolean = contains("!members")
+
+/**
+ * Parses CID of channel to channelType and channelId.
+ *
+ * @return Pair<String, String> Pair with channelType and channelId.
+ * @throws IllegalStateException Throws an exception if format of cid is incorrect.
+ */
+@Throws(IllegalStateException::class)
+public fun String.cidToTypeAndId(): Pair<String, String> {
+    require(isNotEmpty()) { "cid can not be empty" }
+    require(':' in this) { "cid needs to be in the format channelType:channelId. For example, messaging:123" }
+    return requireNotNull(split(":").takeIf { it.size >= 2 }?.let { it.first() to it.last() })
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -99,6 +99,11 @@ public sealed interface ChatDomain {
     public fun getVersion(): String
 
     @CheckResult
+    @Deprecated(
+        message = "Use ChatClient::removeMembers directly",
+        replaceWith = ReplaceWith("ChatClient::removeMembers"),
+        level = DeprecationLevel.WARNING,
+    )
     public fun removeMembers(cid: String, vararg userIds: String): Call<Channel>
 
     // region use-case functions

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/controller/ChannelControllerImpl.kt
@@ -13,7 +13,6 @@ import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.offline.channel.ChannelData
-import io.getstream.chat.android.offline.request.QueryChannelPaginationRequest
 import kotlinx.coroutines.flow.map
 import java.io.File
 import io.getstream.chat.android.offline.channel.ChannelController as ChannelControllerStateFlow
@@ -73,28 +72,10 @@ internal class ChannelControllerImpl(private val channelControllerStateFlow: Cha
     suspend fun loadOlderMessages(messageId: String, limit: Int): Result<Channel> =
         channelControllerStateFlow.loadOlderMessages(messageId, limit)
 
-    suspend fun loadNewerMessages(messageId: String, limit: Int): Result<Channel> =
-        channelControllerStateFlow.loadNewerMessages(messageId, limit)
-
-    suspend fun loadNewerMessages(limit: Int = 30): Result<Channel> =
-        channelControllerStateFlow.loadNewerMessages(limit)
-
-    suspend fun runChannelQuery(pagination: QueryChannelPaginationRequest): Result<Channel> =
-        channelControllerStateFlow.runChannelQuery(pagination)
-
-    suspend fun runChannelQueryOnline(pagination: QueryChannelPaginationRequest): Result<Channel> =
-        channelControllerStateFlow.runChannelQueryOnline(pagination)
-
     suspend fun sendMessage(
         message: Message,
         attachmentTransformer: ((at: Attachment, file: File) -> Attachment)? = null,
     ): Result<Message> = channelControllerStateFlow.sendMessage(message, attachmentTransformer)
-
-    suspend fun cancelMessage(message: Message): Result<Boolean> =
-        channelControllerStateFlow.cancelEphemeralMessage(message)
-
-    suspend fun sendGiphy(message: Message): Result<Message> = channelControllerStateFlow.sendGiphy(message)
-    suspend fun shuffleGiphy(message: Message): Result<Message> = channelControllerStateFlow.shuffleGiphy(message)
 
     suspend fun sendImage(file: File): Result<String> = channelControllerStateFlow.sendImage(file)
     suspend fun sendFile(file: File): Result<String> = channelControllerStateFlow.sendFile(file)
@@ -104,41 +85,14 @@ internal class ChannelControllerImpl(private val channelControllerStateFlow: Cha
 
     suspend fun deleteReaction(reaction: Reaction): Result<Message> =
         channelControllerStateFlow.deleteReaction(reaction)
-
-    internal fun upsertMessage(message: Message) = channelControllerStateFlow.upsertMessage(message)
-
     override fun getMessage(messageId: String): Message? = channelControllerStateFlow.getMessage(messageId)
     override fun clean() = channelControllerStateFlow.clean()
-
-    fun setTyping(userId: String, event: ChatEvent?) = channelControllerStateFlow.setTyping(userId, event)
-    fun isHidden(): Boolean = channelControllerStateFlow.isHidden()
-
-    internal suspend fun handleEvents(events: List<ChatEvent>) = channelControllerStateFlow.handleEvents(events)
     internal fun handleEvent(event: ChatEvent) = channelControllerStateFlow.handleEvent(event)
-
-    fun upsertMembers(members: List<Member>) = channelControllerStateFlow.upsertMembers(members)
-    fun upsertMember(member: Member) = channelControllerStateFlow.upsertMember(member)
-    suspend fun removeMembers(vararg userIds: String): Result<Channel> =
-        channelControllerStateFlow.removeMembers(*userIds)
-
-    fun updateLiveDataFromChannel(c: Channel) = channelControllerStateFlow.updateDataFromChannel(c)
 
     suspend fun editMessage(message: Message): Result<Message> = channelControllerStateFlow.editMessage(message)
     suspend fun deleteMessage(message: Message): Result<Message> = channelControllerStateFlow.deleteMessage(message)
 
     override fun toChannel(): Channel = channelControllerStateFlow.toChannel()
-
-    internal suspend fun loadOlderThreadMessages(
-        threadId: String,
-        limit: Int,
-        firstMessage: Message? = null,
-    ): Result<List<Message>> = channelControllerStateFlow.loadOlderThreadMessages(threadId, limit, firstMessage)
-
-    internal suspend fun loadMessageById(
-        messageId: String,
-        newerMessagesOffset: Int,
-        olderMessagesOffset: Int,
-    ): Result<Message> = channelControllerStateFlow.loadMessageById(messageId, newerMessagesOffset, olderMessagesOffset)
 
     internal fun replyMessage(repliedMessage: Message?) = channelControllerStateFlow.replyMessage(repliedMessage)
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -106,6 +106,11 @@ public sealed interface ChatDomain {
     public fun getVersion(): String
 
     @CheckResult
+    @Deprecated(
+        message = "Use ChatClient::removeMembers directly",
+        replaceWith = ReplaceWith("ChatClient::removeMembers"),
+        level = DeprecationLevel.WARNING,
+    )
     public fun removeMembers(cid: String, vararg userIds: String): Call<Channel>
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -14,6 +14,7 @@ import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.MarkAllReadEvent
+import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.extensions.enrichWithCid
 import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Attachment
@@ -89,7 +90,6 @@ import io.getstream.chat.android.offline.utils.CallRetryService
 import io.getstream.chat.android.offline.utils.DefaultRetryPolicy
 import io.getstream.chat.android.offline.utils.Event
 import io.getstream.chat.android.offline.utils.RetryPolicy
-import io.getstream.chat.android.offline.utils.validateCid
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.SupervisorJob
@@ -466,11 +466,8 @@ internal class ChatDomainImpl internal constructor(
     }
 
     override fun removeMembers(cid: String, vararg userIds: String): Call<Channel> {
-        validateCid(cid)
-        val channelController = channel(cid)
-        return CoroutineCall(scope) {
-            channelController.removeMembers(*userIds)
-        }
+        val (channelType, channelId) = cid.cidToTypeAndId()
+        return client.removeMembers(channelType, channelId, userIds.toList())
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -1193,15 +1193,11 @@ public class ChannelController internal constructor(
         _members.value = _members.value - userId
     }
 
-    internal fun upsertMembers(members: List<Member>) {
+    private fun upsertMembers(members: List<Member>) {
         _members.value = _members.value + members.associateBy { it.user.id }
     }
 
-    internal suspend fun removeMembers(vararg userIds: String): Result<Channel> {
-        return channelClient.removeMembers(*userIds).await()
-    }
-
-    internal fun upsertMember(member: Member) {
+    private fun upsertMember(member: Member) {
         upsertMembers(listOf(member))
     }
 


### PR DESCRIPTION
### 🎯 Goal

Deprecate ChatDomain::removeMembers and use ChatClient::removeMembers directly

Some additional clean ups for unused private and internal methods

### 🛠 Implementation details

Useful extension `String::cidToTypeAndId(): Pair<String, String>` is provided


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~~[ ] New code is covered by unit tests~~
- ~~[ ] Comparison screenshots added for visual changes~~
- ~~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~~
- [x] Reviewers added

### 🎉 GIF

![](https://media2.giphy.com/media/ZbeonvEvZBwNeWGC9V/giphy.gif)
