### PR TITLE
CI - Including java-libraries and applications

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -47,7 +47,7 @@ jobs:
           distribution: adopt
           java-version: 11
       - name: Unit tests
-        run: ./gradlew testDebug --stacktrace
+        run: ./gradlew stream-chat-android-core:test testDebug testDemoDebugUnitTest --stacktrace
       - name: Upload testDebugUnitTest results
         uses: actions/upload-artifact@v2
         if: failure()

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -63,7 +63,7 @@ jobs:
           distribution: adopt
           java-version: 11
       - name: Unit tests
-        run: ./gradlew testDebug --stacktrace
+        run: ./gradlew stream-chat-android-core:test testDebug testDemoDebugUnitTest --stacktrace
       - name: Upload testDebugUnitTest results
         uses: actions/upload-artifact@v2
         if: failure()


### PR DESCRIPTION
### 🎯 Goal

Include all modules in our unit tests.

### 🛠 Implementation details

Changing `./gradlew testDebug` for `./gradlew stream-chat-android-core:test testDebug testDemoDebugUnitTest`. The first command is excluding our applications and java libraries. Now all the tests can run in the CI. 

We could use `./gradlew test` which is very broad, but that would include both debug and release unit tests, which is not necessary and takes much more time to run. 

### 🧪 Testing

Run `./gradlew stream-chat-android-sample:tasks` and check that the `testDebug` task doesn't exist.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/10619102/134347862-98e7eccb-811b-4775-abd6-61c9513097dc.gif)
