### PR TITLE
[CAS-1303] Make retryPolicy immutable and set via Builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- 🚨 Breaking change: `RetryPolicy` in `ChatDomain` is now immutable and can only be set with Builder before creating an instance of it.
 
 ### ❌ Removed
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
@@ -588,20 +588,22 @@ public class Android {
             chatClient.disconnect();
         }
 
-        public void customizeRetryPolicy() {
-            ChatDomain chatDomain = ChatDomain.instance();
+        public void initializeChatDomainWithCustomRetryPolicy() {
+            ChatClient chatClient =
+                    new ChatClient.Builder("apiKey", requireContext()).build();
+            ChatDomain chatDomain = new ChatDomain.Builder(chatClient, requireContext())
+                    .retryPolicy(new RetryPolicy() {
+                        @Override
+                        public boolean shouldRetry(@NotNull ChatClient client, int attempt, @NotNull ChatError error) {
+                            return attempt < 3;
+                        }
 
-            chatDomain.setRetryPolicy(new RetryPolicy() {
-                @Override
-                public boolean shouldRetry(@NotNull ChatClient client, int attempt, @NotNull ChatError error) {
-                    return attempt < 3;
-                }
-
-                @Override
-                public int retryTimeout(@NotNull ChatClient client, int attempt, @NotNull ChatError error) {
-                    return 1000 * attempt;
-                }
-            });
+                        @Override
+                        public int retryTimeout(@NotNull ChatClient client, int attempt, @NotNull ChatError error) {
+                            return 1000 * attempt;
+                        }
+                    })
+                    .build();
         }
 
         public void watchChannel() {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
@@ -623,18 +623,19 @@ class Android {
             val chatDomain = ChatDomain.instance()
         }
 
-        fun customizeRetryPolicy() {
-            val chatDomain = ChatDomain.instance()
+        fun initializeChatDomainWithCustomRetryPolicy() {
+            val chatClient = ChatClient.Builder("apiKey", requireContext()).build()
+            val chatDomain = ChatDomain.Builder(requireContext(), chatClient)
+                .retryPolicy(object : RetryPolicy {
+                    override fun shouldRetry(client: ChatClient, attempt: Int, error: ChatError): Boolean {
+                        return attempt < 3
+                    }
 
-            chatDomain.retryPolicy = object : RetryPolicy {
-                override fun shouldRetry(client: ChatClient, attempt: Int, error: ChatError): Boolean {
-                    return attempt < 3
-                }
-
-                override fun retryTimeout(client: ChatClient, attempt: Int, error: ChatError): Int {
-                    return 1000 * attempt
-                }
-            }
+                    override fun retryTimeout(client: ChatClient, attempt: Int, error: ChatError): Int {
+                        return 1000 * attempt
+                    }
+                })
+                .build()
         }
 
         fun watchChannel() {

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -60,7 +60,6 @@ public abstract interface class io/getstream/chat/android/livedata/ChatDomain {
 	public abstract fun sendReaction (Ljava/lang/String;Lio/getstream/chat/android/client/models/Reaction;Z)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun setMessageForReply (Ljava/lang/String;Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun setOfflineEnabled (Z)V
-	public abstract fun setRetryPolicy (Lio/getstream/chat/android/livedata/utils/RetryPolicy;)V
 	public abstract fun setUserPresence (Z)V
 	public abstract fun showChannel (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun shuffleGiphy (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
@@ -83,6 +82,7 @@ public final class io/getstream/chat/android/livedata/ChatDomain$Builder {
 	public final fun offlineEnabled ()Lio/getstream/chat/android/livedata/ChatDomain$Builder;
 	public final fun recoveryDisabled ()Lio/getstream/chat/android/livedata/ChatDomain$Builder;
 	public final fun recoveryEnabled ()Lio/getstream/chat/android/livedata/ChatDomain$Builder;
+	public final fun retryPolicy (Lio/getstream/chat/android/livedata/utils/RetryPolicy;)Lio/getstream/chat/android/livedata/ChatDomain$Builder;
 	public fun toString ()Ljava/lang/String;
 	public final fun uploadAttachmentsWorkerNetworkType (Lio/getstream/chat/android/offline/message/attachment/UploadAttachmentsNetworkType;)Lio/getstream/chat/android/livedata/ChatDomain$Builder;
 	public final fun userPresenceDisabled ()Lio/getstream/chat/android/livedata/ChatDomain$Builder;
@@ -280,7 +280,6 @@ public abstract interface class io/getstream/chat/android/offline/ChatDomain {
 	public abstract fun sendReaction (Ljava/lang/String;Lio/getstream/chat/android/client/models/Reaction;Z)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun setMessageForReply (Ljava/lang/String;Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun setOfflineEnabled (Z)V
-	public abstract fun setRetryPolicy (Lio/getstream/chat/android/offline/utils/RetryPolicy;)V
 	public abstract fun setUserPresence (Z)V
 	public abstract fun showChannel (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun shuffleGiphy (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
@@ -303,6 +302,7 @@ public final class io/getstream/chat/android/offline/ChatDomain$Builder {
 	public final fun offlineEnabled ()Lio/getstream/chat/android/offline/ChatDomain$Builder;
 	public final fun recoveryDisabled ()Lio/getstream/chat/android/offline/ChatDomain$Builder;
 	public final fun recoveryEnabled ()Lio/getstream/chat/android/offline/ChatDomain$Builder;
+	public final fun retryPolicy (Lio/getstream/chat/android/offline/utils/RetryPolicy;)Lio/getstream/chat/android/offline/ChatDomain$Builder;
 	public fun toString ()Ljava/lang/String;
 	public final fun uploadAttachmentsWorkerNetworkType (Lio/getstream/chat/android/offline/message/attachment/UploadAttachmentsNetworkType;)Lio/getstream/chat/android/offline/ChatDomain$Builder;
 	public final fun userPresenceDisabled ()Lio/getstream/chat/android/offline/ChatDomain$Builder;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -91,7 +91,7 @@ public sealed interface ChatDomain {
     public val banned: LiveData<Boolean>
 
     /** The retry policy for retrying failed requests */
-    public var retryPolicy: RetryPolicy
+    public val retryPolicy: RetryPolicy
 
     /**
      * Updates about currently typing users in active channels. See [TypingEvent].
@@ -635,11 +635,15 @@ public sealed interface ChatDomain {
             offlineChatDomainBuilder.uploadAttachmentsWorkerNetworkType(networkType)
         }
 
+        public fun retryPolicy(retryPolicy: RetryPolicy): Builder = apply {
+            offlineChatDomainBuilder.retryPolicy(retryPolicy)
+        }
+
         public fun build(): ChatDomain {
-            ChatDomain.instance?.run { Log.e("Chat", "[ERROR] You have just re-initialized ChatDomain, old configuration has been overridden [ERROR]") }
+            instance?.run { Log.e("Chat", "[ERROR] You have just re-initialized ChatDomain, old configuration has been overridden [ERROR]") }
             val offlineChatDomain = offlineChatDomainBuilder.build()
-            ChatDomain.instance = buildImpl(offlineChatDomain)
-            return ChatDomain.instance()
+            instance = buildImpl(offlineChatDomain)
+            return instance()
         }
 
         internal fun buildImpl(offlineChatDomainBuilder: OfflineChatDomain): ChatDomainImpl {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -111,11 +111,7 @@ internal class ChatDomainImpl internal constructor(internal val chatDomainStateF
     override val typingUpdates: LiveData<TypingEvent> = chatDomainStateFlow.typingUpdates.asLiveData()
 
     /** The retry policy for retrying failed requests */
-    override var retryPolicy: RetryPolicy
-        get() = chatDomainStateFlow.retryPolicy.toLiveDataRetryPolicy()
-        set(value) {
-            chatDomainStateFlow.retryPolicy = value
-        }
+    override val retryPolicy: RetryPolicy = chatDomainStateFlow.retryPolicy.toLiveDataRetryPolicy()
 
     override fun getVersion(): String = chatDomainStateFlow.getVersion()
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -149,6 +149,7 @@ internal class ChatDomainImpl internal constructor(
     internal var appContext: Context,
     private val offlinePlugin: OfflinePlugin,
     internal val uploadAttachmentsNetworkType: UploadAttachmentsNetworkType = UploadAttachmentsNetworkType.NOT_ROAMING,
+    override val retryPolicy: RetryPolicy = DefaultRetryPolicy()
 ) : ChatDomain {
     internal constructor(
         client: ChatClient,
@@ -256,9 +257,6 @@ internal class ChatDomainImpl internal constructor(
     }
     private val syncStateFlow: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     internal var initJob: Deferred<SyncState?>? = null
-
-    /** The retry policy for retrying failed requests */
-    override var retryPolicy: RetryPolicy = DefaultRetryPolicy()
 
     private val offlineSyncFirebaseMessagingHandler = OfflineSyncFirebaseMessagingHandler()
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/Config.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/Config.kt
@@ -1,10 +1,13 @@
 package io.getstream.chat.android.offline.experimental.plugin
 
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.offline.utils.DefaultRetryPolicy
+import io.getstream.chat.android.offline.utils.RetryPolicy
 
 @InternalStreamChatApi
 public data class Config(
     public val backgroundSyncEnabled: Boolean = true,
     public val userPresence: Boolean = true,
     public val persistenceEnabled: Boolean = true,
+    public val retryPolicy: RetryPolicy = DefaultRetryPolicy()
 )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -11,6 +11,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.android.livedata.utils.toLiveDataRetryPolicy
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.experimental.plugin.state.StateRegistry
@@ -35,6 +36,7 @@ public class OfflinePlugin(private val config: Config) : Plugin {
             if (config.persistenceEnabled) offlineEnabled() else offlineDisabled()
             if (config.userPresence) userPresenceEnabled() else userPresenceDisabled()
             recoveryEnabled()
+            retryPolicy(config.retryPolicy.toLiveDataRetryPolicy())
         }.build()
 
         initState(io.getstream.chat.android.offline.ChatDomain.instance as ChatDomainImpl, chatClient)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1303

### 🎯 Goal

The goal of this PR is to make `retryPolicy` immutable and that should be set only with the Builder.

### 🛠 Implementation details

All mutable vars of `retryPolicy` are converted into `val`. A new function `retryPolicy()` is added to Builders to customize the retry policy while creating ChatDomain instance.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
