### PR TITLE
Use factory functions instead of subclasses for AttachmentFactories

### DIFF
--- a/docusaurus/docs/Android/04-compose/02-general-customization/02-attachment-factory.mdx
+++ b/docusaurus/docs/Android/04-compose/02-general-customization/02-attachment-factory.mdx
@@ -3,7 +3,7 @@
 The `AttachmentFactory` class allows you to build your own attachments to display in the [Message List](../04-message-components/03-message-list.mdx). It exposes the following properties and behavior:
 
 ```kotlin
-public abstract class AttachmentFactory(
+public open class AttachmentFactory(
     public val canHandle: (attachments: List<Attachment>) -> Boolean,
     public val content: @Composable (AttachmentState) -> Unit,
 )

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -326,20 +326,8 @@ public final class io/getstream/chat/android/compose/state/messages/reaction/Rea
 
 public class io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
 	public final fun getCanHandle ()Lkotlin/jvm/functions/Function1;
 	public final fun getContent ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class io/getstream/chat/android/compose/ui/attachments/ComposableSingletons$StreamAttachmentFactoriesKt {
-	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/ComposableSingletons$StreamAttachmentFactoriesKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
-	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-3$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories {
@@ -399,24 +387,20 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Comp
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
-	public static final field $stable I
-	public fun <init> ()V
+public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactoryKt {
+	public static final fun FileAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
-public final class io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
-	public static final field $stable I
-	public fun <init> ()V
+public final class io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactoryKt {
+	public static final fun GiphyAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
-public final class io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
-	public static final field $stable I
-	public fun <init> ()V
+public final class io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactoryKt {
+	public static final fun ImageAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
-public final class io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
-	public static final field $stable I
-	public fun <init> (I)V
+public final class io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactoryKt {
+	public static final fun LinkAttachmentFactory (I)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/ChannelsScreenKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -1,15 +1,13 @@
 package io.getstream.chat.android.compose.ui.attachments
 
 import androidx.compose.runtime.Composable
-import com.getstream.sdk.chat.model.ModelType
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
-import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
-import io.getstream.chat.android.compose.ui.attachments.content.GiphyAttachmentContent
-import io.getstream.chat.android.compose.ui.attachments.content.ImageAttachmentContent
-import io.getstream.chat.android.compose.ui.attachments.content.LinkAttachmentContent
-import io.getstream.chat.android.compose.ui.util.hasLink
-import io.getstream.chat.android.compose.ui.util.isMedia
+import io.getstream.chat.android.compose.ui.attachments.factory.FileAttachmentFactory
+import io.getstream.chat.android.compose.ui.attachments.factory.GiphyAttachmentFactory
+import io.getstream.chat.android.compose.ui.attachments.factory.ImageAttachmentFactory
+import io.getstream.chat.android.compose.ui.attachments.factory.LinkAttachmentFactory
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 /**
  * Provides different attachment factories that build custom message content based on a given attachment.
@@ -33,22 +31,10 @@ public object StreamAttachmentFactories {
     public fun defaultFactories(
         linkDescriptionMaxLines: Int = DEFAULT_LINK_DESCRIPTION_MAX_LINES,
     ): List<AttachmentFactory> = listOf(
-        AttachmentFactory(
-            canHandle = { links -> links.any { it.hasLink() && it.type != ModelType.attach_giphy } },
-            content = @Composable { LinkAttachmentContent(it, linkDescriptionMaxLines) }
-        ),
-        AttachmentFactory(
-            canHandle = { attachments -> attachments.any { it.type == ModelType.attach_giphy } },
-            content = @Composable { GiphyAttachmentContent(it) }
-        ),
-        AttachmentFactory(
-            canHandle = { attachments -> attachments.all { it.isMedia() } },
-            content = @Composable { ImageAttachmentContent(it) }
-        ),
-        AttachmentFactory(
-            canHandle = { attachments -> attachments.isNotEmpty() },
-            content = @Composable { FileAttachmentContent(it) }
-        )
+        LinkAttachmentFactory(linkDescriptionMaxLines),
+        GiphyAttachmentFactory(),
+        ImageAttachmentFactory(),
+        FileAttachmentFactory(),
     )
 }
 
@@ -59,7 +45,7 @@ public object StreamAttachmentFactories {
  * @param content - Composable function that allows users to define the content the [AttachmentFactory] will build using any given
  * [AttachmentState].
  */
-public open class AttachmentFactory(
+public open class AttachmentFactory @InternalStreamChatApi constructor(
     public val canHandle: (attachments: List<Attachment>) -> Boolean,
     public val content: @Composable (AttachmentState) -> Unit,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -5,10 +5,11 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
 
 /**
- * An extension of the [AttachmentFactory] that validates attachments as files and uses [FileAttachmentContent] to
+ * An [AttachmentFactory] that validates attachments as files and uses [FileAttachmentContent] to
  * build the UI for the message.
  */
-public class FileAttachmentFactory : AttachmentFactory(
+@Suppress("FunctionName")
+public fun FileAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.isNotEmpty() },
-    content = @Composable { FileAttachmentContent(it) }
+    content = @Composable { FileAttachmentContent(it) },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -6,9 +6,10 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.GiphyAttachmentContent
 
 /**
- * An extensions of the [AttachmentFactory] that validates and shows Giphy attachments using [GiphyAttachmentContent].
+ * An [AttachmentFactory] that validates and shows Giphy attachments using [GiphyAttachmentContent].
  */
-public class GiphyAttachmentFactory : AttachmentFactory(
+@Suppress("FunctionName")
+public fun GiphyAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.type == ModelType.attach_giphy } },
-    content = @Composable { GiphyAttachmentContent(it) }
+    content = @Composable { GiphyAttachmentContent(it) },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactory.kt
@@ -6,10 +6,11 @@ import io.getstream.chat.android.compose.ui.attachments.content.ImageAttachmentC
 import io.getstream.chat.android.compose.ui.util.isMedia
 
 /**
- * An extension of the [AttachmentFactory] that validates attachments as images and uses [ImageAttachmentContent] to
+ * An [AttachmentFactory] that validates attachments as images and uses [ImageAttachmentContent] to
  * build the UI for the message.
  */
-public class ImageAttachmentFactory : AttachmentFactory(
+@Suppress("FunctionName")
+public fun ImageAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.all { it.isMedia() } },
-    content = @Composable { ImageAttachmentContent(it) }
+    content = @Composable { ImageAttachmentContent(it) },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -7,14 +7,15 @@ import io.getstream.chat.android.compose.ui.attachments.content.LinkAttachmentCo
 import io.getstream.chat.android.compose.ui.util.hasLink
 
 /**
- * An extension of the [AttachmentFactory] that validates attachments as images and uses [LinkAttachmentContent] to
+ * An [AttachmentFactory] that validates attachments as images and uses [LinkAttachmentContent] to
  * build the UI for the message.
  *
  * @param linkDescriptionMaxLines - The limit of how many lines we show for the link description.
  */
-public class LinkAttachmentFactory(
+@Suppress("FunctionName")
+public fun LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
-) : AttachmentFactory(
+): AttachmentFactory = AttachmentFactory(
     canHandle = { links -> links.any { it.hasLink() && it.type != ModelType.attach_giphy } },
-    content = @Composable { LinkAttachmentContent(it, linkDescriptionMaxLines) }
+    content = @Composable { LinkAttachmentContent(it, linkDescriptionMaxLines) },
 )


### PR DESCRIPTION
### 🎯 Goal

Add a workaround for weird compiler crashes related to AttachmentFactory subclasses.

### 🧪 Testing

Run the Compose app. Shouldn't crash on launch.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
