### PR TITLE
[CAS-1296] Add extension requestMembers in ChatClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added new extension function `ChatCliet::requestMembers` to query members without `ChatDomain`.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -475,6 +475,16 @@ public final class io/getstream/chat/android/offline/experimental/querychannels/
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/offline/extensions/ChatClientKt {
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;IILio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/client/call/Call;
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;IILio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;)Lio/getstream/chat/android/client/call/Call;
+	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;IILio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun requestMembers$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;IILio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
+}
+
 public final class io/getstream/chat/android/offline/extensions/ChatErrorKt {
 	public static final fun isPermanent (Lio/getstream/chat/android/client/errors/ChatError;)Z
 }

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -475,7 +475,7 @@ public final class io/getstream/chat/android/offline/experimental/querychannels/
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/offline/extensions/ChatClientKt {
+public final class io/getstream/chat/android/offline/extensions/ChatClientExtensions {
 	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public static final fun requestMembers (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -1,0 +1,33 @@
+package io.getstream.chat.android.offline.extensions
+
+import androidx.annotation.CheckResult
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.NeutralFilterObject
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.offline.ChatDomain
+
+/**
+ * Query members of a channel.
+ *
+ * @param cid CID of the Channel whose members we are querying.
+ * @param offset Indicates how many items to exclude from the start of the result.
+ * @param limit Indicates the maximum allowed number of items in the result.
+ * @param filter Filter applied to online queries for advanced selection criteria.
+ * @param sort The sort criteria applied to the result.
+ * @param members
+ *
+ * @return Executable async [Call] querying members.
+ */
+@JvmOverloads
+@CheckResult
+public fun ChatClient.requestMembers(
+    cid: String,
+    offset: Int = 0,
+    limit: Int = 0,
+    filter: FilterObject = NeutralFilterObject,
+    sort: QuerySort<Member> = QuerySort.desc(Member::createdAt),
+    members: List<Member> = emptyList(),
+): Call<List<Member>> = ChatDomain.instance().queryMembers(cid, offset, limit, filter, sort, members)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -1,3 +1,5 @@
+@file:JvmName("ChatClientExtensions")
+
 package io.getstream.chat.android.offline.extensions
 
 import androidx.annotation.CheckResult


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1296

### 🎯 Goal

The goal is to make it easy to request members without the need for ChatDomain for end users.

### 🛠 Implementation details

Added an extension function `ChatClient::requestMembers`.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
