### PR TITLE
[Compose] - Overall Attachments API improvements and cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,12 +67,20 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fixed a bug where attachments weren't properly stored when editing a message
 
 ### ⬆️ Improved
+- General improvements in the Attachments API and the way we build different attachments
+- Allowed for better long clicks on attachments
 
 ### ✅ Added
 
 ### ⚠️ Changed
+- Removed AttachmentPicker option when editing messages
+- Removed Attachment previews when editing messages with attachments
+- Improved the ease of use of the AttachmentState API by keeping it state & actions only
+- Moved the `modifier` parameter outside of the AttachmentState to the AttachmentFactory
+- Updated Attachments to hold `Message` items instead of `MessageItem`s
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -188,17 +188,15 @@ public final class io/getstream/chat/android/compose/state/messages/attachments/
 
 public final class io/getstream/chat/android/compose/state/messages/attachments/AttachmentState {
 	public static final field $stable I
-	public fun <init> (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public final fun component1 ()Landroidx/compose/ui/Modifier;
-	public final fun component2 ()Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/chat/android/client/models/Message;
+	public final fun component2 ()Lkotlin/jvm/functions/Function1;
 	public final fun component3 ()Lkotlin/jvm/functions/Function1;
-	public final fun component4 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
+	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getMessageItem ()Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
-	public final fun getModifier ()Landroidx/compose/ui/Modifier;
+	public final fun getMessage ()Lio/getstream/chat/android/client/models/Message;
 	public final fun getOnImagePreviewResult ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnLongItemClick ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
@@ -347,9 +345,9 @@ public final class io/getstream/chat/android/compose/state/messages/reaction/Rea
 
 public class io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;)V
 	public final fun getCanHandle ()Lkotlin/jvm/functions/Function1;
-	public final fun getContent ()Lkotlin/jvm/functions/Function3;
+	public final fun getContent ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories {
@@ -360,58 +358,58 @@ public final class io/getstream/chat/android/compose/ui/attachments/StreamAttach
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContentKt {
-	public static final fun FileAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
+	public static final fun FileAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun FileAttachmentImage (Lio/getstream/chat/android/client/models/Attachment;Landroidx/compose/runtime/Composer;I)V
 	public static final fun FileAttachmentItem (Lio/getstream/chat/android/client/models/Attachment;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileUploadContentKt {
-	public static final fun FileUploadContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
+	public static final fun FileUploadContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun FileUploadItem (Lio/getstream/chat/android/client/models/Attachment;Landroidx/compose/runtime/Composer;I)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContentKt {
-	public static final fun GiphyAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
+	public static final fun GiphyAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContentKt {
-	public static final fun ImageAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ImageAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContentKt {
-	public static final fun LinkAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;ILandroidx/compose/runtime/Composer;I)V
+	public static final fun LinkAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;ILandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/MessageAttachmentsContentKt {
-	public static final fun MessageAttachmentsContent (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageAttachmentsContent (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$FileAttachmentFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$FileAttachmentFactoryKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$GiphyAttachmentFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$GiphyAttachmentFactoryKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$ImageAttachmentFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$ImageAttachmentFactoryKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function3;
+	public static field lambda-1 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactoryKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/attachments/AttachmentState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/attachments/AttachmentState.kt
@@ -1,21 +1,17 @@
 package io.getstream.chat.android.compose.state.messages.attachments
 
-import androidx.compose.ui.Modifier
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResult
-import io.getstream.chat.android.compose.state.messages.items.MessageItem
 
 /**
  * Represents the state of Attachment items, used to render and add handlers required for the attachment to work.
  *
- * @param modifier Modifier for styling.
- * @param messageItem Data that represents the message information.
+ * @param message Data that represents the message information.
  * @param onLongItemClick Handler for a long click on the message item.
  * @param onImagePreviewResult Handler when the user selects an action to scroll to and focus an image.
  */
 public data class AttachmentState(
-    val modifier: Modifier,
-    val messageItem: MessageItem,
+    val message: Message,
     val onLongItemClick: (Message) -> Unit = {},
     val onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.compose.ui.attachments
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.attachments.factory.FileAttachmentFactory
@@ -49,5 +50,8 @@ public object StreamAttachmentFactories {
  */
 public open class AttachmentFactory @ExperimentalStreamChatApi constructor(
     public val canHandle: (attachments: List<Attachment>) -> Boolean,
-    public val content: @Composable (AttachmentState) -> Unit,
+    public val content: @Composable (
+        modifier: Modifier,
+        attachmentState: AttachmentState,
+    ) -> Unit,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -1,7 +1,9 @@
 package io.getstream.chat.android.compose.ui.attachments.content
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -48,15 +50,24 @@ internal val FILE_ATTACHMENT_WIDTH = 250.dp
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-public fun FileAttachmentContent(attachmentState: AttachmentState) {
-    val (modifier, messageItem, _) = attachmentState
-    val (message, _) = messageItem
+public fun FileAttachmentContent(
+    attachmentState: AttachmentState,
+    modifier: Modifier = Modifier,
+) {
+    val (message, onLongItemClick) = attachmentState
 
     Column(
         modifier = modifier
             .wrapContentHeight()
             .width(FILE_ATTACHMENT_WIDTH)
+            .combinedClickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {},
+                onLongClick = { onLongItemClick(message) }
+            )
     ) {
         for (attachment in message.attachments) {
             FileAttachmentItem(attachment = attachment)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -35,9 +35,11 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param attachmentState The state of this attachment.
  */
 @Composable
-public fun FileUploadContent(attachmentState: AttachmentState) {
-    val (modifier, messageItem, _) = attachmentState
-    val (message, _) = messageItem
+public fun FileUploadContent(
+    attachmentState: AttachmentState,
+    modifier: Modifier = Modifier,
+) {
+    val message = attachmentState.message
 
     Column(
         modifier = modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -36,10 +36,12 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-public fun GiphyAttachmentContent(attachmentState: AttachmentState) {
+public fun GiphyAttachmentContent(
+    attachmentState: AttachmentState,
+    modifier: Modifier = Modifier,
+) {
     val context = LocalContext.current
-    val (modifier, messageItem, onLongItemClick) = attachmentState
-    val (message, _) = messageItem
+    val (message, onLongItemClick) = attachmentState
     val attachment = message.attachments.firstOrNull { it.type == ModelType.attach_giphy }
 
     checkNotNull(attachment) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
@@ -3,7 +3,6 @@ package io.getstream.chat.android.compose.ui.attachments.content
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Box
@@ -47,9 +46,11 @@ import io.getstream.chat.android.compose.ui.util.isMedia
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-public fun ImageAttachmentContent(attachmentState: AttachmentState) {
-    val (modifier, messageItem, onLongItemClick, onImagePreviewResult) = attachmentState
-    val (message, _) = messageItem
+public fun ImageAttachmentContent(
+    attachmentState: AttachmentState,
+    modifier: Modifier = Modifier,
+) {
+    val (message, onLongItemClick, onImagePreviewResult) = attachmentState
 
     Row(
         modifier
@@ -74,7 +75,8 @@ public fun ImageAttachmentContent(attachmentState: AttachmentState) {
                 modifier = Modifier.weight(1f),
                 message = message,
                 attachmentPosition = 0,
-                onImagePreviewResult = onImagePreviewResult
+                onImagePreviewResult = onImagePreviewResult,
+                onLongItemClick = onLongItemClick
             )
         } else {
             Column(
@@ -89,7 +91,8 @@ public fun ImageAttachmentContent(attachmentState: AttachmentState) {
                             modifier = Modifier.weight(1f),
                             message = message,
                             attachmentPosition = imageIndex,
-                            onImagePreviewResult = onImagePreviewResult
+                            onImagePreviewResult = onImagePreviewResult,
+                            onLongItemClick = onLongItemClick
                         )
                     }
                 }
@@ -111,7 +114,8 @@ public fun ImageAttachmentContent(attachmentState: AttachmentState) {
                                     attachment = attachment,
                                     message = message,
                                     attachmentPosition = imageIndex,
-                                    onImagePreviewResult = onImagePreviewResult
+                                    onImagePreviewResult = onImagePreviewResult,
+                                    onLongItemClick = onLongItemClick
                                 )
 
                                 if (!isUploading) {
@@ -128,7 +132,8 @@ public fun ImageAttachmentContent(attachmentState: AttachmentState) {
                                 modifier = Modifier.weight(1f),
                                 message = message,
                                 attachmentPosition = imageIndex,
-                                onImagePreviewResult = onImagePreviewResult
+                                onImagePreviewResult = onImagePreviewResult,
+                                onLongItemClick = onLongItemClick
                             )
                         }
                     }
@@ -144,12 +149,14 @@ public fun ImageAttachmentContent(attachmentState: AttachmentState) {
  * @param attachment Image attachment data to show.
  * @param modifier Modifier for styling.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun ImageAttachmentContentItem(
     message: Message,
     attachmentPosition: Int,
     attachment: Attachment,
     onImagePreviewResult: (ImagePreviewResult?) -> Unit,
+    onLongItemClick: (Message) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val painter = rememberImagePainter(attachment.imagePreviewUrl)
@@ -162,7 +169,7 @@ internal fun ImageAttachmentContentItem(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .clickable(
+            .combinedClickable(
                 interactionSource = MutableInteractionSource(),
                 indication = rememberRipple(),
                 onClick = {
@@ -172,7 +179,8 @@ internal fun ImageAttachmentContentItem(
                             initialPosition = attachmentPosition
                         )
                     )
-                }
+                },
+                onLongClick = { onLongItemClick(message) }
             )
     ) {
         Image(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -45,9 +45,9 @@ import io.getstream.chat.android.compose.ui.util.hasLink
 public fun LinkAttachmentContent(
     attachmentState: AttachmentState,
     linkDescriptionMaxLines: Int,
+    modifier: Modifier = Modifier,
 ) {
-    val (modifier, messageItem, onLongItemClick) = attachmentState
-    val (message, _) = messageItem
+    val (message, onLongItemClick) = attachmentState
 
     val context = LocalContext.current
     val attachment = message.attachments.firstOrNull { it.hasLink() && it.type != ModelType.attach_giphy }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MessageAttachmentsContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MessageAttachmentsContent.kt
@@ -8,7 +8,6 @@ import com.getstream.sdk.chat.model.ModelType
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResult
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
-import io.getstream.chat.android.compose.state.messages.items.MessageItem
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.hasLink
 
@@ -16,20 +15,17 @@ import io.getstream.chat.android.compose.ui.util.hasLink
  * Represents the content that's shown in message attachments. We decide if we need to show link previews or other
  * attachments.
  *
- * @param messageItem The message that contains the attachments.
+ * @param message The message that contains the attachments.
  * @param onLongItemClick Handler for long item taps on this content.
  * @param onImagePreviewResult Handler when the user selects a message option in the Image Preview screen.
  */
 @Composable
 public fun MessageAttachmentsContent(
-    messageItem: MessageItem,
+    message: Message,
     onLongItemClick: (Message) -> Unit,
     onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
 ) {
-    val (message, _) = messageItem
-
     if (message.attachments.isNotEmpty()) {
-
         val (links, attachments) = message.attachments.partition { it.hasLink() && it.type != ModelType.attach_giphy }
 
         val linkFactory = if (links.isNotEmpty()) {
@@ -45,16 +41,15 @@ public fun MessageAttachmentsContent(
         }
 
         val attachmentState = AttachmentState(
-            modifier = Modifier.padding(4.dp),
-            messageItem = messageItem,
+            message = message,
             onLongItemClick = onLongItemClick,
             onImagePreviewResult = onImagePreviewResult
         )
 
         if (attachmentFactory != null) {
-            attachmentFactory.content(attachmentState)
+            attachmentFactory.content(Modifier.padding(4.dp), attachmentState)
         } else if (linkFactory != null) {
-            linkFactory.content(attachmentState)
+            linkFactory.content(Modifier.padding(4.dp), attachmentState)
         }
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -12,5 +12,10 @@ import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentCo
 @Suppress("FunctionName")
 public fun FileAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.uploadId != null } },
-    content = @Composable { FileAttachmentContent(it) },
+    content = @Composable { modifier, state ->
+        FileAttachmentContent(
+            modifier = modifier,
+            attachmentState = state
+        )
+    },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -11,5 +11,10 @@ import io.getstream.chat.android.compose.ui.attachments.content.GiphyAttachmentC
 @Suppress("FunctionName")
 public fun GiphyAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.type == ModelType.attach_giphy } },
-    content = @Composable { GiphyAttachmentContent(it) },
+    content = @Composable { modifier, state ->
+        GiphyAttachmentContent(
+            modifier = modifier,
+            attachmentState = state
+        )
+    },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/ImageAttachmentFactory.kt
@@ -12,5 +12,10 @@ import io.getstream.chat.android.compose.ui.util.isMedia
 @Suppress("FunctionName")
 public fun ImageAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.all { it.isMedia() } },
-    content = @Composable { ImageAttachmentContent(it) },
+    content = @Composable { modifier, state ->
+        ImageAttachmentContent(
+            modifier = modifier,
+            attachmentState = state
+        )
+    },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -17,5 +17,11 @@ public fun LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { links -> links.any { it.hasLink() && it.type != ModelType.attach_giphy } },
-    content = @Composable { LinkAttachmentContent(it, linkDescriptionMaxLines) },
+    content = @Composable { modifier, state ->
+        LinkAttachmentContent(
+            modifier = modifier,
+            attachmentState = state,
+            linkDescriptionMaxLines = linkDescriptionMaxLines
+        )
+    },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -11,5 +11,10 @@ import io.getstream.chat.android.compose.ui.util.isUploading
 @Suppress("FunctionName")
 public fun UploadAttachmentFactory(): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.isUploading() } },
-    content = @Composable { FileUploadContent(it) },
+    content = @Composable { modifier, state ->
+        FileUploadContent(
+            modifier = modifier,
+            attachmentState = state
+        )
+    },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -3,8 +3,10 @@ package io.getstream.chat.android.compose.ui.messages.composer
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
@@ -13,12 +15,14 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.state.messages.list.Edit
 import io.getstream.chat.android.compose.state.messages.list.MessageAction
 import io.getstream.chat.android.compose.ui.messages.composer.components.DefaultComposerIntegrations
 import io.getstream.chat.android.compose.ui.messages.composer.components.MessageInput
@@ -140,8 +144,14 @@ public fun MessageComposer(
                 verticalAlignment = Alignment.CenterVertically
             ) {
 
-                if (shouldShowIntegrations) {
+                if (shouldShowIntegrations && activeAction !is Edit) {
                     integrations()
+                } else {
+                    Spacer(
+                        modifier = Modifier
+                            .size(48.dp)
+                            .align(CenterVertically)
+                    )
                 }
 
                 input()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
@@ -37,11 +37,12 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.core.net.toUri
 import coil.compose.rememberImagePainter
 import com.getstream.sdk.chat.utils.MediaStringUtil
+import com.getstream.sdk.chat.utils.extensions.imagePreviewUrl
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.state.messages.list.Edit
 import io.getstream.chat.android.compose.state.messages.list.MessageAction
 import io.getstream.chat.android.compose.state.messages.list.Reply
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentImage
@@ -139,7 +140,7 @@ public fun MessageInput(
                     Spacer(modifier = Modifier.size(16.dp))
                 }
 
-                if (attachments.isNotEmpty()) {
+                if (attachments.isNotEmpty() && activeAction !is Edit) {
                     MessageInputAttachments(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -202,7 +203,7 @@ internal fun MessageInputImageAttachments(
         horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start)
     ) {
         items(attachments) { image ->
-            val painter = rememberImagePainter(data = image.upload?.toUri())
+            val painter = rememberImagePainter(data = image.upload ?: image.imagePreviewUrl)
             Box(
                 modifier = Modifier
                     .size(95.dp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -193,7 +193,7 @@ public fun DefaultMessageContainer(
                         } else {
                             Column {
                                 MessageAttachmentsContent(
-                                    messageItem = messageItem,
+                                    message = messageItem.message,
                                     onLongItemClick = onLongItemClick,
                                     onImagePreviewResult = onImagePreviewResult,
                                 )
@@ -500,10 +500,7 @@ internal fun QuotedMessage(
             content = {
                 Column {
                     MessageAttachmentsContent(
-                        messageItem = MessageItem(
-                            message = message,
-                            groupPosition = None
-                        ),
+                        message = message,
                         onLongItemClick = {}
                     )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
@@ -42,8 +42,6 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.compose.R
-import io.getstream.chat.android.compose.state.messages.items.MessageItem
-import io.getstream.chat.android.compose.state.messages.items.None
 import io.getstream.chat.android.compose.state.messages.list.Copy
 import io.getstream.chat.android.compose.state.messages.list.Delete
 import io.getstream.chat.android.compose.state.messages.list.Edit
@@ -218,7 +216,7 @@ private fun SelectedMessage(message: Message) {
                     DeletedMessageContent()
                 } else {
                     Column {
-                        MessageAttachmentsContent(messageItem = MessageItem(message, None), onLongItemClick = {})
+                        MessageAttachmentsContent(message = message, onLongItemClick = {})
 
                         if (message.text.isNotEmpty()) {
                             DefaultMessageContent(message = message)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -102,6 +102,7 @@ public class MessageComposerViewModel(
             }
             is Edit -> {
                 this.input = messageAction.message.text
+                this.selectedAttachments = messageAction.message.attachments
                 messageActions = messageActions + messageAction
             }
             else -> {
@@ -116,6 +117,7 @@ public class MessageComposerViewModel(
     public fun dismissMessageActions() {
         if (isInEditMode) {
             setMessageInput("")
+            this.selectedAttachments = emptyList()
         }
 
         this.messageActions = emptySet()
@@ -129,7 +131,15 @@ public class MessageComposerViewModel(
      * @param attachments The attachments to store and show in the composer.
      */
     public fun addSelectedAttachments(attachments: List<Attachment>) {
-        this.selectedAttachments = attachments
+        val newAttachments = (this.selectedAttachments + attachments).distinctBy {
+            if (it.name != null) {
+                it.name
+            } else {
+                it
+            }
+        }
+
+        this.selectedAttachments = newAttachments
     }
 
     /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -209,7 +209,7 @@ public class MessageListViewModel(
                     lastLoadedMessage = newLastMessage
                     controller.toChannel().let { channel ->
                         ChatClient.dismissChannelNotifications(channelType = channel.type, channelId = channel.id)
-                        setChanel(channel)
+                        setCurrentChannel(channel)
                     }
                 }
         }
@@ -218,7 +218,7 @@ public class MessageListViewModel(
     /**
      * Sets the current channel, used to show info in the UI.
      */
-    private fun setChanel(channel: Channel) {
+    private fun setCurrentChannel(channel: Channel) {
         this.channel = channel
     }
 


### PR DESCRIPTION
Fixes #2237.

Also covers more general improvements that we planned around attachments.

### 🎯 Goal

We wanted to make the Attachments API as easy and intuitive to use, so we removed multiple instances where attachments required extra structure or weren't exposing parameters/properties in a way that suits Composable functions.

We also had to fix bugs with editing messages, where the user would be able to "add/remove" attachments from a given message, which ultimately is not yet supported in our API.

### 🛠 Implementation details

- Removed integrations when the user is editing messages
- Fixed a bug where editing a message with attachments causes it to lose attachments
- Improved various smaller parts of AttachmentsState and AttachmentFactory API

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/17215808/135287559-148e566a-33ec-4b43-a878-afdd382bd6d6.png) | ![after](https://user-images.githubusercontent.com/17215808/135287508-835a435b-b112-434a-b950-42887786c166.png) |

### ☑️ Checklist

- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
