### PR TITLE
[CAS-1443] Fix SqliteException when selecting/inserting more than 999 messages

### DIFF
--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -601,7 +601,6 @@ public final class io/getstream/chat/android/offline/repository/domain/channelco
 
 public final class io/getstream/chat/android/offline/repository/domain/message/MessageDao_Impl {
 	public fun <init> (Landroidx/room/RoomDatabase;)V
-	public fun deleteAttachment (Ljava/lang/String;)V
 	public fun deleteAttachments (Ljava/util/List;)V
 	public fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteMessage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -601,6 +601,7 @@ public final class io/getstream/chat/android/offline/repository/domain/channelco
 
 public final class io/getstream/chat/android/offline/repository/domain/message/MessageDao_Impl {
 	public fun <init> (Landroidx/room/RoomDatabase;)V
+	public fun deleteAttachment (Ljava/lang/String;)V
 	public fun deleteAttachments (Ljava/util/List;)V
 	public fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteMessage (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/integration/MessageRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/integration/MessageRepositoryTest.kt
@@ -1,11 +1,15 @@
 package io.getstream.chat.android.offline.repository.integration
 
+import android.database.sqlite.SQLiteException
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.offline.randomAttachment
 import io.getstream.chat.android.offline.randomMessage
+import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.coInvoking
+import org.amshove.kluent.shouldNotThrow
 import org.junit.Test
 import org.junit.runner.RunWith
 
@@ -13,24 +17,35 @@ import org.junit.runner.RunWith
 internal class MessageRepositoryTest : BaseDomainTest2() {
 
     @Test
-    fun `Given message with 3 attachments When update it in DB Should keep only 3 newer attachments`(): Unit = runBlocking {
-        val attachment1 = randomAttachment { url = "url1" }
-        val attachment2 = randomAttachment { url = "url2" }
-        val attachment3 = randomAttachment { url = "url3" }
-        val message = randomMessage(attachments = mutableListOf(attachment1, attachment2, attachment3))
-        chatDomainImpl.repos.insertMessage(message)
+    fun `Given message with 3 attachments When update it in DB Should keep only 3 newer attachments`(): Unit =
+        runBlocking {
+            val attachment1 = randomAttachment { url = "url1" }
+            val attachment2 = randomAttachment { url = "url2" }
+            val attachment3 = randomAttachment { url = "url3" }
+            val message = randomMessage(attachments = mutableListOf(attachment1, attachment2, attachment3))
+            chatDomainImpl.repos.insertMessage(message)
 
-        val newAttachment1 = attachment1.copy(url = "newUrl1")
-        val newAttachment2 = attachment2.copy(url = "newUrl2")
-        val newAttachment3 = attachment3.copy(url = "newUrl3")
-        message.attachments = mutableListOf(newAttachment1, newAttachment2, newAttachment3)
-        chatDomainImpl.repos.insertMessage(message)
+            val newAttachment1 = attachment1.copy(url = "newUrl1")
+            val newAttachment2 = attachment2.copy(url = "newUrl2")
+            val newAttachment3 = attachment3.copy(url = "newUrl3")
+            message.attachments = mutableListOf(newAttachment1, newAttachment2, newAttachment3)
+            chatDomainImpl.repos.insertMessage(message)
 
-        val messageFromDb = requireNotNull(chatDomainImpl.repos.selectMessage(message.id))
+            val messageFromDb = requireNotNull(chatDomainImpl.repos.selectMessage(message.id))
 
-        messageFromDb.attachments.size `should be equal to` 3
-        messageFromDb.attachments[0].url `should be equal to` "newUrl1"
-        messageFromDb.attachments[1].url `should be equal to` "newUrl2"
-        messageFromDb.attachments[2].url `should be equal to` "newUrl3"
+            messageFromDb.attachments.size `should be equal to` 3
+            messageFromDb.attachments[0].url `should be equal to` "newUrl1"
+            messageFromDb.attachments[1].url `should be equal to` "newUrl2"
+            messageFromDb.attachments[2].url `should be equal to` "newUrl3"
+        }
+
+    @Test
+    fun `When selecting more than 999 messages Should not throw SQLiteException`(): Unit = runBlocking {
+        coInvoking { chatDomainImpl.repos.selectMessages(List(1000) { randomString() }) } shouldNotThrow (SQLiteException::class)
+    }
+
+    @Test
+    fun `When inserting more than 999 messages Should not throw SQLiteException`(): Unit = runBlocking {
+        coInvoking { chatDomainImpl.repos.insertMessages(List(1000) { randomMessage() }) } shouldNotThrow (SQLiteException::class)
     }
 }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1443
#2580 

### 🎯 Goal

Fix SqliteException when selecting/inserting more than 999 messages

### 🛠 Implementation details

Add chunking messages before making SQL queries


### 🧪 Testing

- Run tests
- Check if messages are loading correctly
- Check if attachments are uploaded correctly

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

