### PR TITLE
Add possibility to specify newChannelEventFilter in ChannelListView constructor

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -553,8 +553,8 @@ public final class io/getstream/chat/android/ui/channel/list/viewmodel/ChannelLi
 	public static final field Companion Lio/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel$Companion;
 	public static final field DEFAULT_SORT Lio/getstream/chat/android/client/api/models/QuerySort;
 	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/offline/ChatDomain;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;II)V
-	public synthetic fun <init> (Lio/getstream/chat/android/offline/ChatDomain;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/offline/ChatDomain;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IILkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/offline/ChatDomain;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deleteChannel (Lio/getstream/chat/android/client/models/Channel;)V
 	public final fun getErrorEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getPaginationState ()Landroidx/lifecycle/LiveData;
@@ -652,7 +652,8 @@ public final class io/getstream/chat/android/ui/channel/list/viewmodel/factory/C
 	public fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;)V
 	public fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;I)V
 	public fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;II)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IILkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;IILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/factory/ChannelListViewModelFactory.kt
@@ -16,6 +16,7 @@ import io.getstream.chat.android.ui.channel.list.viewmodel.ChannelListViewModel
  * @param sort How to sort the channels, defaults to last_updated.
  * @param limit How many channels to return.
  * @param messageLimit The number of messages to fetch for each channel.
+ * @param newChannelEventFilter Determines if the channel should be added to the list after receiving NotificationAddedToChannelEvent, ChannelUpdatedByUserEvent, or ChannelUpdatedEvent
  *
  * @see Filters
  * @see QuerySort
@@ -25,6 +26,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
     private val sort: QuerySort<Channel> = ChannelListViewModel.DEFAULT_SORT,
     private val limit: Int = 30,
     private val messageLimit: Int = 1,
+    private var newChannelEventFilter: ((Channel, FilterObject) -> Boolean)? = null,
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         require(modelClass == ChannelListViewModel::class.java) {
@@ -32,6 +34,13 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         }
 
         @Suppress("UNCHECKED_CAST")
-        return ChannelListViewModel(ChatDomain.instance(), filter, sort, limit, messageLimit) as T
+        return ChannelListViewModel(
+            ChatDomain.instance(),
+            filter,
+            sort,
+            limit,
+            messageLimit,
+            newChannelEventFilter,
+        ) as T
     }
 }


### PR DESCRIPTION

### 🎯 Goal

Allow overriding `QueryChannelController::newChannelEventFilter`

### 🛠 Implementation details

Added `newChannelEventFilter` parameter to `ChannelListViewModel` (null by default).
**NOTE:** Ideally we should make `newChannelEventFilter` immutable and pass it to `QueryChannelController` by the constructor, but it's not an easy change and produces a breaking change so I think we should postpone it until we merge ChatDomain into LLC


### 🧪 Testing

Try to create `ChannelListViewModel `with  `newChannelEventFilter` (for example `{_, _ -> false}`). You shouldn't be able to see now channels after creating them.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

