### PR TITLE
[CAS-1213] Fix setting notification's contentTitle when a Channel doesn't have the name

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed setting notification's `contentTitle` when a Channel doesn't have the name. It will now show members names instead
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1811,6 +1811,7 @@ public final class io/getstream/chat/android/client/extensions/AttachmentExtensi
 }
 
 public final class io/getstream/chat/android/client/extensions/ChannelExtensionKt {
+	public static synthetic fun getUsers$default (Lio/getstream/chat/android/client/models/Channel;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
 	public static final fun isAnonymousChannel (Lio/getstream/chat/android/client/models/Channel;)Z
 	public static final fun isMutedFor (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;)Z
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/ChannelExtension.kt
@@ -1,7 +1,9 @@
 package io.getstream.chat.android.client.extensions
 
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 public fun Channel.isAnonymousChannel(): Boolean = id.isAnonymousChannelId()
 
@@ -11,3 +13,7 @@ public fun Channel.isAnonymousChannel(): Boolean = id.isAnonymousChannelId()
  * @return true if the channel is muted for [user]
  */
 public fun Channel.isMutedFor(user: User): Boolean = user.channelMutes.any { mute -> mute.channel.cid == cid }
+
+@InternalStreamChatApi
+public fun Channel.getUsers(excludeUserId: String = ChatClient.instance().getCurrentUser()?.id ?: ""): List<User> =
+    members.map { it.user }.filterNot { it.id == excludeUserId }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
@@ -11,9 +11,9 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.R
 import io.getstream.chat.android.client.events.NewMessageEvent
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Device
 import io.getstream.chat.android.client.models.Message
@@ -278,9 +278,7 @@ public open class ChatNotificationHandler @JvmOverloads constructor(
             ?: getMemberNamesWithoutCurrentUser()
             ?: context.getString(R.string.stream_chat_notification_title)
 
-    private fun Channel.getMemberNamesWithoutCurrentUser(): String? = members.filter {
-        it.getUserId() != ChatClient.instance().getCurrentUser()?.id ?: ""
-    }.map { it.user }
+    private fun Channel.getMemberNamesWithoutCurrentUser(): String? = getUsers()
         .joinToString { it.name }
         .takeIf { it.isNotEmpty() }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
@@ -7,12 +7,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
-import com.getstream.sdk.chat.utils.extensions.getUsers
 import com.getstream.sdk.chat.viewmodel.messages.getCreatedAtOrThrow
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.client.models.name
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -268,7 +268,6 @@ public final class com/getstream/sdk/chat/utils/extensions/AttachmentExtensionKt
 }
 
 public final class com/getstream/sdk/chat/utils/extensions/ChannelKt {
-	public static synthetic fun getUsers$default (Lio/getstream/chat/android/client/models/Channel;Ljava/lang/String;ILjava/lang/Object;)Ljava/util/List;
 	public static synthetic fun isDirectMessaging$default (Lio/getstream/chat/android/client/models/Channel;Ljava/lang/String;ILjava/lang/Object;)Z
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Channel.kt
@@ -1,15 +1,11 @@
 package com.getstream.sdk.chat.utils.extensions
 
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 
 @InternalStreamChatApi
 public fun Channel.isDirectMessaging(currentUserId: String = currentUserId()): Boolean = getUsers(currentUserId).size == 1
-
-@InternalStreamChatApi
-public fun Channel.getUsers(excludeUserId: String = currentUserId()): List<User> =
-    members.map { it.user }.filterNot { it.id == excludeUserId }
 
 private fun currentUserId(): String = ChatDomain.instance().user.value?.id ?: ""

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarBitmapFactory.kt
@@ -9,7 +9,7 @@ import android.graphics.Shader
 import android.graphics.Typeface
 import androidx.annotation.Px
 import com.getstream.sdk.chat.images.StreamImageLoader
-import com.getstream.sdk.chat.utils.extensions.getUsers
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.models.initials

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/avatar/AvatarView.kt
@@ -7,7 +7,7 @@ import android.util.AttributeSet
 import androidx.appcompat.widget.AppCompatImageView
 import com.getstream.sdk.chat.images.StreamImageLoader.ImageTransformation.Circle
 import com.getstream.sdk.chat.images.load
-import com.getstream.sdk.chat.utils.extensions.getUsers
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.extensions.isAnonymousChannel
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/Channel.kt
@@ -2,7 +2,7 @@ package io.getstream.chat.android.ui.common.extensions
 
 import android.content.Context
 import androidx.annotation.StringRes
-import com.getstream.sdk.chat.utils.extensions.getUsers
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.R

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.text.SpannableString
 import android.text.SpannableStringBuilder
 import com.getstream.sdk.chat.model.ModelType
-import com.getstream.sdk.chat.utils.extensions.getUsers
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/AvatarFetcher.kt
@@ -9,7 +9,7 @@ import coil.fetch.FetchResult
 import coil.fetch.Fetcher
 import coil.size.PixelSize
 import coil.size.Size
-import com.getstream.sdk.chat.utils.extensions.getUsers
+import io.getstream.chat.android.client.extensions.getUsers
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.avatar.internal.Avatar
 


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1213

### 🎯 Goal

Fix notifications' grouping

### 🛠 Implementation details

Grouping wasn't working fine when `contentTitle` (== `Channel.name`) was empty

### 🎨 UI Changes


| Before | After |
| --- | --- |
|<img width="322" alt="Screenshot 2021-09-03 at 15 31 50" src="https://user-images.githubusercontent.com/17440581/132184139-feec1974-4f3e-4f16-90db-1de0cdc4416b.png">|<img width="322" alt="Screenshot 2021-09-03 at 15 30 24" src="https://user-images.githubusercontent.com/17440581/132184131-8f1ca061-cdb2-4590-84b1-8f3424f716b4.png">|


### 🧪 Testing
Check push notifications in 1-1 conversation

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

