### PR TITLE
Improve max message width customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@
 ### ⬆️ Improved
 - Better position for icon of failed message
 ### ✅ Added
-- Added `streamUiMessageMaxPossibleWidthFactorMine` and `streamUiMessageMaxPossibleWidthFactorTheirs` `MessageListView` attributes. You can make messages wider by passing values < 100%.
+Added `streamUiMessageMaxWidthFactorMine` and `streamUiMessageMaxWidthFactorTheirs` `MessageListView` attributes. You can adjust messages width by passing values in [75% - 100%] range.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1504,8 +1504,8 @@ public final class io/getstream/chat/android/ui/message/list/MessageListItemStyl
 	public final fun getMessageLinkBackgroundColorTheirs ()I
 	public final fun getMessageLinkTextColorMine ()Ljava/lang/Integer;
 	public final fun getMessageLinkTextColorTheirs ()Ljava/lang/Integer;
-	public final fun getMessageMaxPossibleWidthFactorMine ()F
-	public final fun getMessageMaxPossibleWidthFactorTheirs ()F
+	public final fun getMessageMaxWidthFactorMine ()F
+	public final fun getMessageMaxWidthFactorTheirs ()F
 	public final fun getMessageStartMargin ()I
 	public final fun getMessageStrokeColorMine ()I
 	public final fun getMessageStrokeColorTheirs ()I

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
@@ -60,8 +60,8 @@ import io.getstream.chat.android.ui.message.list.reactions.view.internal.ViewRea
  * @property textStyleErrorMessage Appearance for error message text.
  * @property messageStartMargin Margin for messages in the left side. Default value is 48dp.
  * @property messageEndMargin Margin for messages in the right side. Default value is 0dp.
- * @property messageMaxPossibleWidthFactorMine Factor used to compute max possible width for message sent by the current user. Should be in <0, 1> range. Message will be wider when the factor is smaller
- * @property messageMaxPossibleWidthFactorTheirs Factor used to compute max possible width for message sent by other user. Should be in <0, 1> range. Message will be wider when the factor is smaller
+ * @property messageMaxWidthFactorMine Factor used to compute max width for message sent by the current user. Should be in <0.75, 1> range.
+ * @property messageMaxWidthFactorTheirs Factor used to compute max width for message sent by other user. Should be in <0.75, 1> range.
  */
 public data class MessageListItemStyle(
     @ColorInt public val messageBackgroundColorMine: Int?,
@@ -101,8 +101,8 @@ public data class MessageListItemStyle(
     @ColorInt public val pinnedMessageBackgroundColor: Int,
     @Px public val messageStartMargin: Int,
     @Px public val messageEndMargin: Int,
-    public val messageMaxPossibleWidthFactorMine: Float,
-    public val messageMaxPossibleWidthFactorTheirs: Float,
+    public val messageMaxWidthFactorMine: Float,
+    public val messageMaxWidthFactorTheirs: Float,
 ) {
 
     @ColorInt
@@ -144,8 +144,8 @@ public data class MessageListItemStyle(
         internal val MESSAGE_STROKE_COLOR_THEIRS = R.color.stream_ui_grey_whisper
         internal val MESSAGE_STROKE_WIDTH_THEIRS: Float = 1.dpToPxPrecise()
 
-        private const val BASE_MESSAGE_MAX_POSSIBLE_FACTOR = 1
-        private const val DEFAULT_MESSAGE_MAX_POSSIBLE_FACTOR = 1f
+        private const val BASE_MESSAGE_MAX_WIDTH_FACTOR = 1
+        private const val DEFAULT_MESSAGE_MAX_WIDTH_FACTOR = 0.75f
     }
 
     internal class Builder(private val attributes: TypedArray, private val context: Context) {
@@ -533,18 +533,18 @@ public data class MessageListItemStyle(
                 context.getDimension(R.dimen.stream_ui_message_viewholder_avatar_missing_margin).toFloat()
             ).toInt()
 
-            val messageMaxPossibleWidthFactorMine = attributes.getFraction(
-                R.styleable.MessageListView_streamUiMessageMaxPossibleWidthFactorMine,
-                BASE_MESSAGE_MAX_POSSIBLE_FACTOR,
-                BASE_MESSAGE_MAX_POSSIBLE_FACTOR,
-                DEFAULT_MESSAGE_MAX_POSSIBLE_FACTOR,
+            val messageMaxWidthFactorMine = attributes.getFraction(
+                R.styleable.MessageListView_streamUiMessageMaxWidthFactorMine,
+                BASE_MESSAGE_MAX_WIDTH_FACTOR,
+                BASE_MESSAGE_MAX_WIDTH_FACTOR,
+                DEFAULT_MESSAGE_MAX_WIDTH_FACTOR,
             )
 
-            val messageMaxPossibleWidthFactorTheirs = attributes.getFraction(
-                R.styleable.MessageListView_streamUiMessageMaxPossibleWidthFactorTheirs,
-                BASE_MESSAGE_MAX_POSSIBLE_FACTOR,
-                BASE_MESSAGE_MAX_POSSIBLE_FACTOR,
-                DEFAULT_MESSAGE_MAX_POSSIBLE_FACTOR,
+            val messageMaxWidthFactorTheirs = attributes.getFraction(
+                R.styleable.MessageListView_streamUiMessageMaxWidthFactorTheirs,
+                BASE_MESSAGE_MAX_WIDTH_FACTOR,
+                BASE_MESSAGE_MAX_WIDTH_FACTOR,
+                DEFAULT_MESSAGE_MAX_WIDTH_FACTOR,
             )
 
             return MessageListItemStyle(
@@ -585,19 +585,19 @@ public data class MessageListItemStyle(
                 pinnedMessageBackgroundColor = pinnedMessageBackgroundColor,
                 messageStartMargin = messageStartMargin,
                 messageEndMargin = messageEndMargin,
-                messageMaxPossibleWidthFactorMine = messageMaxPossibleWidthFactorMine,
-                messageMaxPossibleWidthFactorTheirs = messageMaxPossibleWidthFactorTheirs
+                messageMaxWidthFactorMine = messageMaxWidthFactorMine,
+                messageMaxWidthFactorTheirs = messageMaxWidthFactorTheirs
             ).let(TransformStyle.messageListItemStyleTransformer::transform)
-                .also { style -> style.checkMessageMaxPossibleWidthFactorsRange() }
+                .also { style -> style.checkMessageMaxWidthFactorsRange() }
         }
 
         private fun Int.nullIfNotSet(): Int? {
             return if (this == VALUE_NOT_SET) null else this
         }
 
-        private fun MessageListItemStyle.checkMessageMaxPossibleWidthFactorsRange() {
-            require(messageMaxPossibleWidthFactorMine in 0.0..1.0) { "messageMaxPossibleWidthFactorMine cannot be lower than 0 and greater than 1! Current value: $messageMaxPossibleWidthFactorMine" }
-            require(messageMaxPossibleWidthFactorTheirs in 0.0..1.0) { "messageMaxPossibleWidthFactorTheirs cannot be lower than 0 and greater than 1! Current value: $messageMaxPossibleWidthFactorTheirs" }
+        private fun MessageListItemStyle.checkMessageMaxWidthFactorsRange() {
+            require(messageMaxWidthFactorMine in 0.75..1.0) { "messageMaxWidthFactorMine cannot be lower than 0.75 and greater than 1! Current value: $messageMaxWidthFactorMine" }
+            require(messageMaxWidthFactorTheirs in 0.75..1.0) { "messageMaxWidthFactorTheirs cannot be lower than 0.75 and greater than 1! Current value: $messageMaxWidthFactorTheirs" }
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/MaxPossibleWidthDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/MaxPossibleWidthDecorator.kt
@@ -39,10 +39,10 @@ internal class MaxPossibleWidthDecorator(private val style: MessageListItemStyle
         val marginStartPercent = if (data.isTheirs) {
             START_PERCENT
         } else {
-            START_PERCENT + getMaxPossibleWidthFactor(data.isTheirs)
+            START_PERCENT + getMaxWidthFactor(data.isTheirs)
         }
         val marginEndPercent = if (data.isTheirs) {
-            END_PERCENT - getMaxPossibleWidthFactor(data.isTheirs)
+            END_PERCENT - getMaxWidthFactor(data.isTheirs)
         } else {
             END_PERCENT
         }
@@ -51,23 +51,20 @@ internal class MaxPossibleWidthDecorator(private val style: MessageListItemStyle
     }
 
     /**
-     * Gets message's max possible width factor from [style] based on [isTheirs] and scales it using [MAX_POSSIBLE_WIDTH_FACTOR]
+     * Gets message's max width factor from [style] based on [isTheirs]
      */
-    private fun getMaxPossibleWidthFactor(isTheirs: Boolean): Float {
+    private fun getMaxWidthFactor(isTheirs: Boolean): Float {
         val maxPossibleWidthFactor = if (isTheirs) {
-            style.messageMaxPossibleWidthFactorTheirs
+            style.messageMaxWidthFactorTheirs
         } else {
-            style.messageMaxPossibleWidthFactorMine
+            style.messageMaxWidthFactorMine
         }
 
-        return maxPossibleWidthFactor * MAX_POSSIBLE_WIDTH_FACTOR
+        return 1 - maxPossibleWidthFactor
     }
 
     companion object {
-        private const val MAX_POSSIBLE_WIDTH_FACTOR = .25f
         private const val START_PERCENT = 0f
         private const val END_PERCENT = 0.97f
-        private const val MINE_START_PERCENT = START_PERCENT + MAX_POSSIBLE_WIDTH_FACTOR
-        private const val THEIR_END_PERCENT = END_PERCENT - MAX_POSSIBLE_WIDTH_FACTOR
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -402,9 +402,9 @@
         <attr name="streamUiMessageStartMargin" format="dimension|reference" />
         <attr name="streamUiMessageEndMargin" format="dimension|reference" />
 
-        <!-- Fraction used to compute max possible width for message sent by the current user. Should be in <0%, 100%> range. Message will be wider when the fraction is smaller -->
-        <attr name="streamUiMessageMaxPossibleWidthFactorMine" format="fraction" />
-        <!-- Fraction used to compute max possible width for message sent by other user. Should be in <0%, 100%> range. Message will be wider when the fraction is smaller -->
-        <attr name="streamUiMessageMaxPossibleWidthFactorTheirs" format="fraction" />
+        <!-- Fraction used to compute max width for message sent by the current user. Should be in [75% - 100%] range. -->
+        <attr name="streamUiMessageMaxWidthFactorMine" format="fraction" />
+        <!-- Fraction used to compute max width for message sent by other user. Should be in [75% - 100%] range. -->
+        <attr name="streamUiMessageMaxWidthFactorTheirs" format="fraction" />
     </declare-styleable>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -474,8 +474,8 @@
         <item name="streamUiMessageEndMargin">0dp</item>
 
         <!-- Message max possible factors -->
-        <item name="streamUiMessageMaxPossibleWidthFactorMine">100%</item>
-        <item name="streamUiMessageMaxPossibleWidthFactorTheirs">100%</item>
+        <item name="streamUiMessageMaxWidthFactorMine">75%</item>
+        <item name="streamUiMessageMaxWidthFactorTheirs">75%</item>
     </style>
 
     <style name="StreamUi.MessageList.MediaAttachment" parent="StreamUi">


### PR DESCRIPTION
### 🎯 Goal

Improve max message width customization

### 🛠 Implementation details

The previous approach was confusing because the message was wider when the factor was smaller. The one fixes that and allows customizing the message's width in [75 - 100]% range. Unfortunately, we cannot allow values <75% because it breaks UI.

### 🎨 UI Changes
<img width="317" alt="Screenshot 2021-10-25 at 11 50 58" src="https://user-images.githubusercontent.com/17440581/138676579-6ca779fa-ca6d-4826-977e-bde364edbbd6.png">


### 🧪 Testing

Play with newly added attrs.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

