### PR TITLE
[CAS-1445] Fix inserting messages with empty cid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed inserting messages with empty `Message::cid`
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -467,7 +467,8 @@ public class ChannelController internal constructor(
     }
 
     internal suspend fun handleSendMessageSuccess(processedMessage: Message): Message {
-        return processedMessage.apply { enrichWithCid(this.cid) }
+        return processedMessage
+            .let { message -> message.enrichWithCid(cid) }
             .copy(syncStatus = SyncStatus.COMPLETED)
             .also { domainImpl.repos.insertMessage(it) }
             .also { upsertMessage(it) }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1445

### 🎯 Goal

Fix inserting messages with empty cid

### 🛠 Implementation details

Fixed enriching message with cid.

### 🧪 Testing

1. Freeze the channel - you can call:
```kotlin
ChatClient.instance().channel(cid).updatePartial(mapOf("frozen" to true)).await()
```
2. Try to send a message - app shouldn't crash
3. Unfreeze the channel - call:
 ```kotlin
ChatClient.instance().channel(cid).updatePartial(mapOf("frozen" to false)).await()
```

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
