### PR TITLE
Revert [CAS-1398] Using the same MessageListItemViewHolderFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,7 +53,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
-- Using the same `MessageListItemViewHolderFactory` of `MessageListView` in `MessageOptionsDialogFragment`
+
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -288,8 +288,7 @@ public class MessageListView : ConstraintLayout {
                             hasTextToCopy = message.text.isNotBlank(),
                             suppressThreads = adapter.isThread || message.isInThread(),
                         ),
-                        requireStyle(),
-                        messageListItemViewHolderFactory
+                        requireStyle()
                     )
                     .apply {
                         setReactionClickHandler { message, reactionType ->
@@ -389,8 +388,7 @@ public class MessageListView : ConstraintLayout {
                         hasTextToCopy = false, // No effect when displaying reactions
                         suppressThreads = false, // No effect when displaying reactions
                     ),
-                    requireStyle(),
-                    messageListItemViewHolderFactory
+                    requireStyle()
                 ).apply {
                     setReactionClickHandler { message, reactionType ->
                         messageReactionHandler.onMessageReaction(message, reactionType)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -45,7 +45,6 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     }
 
     private val style by lazy { messageListViewStyle!! }
-    private val viewHolderFactory by lazy { messageViewHolderFactory!! }
 
     private val configuration by lazy {
         requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
@@ -165,7 +164,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     }
 
     private fun setupMessageView() {
-        viewHolder = viewHolderFactory
+        viewHolder = MessageListItemViewHolderFactory()
             .apply {
                 decoratorProvider = MessageOptionsDecoratorProvider(style.itemStyle, style.replyMessageStyle)
                 setListenerContainer(MessageListListenerContainerImpl())
@@ -382,24 +381,21 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         internal var messageListViewStyle: MessageListViewStyle? = null
 
         var messageArg: Message? = null
-        var messageViewHolderFactory: MessageListItemViewHolderFactory? = null
 
         fun newReactionOptionsInstance(
             message: Message,
             configuration: MessageOptionsView.Configuration,
             style: MessageListViewStyle,
-            messageViewHolderFactory: MessageListItemViewHolderFactory
         ): MessageOptionsDialogFragment {
-            return newInstance(OptionsMode.REACTION_OPTIONS, message, configuration, style, messageViewHolderFactory)
+            return newInstance(OptionsMode.REACTION_OPTIONS, message, configuration, style)
         }
 
         fun newMessageOptionsInstance(
             message: Message,
             configuration: MessageOptionsView.Configuration,
             style: MessageListViewStyle,
-            messageViewHolderFactory: MessageListItemViewHolderFactory
         ): MessageOptionsDialogFragment {
-            return newInstance(OptionsMode.MESSAGE_OPTIONS, message, configuration, style, messageViewHolderFactory)
+            return newInstance(OptionsMode.MESSAGE_OPTIONS, message, configuration, style)
         }
 
         private fun newInstance(
@@ -407,10 +403,8 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             message: Message,
             configuration: MessageOptionsView.Configuration,
             style: MessageListViewStyle,
-            messageViewHolderFactory: MessageListItemViewHolderFactory
         ): MessageOptionsDialogFragment {
             messageListViewStyle = style
-            this.messageViewHolderFactory = messageViewHolderFactory
             return MessageOptionsDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_OPTIONS_MODE to optionsMode,


### PR DESCRIPTION
### 🎯 Goal
Revert "[CAS-1398] Using the same MessageListItemViewHolderFactory (#2522)"

This reverts commit 7e4e769375cd03ce4da78b1b3cde55eafca4b889.


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added


[CAS-1398]: https://stream-io.atlassian.net/browse/CAS-1398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ