### PR TITLE
[CAS-1344] Show error logs when our SDK is instantiated twice

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1729,7 +1729,13 @@ public class ChatClient internal constructor(
             this.callbackExecutor = callbackExecutor
         }
 
-        public override fun buildChatClient(): ChatClient {
+        @InternalStreamChatApi
+        @Deprecated(
+            message = "It shouldn't be used outside of SDK code. Created for testing purposes",
+            replaceWith = ReplaceWith("this.build()"),
+            level = DeprecationLevel.ERROR
+        )
+        override fun internalBuild(): ChatClient {
 
             if (apiKey.isEmpty()) {
                 throw IllegalStateException("apiKey is not defined in " + this::class.java.simpleName)
@@ -1777,11 +1783,12 @@ public class ChatClient internal constructor(
          * Create a [ChatClient] instance based on the current configuration
          * of the [Builder].
          */
-        public fun build(): ChatClient = buildChatClient().also {
+        public fun build(): ChatClient = internalBuild().also {
             instance = it
         }
 
-        public abstract fun buildChatClient(): ChatClient
+        @InternalStreamChatApi
+        public abstract fun internalBuild(): ChatClient
     }
 
     public companion object {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -4,6 +4,7 @@ package io.getstream.chat.android.client
 
 import android.content.Context
 import android.util.Base64
+import android.util.Log
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
 import androidx.lifecycle.Lifecycle
@@ -1740,6 +1741,8 @@ public class ChatClient internal constructor(
             if (apiKey.isEmpty()) {
                 throw IllegalStateException("apiKey is not defined in " + this::class.java.simpleName)
             }
+
+            instance?.run { Log.e("Chat", "[ERROR] You have just re-initialized ChatClient, old configuration has been overridden [ERROR]") }
 
             val config = ChatClientConfig(
                 apiKey = apiKey,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.livedata
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.CheckResult
 import androidx.lifecycle.LiveData
 import io.getstream.chat.android.client.ChatClient
@@ -633,6 +634,7 @@ public sealed interface ChatDomain {
         }
 
         public fun build(): ChatDomain {
+            ChatDomain.instance?.run { Log.e("Chat", "[ERROR] You have just re-initialized ChatDomain, old configuration has been overridden [ERROR]") }
             val offlineChatDomain = offlineChatDomainBuilder.build()
             ChatDomain.instance = buildImpl(offlineChatDomain)
             return ChatDomain.instance()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.offline
 import android.content.Context
 import android.os.Handler
 import android.os.Looper
+import android.util.Log
 import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.FilterObject
@@ -644,6 +645,7 @@ public sealed interface ChatDomain {
         }
 
         public fun build(): ChatDomain {
+            instance?.run { Log.e("Chat", "[ERROR] You have just re-initialized ChatDomain, old configuration has been overridden [ERROR]") }
             instance = buildImpl()
             return instance()
         }

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/MockChatClientBuilder.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/MockChatClientBuilder.kt
@@ -4,5 +4,5 @@ import com.nhaarman.mockitokotlin2.mock
 import io.getstream.chat.android.client.ChatClient
 
 public class MockChatClientBuilder(private val builderFunction: () -> ChatClient = { mock() }) : ChatClient.ChatClientBuilder() {
-    override fun buildChatClient(): ChatClient = builderFunction()
+    override fun internalBuild(): ChatClient = builderFunction()
 }


### PR DESCRIPTION
### 🎯 Goal
Show error logs when our SDK is instantiated twice

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF
![](https://media2.giphy.com/media/bXveYFUaYr67e/giphy.webp)
