### PR TITLE
Fix flaky random data generation in username test

### DIFF
--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/mention/DefaultUserLookupHandlerTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/mention/DefaultUserLookupHandlerTest.kt
@@ -56,8 +56,8 @@ internal class DefaultUserLookupHandlerTest {
 
         val users = listOf(
             user1,
-            createUser().apply { name = randomString() },
-            createUser().apply { name = randomString() },
+            createUser().apply { name = randomStringWithout(query) },
+            createUser().apply { name = randomStringWithout(query) },
         )
 
         val result = MessageInputView.DefaultUserLookupHandler(users).handleUserLookup(query)
@@ -67,5 +67,9 @@ internal class DefaultUserLookupHandlerTest {
         } else {
             assertEquals(listOf(user1), result)
         }
+    }
+
+    private fun randomStringWithout(query: String): String {
+        return generateSequence { randomString() }.first { string -> query !in string }
     }
 }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/mention/DefaultUserLookupHandlerTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/mention/DefaultUserLookupHandlerTest.kt
@@ -70,6 +70,6 @@ internal class DefaultUserLookupHandlerTest {
     }
 
     private fun randomStringWithout(query: String): String {
-        return generateSequence { randomString() }.first { string -> query !in string }
+        return generateSequence { randomString() }.first { string -> !string.contains(query, ignoreCase = true) }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Fix a flaky test

### 🛠 Implementation details

The test was looking for just a single result out of the [expected, random, random] array of users. However, the random-generated usernames occasionally match our search query...

For example, with `Leandro` being the expected user result for `Le`, a random generated `UWIyFTQ3HtKrLemsciqp` also matches, and breaks the test.

```
org.amshove.kluent.internal.ComparisonFailedException: Expected: 
<[User(id=5WDFBH3U4tA3uh19c6uG, role=cLxBqLSePLUMWHjFAMl9, invisible=true, banned=false, devices=[], online=true, createdAt=Sat Jul 24 16:37:24 UTC 161846962, updatedAt=Thu Apr 09 00:23:46 UTC 85880809, lastActive=Thu Nov 16 07:21:54 UTC 105965284, totalUnreadCount=2110445997, unreadChannels=137497568, mutes=[], teams=[], channelMutes=[], extraData={name=Leandro})]>
but was: 
<[User(id=5WDFBH3U4tA3uh19c6uG, role=cLxBqLSePLUMWHjFAMl9, invisible=true, banned=false, devices=[], online=true, createdAt=Sat Jul 24 16:37:24 UTC 161846962, updatedAt=Thu Apr 09 00:23:46 UTC 85880809, lastActive=Thu Nov 16 07:21:54 UTC 105965284, totalUnreadCount=2110445997, unreadChannels=137497568, mutes=[], teams=[], channelMutes=[], extraData={name=Leandro}), User(id=KgnCPC9Z9I4CaEkpDLth, role=X17o8kHeFMO06Y0XGVUy, invisible=true, banned=false, devices=[], online=true, createdAt=Mon Sep 27 17:53:27 UTC 280853706, updatedAt=Sun Mar 17 22:29:52 UTC 192053963, lastActive=Tue Jan 23 22:30:52 UTC 53817596, totalUnreadCount=420391906, unreadChannels=1311283705, mutes=[], teams=[], channelMutes=[], extraData={name=UWIyFTQ3HtKrLemsciqp})]>
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests ✅✅✅✅✅✅✅✅✅
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
