### PR TITLE
[Compose] - Improve MessagesViewModelFactory constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved the experience of creating the MessagesViewModelFactory with default arguments
 
 ### ✅ Added
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
@@ -1,6 +1,5 @@
 package io.getstream.chat.android.compose.sample
 
-import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
@@ -30,7 +29,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResultType
 import io.getstream.chat.android.compose.state.messages.Thread
 import io.getstream.chat.android.compose.state.messages.list.Reply
@@ -46,19 +44,13 @@ import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerVie
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
-import io.getstream.chat.android.offline.ChatDomain
 
 class MessagesActivity : AppCompatActivity() {
 
     private val factory by lazy {
         MessagesViewModelFactory(
             context = this,
-            clipboardManager = getSystemService(CLIPBOARD_SERVICE) as ClipboardManager,
-            chatClient = ChatClient.instance(),
-            chatDomain = ChatDomain.instance(),
             channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: "",
-            enforceUniqueReactions = true,
-            messageLimit = 30
         )
     }
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -929,7 +929,8 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Landroid/content/ClipboardManager;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;Ljava/lang/String;ZI)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZI)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.compose.ui.messages
 
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.Context.CLIPBOARD_SERVICE
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -20,7 +19,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.handlers.SystemBackPressedHandler
@@ -40,7 +38,6 @@ import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerVie
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
-import io.getstream.chat.android.offline.ChatDomain
 
 /**
  * Default root Messages screen component, that provides the necessary ViewModels and
@@ -209,6 +206,7 @@ public fun MessagesScreen(
  *
  * @param context Used to build the [ClipboardManager].
  * @param channelId The current channel ID, to load the messages from.
+ * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
  * @param messageLimit The limit when loading messages.
  */
 private fun buildViewModelFactory(
@@ -217,15 +215,10 @@ private fun buildViewModelFactory(
     enforceUniqueReactions: Boolean,
     messageLimit: Int,
 ): MessagesViewModelFactory {
-    val clipboardManager = context.getSystemService(CLIPBOARD_SERVICE) as ClipboardManager
-
     return MessagesViewModelFactory(
-        context,
-        clipboardManager,
-        ChatClient.instance(),
-        ChatDomain.instance(),
-        channelId,
-        enforceUniqueReactions,
-        messageLimit
+        context = context,
+        channelId = channelId,
+        enforceUniqueReactions = enforceUniqueReactions,
+        messageLimit = messageLimit
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -13,15 +13,20 @@ import io.getstream.chat.android.offline.ChatDomain
 /**
  * Holds all the dependencies needed to build the ViewModels for the Messages Screen.
  * Currently builds the [MessageComposerViewModel], [MessageListViewModel] and [AttachmentsPickerViewModel].
+ * @param context Used to build the [ClipboardManager].
+ * @param channelId The current channel ID, to load the messages from.
+ * @param chatClient The client to use for API calls.
+ * @param chatDomain The domain used to fetch data.
+ * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
+ * @param messageLimit The limit when loading messages.
  */
 public class MessagesViewModelFactory(
     private val context: Context,
-    private val clipboardManager: ClipboardManager,
-    private val chatClient: ChatClient,
-    private val chatDomain: ChatDomain,
     private val channelId: String,
-    private val enforceUniqueReactions: Boolean,
-    private val messageLimit: Int,
+    private val chatClient: ChatClient = ChatClient.instance(),
+    private val chatDomain: ChatDomain = ChatDomain.instance(),
+    private val enforceUniqueReactions: Boolean = true,
+    private val messageLimit: Int = 30,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(
@@ -35,7 +40,7 @@ public class MessagesViewModelFactory(
                 channelId,
                 messageLimit,
                 enforceUniqueReactions,
-                ClipboardHandlerImpl(clipboardManager)
+                ClipboardHandlerImpl(context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager)
             )
         },
         AttachmentsPickerViewModel::class.java to {


### PR DESCRIPTION
Fixes #2395 

### 🎯 Goal

We wanted to improve the experience when creating Messages screen ViewModels.

### 🛠 Implementation details

Made most of the parameters optional by supplying default arguments. Removed the `ClipboardManager` as a parameter and created it internally

### ☑️ Checklist
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF
![easier](https://user-images.githubusercontent.com/17215808/135240563-46dd7c03-dbdd-4ceb-b160-c6ec08f35708.gif)