### PR TITLE
[Compose] - 2582 - Implement search channels by name and participants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,23 +77,23 @@
 ### ❌ Removed
 
 ## stream-chat-android-compose
-- Added `StreamDimens` option to the `ChatTheme`, to allow for dimension customization across the app.
-- Added localization support for the components related the channel list.
-- Added the `emptySearchContent` parameter to `ChannelList` component that allows to customize the empty placeholder, when there are no channels matching the search query.
-- Fixed channel options that are displayed in the `ChannelInfo` component.
-- Added support for the muted channel indicator in the message list.
-- Added `ChannelNameFormatter` option to the `ChatTheme`, to allow for channel name format customization across the app.
-
 ### 🐞 Fixed
+- Fixed channel options that are displayed in the `ChannelInfo` component.
 
 ### ⬆️ Improved
 - Improved the icon set and polished the UI for various Messages features
 - Improved the set of customization options for the `DefaultChannelItem`
 - Updated documentation for Channels set of features
+- Now it is possible to search for distinct channels by member names using `ChannelListViewModel`.
 
 ### ✅ Added
 - Added a new parameter to the `AttachmentFactory` called `previewContent` that represents attachments within the MessageInput
 - Added the `leadingContent`, `detailsContent`, `trailingContent` and `divider` Slot APIs for the `DefaultChannelItem`
+- Added `StreamDimens` option to the `ChatTheme`, to allow for dimension customization across the app.
+- Added localization support for the components related the channel list.
+- Added the `emptySearchContent` parameter to `ChannelList` component that allows to customize the empty placeholder, when there are no channels matching the search query.
+- Added support for the muted channel indicator in the message list.
+- Added `ChannelNameFormatter` option to the `ChatTheme`, to allow for channel name format customization across the app.
 
 ### ⚠️ Changed
 - The `AttachmentFactory` now requires an additional parameter - `previewContent` that's used to preview the attachment within the MessageInput, so please be aware of this!

--- a/docusaurus/docs/Android/04-compose/06-utility-components/03-search-input.mdx
+++ b/docusaurus/docs/Android/04-compose/06-utility-components/03-search-input.mdx
@@ -49,7 +49,7 @@ fun SearchInput(
 * `onValueChange`: Handler when the value changes.
 * `onSearchStarted`: Handler when the search starts, by focusing the input field. 
 
-You can use the `ChannelListViewModel` to search for channels by name. To do so, simply pass the search query from `onValueChange` callback to the `ChannelListViewModel`. The results can be displayed using the `ChannelList`.
+You can use the `ChannelListViewModel` to search for named channels by name and distinct channels by member name. To do so, simply pass the search query from `onValueChange` callback to the `ChannelListViewModel`. The results can be displayed using the `ChannelList`.
 
 ```kotlin
 var searchQuery by rememberSaveable { mutableStateOf("") }


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2582

### 🎯 Goal

Implement channels search by either channel name (for named channels) or member name (for distinct channels).

### 🛠 Implementation details

There is no easy way to check if the channel is distinct. As a workaround, I treat distinct channels as channels without name (which is not always the case).

```json
{
   "$or":[
      {
         "$and":[
            {
               "member.user.name":{
                  "$autocomplete":"Leandro"
               }
            },
            {
               "name":{
                  "$exists":false
               }
            }
         ]
      },
      {
         "name":{
            "$autocomplete":"Leandro"
         }
      }
   ]
}
```

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/140742358-aeb94efa-6f32-46ff-b585-4d9fd21b1b09.mov

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
