### PR TITLE
[CAS-1101] Cancel notification when entering in a channel

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -119,6 +119,10 @@ public class ChatClient internal constructor(
     @InternalStreamChatApi
     public val notificationHandler: ChatNotificationHandler = notifications.handler
 
+    public fun displayedNotifications(): Set<Triple<String, String, Int>> {
+        return notifications.showedNotifications()
+    }
+
     private var connectionListener: InitConnectionListener? = null
     private val logger = ChatLogger.get("Client")
     private val eventsObservable = ChatEventsObservable(socket, this)
@@ -1753,11 +1757,13 @@ public class ChatClient internal constructor(
             channelType: String,
             channelId: String,
             messageId: String,
+            notificationId: Int,
         ) {
             ensureClientInitialized().notifications.displayNotificationWithData(
                 channelId = channelId,
                 channelType = channelType,
                 messageId = messageId,
+                notificationId = notificationId,
             )
         }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
@@ -28,6 +28,7 @@ internal class LoadNotificationDataWorker(
         val channelId: String = inputData.getString(DATA_CHANNEL_ID)!!
         val channelType: String = inputData.getString(DATA_CHANNEL_TYPE)!!
         val messageId: String = inputData.getString(DATA_MESSAGE_ID)!!
+        val notificationId: Int = inputData.getInt(DATA_NOTIFICATION_ID, 0)
         val notificationTitle: String = inputData.getString(DATA_NOTIFICATION_TITLE)!!
         val notificationIcon: Int = inputData.getInt(DATA_NOTIFICATION_ICON, R.drawable.stream_ic_notification)
         val notificationChannelName: String = inputData.getString(DATA_NOTIFICATION_CHANNEL_NAME)!!
@@ -46,6 +47,7 @@ internal class LoadNotificationDataWorker(
                 channelId = channelId,
                 channelType = channelType,
                 messageId = messageId,
+                notificationId = notificationId,
             )
             Result.success()
         } catch (exception: IllegalStateException) {
@@ -108,6 +110,7 @@ internal class LoadNotificationDataWorker(
         private const val DATA_CHANNEL_TYPE = "DATA_CHANNEL_TYPE"
         private const val DATA_CHANNEL_ID = "DATA_CHANNEL_ID"
         private const val DATA_MESSAGE_ID = "DATA_MESSAGE_ID"
+        private const val DATA_NOTIFICATION_ID = "DATA_NOTIFICATION_ID"
         private const val DATA_NOTIFICATION_TITLE = "DATA_NOTIFICATION_TITLE"
         private const val DATA_NOTIFICATION_ICON = "DATA_NOTIFICATION_ICON"
         private const val DATA_NOTIFICATION_CHANNEL_NAME = "DATA_NOTIFICATION_CHANNEL_NAME"
@@ -121,6 +124,7 @@ internal class LoadNotificationDataWorker(
             channelId: String,
             channelType: String,
             messageId: String,
+            notificationId: Int,
             notificationChannelName: String,
             notificationIcon: Int,
             notificationTitle: String,
@@ -131,6 +135,7 @@ internal class LoadNotificationDataWorker(
                         DATA_CHANNEL_ID to channelId,
                         DATA_CHANNEL_TYPE to channelType,
                         DATA_MESSAGE_ID to messageId,
+                        DATA_NOTIFICATION_ID to notificationId,
                         DATA_NOTIFICATION_CHANNEL_NAME to notificationChannelName,
                         DATA_NOTIFICATION_ICON to notificationIcon,
                         DATA_NOTIFICATION_TITLE to notificationTitle,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.ui.message.list
 
 import android.animation.LayoutTransition
 import android.app.AlertDialog
+import android.app.NotificationManager
 import android.content.Context
 import android.util.AttributeSet
 import android.view.Gravity
@@ -10,6 +11,8 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.Toast
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.app.NotificationManagerCompat
+import androidx.core.content.ContextCompat.getSystemService
 import androidx.core.view.isVisible
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
@@ -26,6 +29,7 @@ import com.getstream.sdk.chat.utils.extensions.showToast
 import com.getstream.sdk.chat.view.EndlessScrollListener
 import com.getstream.sdk.chat.view.messages.MessageListItemWrapper
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Flag
@@ -577,7 +581,17 @@ public class MessageListView : ConstraintLayout {
         this.channel = channel
         initAdapter()
 
-        messageListViewStyle = requireStyle().copy(
+        val notificationManager = NotificationManagerCompat.from(context)
+
+        val channelNotifications = ChatClient.instance().displayedNotifications().filter { (_, channelId, _) ->
+            channelId == channel.id
+        }
+
+        channelNotifications.forEach { (messageId, _, notificationId) ->
+            notificationManager.cancel(messageId, notificationId)
+        }
+
+         messageListViewStyle = requireStyle().copy(
             replyEnabled = requireStyle().replyEnabled && channel.config.isRepliesEnabled,
             threadsEnabled = requireStyle().threadsEnabled && channel.config.isRepliesEnabled,
         )


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1101

### 🎯 Goal

POC for Notification cancelation when a user enters in our channel. This is just a POC of a possible logic that can be implemented. This is not a final solution.

Persistence should be added instead of using only memory to keep record of notification of each channel. 

### 🛠 Implementation details

We keep track of each notification with its ID, channelId and messageId. Then we can use then to cancel the notification when the user enters the channel. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/132767757-56b1710d-98d9-4fb5-ac6e-d56aa06c7ea9.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/132767490-b3d009ff-1204-4260-8034-96ccba9c74a6.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
