### PR TITLE
Fix docusaurus docs for removed extension

### DIFF
--- a/docusaurus/docs/Android/04-compose/03-channel-components/03-channel-list.mdx
+++ b/docusaurus/docs/Android/04-compose/03-channel-components/03-channel-list.mdx
@@ -190,7 +190,7 @@ fun CustomChannelListItem() {
                     Spacer(modifier = Modifier.width(8.dp))
 
                     Text(
-                        text = it.getDisplayName(),
+                        text = ChatTheme.channelNameFormatter.format(it),
                         style = ChatTheme.typography.bodyBold,
                         maxLines = 1,
                     )

--- a/docusaurus/docs/Android/04-compose/03-channel-components/04-default-channel-item.mdx
+++ b/docusaurus/docs/Android/04-compose/03-channel-components/04-default-channel-item.mdx
@@ -184,7 +184,7 @@ fun CustomChannelListItem(channel: Channel, user: User?) {
         },
         detailsContent = { // Replace the details content with a simple Text
             Text(
-                text = it.getDisplayName(),
+                text = ChatTheme.channelNameFormatter.format(it),
                 style = ChatTheme.typography.bodyBold
             )
         }


### PR DESCRIPTION
### 🎯 Goal
Fixed docusaurus docs for a removed extension. (I missed this in #2573)

`Channel.getDisplayName()` extension has been replaced to `ChatTheme.channelNameFormatter.format(channel)`.

### ☑️ Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
