### PR TITLE
[CAS-1319] Fix sending messages via ChatClient::sendMessage

### DIFF
--- a/UNRELEASED_CHANGELOG.md
+++ b/UNRELEASED_CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed sending messages using `ChatClient::sendMessage` without explicitly specifying the sender user id.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -870,6 +870,15 @@ public class ChatClient internal constructor(
         return api.getMessage(messageId)
     }
 
+    /**
+     * Sends the message to the given channel.
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param message Message object
+     *
+     * @return Executable async [Call] responsible for sending a message.
+     */
     @CheckResult
     public fun sendMessage(
         channelType: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/MessageMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/MessageMapping.kt
@@ -28,7 +28,6 @@ internal fun Message.toDto(): UpstreamMessageDto =
         silent = silent,
         text = text,
         thread_participants = threadParticipants.map(User::toDto),
-        user = user.toDto(),
         extraData = extraData,
     )
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
@@ -26,7 +26,6 @@ internal data class UpstreamMessageDto(
     val silent: Boolean,
     val text: String,
     val thread_participants: List<UpstreamUserDto>,
-    val user: UpstreamUserDto,
 
     val extraData: Map<String, Any>,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -253,6 +253,13 @@ public class ChannelClient internal constructor(
         return client.deleteMessage(messageId)
     }
 
+    /**
+     * Sends the message to the given channel.
+     *
+     * @param message Message object
+     *
+     * @return Executable async [Call] responsible for sending a message.
+     */
     @CheckResult
     public fun sendMessage(message: Message): Call<Message> {
         return client.sendMessage(channelType, channelId, message)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.client.parser2.testdata
 
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamMessageDto
-import io.getstream.chat.android.client.api2.model.dto.UpstreamUserDto
 import org.intellij.lang.annotations.Language
 import java.util.Date
 
@@ -174,14 +173,6 @@ internal object MessageDtoTestData {
           "silent": false,
           "text": "text",
           "thread_participants": [],
-          "user": {
-            "banned": false,
-            "id": "",
-            "invisible": false,
-            "role": "",
-            "devices": [],
-            "teams": []
-          },
           "extraData": {
             "key1": "value1",
             "key2": true,
@@ -204,15 +195,6 @@ internal object MessageDtoTestData {
         html = "html",
         parent_id = null,
         command = null,
-        user = UpstreamUserDto(
-            banned = false,
-            id = "",
-            invisible = false,
-            role = "",
-            devices = emptyList(),
-            teams = emptyList(),
-            extraData = emptyMap()
-        ),
         silent = false,
         shadowed = false,
         extraData = mapOf(
@@ -255,15 +237,7 @@ internal object MessageDtoTestData {
           "show_in_channel": false,
           "silent": false,
           "text": "",
-          "thread_participants": [],
-          "user": {
-            "banned": false,
-            "id": "",
-            "invisible": false,
-            "role": "",
-            "devices": [],
-            "teams": []
-          }
+          "thread_participants": []
         }""".withoutWhitespace()
     val upstreamMessageWithoutExtraData = UpstreamMessageDto(
         id = "8584452-6d711169-0224-41c2-b9aa-1adbe624521b",
@@ -272,15 +246,6 @@ internal object MessageDtoTestData {
         html = "",
         parent_id = null,
         command = null,
-        user = UpstreamUserDto(
-            banned = false,
-            id = "",
-            invisible = false,
-            role = "",
-            devices = emptyList(),
-            teams = emptyList(),
-            extraData = emptyMap()
-        ),
         silent = false,
         shadowed = false,
         extraData = emptyMap(),


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1319

### 🎯 Goal

An authenticated user is able to send a message using the code snippet below without encountering the `SendMessage failed with error: "message.user.id is a required field"` error:

```kotlin
ChatClient.instance().channel(cid).sendMessage(
    Message(text = "message text")).enqueue {
        // handle message sending result
     }
}
```

### 🛠 Implementation details

According to this [PR](https://github.com/GetStream/stream-chat-android/commit/f205cc04e57ba8a9acb0202896c025650544319f#diff-fc111330781f084c311d0475a0e328674c11f27ac633ae684ca46fe573f8806c), user was not sent with message object. 

```kotlin
@IgnoreSerialisation
var user: User = User()
```

Therefore, removing it from the upstream message DTO.

### 🧪 Testing

The list of affected methods which should be tested:
- `ChatClient::sendMessage`
- `ChatClient::updateChannel`
- `ChatClient::updateMessage`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/9600921/133728892-0ba680e7-b631-4722-9fce-e7010152d712.gif)


