### PR TITLE
Handle attachments with and without files separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,10 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fixed sending messages using `ChatClient::sendMessage` without explicitly specifying the sender user id.
+- Fixed sending custom attachments without files to upload
 
 ### ⬆️ Improved
+- Custom attachment types are now preserved after file uploads
 
 ### ✅ Added
 

--- a/docusaurus/docs/Android/02-client/06-guides/02-sending-custom-attachments.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/02-sending-custom-attachments.mdx
@@ -1,0 +1,62 @@
+# Sending Custom Attachments
+
+The Stream Chat SDK has support for some built-in attachment types like images, videos, and files. However, you can also create your custom attachments that have their own type and contain arbitrary data. You can use this to add location info, custom media like audio, product details, or whatever other content your app deals with to a message.
+
+In this guide, we'll look at how to create custom attachments and send them to a channel.
+
+<!-- TODO Android docs link -->
+
+> To render custom attachments with the Compose SDK, see the [Custom Attachments](../../04-compose/02-general-customization/02-attachment-factory.mdx) page.
+
+Sending an attachment requires you to create the `Attachment` object, add it to a message, and then send that message:
+
+```kotlin
+val attachment = Attachment(...)
+val message = Message(
+    cid = "messaging:general",
+    text = "Look at this attachment!",
+    attachments = mutableListOf(attachment),
+)
+ChatDomain.instance().sendMessage(message).enqueue { result ->
+    if (result.isSuccess) {
+        // Use result.data()
+    } else {
+        // Handle result.error()
+    }
+}
+```
+
+Let's see how you can create an `Attachment`.
+
+### Create an Attachment Without Files
+
+If your attachment is just plain data (for example, location coordinates), and requires no file to be transferred, you can create and send it the following way:
+
+```kotlin
+val attachment = Attachment(
+    type = "location", // 1
+    extraData = mutableMapOf( // 2
+        "lat" to 40.017985,
+        "lon" to -105.280184,
+    ),
+)
+```
+
+1. Setting a custom value for the `type` of the attachment makes it easy to identify the custom attachment on the receiving side to render it in the Message Líist.
+2. The `extraData` Map allows you to add arbitrary pieces of data to the attachment. In this example, we use this to add a pair of location coordinates.
+
+### Create an Attachment With Files
+
+If you want to upload a file for your attachment, you need to create an `Attachment` object that has its `upload` property set:
+
+```kotlin
+val attachment = Attachment(
+    type = "audio", // 1
+    upload = File("audio-file.mp3"), // 2
+)
+```
+
+1. Again, a custom `type` allows you to identify your custom attachments to render them in the Message List.
+2. The file in the `upload` property will be uploaded automatically before the message is sent. The URL where it's available from will be placed in the `url` property of the `Attachment`.
+   
+By default, files are uploaded to Stream's CDN, which has a 20 MB size limit. However, you can also [use your own CDN for files](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin#using-your-own-cdn).

--- a/docusaurus/sidebars-android.js
+++ b/docusaurus/sidebars-android.js
@@ -26,6 +26,10 @@ module.exports = {
                 },
                 {
                   type: 'doc',
+                  id: 'client/guides/sending-custom-attachments',
+                },
+                {
+                  type: 'doc',
                   id: 'client/guides/working-with-offline',
                 },
             ]

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Attachment.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Attachment.kt
@@ -22,6 +22,13 @@ public data class Attachment(
     var name: String? = null,
     var fallback: String? = null,
 
+    /**
+     * The local file to upload when the attachment is sent. The [url] property
+     * will be populated with the URL of the uploaded file when done.
+     *
+     * Leaving this property empty means that there is no file to upload for
+     * this attachment.
+     */
     @Transient
     var upload: File? = null,
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUploader.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUploader.kt
@@ -75,8 +75,12 @@ internal class AttachmentUploader(
             mimeType = mimeType,
             url = url,
             uploadState = Attachment.UploadState.Success,
-            type = attachmentType.toString(),
         ).apply {
+            // If attachment type was not set, set it based on this value
+            // determined by the MIME type guessed from the file's extension
+            if (type == null) {
+                type = attachmentType.toString()
+            }
             if (attachmentType == AttachmentType.IMAGE) {
                 imageUrl = url
             } else {


### PR DESCRIPTION
### 🎯 Goal

Fix the problem where attachments with no files to upload get stuck forever without syncing to the backend.

### 🛠 Implementation details

Check whether an attachment has a file to upload (based on its `upload` property), and mark it synced immediately if there's no upload required.

### 🧪 Testing

Here's test code for non-file attachments (can be added in `ChatFragment`):

```kotlin
// Call in some listener
val attachment = Attachment(
    type = "location",
    extraData = mutableMapOf(
        "lat" to 111.1111,
        "lon" to -105.280184,
    ),
)
val message = Message(
    cid = args.cid,
    text = "Look at this attachment!",
    attachments = mutableListOf(attachment),
)
ChatDomain.instance().sendMessage(message).enqueue()

// Call on the MessageList
setAttachmentViewFactory(object:AttachmentViewFactory() {
    override fun createAttachmentView(
        data: MessageListItem.MessageItem,
        listeners: MessageListListenerContainer,
        style: MessageListItemStyle,
        parent: ViewGroup,
    ): View {
        val locAttachment  = data.message.attachments.firstOrNull { it.type == "location" }
        if (locAttachment != null) {
            return TextView(parent.context).apply {
                setText("Location is ${locAttachment.extraData["lat"]}, ${locAttachment.extraData["lon"]}")
            }
        }
        return super.createAttachmentView(data, listeners, style, parent)
    }
})
```

Test code for file attachments:

```kotlin
// Call in some listener
val file = File(requireContext().filesDir, "test.txt")
file.writeText("EMULATOR TEXT HERE")
val attachment = Attachment(
    type = "textfile",
    upload = file,
)
val message = Message(
    cid = args.cid,
    text = "Here's the file",
    attachments = mutableListOf(attachment),
)
ChatDomain.instance().sendMessage(message).enqueue()

// Call on the MessageList
setAttachmentViewFactory(object: AttachmentViewFactory() {
    override fun createAttachmentView(
        data: MessageListItem.MessageItem,
        listeners: MessageListListenerContainer,
        style: MessageListItemStyle,
        parent: ViewGroup,
    ): View {
        val textAttachment  = data.message.attachments.firstOrNull { it.type == "textfile" }
        if (textAttachment != null && textAttachment.uploadState in setOf(Attachment.UploadState.Success, null)) {
            return TextView(parent.context).apply {
                thread {
                    val fileText = URL(textAttachment.url).readText()
                    this.post {
                        setText("Text file says \"$fileText\"")
                    }
                }
            }
        }
        return super.createAttachmentView(data, listeners, style, parent)
    }
})
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
