### PR TITLE
[Compose] - Add UploadAttachmentFactory to list of factories we provide

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -81,6 +81,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fixed a bug where the Message list flickered when sending new messages
+- Fixed a few bugs where some attachments had upload state and weren't file/image uploads
 
 ### ⬆️ Improved
 - Improved the Message list scrolling behavior and scroll to bottom actions
@@ -93,6 +94,7 @@
 - Added an uploading indicator to files and images
 - Images being uploaded are now preloaded from the system
 - Upload indicators show the upload progress and how much data is left to send
+- Added UploadAttachmentFactory that handles attachment uploads
 
 ### ⚠️ Changed
 - `StreamAttachment.defaultFactories()` is a function now, instead of a property.

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -342,7 +342,6 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/File
 	public static final fun FileAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
 	public static final fun FileAttachmentImage (Lio/getstream/chat/android/client/models/Attachment;Landroidx/compose/runtime/Composer;I)V
 	public static final fun FileAttachmentItem (Lio/getstream/chat/android/client/models/Attachment;Landroidx/compose/runtime/Composer;I)V
-	public static final fun FileAttachmentList (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileUploadContentKt {
@@ -356,7 +355,6 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Giph
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContentKt {
 	public static final fun ImageAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
-	public static final fun ImageAttachmentGallery (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContentKt {
@@ -388,6 +386,13 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Comp
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+}
+
 public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactoryKt {
 	public static final fun FileAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
@@ -402,6 +407,10 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Imag
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactoryKt {
 	public static final fun LinkAttachmentFactory (I)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+}
+
+public final class io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactoryKt {
+	public static final fun UploadAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/ChannelsScreenKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -36,7 +36,7 @@ public object StreamAttachmentFactories {
         LinkAttachmentFactory(linkDescriptionMaxLines),
         GiphyAttachmentFactory(),
         ImageAttachmentFactory(),
-        FileAttachmentFactory()
+        FileAttachmentFactory(),
     )
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.compose.ui.attachments.factory.FileAttachmentFa
 import io.getstream.chat.android.compose.ui.attachments.factory.GiphyAttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.factory.ImageAttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.factory.LinkAttachmentFactory
+import io.getstream.chat.android.compose.ui.attachments.factory.UploadAttachmentFactory
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
@@ -31,10 +32,11 @@ public object StreamAttachmentFactories {
     public fun defaultFactories(
         linkDescriptionMaxLines: Int = DEFAULT_LINK_DESCRIPTION_MAX_LINES,
     ): List<AttachmentFactory> = listOf(
+        UploadAttachmentFactory(),
         LinkAttachmentFactory(linkDescriptionMaxLines),
         GiphyAttachmentFactory(),
         ImageAttachmentFactory(),
-        FileAttachmentFactory(),
+        FileAttachmentFactory()
     )
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -38,29 +38,13 @@ import io.getstream.chat.android.compose.ui.util.MimeTypeIconProvider
 import io.getstream.chat.android.offline.ChatDomain
 
 /**
- * Builds a file attachment message which shows a list of files or those files being uploaded.
+ * Builds a file attachment message which shows a list of files.
  *
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
  */
 @Composable
 public fun FileAttachmentContent(attachmentState: AttachmentState) {
-    val message = attachmentState.messageItem.message
-
-    if (message.attachments.any { it.uploadState == Attachment.UploadState.InProgress }) {
-        FileUploadContent(attachmentState = attachmentState)
-    } else {
-        FileAttachmentList(attachmentState = attachmentState)
-    }
-}
-
-/**
- * Represents the file attachment list of files that are already uploaded.
- *
- * @param attachmentState The state of this attachment.
- */
-@Composable
-public fun FileAttachmentList(attachmentState: AttachmentState) {
     val (modifier, messageItem, _) = attachmentState
     val (message, _) = messageItem
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -100,11 +100,12 @@ public fun FileUploadItem(attachment: Attachment) {
 
                         Spacer(modifier = Modifier.size(8.dp))
 
+                        val uploadedSize = (uploadProgress / 100F * tracker.maxValue).toLong()
                         Text(
                             text = stringResource(
                                 id = R.string.stream_compose_upload_progress,
-                                MediaStringUtil.convertFileSizeByteCount(uploadProgress.toLong()),
-                                MediaStringUtil.convertFileSizeByteCount(maxValue)
+                                MediaStringUtil.convertFileSizeByteCount(uploadedSize),
+                                MediaStringUtil.convertFileSizeByteCount(maxValue),
                             ),
                             style = ChatTheme.typography.footnote,
                             color = ChatTheme.colors.textLowEmphasis

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
@@ -35,8 +35,7 @@ import io.getstream.chat.android.compose.ui.util.hasLink
 import io.getstream.chat.android.compose.ui.util.isMedia
 
 /**
- * Builds an image attachment message, which can be composed of several images or will show an upload state if we're
- * currently uploading images.
+ * Builds an image attachment message, which can be composed of several images in a gallery.
  *
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
@@ -44,23 +43,6 @@ import io.getstream.chat.android.compose.ui.util.isMedia
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 public fun ImageAttachmentContent(attachmentState: AttachmentState) {
-    val message = attachmentState.messageItem.message
-
-    if (message.attachments.any { it.uploadState == Attachment.UploadState.InProgress }) {
-        FileUploadContent(attachmentState = attachmentState)
-    } else {
-        ImageAttachmentGallery(attachmentState = attachmentState)
-    }
-}
-
-/**
- * Represents the image attachment gallery content.
- *
- * @param attachmentState The state of this attachment.
- */
-@OptIn(ExperimentalFoundationApi::class)
-@Composable
-public fun ImageAttachmentGallery(attachmentState: AttachmentState) {
     val (modifier, messageItem, onLongItemClick) = attachmentState
     val (message, _) = messageItem
     val context = LocalContext.current

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.compose.ui.attachments.factory
 
 import androidx.compose.runtime.Composable
+import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
 
@@ -10,6 +11,6 @@ import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentCo
  */
 @Suppress("FunctionName")
 public fun FileAttachmentFactory(): AttachmentFactory = AttachmentFactory(
-    canHandle = { attachments -> attachments.isNotEmpty() },
+    canHandle = { attachments -> attachments.any { it.uploadId != null } },
     content = @Composable { FileAttachmentContent(it) },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -1,0 +1,15 @@
+package io.getstream.chat.android.compose.ui.attachments.factory
+
+import androidx.compose.runtime.Composable
+import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
+import io.getstream.chat.android.compose.ui.attachments.content.FileUploadContent
+import io.getstream.chat.android.compose.ui.util.isUploading
+
+/**
+ * An [AttachmentFactory] that validates and shows uploading attachments using [FileUploadContent].
+ */
+@Suppress("FunctionName")
+public fun UploadAttachmentFactory(): AttachmentFactory = AttachmentFactory(
+    canHandle = { attachments -> attachments.any { it.isUploading() } },
+    content = @Composable { FileUploadContent(it) },
+)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -60,6 +60,7 @@ import io.getstream.chat.android.compose.ui.common.Timestamp
 import io.getstream.chat.android.compose.ui.common.avatar.Avatar
 import io.getstream.chat.android.compose.ui.common.avatar.UserAvatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.isUploading
 import java.util.Date
 
 /**
@@ -90,7 +91,7 @@ public fun DefaultMessageContainer(
 
     val isDeleted = message.deletedAt != null
     val hasThread = message.threadParticipants.isNotEmpty()
-    val isUploading = message.attachments.any { it.uploadState == Attachment.UploadState.InProgress }
+    val isUploading = message.attachments.any { it.isUploading() }
     val ownsMessage = messageItem.isMine
 
     val messageCardColor =

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/AttachmentsUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/AttachmentsUtils.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.compose.ui.util
 
 import com.getstream.sdk.chat.model.ModelType
+import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.client.models.Attachment
 
 /**
@@ -17,3 +18,9 @@ internal fun Attachment.isMedia(): Boolean = type in MEDIA_ATTACHMENT_TYPES
  * @return If the [Attachment] is a link attachment or not.
  */
 internal fun Attachment.hasLink(): Boolean = titleLink != null || ogUrl != null
+
+/**
+ * @return If the attachment is currently being uploaded to the server.
+ */
+internal fun Attachment.isUploading(): Boolean =
+    uploadState == Attachment.UploadState.InProgress && upload != null && uploadId != null


### PR DESCRIPTION
Fixes #2339 

### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

Built a new factory that takes responsibility of uploading attachments. Added an AttachmentUtils check for uploading attachments.

Changed the way we find File attachments.

### 🧪 Testing

Attachments should work like before, upload attachments should still work fine even though it's using another factory.

### ☑️ Checklist

- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
~~- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~~ Will update with the tutorial.
- [x] Reviewers added
