### PR TITLE
Fix recovery flow for query channels request

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -359,6 +359,7 @@ internal class ChatDomainImpl internal constructor(
         clearState()
         offlineSyncFirebaseMessagingHandler.cancel(appContext)
         activeChannelMapImpl.values.forEach(ChannelController::cancelJobs)
+        eventHandler.clear()
     }
 
     override fun getVersion(): String {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -641,7 +641,7 @@ internal class ChatDomainImpl internal constructor(
             .take(3)
         for (queryChannelController in queriesToRetry) {
             val pagination = QueryChannelsPaginationRequest(
-                QuerySort(),
+                queryChannelController.sort,
                 INITIAL_CHANNEL_OFFSET,
                 CHANNEL_LIMIT,
                 MESSAGE_LIMIT,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -83,8 +83,6 @@ internal class EventHandlerImpl(
                 }
                 is ConnectedEvent -> {
                     logger.logI("Received ConnectedEvent, marking the domain as online and initialized")
-                    val recovered = domainImpl.isInitialized()
-
                     domainImpl.setOnline()
                     domainImpl.setInitialized()
                     domainImpl.scope.launch {
@@ -451,5 +449,9 @@ internal class EventHandlerImpl(
         } else {
             // for events of current user we keep "ownReactions" from the event
         }
+    }
+
+    internal fun clear() {
+        firstConnect = true
     }
 }


### PR DESCRIPTION
### 🎯 Goal

This pr makes an improvement for the query channels flow when recovery happens.
It fixes two cases:
1) We don't make recovery after logout-login
2) We do a recovery with the same sort that injected in `QueryChannelsController`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media1.giphy.com/media/RK9udF1XhY9L7IZRaZ/giphy.gif)
