### PR TITLE
MessageListViewModel initialization using OfflinePlugin

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
@@ -23,6 +23,7 @@ public class ToggleService private constructor(private val sharedPreferences: Sh
 
     public companion object {
         private const val PREFS_NAME = "toggle_storage"
+        public const val TOGGLE_KEY_OFFLINE: String = "offline plugin"
 
         private var instance: ToggleService? = null
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/dialog/ToggleAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/dialog/ToggleAdapter.kt
@@ -28,7 +28,9 @@ internal class ToggleAdapter(context: Context) :
         val itemView =
             convertView ?: LayoutInflater.from(parent.context).inflate(R.layout.stream_toggle_list_item, parent, false)
         val label: TextView = itemView.findViewById(R.id.label)
-        val switch: SwitchCompat = itemView.findViewById(R.id.switcher)
+        val switch: SwitchCompat = itemView.findViewById<SwitchCompat>(R.id.switcher).also {
+            it.setOnCheckedChangeListener(null)
+        }
         val toggle = getItem(position)
         label.text = toggle.first
         switch.isChecked = toggle.second

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -153,6 +153,7 @@ internal class ChannelLogic(
         setWatchers(c.watchers)
         upsertMessages(c.messages)
         mutableState.lastMessageAt.value = c.lastMessageAt
+        mutableState.channelConfig.value = c.config
     }
 
     internal fun upsertMessages(messages: List<Message>) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelState.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.experimental.channel.state
 
+import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
@@ -82,4 +83,7 @@ public interface ChannelState {
 
     /** If we need to recover state when connection established again. */
     public val recoveryNeeded: Boolean
+
+    /** Function that builds a channel based on data from StateFlows. */
+    public fun toChannel(): Channel
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -78,5 +78,6 @@ public class OfflinePlugin(private val config: Config) : Plugin {
 
     public companion object {
         public const val MODULE_NAME: String = "Offline"
+        public const val TOGGLE_KEY_OFFLINE: String = "offline plugin toggle"
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -78,6 +78,5 @@ public class OfflinePlugin(private val config: Config) : Plugin {
 
     public companion object {
         public const val MODULE_NAME: String = "Offline"
-        public const val TOGGLE_KEY_OFFLINE: String = "offline plugin toggle"
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
@@ -79,7 +79,7 @@ internal class QueryChannelsLogic(
             .also { onQueryChannelsResult(it, request) }
     }
 
-    internal suspend fun onOnlineQueryResult(result: Result<List<Channel>>, request: QueryChannelsRequest) {
+    private suspend fun onOnlineQueryResult(result: Result<List<Channel>>, request: QueryChannelsRequest) {
         if (result.isSuccess) {
             mutableState.recoveryNeeded.value = false
 

--- a/stream-chat-android-ui-common/build.gradle
+++ b/stream-chat-android-ui-common/build.gradle
@@ -62,6 +62,7 @@ dependencies {
     implementation Dependencies.androidxStartup
     implementation Dependencies.constraintLayout
     implementation Dependencies.materialComponents
+    implementation Dependencies.androidxLifecycleLiveDataKtx
 
     api Dependencies.threeTenAbp
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -29,7 +29,6 @@ import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
 import io.getstream.chat.android.offline.experimental.channel.state.MessagesState
 import io.getstream.chat.android.offline.experimental.extensions.asReferenced
-import io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin
 import kotlinx.coroutines.flow.map
 import kotlin.properties.Delegates
 import io.getstream.chat.android.livedata.utils.Event as EventWrapper
@@ -101,7 +100,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         }
 
     init {
-        if (ToggleService.instance().isEnabled(OfflinePlugin.TOGGLE_KEY_OFFLINE)) {
+        if (ToggleService.instance().isEnabled(ToggleService.TOGGLE_KEY_OFFLINE)) {
             initWithOfflinePlugin()
         } else {
             initWithChatDomain()

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -122,7 +122,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         _channel.addSource(channelDataLiveData) {
             _channel.value = channelState.toChannel()
             // Channel should be propagated only once because it's used to initialize MessageListView
-            _channel.removeSource(channelState.channelData.asLiveData())
+            _channel.removeSource(channelDataLiveData)
         }
         val typingIds = channelState.typing.map { (_, idList) -> idList }.asLiveData()
 

--- a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
+++ b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
@@ -11,7 +11,6 @@ import io.getstream.chat.android.client.di.networkFlipper
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
-import io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin
 
 @OptIn(ExperimentalStreamChatApi::class)
 object ApplicationConfigurator {
@@ -30,6 +29,6 @@ object ApplicationConfigurator {
             }.start()
         }
 
-        ToggleService.init(application, mapOf(OfflinePlugin.TOGGLE_KEY_OFFLINE to true))
+        ToggleService.init(application, mapOf(ToggleService.TOGGLE_KEY_OFFLINE to true))
     }
 }

--- a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
+++ b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
@@ -9,8 +9,11 @@ import com.facebook.flipper.plugins.inspector.InspectorFlipperPlugin
 import com.facebook.soloader.SoLoader
 import io.getstream.chat.android.client.di.networkFlipper
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin
 
+@OptIn(ExperimentalStreamChatApi::class)
 object ApplicationConfigurator {
 
     const val HUAWEI_APP_ID = "104598359"
@@ -27,6 +30,6 @@ object ApplicationConfigurator {
             }.start()
         }
 
-        ToggleService.init(application, mapOf("ToggleSample" to false))
+        ToggleService.init(application, mapOf(OfflinePlugin.TOGGLE_KEY_OFFLINE to true))
     }
 }


### PR DESCRIPTION
### 🎯 Goal

#2530 introduced new approach to init `ChannelState`. This PR adopts it in `MessageListViewModel`

### 🛠 Implementation details

1. Add toggle for `OfflinePlugin`. Which is `false` by default and `true` in debug version of the sample app
2. Init `LiveData`s of `MessageListViewModel` by OfflinePlugin and it's `ChannelState`

### 🧪 Testing

Run sample app and be sure you don't have changed experience of the chat screen

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media2.giphy.com/media/8FlypZDVSG8qs8UDU8/giphy.gif)
