### PR TITLE
Provide filter object as argument to function of ChatEventsHandler

### DIFF
--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -464,14 +464,14 @@ public final class io/getstream/chat/android/offline/message/attachment/UploadAt
 
 public abstract class io/getstream/chat/android/offline/querychannels/BaseChannelEventsHandler : io/getstream/chat/android/offline/querychannels/ChannelEventsHandler {
 	public fun <init> ()V
-	public fun onChannelEvent (Lio/getstream/chat/android/client/events/HasChannel;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
-	public abstract fun onChannelUpdatedByUserEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedByUserEvent;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
-	public abstract fun onChannelUpdatedEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedEvent;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
-	public abstract fun onNotificationAddedToChannelEvent (Lio/getstream/chat/android/client/events/NotificationAddedToChannelEvent;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
+	public fun onChannelEvent (Lio/getstream/chat/android/client/events/HasChannel;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
+	public abstract fun onChannelUpdatedByUserEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedByUserEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
+	public abstract fun onChannelUpdatedEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
+	public abstract fun onNotificationAddedToChannelEvent (Lio/getstream/chat/android/client/events/NotificationAddedToChannelEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
 }
 
 public abstract interface class io/getstream/chat/android/offline/querychannels/ChannelEventsHandler {
-	public abstract fun onChannelEvent (Lio/getstream/chat/android/client/events/HasChannel;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
+	public abstract fun onChannelEvent (Lio/getstream/chat/android/client/events/HasChannel;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/querychannels/EventHandlingResult;
 }
 
 public final class io/getstream/chat/android/offline/querychannels/EventHandlingResult : java/lang/Enum {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -574,13 +574,7 @@ internal class ChatDomainImpl internal constructor(
         activeQueryMapImpl.getOrPut("${filter.hashCode()}-${sort.hashCode()}") {
             val mutableState = offlinePlugin.state.queryChannels(filter, sort).toMutableState()
             val logic = offlinePlugin.logic.queryChannels(filter, sort)
-            QueryChannelsController(
-                filter,
-                sort,
-                this,
-                mutableState,
-                logic
-            )
+            QueryChannelsController(domainImpl = this, mutableState = mutableState, queryChannelsLogic = logic)
         }
 
     private suspend fun queryEvents(cids: List<String>): Result<List<ChatEvent>> =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
@@ -38,7 +38,7 @@ internal class QueryChannelsMutableState(
     internal val recoveryNeeded: MutableStateFlow<Boolean> = MutableStateFlow(false)
     internal val channelsOffset: MutableStateFlow<Int> = MutableStateFlow(0)
 
-    internal var defaultChannelEventsHandler: DefaultChannelEventsHandler = DefaultChannelEventsHandler(client, filter)
+    internal var defaultChannelEventsHandler: DefaultChannelEventsHandler = DefaultChannelEventsHandler(client)
     override var checkFilterOnChannelUpdatedEvent: Boolean by defaultChannelEventsHandler::checkFilterOnChannelUpdatedEvent
     override var newChannelEventFilter: suspend (Channel, FilterObject) -> Boolean by defaultChannelEventsHandler::newChannelEventFilter
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChannelEventsHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChannelEventsHandler.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.querychannels
 
+import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.events.ChannelDeletedEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedByUserEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedEvent
@@ -8,16 +9,19 @@ import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
 import io.getstream.chat.android.client.events.NotificationChannelDeletedEvent
 
 /**
- * Events handler that handles events related to channels and compute which kind of action should be applied.
+ * Interface that handles events related to the particular set of channels. These channels correspond to particular [FilterObject].
+ * Events handler computes which kind of action [EventHandlingResult] should be applied to this set.
  */
 public fun interface ChannelEventsHandler {
     /**
      * Function that computes result of handling event. It runs in background.
      *
      * @param event Event that contains particular channel. See more [HasChannel]
+     * @param filter [FilterObject] that can be used to define result of handling.
+     *
      * @return [EventHandlingResult] Result of handling.
      */
-    public fun onChannelEvent(event: HasChannel): EventHandlingResult
+    public fun onChannelEvent(event: HasChannel, filter: FilterObject): EventHandlingResult
 }
 
 /**
@@ -28,10 +32,12 @@ public enum class EventHandlingResult {
      * Add a channel to a query channels collection.
      */
     ADD,
+
     /**
      * Remove a channel from a query channels collection.
      */
     REMOVE,
+
     /**
      * Skip handling of this event.
      */
@@ -48,23 +54,31 @@ public abstract class BaseChannelEventsHandler : ChannelEventsHandler {
     /**
      * Handles [NotificationAddedToChannelEvent] event. It runs in background.
      */
-    public abstract fun onNotificationAddedToChannelEvent(event: NotificationAddedToChannelEvent): EventHandlingResult
+    public abstract fun onNotificationAddedToChannelEvent(
+        event: NotificationAddedToChannelEvent,
+        filter: FilterObject,
+    ): EventHandlingResult
+
     /**
      * Handles [ChannelUpdatedByUserEvent] event. It runs in background.
      */
-    public abstract fun onChannelUpdatedByUserEvent(event: ChannelUpdatedByUserEvent): EventHandlingResult
+    public abstract fun onChannelUpdatedByUserEvent(
+        event: ChannelUpdatedByUserEvent,
+        filter: FilterObject,
+    ): EventHandlingResult
+
     /**
      * Handles [ChannelUpdatedEvent] event. It runs in background.
      */
-    public abstract fun onChannelUpdatedEvent(event: ChannelUpdatedEvent): EventHandlingResult
+    public abstract fun onChannelUpdatedEvent(event: ChannelUpdatedEvent, filter: FilterObject): EventHandlingResult
 
-    override fun onChannelEvent(event: HasChannel): EventHandlingResult {
+    override fun onChannelEvent(event: HasChannel, filter: FilterObject): EventHandlingResult {
         return when (event) {
-            is NotificationAddedToChannelEvent -> onNotificationAddedToChannelEvent(event)
+            is NotificationAddedToChannelEvent -> onNotificationAddedToChannelEvent(event, filter)
             is ChannelDeletedEvent -> EventHandlingResult.REMOVE
             is NotificationChannelDeletedEvent -> EventHandlingResult.REMOVE
-            is ChannelUpdatedByUserEvent -> onChannelUpdatedByUserEvent(event)
-            is ChannelUpdatedEvent -> onChannelUpdatedEvent(event)
+            is ChannelUpdatedByUserEvent -> onChannelUpdatedByUserEvent(event, filter)
+            is ChannelUpdatedEvent -> onChannelUpdatedEvent(event, filter)
             else -> EventHandlingResult.SKIP
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChannelEventsHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChannelEventsHandler.kt
@@ -13,10 +13,7 @@ import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.utils.map
 import kotlinx.coroutines.runBlocking
 
-internal class DefaultChannelEventsHandler(
-    private val client: ChatClient,
-    private val filter: FilterObject,
-) : BaseChannelEventsHandler() {
+internal class DefaultChannelEventsHandler(private val client: ChatClient) : BaseChannelEventsHandler() {
     internal var checkFilterOnChannelUpdatedEvent: Boolean = false
 
     internal var newChannelEventFilter: suspend (Channel, FilterObject) -> Boolean = { channel, filter ->
@@ -36,24 +33,30 @@ internal class DefaultChannelEventsHandler(
             .let { it.isSuccess && it.data() }
     }
 
-    override fun onNotificationAddedToChannelEvent(event: NotificationAddedToChannelEvent): EventHandlingResult =
-        handleCidEventByRequest(event)
+    override fun onNotificationAddedToChannelEvent(
+        event: NotificationAddedToChannelEvent,
+        filter: FilterObject,
+    ): EventHandlingResult =
+        handleCidEventByRequest(event, filter)
 
-    override fun onChannelUpdatedByUserEvent(event: ChannelUpdatedByUserEvent): EventHandlingResult =
-        handleCidEventByRequestIfNeeded(event)
+    override fun onChannelUpdatedByUserEvent(
+        event: ChannelUpdatedByUserEvent,
+        filter: FilterObject,
+    ): EventHandlingResult =
+        handleCidEventByRequestIfNeeded(event, filter)
 
-    override fun onChannelUpdatedEvent(event: ChannelUpdatedEvent): EventHandlingResult =
-        handleCidEventByRequestIfNeeded(event)
+    override fun onChannelUpdatedEvent(event: ChannelUpdatedEvent, filter: FilterObject): EventHandlingResult =
+        handleCidEventByRequestIfNeeded(event, filter)
 
-    private fun handleCidEventByRequestIfNeeded(event: HasChannel): EventHandlingResult {
+    private fun handleCidEventByRequestIfNeeded(event: HasChannel, filter: FilterObject): EventHandlingResult {
         return if (checkFilterOnChannelUpdatedEvent) {
-            handleCidEventByRequest(event)
+            handleCidEventByRequest(event, filter)
         } else {
             EventHandlingResult.SKIP
         }
     }
 
-    private fun handleCidEventByRequest(event: HasChannel): EventHandlingResult {
+    private fun handleCidEventByRequest(event: HasChannel, filter: FilterObject): EventHandlingResult {
         return runBlocking {
             if (newChannelEventFilter(event.channel, filter)) {
                 EventHandlingResult.ADD

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
@@ -38,13 +38,14 @@ private const val CHANNEL_LIMIT = 30
 
 @OptIn(ExperimentalStreamChatApi::class)
 public class QueryChannelsController internal constructor(
-    public val filter: FilterObject,
-    public val sort: QuerySort<Channel>,
     private val domainImpl: ChatDomainImpl,
     private val mutableState: QueryChannelsMutableState,
     private val queryChannelsLogic: QueryChannelsLogic,
 ) {
     public val recoveryNeeded: MutableStateFlow<Boolean> by mutableState::recoveryNeeded
+
+    public val filter: FilterObject by mutableState::filter
+    public val sort: QuerySort<Channel> by mutableState::sort
 
     /**
      * Instance of [ChannelEventsHandler] that handles logic of event handling for this [QueryChannelsController].
@@ -115,7 +116,7 @@ public class QueryChannelsController internal constructor(
 
     internal suspend fun handleEvent(event: ChatEvent) {
         if (event is HasChannel) {
-            when (mutableState.eventsHandler.onChannelEvent(event)) {
+            when (mutableState.eventsHandler.onChannelEvent(event, filter)) {
                 EventHandlingResult.ADD -> addChannel(event.channel)
                 EventHandlingResult.REMOVE -> removeChannel(event.channel.cid)
                 EventHandlingResult.SKIP -> Unit

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
@@ -429,8 +429,6 @@ private class Fixture {
         val filter = Filters.neutral()
         val mutableState = QueryChannelsMutableState(filter, querySort, chatClient, chatDomainImpl.scope)
         return QueryChannelsController(
-            filter,
-            querySort,
             chatDomainImpl,
             mutableState,
             QueryChannelsLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
@@ -225,8 +225,6 @@ internal class WhenQuery {
             val mutableState = QueryChannelsMutableState(filter, querySort, chatClient, chatDomainImpl.scope)
 
             return QueryChannelsController(
-                filter,
-                querySort,
                 chatDomainImpl,
                 mutableState,
                 QueryChannelsLogic(mutableState, chatDomainImpl),


### PR DESCRIPTION
### 🎯 Goal
In order to give more context on how to calculate possible output in ChatEventHandler we need to provide filter object as an argu,ent

### 🛠 Implementation details

Add filter object to fun as argument, filter is taken from `QueryChannelsController`

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media1.giphy.com/media/UN36HWUB6PuX4nyV2Y/giphy-downsized-medium.gif)
