### PR TITLE
Init ToggleService by default in ChatClient.Builder

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -88,6 +88,7 @@ import io.getstream.chat.android.client.user.storage.UserCredentialStorage
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.TokenUtils
+import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.client.utils.observable.ChatEventsObservable
 import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
@@ -1822,6 +1823,10 @@ public class ChatClient internal constructor(
                 warmUp = warmUp,
                 loggerConfig = ChatLogger.Config(logLevel, loggerHandler),
             )
+
+            if (ToggleService.isInitialized().not()) {
+                ToggleService.init(appContext, emptyMap())
+            }
 
             val module =
                 ChatModule(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
@@ -30,7 +30,7 @@ public class ToggleService private constructor(private val sharedPreferences: Sh
         /**
          * Internal check used to avoid NPE in cases when SDK users don't initialize it.
          */
-        internal fun isInitialized() = instance == null
+        internal fun isInitialized() = instance != null
 
         @InternalStreamChatApi
         public fun instance(): ToggleService = requireNotNull(instance) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
@@ -27,6 +27,11 @@ public class ToggleService private constructor(private val sharedPreferences: Sh
 
         private var instance: ToggleService? = null
 
+        /**
+         * Internal check used to avoid NPE in cases when SDK users don't initialize it.
+         */
+        internal fun isInitialized() = instance == null
+
         @InternalStreamChatApi
         public fun instance(): ToggleService = requireNotNull(instance) {
             "Toggle service must be initialized via the init method!"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/toggle/ToggleService.kt
@@ -49,5 +49,10 @@ public class ToggleService private constructor(private val sharedPreferences: Sh
 
             return ToggleService(sp).also { instance = it }
         }
+
+        @InternalStreamChatApi
+        public fun isEnabled(featureKey: String): Boolean {
+            return instance?.isEnabled(featureKey) ?: false
+        }
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -100,7 +100,7 @@ public class MessageListViewModel @JvmOverloads constructor(
         }
 
     init {
-        if (ToggleService.instance().isEnabled(ToggleService.TOGGLE_KEY_OFFLINE)) {
+        if (ToggleService.isEnabled(ToggleService.TOGGLE_KEY_OFFLINE)) {
             initWithOfflinePlugin()
         } else {
             initWithChatDomain()


### PR DESCRIPTION
### 🎯 Goal

Avoid NPE when SDK users don't init ToggleService

### 🛠 Implementation details

Init by default in ChatClient.Builder

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![](https://media4.giphy.com/media/3orieMQS2105J5Sn5K/giphy.gif)
