### PR TITLE
Staying when user is updated, but is not set

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
-
+- But related to FiniteStateMachine in a wrong state. 
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
-- But related to FiniteStateMachine in a wrong state. 
+
 ### ⬆️ Improved
 
 ### ✅ Added
@@ -24,7 +24,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
-
+- Fixed bug which can lead to crash when immediate logout after login
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
@@ -34,6 +34,7 @@ internal class UserStateService {
             onEvent<UserStateEvent.ConnectUser> { _, event -> UserState.UserSet(event.user) }
             onEvent<UserStateEvent.ConnectAnonymous> { _, _ -> UserState.Anonymous.Pending }
             onEvent<UserStateEvent.UnsetUser> { _, _ -> stay() }
+            onEvent<UserStateEvent.UserUpdated> { _, _ -> stay() }
         }
         state<UserState.UserSet> {
             onEvent<UserStateEvent.UserUpdated> { _, event -> UserState.UserSet(event.user) }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
@@ -33,13 +33,6 @@ internal class UserStateServiceTests {
     }
 
     @Test
-    fun `Given Idle state When user updated Should throw an exception`() {
-        val sut = Fixture().please()
-
-        assertThrows<IllegalStateException> { sut.onUserUpdated(Mother.randomUser()) }
-    }
-
-    @Test
     fun `Given user set state When logout Should move to user not set state`() {
         val sut = Fixture().givenUserSetState().please()
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
@@ -4,8 +4,6 @@ import com.google.common.truth.Truth
 import io.getstream.chat.android.client.Mother
 import io.getstream.chat.android.client.models.User
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import java.lang.IllegalStateException
 
 internal class UserStateServiceTests {
 


### PR DESCRIPTION
### 🎯 Goal

Fix for invalid state. We believe that an event of `userUpated` may arrive after a logout happens in our app, so that state would be UserNotSet. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- ~[ ] PR targets the `develop` branch~. No it targets `main`, which is what is needed for a hotfix.
- [x] Changelog is updated with client-facing changes. todo
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/132018999-d0e64a96-39c8-4356-b28b-8fedff61d790.gif)
