### PR TITLE
[CAS-1322] Clean state when logout. Fix error isFirstPage func

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -364,6 +364,9 @@ internal class ChatDomainImpl internal constructor(
         clearState()
         offlineSyncFirebaseMessagingHandler.cancel(appContext)
         activeChannelMapImpl.values.forEach(ChannelController::cancelJobs)
+        activeChannelMapImpl.clear()
+        activeQueryMapImpl.clear()
+        offlinePlugin.clear()
     }
 
     override fun getVersion(): String {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -46,6 +46,11 @@ public class OfflinePlugin(private val config: Config) : Plugin {
         request: QueryChannelRequest,
     ): Unit = logic.queryChannel().onQueryChannelResult(result, channelType, channelId, request)
 
+    internal fun clear() {
+        logic.clear()
+        state.clear()
+    }
+
     public companion object {
         public const val MODULE_NAME: String = "Offline"
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/logic/LogicRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/logic/LogicRegistry.kt
@@ -32,4 +32,8 @@ internal class LogicRegistry internal constructor(private val stateRegistry: Sta
         queryChannels(queryChannelsRequest.filter, queryChannelsRequest.querySort)
 
     fun queryChannel(): QueryChannelLogic = QueryChannelLogic(chatDomain)
+
+    fun clear() {
+        queryChannels.clear()
+    }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
@@ -27,4 +27,8 @@ public class StateRegistry {
             QueryChannelsMutableState(filter, sort, scope)
         }
     }
+
+    public fun clear() {
+        queryChannels.clear()
+    }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/request/AnyChannelPaginationRequest.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/request/AnyChannelPaginationRequest.kt
@@ -24,21 +24,11 @@ internal fun AnyChannelPaginationRequest.hasFilter(): Boolean {
 }
 
 internal fun AnyChannelPaginationRequest.isFirstPage(): Boolean {
-    return messageFilterDirection == null
+    return channelOffset == 0
 }
 
 internal fun AnyChannelPaginationRequest.isRequestingMoreThanLastMessage(): Boolean {
     return (isFirstPage() && messageLimit > 1) || (isNotFirstPage() && messageLimit > 0)
 }
 
-internal fun AnyChannelPaginationRequest.isNotFirstPage(): Boolean {
-    return !isFirstPage()
-}
-
-internal fun AnyChannelPaginationRequest.isFilteringNewerMessages(): Boolean {
-    return (messageFilterDirection != null && (messageFilterDirection == Pagination.GREATER_THAN_OR_EQUAL || messageFilterDirection == Pagination.GREATER_THAN))
-}
-
-internal fun AnyChannelPaginationRequest.isFilteringOlderMessages(): Boolean {
-    return (messageFilterDirection != null && (messageFilterDirection == Pagination.LESS_THAN || messageFilterDirection == Pagination.LESS_THAN_OR_EQUAL))
-}
+internal fun AnyChannelPaginationRequest.isNotFirstPage(): Boolean = isFirstPage().not()


### PR DESCRIPTION

### 🎯 Goal

Fix of infinite shimmer even after logout

### 🛠 Implementation details

1. Clean state of controllers and state on logout
2. Fix `AnyChannelPaginationRequest::isFirstPage` (it used never set property in the query channels)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media0.giphy.com/media/rCXHwP1EznoL7U6IBJ/giphy.gif)