### PR TITLE
Fix soft delete

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MessageApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MessageApi.kt
@@ -54,7 +54,7 @@ internal interface MessageApi {
     @DELETE("/messages/{id}")
     fun deleteMessage(
         @Path("id") messageId: String,
-        @Query(QueryParams.HARD_DELETE) hard: Boolean,
+        @Query(QueryParams.HARD_DELETE) hard: Boolean?,
         @Query(QueryParams.CONNECTION_ID) connectionId: String,
     ): RetrofitCall<MessageResponse>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -144,7 +144,7 @@ internal class MoshiChatApi(
         return messageApi.deleteMessage(
             messageId = messageId,
             connectionId = connectionId,
-            hard = hard
+            hard = if (hard) true else null
         ).map { response -> response.message.toDomain() }
     }
 
@@ -718,7 +718,7 @@ internal class MoshiChatApi(
         offset: Int?,
         limit: Int?,
         next: String?,
-        sort: QuerySort<Message>?
+        sort: QuerySort<Message>?,
     ): Call<SearchMessagesResult> {
         val newRequest = io.getstream.chat.android.client.api2.model.requests.SearchMessagesRequest(
             filter_conditions = channelFilter.toMap(),


### PR DESCRIPTION
https://getstream.slack.com/archives/CE5N802GP/p1632075397158100

### 🎯 Goal

Fix soft message delete

### 🛠 Implementation details

The following error is returned from the backend when trying to delete a message with `hard=false`:

```json
{
   "code":4,
   "message":"DeleteMessage failed with error: \"false is an invalid value for the hard parameter. please specify either true or 1\"",
   "StatusCode":400,
   "duration":"0.00ms",
   "more_info":"https://getstream.io/chat/docs/api_errors_response"
}
```

Therefore, omitting the parameter if it is false.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
