### PR TITLE
Fix `cancel-in-progress` option

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.head_ref }}
+  group: ${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
### 🎯 Goal
`github.head_ref` only works on PRs, but if we want to use it into a no PR Workflow, we need to use `github.ref` instead

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- ~[ ] PR targets the `develop` branch~
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF
![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/4047514/135851690-fd073a55-2695-4293-b279-8fa8ede91eef.gif)

