### PR TITLE
Store name in local user credentials storage

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -151,7 +151,7 @@ public class ChatClient internal constructor(
                     userStateService.onUserUpdated(user)
                     api.setConnection(user.id, connectionId)
                     lifecycleObserver.observe()
-                    storePushNotificationsConfig(user.id)
+                    storePushNotificationsConfig(user.id, user.name)
                     notifications.onSetUser()
                 }
                 is DisconnectedEvent -> {
@@ -328,7 +328,7 @@ public class ChatClient internal constructor(
 
         encryptedUserConfigStorage.get()?.let { config ->
             initializeClientWithUser(
-                user = User(id = config.userId),
+                user = User(id = config.userId).apply { name = config.userName },
                 tokenProvider = ConstantTokenProvider(config.userToken),
             )
         }
@@ -343,11 +343,12 @@ public class ChatClient internal constructor(
         preSetUserListeners.forEach { it(user) }
     }
 
-    private fun storePushNotificationsConfig(userId: String) {
+    private fun storePushNotificationsConfig(userId: String, userName: String) {
         encryptedUserConfigStorage.put(
             PushNotificationsConfig(
                 userToken = getCurrentToken() ?: "",
                 userId = userId,
+                userName = userName,
             ),
         )
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/storage/EncryptedPushNotificationsConfigStore.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/storage/EncryptedPushNotificationsConfigStore.kt
@@ -36,15 +36,19 @@ internal class EncryptedPushNotificationsConfigStore(context: Context) {
         prefs.edit().apply {
             putString(KEY_USER_ID, config.userId)
             putString(KEY_USER_TOKEN, config.userToken)
+            putString(KEY_USER_NAME, config.userName)
         }.apply()
     }
 
     fun get(): PushNotificationsConfig? = prefs.run {
         val userId = getString(KEY_USER_ID, "") ?: ""
         val userToken = getString(KEY_USER_TOKEN, "") ?: ""
+        val userName = getString(KEY_USER_NAME, "") ?: ""
 
-        val config = PushNotificationsConfig(userId, userToken)
-        return if (config.isValid()) config else { null }
+        val config = PushNotificationsConfig(userId = userId, userToken = userToken, userName = userName)
+        return if (config.isValid()) config else {
+            null
+        }
     }
 
     fun clear() = prefs.edit().clear().apply()
@@ -55,5 +59,6 @@ internal class EncryptedPushNotificationsConfigStore(context: Context) {
         private const val SYNC_CONFIG_PREFS_NAME = ".stream_livedata_sync_config_store"
         private const val KEY_USER_ID = "user_id"
         private const val KEY_USER_TOKEN = "user_token"
+        private const val KEY_USER_NAME = "user_name"
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/storage/PushNotificationsConfig.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/storage/PushNotificationsConfig.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.client.notifications.storage
 internal data class PushNotificationsConfig(
     val userId: String,
     val userToken: String,
+    val userName: String,
 ) {
-    internal fun isValid(): Boolean = userId.isNotEmpty() && userToken.isNotEmpty()
+    internal fun isValid(): Boolean = userId.isNotEmpty() && userToken.isNotEmpty() && userName.isNotEmpty()
 }


### PR DESCRIPTION
### 🎯 Goal

TO show new messaging style notification we require `User::name` property. But we don't have it in local credentials storage.
It leads to problem that we don't show notification at all if app was killed.

### 🛠 Implementation details

Store user name property in local storage

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media0.giphy.com/media/eplJruRCWfAZLYmjqN/giphy-downsized-medium.gif)
