### PR TITLE
[Compose] Fix the display of channel options in the ChannelInfo component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Added `StreamDimens` option to the `ChatTheme`, to allow for dimension customization across the app.
 - Added localization support for the components related the channel list.
 - Added the `emptySearchContent` parameter to `ChannelList` component that allows to customize the empty placeholder, when there are no channels matching the search query.
+- Fixed channel options that are displayed in the `ChannelInfo` component.
 
 ### 🐞 Fixed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -886,6 +886,7 @@ public final class io/getstream/chat/android/compose/ui/util/ChannelUtilsKt {
 	public static final fun getLastMessage (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;)Lio/getstream/chat/android/client/models/Message;
 	public static final fun getLastMessagePreviewText (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/AnnotatedString;
 	public static final fun getReadStatuses (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;)Ljava/util/List;
+	public static final fun isDistinct (Lio/getstream/chat/android/client/models/Channel;)Z
 }
 
 public final class io/getstream/chat/android/compose/ui/util/DefaultReactionTypes {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
@@ -130,3 +130,14 @@ public fun Channel.getReadStatuses(userToIgnore: User?): List<Date> {
     return read.filter { it.user.id != userToIgnore?.id }
         .mapNotNull { it.lastRead }
 }
+
+/**
+ * Checks if the channel is distinct.
+ *
+ * A distinct channel is a channel created without ID based on members. Internally
+ * the server creates a CID which starts with "!members" prefix and is unique for
+ * this particular group of users.
+ *
+ * @return True if the channel is distinct.
+ */
+public fun Channel.isDistinct(): Boolean = cid.contains("!members")


### PR DESCRIPTION
### 🎯 Goal

Fix the conditions under which the "leave group" and "delete conversation" channel actions are displayed.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
