### PR TITLE
[Compose] - 2468 - Add possibility to customize the message bubble color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,7 @@
 - Added `MessagePreviewFormatter` option to the `ChatTheme`, to allow for message preview text format customization across the app.
 - Added the `leadingContent`, `headerContent`, `footerContent`, `trailingContent` and `content` Slot APIs for the `DefaultMessageItem`
 - Added `channelInfoUserItemWidth`, `channelInfoUserItemHorizontalPadding` and `channelInfoUserItemAvatarSize` options to `StreamDimens`, to make it possible to customize the dimensions inside the `ChannelInfo` component via `ChatTheme`. 
+- Added `ownMessagesBackground`, `otherMessagesBackground` and `deletedMessagesBackgroundColor` options to `StreamColors`, to make it possible to customize the message bubble color via `ChatTheme`. 
 
 ### ⚠️ Changed
 - The `AttachmentFactory` now requires an additional parameter - `previewContent` that's used to preview the attachment within the MessageInput, so please be aware of this!

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -795,13 +795,16 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamColors$Companion;
-	public synthetic fun <init> (JJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
 	public final fun component12-0d7_KjU ()J
 	public final fun component13-0d7_KjU ()J
 	public final fun component14-0d7_KjU ()J
+	public final fun component15-0d7_KjU ()J
+	public final fun component16-0d7_KjU ()J
+	public final fun component17-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
 	public final fun component4-0d7_KjU ()J
@@ -810,20 +813,23 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component7-0d7_KjU ()J
 	public final fun component8-0d7_KjU ()J
 	public final fun component9-0d7_KjU ()J
-	public final fun copy-dVHXu7A (JJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
-	public static synthetic fun copy-dVHXu7A$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public final fun copy-OG5zQOY (JJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public static synthetic fun copy-OG5zQOY$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppBackground-0d7_KjU ()J
 	public final fun getBarsBackground-0d7_KjU ()J
 	public final fun getBorders-0d7_KjU ()J
+	public final fun getDeletedMessagesBackgroundColor-0d7_KjU ()J
 	public final fun getDisabled-0d7_KjU ()J
 	public final fun getErrorAccent-0d7_KjU ()J
 	public final fun getHighlight-0d7_KjU ()J
 	public final fun getInfoAccent-0d7_KjU ()J
 	public final fun getInputBackground-0d7_KjU ()J
 	public final fun getLinkBackground-0d7_KjU ()J
+	public final fun getOtherMessagesBackground-0d7_KjU ()J
 	public final fun getOverlay-0d7_KjU ()J
 	public final fun getOverlayDark-0d7_KjU ()J
+	public final fun getOwnMessagesBackground-0d7_KjU ()J
 	public final fun getPrimaryAccent-0d7_KjU ()J
 	public final fun getTextHighEmphasis-0d7_KjU ()J
 	public final fun getTextLowEmphasis-0d7_KjU ()J

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -468,7 +468,11 @@ public fun DefaultMessageItemContent(
         }
     }
 
-    val messageCardColor = if (ownsMessage) ChatTheme.colors.borders else ChatTheme.colors.barsBackground
+    val messageCardColor = when {
+        message.isDeleted() -> ChatTheme.colors.deletedMessagesBackgroundColor
+        ownsMessage -> ChatTheme.colors.ownMessagesBackground
+        else -> ChatTheme.colors.otherMessagesBackground
+    }
 
     MessageBubble(
         modifier = modifier,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -23,6 +23,9 @@ import io.getstream.chat.android.compose.R
  * @param errorAccent Used for error text labels, notification badges and disruptive action text and icons.
  * @param infoAccent Used for the online status.
  * @param highlight Used for message highlights.
+ * @param ownMessagesBackground Used as a background color for the messages sent by the current user.
+ * @param otherMessagesBackground Used as a background color for the messages sent by other users.
+ * @param deletedMessagesBackgroundColor Used as a background for deleted messages.
  */
 @Immutable
 public data class StreamColors(
@@ -40,6 +43,9 @@ public data class StreamColors(
     public val errorAccent: Color,
     public val infoAccent: Color,
     public val highlight: Color,
+    public val ownMessagesBackground: Color,
+    public val otherMessagesBackground: Color,
+    public val deletedMessagesBackgroundColor: Color,
 ) {
 
     public companion object {
@@ -59,11 +65,14 @@ public data class StreamColors(
             barsBackground = colorResource(R.color.stream_compose_bars_background),
             linkBackground = colorResource(R.color.stream_compose_link_background),
             overlay = colorResource(R.color.stream_compose_overlay_regular),
-            overlayDark = colorResource(id = R.color.stream_compose_overlay_dark),
+            overlayDark = colorResource(R.color.stream_compose_overlay_dark),
             primaryAccent = colorResource(R.color.stream_compose_primary_accent),
             errorAccent = colorResource(R.color.stream_compose_error_accent),
             infoAccent = colorResource(R.color.stream_compose_info_accent),
             highlight = colorResource(R.color.stream_compose_highlight),
+            ownMessagesBackground = colorResource(R.color.stream_compose_borders),
+            otherMessagesBackground = colorResource(R.color.stream_compose_bars_background),
+            deletedMessagesBackgroundColor = colorResource(R.color.stream_compose_input_background),
         )
 
         /**
@@ -82,11 +91,14 @@ public data class StreamColors(
             barsBackground = colorResource(R.color.stream_compose_bars_background_dark),
             linkBackground = colorResource(R.color.stream_compose_link_background_dark),
             overlay = colorResource(R.color.stream_compose_overlay_regular_dark),
-            overlayDark = colorResource(id = R.color.stream_compose_overlay_dark_dark),
+            overlayDark = colorResource(R.color.stream_compose_overlay_dark_dark),
             primaryAccent = colorResource(R.color.stream_compose_primary_accent_dark),
             errorAccent = colorResource(R.color.stream_compose_error_accent_dark),
             infoAccent = colorResource(R.color.stream_compose_info_accent_dark),
             highlight = colorResource(R.color.stream_compose_highlight_dark),
+            ownMessagesBackground = colorResource(R.color.stream_compose_borders_dark),
+            otherMessagesBackground = colorResource(R.color.stream_compose_bars_background_dark),
+            deletedMessagesBackgroundColor = colorResource(R.color.stream_compose_input_background_dark),
         )
     }
 }


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2468
https://github.com/GetStream/stream-chat-android/issues/2500

### 🎯 Goal

Add the following props to `StreamColors` to allow granular customization of the message bubble color:

- ownMessagesBackgroundColor
- otherMessagesBackgroundColor
- deletedMessagesBackgroundColor

### 🎨 UI Changes

```kotlin
setContent {
    ChatTheme(
        colors = StreamColors.defaultColors().copy(
            ownMessagesBackground = colorResource(R.color.stream_compose_avatar_gradient_red),
            otherMessagesBackground = colorResource(R.color.stream_compose_avatar_gradient_yellow),
            deletedMessagesBackgroundColor = colorResource(R.color.stream_compose_avatar_gradient_blue),
         )
    ) {
        MessagesScreen(...)
    }
}
```

<img src="https://user-images.githubusercontent.com/9600921/141301331-ac5dbadc-8bfa-4016-b444-60b06e6b4b56.jpeg" width="40%">

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
