### PR TITLE
Fix single reaction position

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/ReactionsDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/decorator/internal/ReactionsDecorator.kt
@@ -10,6 +10,7 @@ import androidx.core.view.updateLayoutParams
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.utils.extensions.updateConstraints
 import io.getstream.chat.android.ui.common.extensions.hasReactions
+import io.getstream.chat.android.ui.common.extensions.hasSingleReaction
 import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
 import io.getstream.chat.android.ui.message.list.MessageListItemStyle
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.GiphyViewHolder
@@ -120,10 +121,11 @@ internal class ReactionsDecorator(private val style: MessageListItemStyle) : Bas
 
         val expectedReactionsAndOffsetWidth = offsetFromParent + reactionsView.measuredWidth
 
-        return if (expectedReactionsAndOffsetWidth > rootConstraintLayout.measuredWidth)
-            expectedReactionsAndOffsetWidth - rootWidth
-        else
-            MULTIPLE_REACTIONS_OFFSET
+        return when {
+            expectedReactionsAndOffsetWidth > rootConstraintLayout.measuredWidth -> expectedReactionsAndOffsetWidth - rootWidth
+            data.message.hasSingleReaction() -> SINGLE_REACTION_OFFSET
+            else -> MULTIPLE_REACTIONS_OFFSET
+        }
     }
 
     private fun updateOffset(


### PR DESCRIPTION
### 🎯 Goal

Fix single reaction position

### 🛠 Implementation details

Decrease single reaction offset when reactions can be drew in bubble's left top corner

### 🎨 UI Changes

| Before | After |
| --- | --- |
| <img width="321" alt="before1" src="https://user-images.githubusercontent.com/17440581/139050877-78a8acef-be8c-4394-889a-d383c0b90203.png">|<img width="321" alt="after1" src="https://user-images.githubusercontent.com/17440581/139050872-1f471fd3-00d4-4e6a-9229-f0c0dd1524ad.png">|
|<img width="321" alt="before2" src="https://user-images.githubusercontent.com/17440581/139050919-dc86f621-25ec-4ef4-8879-8b8cfa53ef9e.png">|<img width="321" alt="after2" src="https://user-images.githubusercontent.com/17440581/139050918-0b9bf940-1a8b-4805-b49d-8b310b9f1847.png">|


### 🧪 Testing

Play with reactions. Try to change the message's width

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

