### PR TITLE
Add a border parameter to MessageBubble

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -505,7 +505,7 @@ public final class io/getstream/chat/android/compose/ui/common/LoadingViewKt {
 }
 
 public final class io/getstream/chat/android/compose/ui/common/MessageBubbleKt {
-	public static final fun MessageBubble-euL9pac (JLandroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageBubble-yWKOrZg (JLandroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/BorderStroke;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/common/NetworkLoadingViewKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/MessageBubble.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/MessageBubble.kt
@@ -12,23 +12,25 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 /**
  * Wraps the content of a message in a bubble.
  *
- * @param content The content of the message.
- * @param modifier Modifier for styling.
  * @param color The color of the bubble.
  * @param shape The shape of the bubble.
+ * @param modifier Modifier for styling.
+ * @param border The optional border of the bubble.
+ * @param content The content of the message.
  */
 @Composable
 public fun MessageBubble(
     color: Color,
     shape: Shape,
     modifier: Modifier = Modifier,
+    border: BorderStroke? = BorderStroke(1.dp, ChatTheme.colors.borders),
     content: @Composable () -> Unit,
 ) {
     Surface(
         modifier = modifier,
         shape = shape,
         color = color,
-        border = BorderStroke(1.dp, ChatTheme.colors.borders),
+        border = border,
     ) {
         content()
     }


### PR DESCRIPTION
### 🎯 Goal

Make the border removable from a `MessageBubble` without modifying it at the theme level.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
