### PR TITLE
[CAS-1307] Fixing isFirstRequest problem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-
+- Fixed bug in first page with cache usage. When no results were returned, `QueryChannelsController` behaved as the first page.
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -443,6 +443,7 @@ public final class io/getstream/chat/android/offline/querychannels/QueryChannels
 	public final fun getNewChannelEventFilter ()Lkotlin/jvm/functions/Function3;
 	public final fun getRecoveryNeeded ()Z
 	public final fun getSort ()Lio/getstream/chat/android/client/api/models/QuerySort;
+	public final fun isFirstRequest ()Z
 	public final fun query (IIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun query$default (Lio/getstream/chat/android/offline/querychannels/QueryChannelsController;IIILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun refreshChannel (Ljava/lang/String;)V

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -443,7 +443,6 @@ public final class io/getstream/chat/android/offline/querychannels/QueryChannels
 	public final fun getNewChannelEventFilter ()Lkotlin/jvm/functions/Function3;
 	public final fun getRecoveryNeeded ()Z
 	public final fun getSort ()Lio/getstream/chat/android/client/api/models/QuerySort;
-	public final fun isFirstRequest ()Z
 	public final fun query (IIILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun query$default (Lio/getstream/chat/android/offline/querychannels/QueryChannelsController;IIILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun refreshChannel (Ljava/lang/String;)V

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -647,7 +647,7 @@ internal class ChatDomainImpl internal constructor(
             )
             val response = queryChannelController.runQueryOnline(pagination)
             if (response.isSuccess) {
-                queryChannelController.updateOnlineChannels(response.data(), queryChannelController.isFirstRequest)
+                queryChannelController.updateOnlineChannels(response.data(), true)
                 updatedChannelIds.addAll(response.data().map { it.cid })
             }
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -639,7 +639,7 @@ internal class ChatDomainImpl internal constructor(
             .take(3)
         for (queryChannelController in queriesToRetry) {
             val pagination = QueryChannelsPaginationRequest(
-                QuerySort<Channel>(),
+                QuerySort(),
                 INITIAL_CHANNEL_OFFSET,
                 CHANNEL_LIMIT,
                 MESSAGE_LIMIT,
@@ -647,7 +647,7 @@ internal class ChatDomainImpl internal constructor(
             )
             val response = queryChannelController.runQueryOnline(pagination)
             if (response.isSuccess) {
-                queryChannelController.updateOnlineChannels(response.data(), pagination.isFirstPage)
+                queryChannelController.updateOnlineChannels(response.data(), queryChannelController.isFirstRequest)
                 updatedChannelIds.addAll(response.data().map { it.cid })
             }
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
@@ -61,7 +61,7 @@ public class QueryChannelsController internal constructor(
     private var channelOffset = INITIAL_CHANNEL_OFFSET
     public var isFirstRequest: Boolean = true
         private set
-    
+
     public var newChannelEventFilter: suspend (Channel, FilterObject) -> Boolean = { channel, filterObject ->
         client.queryChannels(
             QueryChannelsRequest(
@@ -143,8 +143,10 @@ public class QueryChannelsController internal constructor(
             is NotificationAddedToChannelEvent -> updateQueryChannelSpec(event.channel)
             is ChannelDeletedEvent -> removeChannel(event.channel.cid)
             is NotificationChannelDeletedEvent -> removeChannel(event.channel.cid)
-            is ChannelUpdatedByUserEvent -> event.channel.takeIf { checkFilterOnChannelUpdatedEvent }?.let { updateQueryChannelSpec(it) }
-            is ChannelUpdatedEvent -> event.channel.takeIf { checkFilterOnChannelUpdatedEvent }?.let { updateQueryChannelSpec(it) }
+            is ChannelUpdatedByUserEvent -> event.channel.takeIf { checkFilterOnChannelUpdatedEvent }
+                ?.let { updateQueryChannelSpec(it) }
+            is ChannelUpdatedEvent -> event.channel.takeIf { checkFilterOnChannelUpdatedEvent }
+                ?.let { updateQueryChannelSpec(it) }
         }
 
         if (event is MarkAllReadEvent) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
@@ -60,6 +60,8 @@ public class QueryChannelsController internal constructor(
 
     private var channelOffset = INITIAL_CHANNEL_OFFSET
     public var isFirstRequest: Boolean = true
+        private set
+    
     public var newChannelEventFilter: suspend (Channel, FilterObject) -> Boolean = { channel, filterObject ->
         client.queryChannels(
             QueryChannelsRequest(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
@@ -59,7 +59,7 @@ public class QueryChannelsController internal constructor(
     ) : this(filter, sort, client, domain as ChatDomainImpl)
 
     private var channelOffset = INITIAL_CHANNEL_OFFSET
-    public var isFirstRequest: Boolean = true
+    internal var isFirstRequest: Boolean = true
         private set
 
     public var newChannelEventFilter: suspend (Channel, FilterObject) -> Boolean = { channel, filterObject ->

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/request/QueryChannelsPaginationRequest.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/request/QueryChannelsPaginationRequest.kt
@@ -8,9 +8,5 @@ internal data class QueryChannelsPaginationRequest(
     val channelOffset: Int = 0,
     val channelLimit: Int = 30,
     val messageLimit: Int = 10,
-    val memberLimit: Int
-) {
-
-    val isFirstPage: Boolean
-        get() = channelOffset == 0
-}
+    val memberLimit: Int,
+)


### PR DESCRIPTION
[CAS-1307](https://stream-io.atlassian.net/browse/CAS-1307)

### 🎯 Goal

Fix shimmer effect. We are showing the shimmer effect if we don't change `channelOffset` of `QueryChannelsController` because our online request may not return any new channel, so it behaves like it was the first request.

We can't use channelOffset to check that we are in the firstPage because `updateOnlineChannels` doesn't run when there's no internet and that would cause all offline requests to behave like the firstPage. 

### 🛠 Implementation details

Now the first page is tracked in `QueryChannelsController`. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/134380328-5282f2f9-13e7-4f82-a7ec-11e4f8559107.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/134380532-7a1692fa-c10e-4b49-bc0e-9434280c9fca.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing

Follow the videos: 
- Go to the `develop` branch. Disable the internet and request new pages. Check that the shimmer effect appears many times. 
- Go to this branch. Disable the internet and request new pages. Check that the shimmer effect appears only one time.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
