### PR TITLE
[CAS-1333] Add missing border related attributes to ViewReactionsView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,7 @@
 
 ### ✅ Added
 - Notifications are dismissed after the user go into the channel conversation when you are using `MessageListView`
+- Added `bubbleBorderColorMine`, `bubbleBorderColorTheirs`, `bubbleBorderWidthMine`, `bubbleBorderWidthTheirs` to `ViewReactionsViewStyle` for customizing reactions` border
 
 ### ⚠️ Changed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,8 +4,9 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `NotificationConfig` attributes <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.15 ⌛ | Some attributes are not needed anymore |
-| `NotificationLoadDataListener` <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.15 ⌛ | This class is not used anymore, you will be asked to build your notification |
+| `ViewReactionsViewStyle#bubbleBorderColor` <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | 2021.10.26 ⌛ | Use bubbleBorderColorMine instead  |
+| `NotificationConfig` attributes <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | Some attributes are not needed anymore |
+| `NotificationLoadDataListener` <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | This class is not used anymore, you will be asked to build your notification |
 | `ChatClient#searchMessages` <br/>*client* | 2021.09.15<br/>4.18.0 | 2021.10.15 ⌛ | 2021.11.15 ⌛ | Use the `ChatClient#searchMessages` method with unwrapped parameters instead |
 | `ChatDomain#createDistinctChannel` <br/>*offline* | 2021.09.15<br/>4.18.0 | 2021.10.15 ⌛ | 2021.11.15 ⌛ | Use ChatClient::createChannel directly |
 | `ChatDomain#removeMembers` <br/>*offline* | 2021.09.15<br/>4.18.0 | 2021.10.15 ⌛ | 2021.11.15 ⌛ | Use ChatClient::removeMembers directly |

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2123,25 +2123,33 @@ public final class io/getstream/chat/android/ui/message/list/reactions/edit/Edit
 }
 
 public final class io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle {
-	public fun <init> (IIIIIIIIIIIIII)V
+	public fun <init> (IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)V
 	public final fun component1 ()I
 	public final fun component10 ()I
 	public final fun component11 ()I
 	public final fun component12 ()I
 	public final fun component13 ()I
 	public final fun component14 ()I
+	public final fun component15 ()I
+	public final fun component16 ()I
+	public final fun component17 ()I
+	public final fun component18 ()I
 	public final fun component2 ()I
-	public final fun component3 ()I
+	public final fun component3 ()Ljava/lang/Integer;
 	public final fun component4 ()I
 	public final fun component5 ()I
-	public final fun component6 ()I
-	public final fun component7 ()I
+	public final fun component6 ()F
+	public final fun component7 ()Ljava/lang/Float;
 	public final fun component8 ()I
 	public final fun component9 ()I
-	public final fun copy (IIIIIIIIIIIIII)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;IIIIIIIIIIIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
+	public final fun copy (IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBubbleBorderColor ()I
+	public final fun getBubbleBorderColorMine ()I
+	public final fun getBubbleBorderColorTheirs ()Ljava/lang/Integer;
+	public final fun getBubbleBorderWidthMine ()F
+	public final fun getBubbleBorderWidthTheirs ()Ljava/lang/Float;
 	public final fun getBubbleColorMine ()I
 	public final fun getBubbleColorTheirs ()I
 	public final fun getBubbleHeight ()I

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2123,8 +2123,8 @@ public final class io/getstream/chat/android/ui/message/list/reactions/edit/Edit
 }
 
 public final class io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle {
-	public fun <init> (IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)V
-	public final fun component1 ()I
+	public fun <init> (Ljava/lang/Integer;ILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)V
+	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component10 ()I
 	public final fun component11 ()I
 	public final fun component12 ()I
@@ -2142,10 +2142,10 @@ public final class io/getstream/chat/android/ui/message/list/reactions/view/View
 	public final fun component7 ()Ljava/lang/Float;
 	public final fun component8 ()I
 	public final fun component9 ()I
-	public final fun copy (IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;IILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
+	public final fun copy (Ljava/lang/Integer;ILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIII)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;Ljava/lang/Integer;ILjava/lang/Integer;IIFLjava/lang/Float;IIIIIIIIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBubbleBorderColor ()I
+	public final fun getBubbleBorderColor ()Ljava/lang/Integer;
 	public final fun getBubbleBorderColorMine ()I
 	public final fun getBubbleBorderColorTheirs ()Ljava/lang/Integer;
 	public final fun getBubbleBorderWidthMine ()F

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/TypedArray.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/TypedArray.kt
@@ -2,8 +2,10 @@ package io.getstream.chat.android.ui.common.extensions.internal
 
 import android.content.res.TypedArray
 import androidx.annotation.ColorInt
+import androidx.annotation.Px
 import androidx.annotation.StyleableRes
 import androidx.core.content.res.getColorOrThrow
+import androidx.core.content.res.getDimensionOrThrow
 import kotlin.contracts.InvocationKind
 import kotlin.contracts.contract
 
@@ -24,3 +26,7 @@ internal inline fun <reified T : Enum<T>> TypedArray.getEnum(index: Int, default
 @ColorInt
 internal fun TypedArray.getColorOrNull(@StyleableRes index: Int): Int? =
     runCatching { getColorOrThrow(index) }.getOrNull()
+
+@Px
+internal fun TypedArray.getDimensionOrNull(@StyleableRes index: Int): Float? =
+    runCatching { getDimensionOrThrow(index) }.getOrNull()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
@@ -387,7 +387,10 @@ public data class MessageListItemStyle(
                 .build()
 
             val reactionsViewStyle = ViewReactionsViewStyle.Companion.Builder(attributes, context)
-                .bubbleBorderColor(R.styleable.MessageListView_streamUiMessageReactionsBubbleBorderColorMine)
+                .bubbleBorderColorMine(R.styleable.MessageListView_streamUiMessageReactionsBubbleBorderColorMine)
+                .bubbleBorderColorTheirs(R.styleable.MessageListView_streamUiMessageReactionsBubbleBorderColorTheirs)
+                .bubbleBorderWidthMine(R.styleable.MessageListView_streamUiMessageReactionsBubbleBorderWidthMine)
+                .bubbleBorderWidthTheirs(R.styleable.MessageListView_streamUiMessageReactionsBubbleBorderWidthTheirs)
                 .bubbleColorMine(R.styleable.MessageListView_streamUiMessageReactionsBubbleColorMine)
                 .bubbleColorTheirs(R.styleable.MessageListView_streamUiMessageReactionsBubbleColorTheirs)
                 .build()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle.kt
@@ -8,14 +8,26 @@ import androidx.annotation.Px
 import androidx.annotation.StyleableRes
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
+import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getColorOrNull
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
+import io.getstream.chat.android.ui.common.extensions.internal.getDimensionOrNull
 import io.getstream.chat.android.ui.common.extensions.internal.use
 
 public data class ViewReactionsViewStyle(
+    @Deprecated(
+        message  = "Use bubbleBorderColorMine instead",
+        replaceWith = ReplaceWith("bubbleBorderColorMine"),
+        level = DeprecationLevel.WARNING,
+    )
     @ColorInt public val bubbleBorderColor: Int,
+    @ColorInt public val bubbleBorderColorMine: Int,
+    @ColorInt public val bubbleBorderColorTheirs: Int?,
     @ColorInt public val bubbleColorMine: Int,
     @ColorInt public val bubbleColorTheirs: Int,
+    @Px public val bubbleBorderWidthMine: Float,
+    @Px public val bubbleBorderWidthTheirs: Float?,
     @Px public val totalHeight: Int,
     @Px public val horizontalPadding: Int,
     @Px public val itemSize: Int,
@@ -29,10 +41,21 @@ public data class ViewReactionsViewStyle(
     @Px public val smallTailBubbleOffset: Int,
 ) {
 
+    //TODO Remove after removing bubbleBorderColor
+    @ColorInt
+    internal fun getBubbleBorderColorMine(): Int {
+        return if (bubbleBorderColor != DEFAULT_BUBBLE_BORDER_COLOR_MINE) {
+            bubbleBorderColor
+        } else {
+            bubbleBorderColorMine
+        }
+    }
+
     internal companion object {
-        private val DEFAULT_BUBBLE_BORDER_COLOR = R.color.stream_ui_grey_whisper
+        private val DEFAULT_BUBBLE_BORDER_COLOR_MINE = R.color.stream_ui_grey_whisper
         private val DEFAULT_BUBBLE_COLOR_MINE = R.color.stream_ui_grey_whisper
         private val DEFAULT_BUBBLE_COLOR_THEIRS = R.color.stream_ui_grey_gainsboro
+        private val DEFAULT_BUBBLE_BORDER_WIDTH_MINE = 1.dpToPx() * 1.5f
 
         operator fun invoke(context: Context, attrs: AttributeSet?): ViewReactionsViewStyle {
             context.obtainStyledAttributes(
@@ -42,7 +65,10 @@ public data class ViewReactionsViewStyle(
                 0,
             ).use { a ->
                 return Builder(a, context)
-                    .bubbleBorderColor(R.styleable.ViewReactionsView_streamUiReactionsBubbleBorderColorMine)
+                    .bubbleBorderColorMine(R.styleable.ViewReactionsView_streamUiReactionsBubbleBorderColorMine)
+                    .bubbleBorderColorTheirs(R.styleable.ViewReactionsView_streamUiReactionsBubbleBorderColorTheirs)
+                    .bubbleBorderWidthMine(R.styleable.ViewReactionsView_streamUiReactionsBubbleBorderWidthMine)
+                    .bubbleBorderWidthTheirs(R.styleable.ViewReactionsView_streamUiReactionsBubbleBorderWidthTheirs)
                     .bubbleColorMine(R.styleable.ViewReactionsView_streamUiReactionsBubbleColorMine)
                     .bubbleColorTheirs(R.styleable.ViewReactionsView_streamUiReactionsBubbleColorTheirs)
                     .build()
@@ -55,7 +81,13 @@ public data class ViewReactionsViewStyle(
             @ColorInt
             private var bubbleColorMine: Int = context.getColorCompat(DEFAULT_BUBBLE_COLOR_MINE)
             @ColorInt
-            private var bubbleBorderColor: Int = context.getColorCompat(DEFAULT_BUBBLE_BORDER_COLOR)
+            private var bubbleBorderColorMine: Int = context.getColorCompat(DEFAULT_BUBBLE_BORDER_COLOR_MINE)
+            @ColorInt
+            private var bubbleBorderColorTheirs: Int? = null
+            @Px
+            private var bubbleBorderWidthMine: Float = DEFAULT_BUBBLE_BORDER_WIDTH_MINE
+            @Px
+            private var bubbleBorderWidthTheirs: Float? = null
 
             fun bubbleColorTheirs(@StyleableRes theirsBubbleColorAttribute: Int) = apply {
                 bubbleColorTheirs =
@@ -67,9 +99,21 @@ public data class ViewReactionsViewStyle(
                     array.getColor(mineBubbleColorAttribute, context.getColorCompat(DEFAULT_BUBBLE_COLOR_MINE))
             }
 
-            fun bubbleBorderColor(@StyleableRes bubbleBorderColorAttribute: Int) = apply {
-                bubbleBorderColor =
-                    array.getColor(bubbleBorderColorAttribute, context.getColorCompat(DEFAULT_BUBBLE_BORDER_COLOR))
+            fun bubbleBorderColorMine(@StyleableRes bubbleBorderColorAttribute: Int) = apply {
+                bubbleBorderColorMine =
+                    array.getColor(bubbleBorderColorAttribute, context.getColorCompat(DEFAULT_BUBBLE_BORDER_COLOR_MINE))
+            }
+
+            fun bubbleBorderColorTheirs(@StyleableRes bubbleBorderColorAttribute: Int) = apply {
+                bubbleBorderColorTheirs = array.getColorOrNull(bubbleBorderColorAttribute)
+            }
+
+            fun bubbleBorderWidthMine(@StyleableRes bubbleBorderWidthAttribute: Int) = apply {
+                bubbleBorderWidthMine = array.getDimension(bubbleBorderWidthAttribute, DEFAULT_BUBBLE_BORDER_WIDTH_MINE)
+            }
+
+            fun bubbleBorderWidthTheirs(@StyleableRes bubbleBorderWidthAttribute: Int) = apply {
+                bubbleBorderWidthTheirs = array.getDimensionOrNull(bubbleBorderWidthAttribute)
             }
 
             fun build(): ViewReactionsViewStyle {
@@ -97,7 +141,11 @@ public data class ViewReactionsViewStyle(
                     context.getDimension(R.dimen.stream_ui_view_reactions_small_tail_bubble_offset)
 
                 return ViewReactionsViewStyle(
-                    bubbleBorderColor = bubbleBorderColor,
+                    bubbleBorderColor = bubbleBorderColorMine,
+                    bubbleBorderColorMine = bubbleBorderColorMine,
+                    bubbleBorderColorTheirs = bubbleBorderColorTheirs,
+                    bubbleBorderWidthMine = bubbleBorderWidthMine,
+                    bubbleBorderWidthTheirs = bubbleBorderWidthTheirs,
                     bubbleColorMine = bubbleColorMine,
                     bubbleColorTheirs = bubbleColorTheirs,
                     totalHeight = totalHeight,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/ViewReactionsViewStyle.kt
@@ -21,7 +21,7 @@ public data class ViewReactionsViewStyle(
         replaceWith = ReplaceWith("bubbleBorderColorMine"),
         level = DeprecationLevel.WARNING,
     )
-    @ColorInt public val bubbleBorderColor: Int,
+    @ColorInt public val bubbleBorderColor: Int?,
     @ColorInt public val bubbleBorderColorMine: Int,
     @ColorInt public val bubbleBorderColorTheirs: Int?,
     @ColorInt public val bubbleColorMine: Int,
@@ -40,16 +40,6 @@ public data class ViewReactionsViewStyle(
     @Px public val smallTailBubbleRadius: Int,
     @Px public val smallTailBubbleOffset: Int,
 ) {
-
-    //TODO Remove after removing bubbleBorderColor
-    @ColorInt
-    internal fun getBubbleBorderColorMine(): Int {
-        return if (bubbleBorderColor != DEFAULT_BUBBLE_BORDER_COLOR_MINE) {
-            bubbleBorderColor
-        } else {
-            bubbleBorderColorMine
-        }
-    }
 
     internal companion object {
         private val DEFAULT_BUBBLE_BORDER_COLOR_MINE = R.color.stream_ui_grey_whisper
@@ -141,7 +131,7 @@ public data class ViewReactionsViewStyle(
                     context.getDimension(R.dimen.stream_ui_view_reactions_small_tail_bubble_offset)
 
                 return ViewReactionsViewStyle(
-                    bubbleBorderColor = bubbleBorderColorMine,
+                    bubbleBorderColor = null,
                     bubbleBorderColorMine = bubbleBorderColorMine,
                     bubbleBorderColorTheirs = bubbleBorderColorTheirs,
                     bubbleBorderWidthMine = bubbleBorderWidthMine,
@@ -158,7 +148,7 @@ public data class ViewReactionsViewStyle(
                     largeTailBubbleOffset = largeTailBubbleOffset,
                     smallTailBubbleCy = smallTailBubbleCy,
                     smallTailBubbleRadius = smallTailBubbleRadius,
-                    smallTailBubbleOffset = smallTailBubbleOffset
+                    smallTailBubbleOffset = smallTailBubbleOffset,
                 ).let(TransformStyle.viewReactionsStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/internal/ViewReactionsBubbleDrawer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/internal/ViewReactionsBubbleDrawer.kt
@@ -19,7 +19,7 @@ internal class ViewReactionsBubbleDrawer(
         style = Paint.Style.FILL
     }
     private val bubbleStrokePaintMine = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = viewReactionsViewStyle.getBubbleBorderColorMine()
+        color = viewReactionsViewStyle.bubbleBorderColor ?: viewReactionsViewStyle.bubbleBorderColorMine
         strokeWidth = viewReactionsViewStyle.bubbleBorderWidthMine
         style = Paint.Style.STROKE
     }
@@ -72,15 +72,7 @@ internal class ViewReactionsBubbleDrawer(
         viewReactionsViewStyle.bubbleBorderColorTheirs != null && viewReactionsViewStyle.bubbleBorderWidthTheirs != null
 
     private fun createBubbleRoundRectPath(): Path {
-        val strokeOffset: Float = if (isMyMessage) {
-            viewReactionsViewStyle.bubbleBorderWidthMine / 2
-        } else {
-            if (shouldDrawTheirsBorder()) {
-                viewReactionsViewStyle.bubbleBorderWidthTheirs!! / 2
-            } else {
-                0f
-            }
-        }
+        val strokeOffset = getStrokeOffset()
         return Path().apply {
             addRoundRect(
                 strokeOffset,
@@ -91,6 +83,20 @@ internal class ViewReactionsBubbleDrawer(
                 viewReactionsViewStyle.bubbleRadius.toFloat(),
                 Path.Direction.CW
             )
+        }
+    }
+
+    private fun getStrokeOffset(): Float {
+        return when {
+            isMyMessage -> {
+                viewReactionsViewStyle.bubbleBorderWidthMine / 2
+            }
+            shouldDrawTheirsBorder() -> {
+                viewReactionsViewStyle.bubbleBorderWidthTheirs!! / 2
+            }
+            else -> {
+                0f
+            }
         }
     }
 
@@ -110,7 +116,7 @@ internal class ViewReactionsBubbleDrawer(
             addCircle(
                 calculateBubbleCenterX(viewReactionsViewStyle.smallTailBubbleOffset.toFloat()),
                 viewReactionsViewStyle.smallTailBubbleCy.toFloat(),
-                viewReactionsViewStyle.smallTailBubbleRadius.toFloat(),
+                viewReactionsViewStyle.smallTailBubbleRadius.toFloat() - getStrokeOffset(),
                 Path.Direction.CW
             )
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/internal/ViewReactionsBubbleDrawer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/view/internal/ViewReactionsBubbleDrawer.kt
@@ -7,10 +7,8 @@ import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
 import io.getstream.chat.android.ui.message.list.reactions.view.ViewReactionsViewStyle
 
 internal class ViewReactionsBubbleDrawer(
-    private val viewReactionsViewStyle: ViewReactionsViewStyle
+    private val viewReactionsViewStyle: ViewReactionsViewStyle,
 ) {
-
-    private val bubbleStrokeWidth: Float = 1.dpToPx() * 1.5f
 
     private val bubblePaintTheirs = Paint(Paint.ANTI_ALIAS_FLAG).apply {
         color = viewReactionsViewStyle.bubbleColorTheirs
@@ -21,9 +19,20 @@ internal class ViewReactionsBubbleDrawer(
         style = Paint.Style.FILL
     }
     private val bubbleStrokePaintMine = Paint(Paint.ANTI_ALIAS_FLAG).apply {
-        color = viewReactionsViewStyle.bubbleBorderColor
-        strokeWidth = bubbleStrokeWidth
+        color = viewReactionsViewStyle.getBubbleBorderColorMine()
+        strokeWidth = viewReactionsViewStyle.bubbleBorderWidthMine
         style = Paint.Style.STROKE
+    }
+
+    private val bubbleStrokePaintTheirs by lazy {
+        check(shouldDrawTheirsBorder()) {
+            "You need to specify either bubbleBorderColorTheirs and bubbleBorderWidthTheirs to draw a border for another user reaction bubble"
+        }
+        Paint(Paint.ANTI_ALIAS_FLAG).apply {
+            color = viewReactionsViewStyle.bubbleBorderColorTheirs!!
+            strokeWidth = viewReactionsViewStyle.bubbleBorderWidthTheirs!!
+            style = Paint.Style.STROKE
+        }
     }
 
     private var bubbleWidth: Int = 0
@@ -35,7 +44,7 @@ internal class ViewReactionsBubbleDrawer(
         bubbleWidth: Int,
         isMyMessage: Boolean,
         isSingleReaction: Boolean,
-        inverseBubbleStyle: Boolean = false
+        inverseBubbleStyle: Boolean = false,
     ) {
         this.isMyMessage = isMyMessage
         this.bubbleWidth = bubbleWidth
@@ -53,14 +62,24 @@ internal class ViewReactionsBubbleDrawer(
             canvas.drawPath(path, bubbleStrokePaintMine)
         } else {
             canvas.drawPath(path, bubblePaintTheirs)
+            if (shouldDrawTheirsBorder()) {
+                canvas.drawPath(path, bubbleStrokePaintTheirs)
+            }
         }
     }
 
+    private fun shouldDrawTheirsBorder(): Boolean =
+        viewReactionsViewStyle.bubbleBorderColorTheirs != null && viewReactionsViewStyle.bubbleBorderWidthTheirs != null
+
     private fun createBubbleRoundRectPath(): Path {
         val strokeOffset: Float = if (isMyMessage) {
-            bubbleStrokeWidth / 2
+            viewReactionsViewStyle.bubbleBorderWidthMine / 2
         } else {
-            0f
+            if (shouldDrawTheirsBorder()) {
+                viewReactionsViewStyle.bubbleBorderWidthTheirs!! / 2
+            } else {
+                0f
+            }
         }
         return Path().apply {
             addRoundRect(

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -192,6 +192,9 @@
         <attr name="streamUiMessageReactionsBubbleColorMine" format="color" />
         <attr name="streamUiMessageReactionsBubbleColorTheirs" format="color" />
         <attr name="streamUiMessageReactionsBubbleBorderColorMine" format="color|reference" />
+        <attr name="streamUiMessageReactionsBubbleBorderColorTheirs" format="color|reference" />
+        <attr name="streamUiMessageReactionsBubbleBorderWidthMine" format="dimension|reference" />
+        <attr name="streamUiMessageReactionsBubbleBorderWidthTheirs" format="dimension|reference" />
 
         <!-- Message edit reactions view style -->
         <attr name="streamUiEditReactionsBubbleColorMine" format="color" />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_view_reactions_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_view_reactions_view.xml
@@ -7,5 +7,11 @@
         <attr name="streamUiReactionsBubbleColorTheirs" />
         <!-- Border color of the reactions bubble for the message sent by the current user -->
         <attr name="streamUiReactionsBubbleBorderColorMine" format="color|reference" />
+        <!-- Border color of the reactions bubble for the message sent by another user -->
+        <attr name="streamUiReactionsBubbleBorderColorTheirs" format="color|reference" />
+        <!-- Border width of the reactions bubble for the message sent by the current user -->
+        <attr name="streamUiReactionsBubbleBorderWidthMine" format="dimension|reference" />
+        <!-- Border width of the reactions bubble for the message sent by another user -->
+        <attr name="streamUiReactionsBubbleBorderWidthTheirs" format="dimension|reference" />
     </declare-styleable>
 </resources>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1333

### 🎯 Goal

[CAS-1333] Add missing border-related attributes to `ViewReactionsView`

### 🛠 Implementation details

- Added `bubbleBorderColorMine`, `bubbleBorderColorTheirs`, `bubbleBorderWidthMine`, `bubbleBorderWidthTheirs` attributes
- Deprecated `bubbleBorderColor`
- Fixed small bubble size when border is applied

### 🎨 UI Changes

_ Add relevant screenshots_

| Before | After |
| --- | --- |
|<img width="320" alt="before_3" src="https://user-images.githubusercontent.com/17440581/134505771-f3408961-736b-41ba-8fc5-22ed7ea67a89.png">|<img width="320" alt="after_3" src="https://user-images.githubusercontent.com/17440581/134505758-e9b24552-6711-4f19-a108-32816aa347a1.png">
|<img width="320" alt="before_1" src="https://user-images.githubusercontent.com/17440581/134505763-c2bc65f2-7c42-42cc-98e4-c0b1f3293530.png">|<img width="320" alt="after_1" src="https://user-images.githubusercontent.com/17440581/134505751-abd5821e-1706-45b8-ab60-f529b341c6d5.png">
|<img width="320" alt="before_2" src="https://user-images.githubusercontent.com/17440581/134505767-ff3d3f56-abc6-4f93-9dc3-6e8c53814fc4.png">|<img width="320" alt="after_2" src="https://user-images.githubusercontent.com/17440581/134505756-81a0ebd4-8406-4013-acee-4ac7487d876e.png">|


### 🧪 Testing

Play with newly added attributes and check reaction views are working fine. You can use the following style transformer:
```
TransformStyle.viewReactionsStyleTransformer = StyleTransformer {
    it.copy(
        bubbleBorderColorMine = Color.RED,
        bubbleBorderColorTheirs = Color.GREEN,
        bubbleBorderWidthTheirs = it.bubbleBorderWidthMine,
    )
}

```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added



[CAS-1333]: https://stream-io.atlassian.net/browse/CAS-1333