### PR TITLE
 Add Kdocs on `ChatClient.Builder` methods, deprecate `cdnUrl`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,12 +28,14 @@
 - Fixed issues with Proguard stripping response classes incorrectly
 
 ### ⬆️ Improved
+- Added KDocs for `ChatClient.Builder` methods.
 - `ChatClient` now defaults to using the `https://chat.stream-io-api.com` base URL, using [Stream's Edge API Infrastructure](https://getstream.io/blog/chat-edge-infrastructure/) instead of connecting to a region-specific API. If you're not on a dedicated chat infrastructure, remove any region-specific base URL settings from the `ChatClient.Builder` to use Edge instead. 
 
 ### ✅ Added
 - Added the possibility to add your own instance of OkHttpClient with `ChatClient.okHttpClient`.
 
 ### ⚠️ Changed
+- Deprecated the `ChatClient.Builder#cdnUrl` method. To customize file uploads, set a custom `FileUploader` implementation instead. More info in the documentation: [Using Your Own CDN](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin#using-your-own-cdn).
 
 ### ❌ Removed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,8 +4,8 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| ChatClient#cdnTimeout | 2021.10.12<br/>4.20.0 | 2021.10.26 ⌛ | 2021.11.09 ⌛ | Use ChatClient.okHttpClient() to set the timeouts  |
-| ChatClient#baseTimeout | 2021.10.12<br/>4.20.0 | 2021.10.26 ⌛ | 2021.11.09 ⌛ | Use ChatClient.okHttpClient() to set the timeouts  |
+| `ChatClient#cdnUrl`  <br/>*client* | 2021.10.12<br/>4.20.0 | 2021.10.12 | 2021.11.09 ⌛ | Use `ChatClient.fileUploader()` to add custom file uploading logic instead  |
+| `ChatClient#cdnTimeout` and `ChatClient#baseTimeout` <br/>*client* | 2021.10.12<br/>4.20.0 | 2021.10.26 ⌛ | 2021.11.09 ⌛ | Use `ChatClient.okHttpClient()` to set the timeouts instead |
 | `DeviceRegisteredListener` <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | This class is not used anymore |
 | `ViewReactionsViewStyle#bubbleBorderColor` <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | 2021.10.26 ⌛ | Use bubbleBorderColorMine instead  |
 | `NotificationConfig` attributes <br/>*client* | 2021.09.28<br/>4.19.0 | 2021.09.28<br/>4.19.0 | 2021.10.12 ⌛ | Some attributes are not needed anymore |

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1703,6 +1703,11 @@ public class ChatClient internal constructor(
             return this
         }
 
+        @Deprecated(
+            message = "Do not use this method for file upload customization. Instead, implement the FileUploader interface and use the fileUploader method of this builder.",
+            level = DeprecationLevel.ERROR,
+            replaceWith = ReplaceWith("this.fileUploader(CustomFileUploader())")
+        )
         public fun cdnUrl(value: String): Builder {
             var cdnUrl = value
             if (cdnUrl.startsWith("https://")) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1558,6 +1558,12 @@ public class ChatClient internal constructor(
         return "$header.$payload.$devSignature"
     }
 
+    /**
+     * Builder to initialize the singleton [ChatClient] instance and configure its parameters.
+     *
+     * @param apiKey The API key of your Stream Chat app obtained from the [Stream Dashboard](https://dashboard.getstream.io/).
+     * @param appContext The application [Context].
+     */
     public class Builder(private val apiKey: String, private val appContext: Context) : ChatClientBuilder() {
 
         private var baseUrl: String = "chat.stream-io-api.com"
@@ -1574,21 +1580,61 @@ public class ChatClient internal constructor(
         private val tokenManager: TokenManager = TokenManagerImpl()
         private var customOkHttpClient: OkHttpClient? = null
 
+        /**
+         * Sets the log level to be used by the client.
+         *
+         * See [ChatLogLevel] for details about the available options.
+         *
+         * We strongly recommend using [ChatLogLevel.NOTHING] in production builds,
+         * which produces no logs.
+         *
+         * @param level The log level to use.
+         */
         public fun logLevel(level: ChatLogLevel): Builder {
             logLevel = level
             return this
         }
 
+        /**
+         * Sets a [ChatLoggerHandler] instance that will receive log events from the SDK.
+         *
+         * Use this to forward SDK events to your own logging solutions.
+         *
+         * See the FirebaseLogger class in the UI Components sample app for an example implementation.
+         *
+         * @param loggerHandler Your custom [ChatLoggerHandler] implementation.
+         */
         public fun loggerHandler(loggerHandler: ChatLoggerHandler): Builder {
             this.loggerHandler = loggerHandler
             return this
         }
 
+        /**
+         * Sets a custom [ChatNotificationHandler] that the SDK will use to handle everything
+         * around push notifications. Create your own subclass and override methods to customize
+         * notification appearance and behavior.
+         *
+         * See the [Push Notifications](https://staging.getstream.io/chat/docs/sdk/android/client/guides/push-notifications/)
+         * documentation for more information.
+         *
+         * @param notificationsHandler Your custom subclass of [ChatNotificationHandler].
+         */
         public fun notifications(notificationsHandler: ChatNotificationHandler): Builder {
             this.notificationsHandler = notificationsHandler
             return this
         }
 
+        /**
+         * Sets a custom file uploader implementation that will be used by the client
+         * to upload files and images.
+         *
+         * The default implementation uses Stream's own CDN to store these files,
+         * which has a 20 MB upload size limit.
+         *
+         * For more info, see [the File Uploads documentation](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin).
+         *
+         * @param fileUploader Your custom implementation of [FileUploader].
+         */
         public fun fileUploader(fileUploader: FileUploader): Builder {
             this.fileUploader = fileUploader
             return this
@@ -1606,6 +1652,13 @@ public class ChatClient internal constructor(
             return this
         }
 
+        /**
+         * By default, ChatClient performs a dummy HTTP call to the Stream API
+         * when a user is set to initialize the HTTP connection and make subsequent
+         * requests reusing this connection execute faster.
+         *
+         * Calling this method disables this connection warm-up behavior.
+         */
         public fun disableWarmUp(): Builder = apply {
             warmUp = false
         }
@@ -1623,6 +1676,18 @@ public class ChatClient internal constructor(
             this.customOkHttpClient = okHttpClient
         }
 
+        /**
+         * Sets the base URL to be used by the client.
+         *
+         * By default, this is the URL of Stream's [Edge API Infrastructure](https://getstream.io/blog/chat-edge-infrastructure/),
+         * which provides low latency regardless of which region your Stream
+         * app is hosted in.
+         *
+         * You should only change this URL if you're on dedicated Stream
+         * Chat infrastructure.
+         *
+         * @param value The base URL to use.
+         */
         public fun baseUrl(value: String): Builder {
             var baseUrl = value
             if (baseUrl.startsWith("https://")) {
@@ -1703,7 +1768,10 @@ public class ChatClient internal constructor(
     }
 
     public abstract class ChatClientBuilder @InternalStreamChatApi public constructor() {
-
+        /**
+         * Create a [ChatClient] instance based on the current configuration
+         * of the [Builder].
+         */
         public fun build(): ChatClient = buildChatClient().also {
             instance = it
         }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -5,14 +5,12 @@ import com.google.firebase.FirebaseApp
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.pushprovider.firebase.FirebasePushDeviceGenerator
 import io.getstream.chat.android.pushprovider.huawei.HuaweiPushDeviceGenerator
 import io.getstream.chat.ui.sample.BuildConfig
 import io.getstream.chat.ui.sample.R
 
-@OptIn(InternalStreamChatApi::class)
 class ChatInitializer(private val context: Context) {
 
     @Suppress("UNUSED_VARIABLE")


### PR DESCRIPTION
### 🎯 Goal

Make `ChatClient.Builder` methods more obvious.

More info on `cdnUrl` deprecation: [Slack discussion](https://getstream.slack.com/archives/CE5N802GP/p1633338690250200)

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
