### PR TITLE
Fixing theme for AttachmentDocumentActivity

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -36,7 +36,7 @@
 
 ### ❌ Removed
 - Completely removed the old serialization implementation. You can no longer opt-out of using the new serialization implementation.
-- Removed the `UpdateUsersRequest` class. 
+- Removed the `UpdateUsersRequest` class.
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
@@ -52,7 +52,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
-
+- Fixed theme for `AttachmentDocumentActivity`. Now it is applied: `Theme.AppCompat.DayNight.NoActionBar`
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-common/build.gradle
+++ b/stream-chat-android-ui-common/build.gradle
@@ -61,6 +61,7 @@ dependencies {
     implementation Dependencies.androidxRecyclerview
     implementation Dependencies.androidxStartup
     implementation Dependencies.constraintLayout
+    implementation Dependencies.materialComponents
 
     api Dependencies.threeTenAbp
 

--- a/stream-chat-android-ui-common/src/main/AndroidManifest.xml
+++ b/stream-chat-android-ui-common/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
     </queries>
 
     <application>
-        <activity android:name="com.getstream.sdk.chat.view.activity.AttachmentDocumentActivity" />
+        <activity android:name="com.getstream.sdk.chat.view.activity.AttachmentDocumentActivity"
+            android:theme="@style/Theme.AppCompat.DayNight.NoActionBar"/>
 
         <provider
             android:name="com.getstream.sdk.chat.StreamFileProvider"


### PR DESCRIPTION
### 🎯 Goal

Fix theme break for `AttachmentDocumentActivity`

### 🛠 Implementation details

Adding a theme for `AttachmentDocumentActivity` in manifest file.

### 🧪 Testing

Open `AttachmentDocumentActivity` and check that it does not break anymore. 

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes. todo
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/10619102/132736677-e3597576-0427-42b0-abff-d078fa73c38f.gif)
