### PR TITLE
Proper handle network changes. Check if we got disconnected

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/network/NetworkStateProvider.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/network/NetworkStateProvider.kt
@@ -12,19 +12,15 @@ internal class NetworkStateProvider(private val connectivityManager: Connectivit
     private val lock: Any = Any()
     private val callback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            notifyListenersIfActiveNetworkAvailable()
+            notifyListenersIfNetworkStateChanged()
         }
 
         override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
-            notifyListenersIfActiveNetworkAvailable()
+            notifyListenersIfNetworkStateChanged()
         }
 
         override fun onLost(network: Network) {
-            // Checks whether the network was switched or connection was lost
-            if (!isConnected() && this@NetworkStateProvider.isConnected) {
-                this@NetworkStateProvider.isConnected = false
-                listeners.forEach { it.onDisconnected() }
-            }
+            notifyListenersIfNetworkStateChanged()
         }
     }
 
@@ -36,10 +32,14 @@ internal class NetworkStateProvider(private val connectivityManager: Connectivit
 
     private val isRegistered: AtomicBoolean = AtomicBoolean(false)
 
-    private fun notifyListenersIfActiveNetworkAvailable() {
-        if (!isConnected && isConnected()) {
+    private fun notifyListenersIfNetworkStateChanged() {
+        val isNowConnected = isConnected()
+        if (!isConnected && isNowConnected) {
             isConnected = true
             listeners.forEach { it.onConnected() }
+        } else if (isConnected && !isNowConnected) {
+            isConnected = false
+            listeners.forEach { it.onDisconnected() }
         }
     }
 


### PR DESCRIPTION
Sometimes we don't get a callback from `ConnectivityManager`. I suspect that it happens when the app is background. So we keep the last state (`connected`) and don't retrigger the socket connection in this case when we got connected again

### 🎯 Goal
Bug with going to app from push when you're not connected


### 🛠 Implementation details

Check if we got disconnected everytime when network changed

### 🧪 Testing

1. Kill app
2. Send push from other device
3. Switch on airplane mode
4. Tap on push
5. You see app
6. Switch off airplane mode

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media3.giphy.com/media/W2KcfZICjiFtdBOMvF/giphy.gif)
