### PR TITLE
Add script for closing issues without response

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -1,0 +1,25 @@
+name: No Response
+
+on:
+  issue_comment:
+    types: [created]
+  schedule:
+    # Schedule at the end of every day
+    - cron: '0 0 * * *'
+
+jobs:
+  noResponse:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: lee-dohm/no-response@v0.5.0
+        with:
+          token: ${{ github.token }}
+          daysUntilClose: 7
+          responseRequiredLabel: waiting for response
+          responseRequiredColor: D28960
+          closeComment: >
+            This issue has been automatically closed because there has been no response
+            to our request from the original author.
+            Please don't hesitate to comment on the bug if you have
+            any more information for us - we will reopen it right away!
+            Thanks for your contribution.

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -16,7 +16,6 @@ jobs:
           token: ${{ github.token }}
           daysUntilClose: 7
           responseRequiredLabel: waiting for response
-          responseRequiredColor: D28960
           closeComment: >
             This issue has been automatically closed because there has been no response
             to our request from the original author.


### PR DESCRIPTION
### 🎯 Goal

Add script for closing issues without response

### 🛠 Implementation details

Added a Github action for closing issues marked with `waiting for response` label that didn't receive any response from the author for at least 7 days.
If the original author comes back and gives more information, the label is removed and the issue is reopened, if necessary

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
