### PR TITLE
[CAS-1419] Add clearing MessageInputView after dismissing message to edit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed clearing `MessageInputView` after dismissing message to edit
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -166,6 +166,8 @@ public class MessageInputView : ConstraintLayout {
                 binding.inputModeHeader.isVisible = false
                 if (previousValue is InputMode.Reply) {
                     binding.messageInputFieldView.onReplyDismissed()
+                } else if (previousValue is InputMode.Edit) {
+                    binding.messageInputFieldView.onEditMessageDismissed()
                 }
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -202,6 +202,13 @@ internal class MessageInputFieldView : FrameLayout {
         }
     }
 
+    fun onEditMessageDismissed() {
+        if (mode is Mode.EditMessageMode) {
+            mode = Mode.MessageMode
+            clearContent()
+        }
+    }
+
     fun onEdit(edit: Message) {
         mode = Mode.EditMessageMode(edit)
     }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1419

### 🎯 Goal

Add clearing MessageInputView after dismissing message to edit

### 🛠 Implementation details

Added changing `MessageInputFieldView's` mode and clearing the content, if the previous mode was edited, after clicking on dismiss mode button.

### 🎨 UI Changes

_ Add relevant screenshots_

| Before | After |
| --- | --- |
| https://user-images.githubusercontent.com/17440581/139529772-7a1e0d71-c6cb-4e84-943a-d20265c95b23.mp4|https://user-images.githubusercontent.com/17440581/139529768-2207a7c5-85d4-4dd6-9a59-c017ae736559.mp4|


### 🧪 Testing

Try to dismiss edit mode - message to edit should disappear

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

