### PR TITLE
[Compose] - 2624 - Improve thread design

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added the "mute" option to the `ChannelInfo` action dialog.
 - Added a wrapper for the message input state in the form of `MessageInputState`
 - Added `attachmentsContentImageWidth`, `attachmentsContentImageHeight`, `attachmentsContentGiphyWidth`, `attachmentsContentGiphyHeight`, `attachmentsContentLinkWidth`, `attachmentsContentFileWidth` and `attachmentsContentFileUploadWidth` options to `StreamDimens`, to make it possible to customize the dimensions of attachments content via `ChatTheme`.
+- Added a thread separator between a parent message and thread replies.
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added a wrapper for the message input state in the form of `MessageInputState`
 - Added `attachmentsContentImageWidth`, `attachmentsContentImageHeight`, `attachmentsContentGiphyWidth`, `attachmentsContentGiphyHeight`, `attachmentsContentLinkWidth`, `attachmentsContentFileWidth` and `attachmentsContentFileUploadWidth` options to `StreamDimens`, to make it possible to customize the dimensions of attachments content via `ChatTheme`.
 - Added a thread separator between a parent message and thread replies.
+- Added the `threadSeparatorGradientStart` and `threadSeparatorGradientEnd` options to `StreamColors`, to make it possible to customize the thread separator background gradient colors via `ChatTheme`.
+- Added the `threadSeparatorVerticalPadding` and `threadSeparatorTextVerticalPadding` options to `StreamDimens`, to make it possible to customize the dimensions of thread separator via `ChatTheme`.
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -255,21 +255,23 @@ public final class io/getstream/chat/android/compose/state/messages/items/DateSe
 
 public final class io/getstream/chat/android/compose/state/messages/items/MessageItem : io/getstream/chat/android/compose/state/messages/items/MessageListItem {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZ)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZZ)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/Message;
 	public final fun component2 ()Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Z
 	public final fun component5 ()Z
-	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZ)Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
+	public final fun component6 ()Z
+	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZZ)Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;Ljava/lang/String;ZZZILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/items/MessageItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getGroupPosition ()Lio/getstream/chat/android/compose/state/messages/items/MessageItemGroupPosition;
 	public final fun getMessage ()Lio/getstream/chat/android/client/models/Message;
 	public final fun getParentMessageId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isFocused ()Z
+	public final fun isInThread ()Z
 	public final fun isMine ()Z
 	public fun toString ()Ljava/lang/String;
 }
@@ -300,6 +302,18 @@ public final class io/getstream/chat/android/compose/state/messages/items/Messag
 
 public abstract class io/getstream/chat/android/compose/state/messages/items/MessageListItem {
 	public static final field $stable I
+}
+
+public final class io/getstream/chat/android/compose/state/messages/items/ThreadSeparator : io/getstream/chat/android/compose/state/messages/items/MessageListItem {
+	public static final field $stable I
+	public fun <init> (I)V
+	public final fun component1 ()I
+	public final fun copy (I)Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;IILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getReplyCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/compose/state/messages/list/MessageOption {
@@ -715,6 +729,7 @@ public final class io/getstream/chat/android/compose/ui/messages/list/MessageIte
 	public static final fun MessageDateSeparator (Lio/getstream/chat/android/compose/state/messages/items/DateSeparator;Landroidx/compose/runtime/Composer;I)V
 	public static final fun MessageReactions (Ljava/util/List;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageReactionsItem (Lio/getstream/chat/android/compose/state/messages/reaction/ReactionOption;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageThreadSeparator (Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;Landroidx/compose/runtime/Composer;I)V
 	public static final fun ThreadParticipants (Ljava/util/List;Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
 	public static final fun UploadingFooter (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -726,10 +726,10 @@ public final class io/getstream/chat/android/compose/ui/messages/list/MessageIte
 	public static final fun DefaultMessageItemHeaderContent (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public static final fun DefaultMessageItemLeadingContent (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DefaultMessageItemTrailingContent (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun MessageDateSeparator (Lio/getstream/chat/android/compose/state/messages/items/DateSeparator;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MessageDateSeparator (Lio/getstream/chat/android/compose/state/messages/items/DateSeparator;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageReactions (Ljava/util/List;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageReactionsItem (Lio/getstream/chat/android/compose/state/messages/reaction/ReactionOption;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun MessageThreadSeparator (Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;Landroidx/compose/runtime/Composer;I)V
+	public static final fun MessageThreadSeparator (Lio/getstream/chat/android/compose/state/messages/items/ThreadSeparator;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ThreadParticipants (Ljava/util/List;Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
 	public static final fun UploadingFooter (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
@@ -774,7 +774,7 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamColors$Companion;
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
@@ -784,6 +784,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component15-0d7_KjU ()J
 	public final fun component16-0d7_KjU ()J
 	public final fun component17-0d7_KjU ()J
+	public final fun component18-0d7_KjU ()J
+	public final fun component19-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
 	public final fun component4-0d7_KjU ()J
@@ -792,13 +794,13 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component7-0d7_KjU ()J
 	public final fun component8-0d7_KjU ()J
 	public final fun component9-0d7_KjU ()J
-	public final fun copy-OG5zQOY (JJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
-	public static synthetic fun copy-OG5zQOY$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public final fun copy-USMLqHw (JJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public static synthetic fun copy-USMLqHw$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppBackground-0d7_KjU ()J
 	public final fun getBarsBackground-0d7_KjU ()J
 	public final fun getBorders-0d7_KjU ()J
-	public final fun getDeletedMessagesBackgroundColor-0d7_KjU ()J
+	public final fun getDeletedMessagesBackground-0d7_KjU ()J
 	public final fun getDisabled-0d7_KjU ()J
 	public final fun getErrorAccent-0d7_KjU ()J
 	public final fun getHighlight-0d7_KjU ()J
@@ -812,6 +814,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun getPrimaryAccent-0d7_KjU ()J
 	public final fun getTextHighEmphasis-0d7_KjU ()J
 	public final fun getTextLowEmphasis-0d7_KjU ()J
+	public final fun getThreadSeparatorGradientEnd-0d7_KjU ()J
+	public final fun getThreadSeparatorGradientStart-0d7_KjU ()J
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -823,12 +827,14 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors$Compa
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamDimens$Companion;
-	public synthetic fun <init> (FFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
 	public final fun component10-D9Ej5fM ()F
 	public final fun component11-D9Ej5fM ()F
 	public final fun component12-D9Ej5fM ()F
 	public final fun component13-D9Ej5fM ()F
+	public final fun component14-D9Ej5fM ()F
+	public final fun component15-D9Ej5fM ()F
 	public final fun component2-D9Ej5fM ()F
 	public final fun component3-D9Ej5fM ()F
 	public final fun component4-D9Ej5fM ()F
@@ -837,8 +843,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun component7-D9Ej5fM ()F
 	public final fun component8-D9Ej5fM ()F
 	public final fun component9-D9Ej5fM ()F
-	public final fun copy-UucoBsQ (FFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
-	public static synthetic fun copy-UucoBsQ$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public final fun copy-EEHxY70 (FFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public static synthetic fun copy-EEHxY70$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachmentsContentFileUploadWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentFileWidth-D9Ej5fM ()F
@@ -853,6 +859,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun getChannelInfoUserItemWidth-D9Ej5fM ()F
 	public final fun getChannelItemHorizontalPadding-D9Ej5fM ()F
 	public final fun getChannelItemVerticalPadding-D9Ej5fM ()F
+	public final fun getThreadSeparatorTextVerticalPadding-D9Ej5fM ()F
+	public final fun getThreadSeparatorVerticalPadding-D9Ej5fM ()F
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/items/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/items/MessageItem.kt
@@ -16,6 +16,13 @@ public sealed class MessageListItem
 public data class DateSeparator(val date: Date) : MessageListItem()
 
 /**
+ * Represents a separator between thread parent message and thread replies.
+ *
+ * @param replyCount The number of thread replies to the message.
+ */
+public data class ThreadSeparator(val replyCount: Int) : MessageListItem()
+
+/**
  * Represents each message item we show in the list of messages.
  *
  * @param message The message to show.
@@ -23,6 +30,7 @@ public data class DateSeparator(val date: Date) : MessageListItem()
  * @param parentMessageId The id of the parent message, when we're in a thread.
  * @param isMine If the message is of the current user or someone else.
  * @param isFocused If the message is being focused currently.
+ * @param isInThread If the message is being displayed in a thread.
  */
 public data class MessageItem(
     val message: Message,
@@ -30,4 +38,5 @@ public data class MessageItem(
     val parentMessageId: String? = null,
     val isMine: Boolean = false,
     val isFocused: Boolean = false,
+    val isInThread: Boolean = false,
 ) : MessageListItem()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.End
 import androidx.compose.ui.Alignment.Companion.Start
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -66,6 +67,7 @@ import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPo
 import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPosition.None
 import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPosition.Top
 import io.getstream.chat.android.compose.state.messages.items.MessageListItem
+import io.getstream.chat.android.compose.state.messages.items.ThreadSeparator
 import io.getstream.chat.android.compose.state.messages.reaction.ReactionOption
 import io.getstream.chat.android.compose.ui.attachments.content.MessageAttachmentsContent
 import io.getstream.chat.android.compose.ui.common.MessageBubble
@@ -149,6 +151,7 @@ public fun DefaultMessageItem(
 ) {
     when (messageListItem) {
         is DateSeparator -> MessageDateSeparator(messageListItem)
+        is ThreadSeparator -> MessageThreadSeparator(messageListItem)
         is MessageItem -> DefaultMessageContainer(
             modifier = modifier,
             messageItem = messageListItem,
@@ -192,6 +195,44 @@ public fun MessageDateSeparator(
                 style = ChatTheme.typography.body
             )
         }
+    }
+}
+
+/**
+ * Represents a thread separator item that is displayed in thread mode to separate a parent message
+ * from thread replies.
+ *
+ * @param threadSeparator The data used to show the separator text.
+ */
+@Composable
+public fun MessageThreadSeparator(
+    threadSeparator: ThreadSeparator,
+) {
+    val backgroundGradient = Brush.verticalGradient(
+        listOf(
+            ChatTheme.colors.inputBackground,
+            ChatTheme.colors.appBackground
+        )
+    )
+    val replyCount = threadSeparator.replyCount
+
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp)
+            .background(brush = backgroundGradient),
+        contentAlignment = Center
+    ) {
+        Text(
+            modifier = Modifier.padding(vertical = 2.dp, horizontal = 16.dp),
+            text = LocalContext.current.resources.getQuantityString(
+                R.plurals.stream_compose_message_list_thread_separator,
+                replyCount,
+                replyCount
+            ),
+            color = ChatTheme.colors.textLowEmphasis,
+            style = ChatTheme.typography.body
+        )
     }
 }
 
@@ -850,11 +891,16 @@ internal fun MessageFooter(
     val (message, position) = messageItem
     val hasThread = message.threadParticipants.isNotEmpty()
 
-    if (hasThread) {
+    if (hasThread && !messageItem.isInThread) {
+        val replyCount = message.replyCount
         ThreadParticipants(
             modifier = modifier,
             participants = message.threadParticipants,
-            text = stringResource(id = R.string.stream_compose_thread_footnote)
+            text = LocalContext.current.resources.getQuantityString(
+                R.plurals.stream_compose_message_list_thread_footnote,
+                replyCount,
+                replyCount
+            )
         )
     } else if (!hasThread && (position == Bottom || position == None)) {
         Row(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -150,8 +150,16 @@ public fun DefaultMessageItem(
     },
 ) {
     when (messageListItem) {
-        is DateSeparator -> MessageDateSeparator(messageListItem)
-        is ThreadSeparator -> MessageThreadSeparator(messageListItem)
+        is DateSeparator -> MessageDateSeparator(
+            modifier = Modifier.fillMaxWidth(),
+            dateSeparator = messageListItem
+        )
+        is ThreadSeparator -> MessageThreadSeparator(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = ChatTheme.dimens.threadSeparatorVerticalPadding),
+            threadSeparator = messageListItem
+        )
         is MessageItem -> DefaultMessageContainer(
             modifier = modifier,
             messageItem = messageListItem,
@@ -171,12 +179,14 @@ public fun DefaultMessageItem(
  * Represents a date separator item that shows whenever messages are too far apart in time.
  *
  * @param dateSeparator The data used to show the separator text.
+ * @param modifier Modifier for styling.
  */
 @Composable
 public fun MessageDateSeparator(
     dateSeparator: DateSeparator,
+    modifier: Modifier = Modifier,
 ) {
-    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Center) {
+    Box(modifier = modifier, contentAlignment = Center) {
         Surface(
             modifier = Modifier
                 .padding(vertical = 8.dp),
@@ -203,28 +213,28 @@ public fun MessageDateSeparator(
  * from thread replies.
  *
  * @param threadSeparator The data used to show the separator text.
+ * @param modifier Modifier for styling.
  */
 @Composable
 public fun MessageThreadSeparator(
     threadSeparator: ThreadSeparator,
+    modifier: Modifier = Modifier,
 ) {
     val backgroundGradient = Brush.verticalGradient(
         listOf(
-            ChatTheme.colors.inputBackground,
-            ChatTheme.colors.appBackground
+            ChatTheme.colors.threadSeparatorGradientStart,
+            ChatTheme.colors.threadSeparatorGradientEnd
         )
     )
     val replyCount = threadSeparator.replyCount
 
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 8.dp)
+        modifier = modifier
             .background(brush = backgroundGradient),
         contentAlignment = Center
     ) {
         Text(
-            modifier = Modifier.padding(vertical = 2.dp, horizontal = 16.dp),
+            modifier = Modifier.padding(vertical = ChatTheme.dimens.threadSeparatorTextVerticalPadding),
             text = LocalContext.current.resources.getQuantityString(
                 R.plurals.stream_compose_message_list_thread_separator,
                 replyCount,
@@ -521,7 +531,7 @@ public fun DefaultMessageItemContent(
     }
 
     val messageCardColor = when {
-        message.isDeleted() -> ChatTheme.colors.deletedMessagesBackgroundColor
+        message.isDeleted() -> ChatTheme.colors.deletedMessagesBackground
         ownsMessage -> ChatTheme.colors.ownMessagesBackground
         else -> ChatTheme.colors.otherMessagesBackground
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -25,7 +25,9 @@ import io.getstream.chat.android.compose.R
  * @param highlight Used for message highlights.
  * @param ownMessagesBackground Used as a background color for the messages sent by the current user.
  * @param otherMessagesBackground Used as a background color for the messages sent by other users.
- * @param deletedMessagesBackgroundColor Used as a background for deleted messages.
+ * @param deletedMessagesBackground Used as a background for deleted messages.
+ * @param threadSeparatorGradientStart Used as a start color for vertical gradient background in a thread separator.
+ * @param threadSeparatorGradientEnd Used as an end color for vertical gradient background in a thread separator.
  */
 @Immutable
 public data class StreamColors(
@@ -45,7 +47,9 @@ public data class StreamColors(
     public val highlight: Color,
     public val ownMessagesBackground: Color,
     public val otherMessagesBackground: Color,
-    public val deletedMessagesBackgroundColor: Color,
+    public val deletedMessagesBackground: Color,
+    public val threadSeparatorGradientStart: Color,
+    public val threadSeparatorGradientEnd: Color,
 ) {
 
     public companion object {
@@ -72,7 +76,9 @@ public data class StreamColors(
             highlight = colorResource(R.color.stream_compose_highlight),
             ownMessagesBackground = colorResource(R.color.stream_compose_borders),
             otherMessagesBackground = colorResource(R.color.stream_compose_bars_background),
-            deletedMessagesBackgroundColor = colorResource(R.color.stream_compose_input_background),
+            deletedMessagesBackground = colorResource(R.color.stream_compose_input_background),
+            threadSeparatorGradientStart = colorResource(R.color.stream_compose_input_background),
+            threadSeparatorGradientEnd = colorResource(R.color.stream_compose_app_background),
         )
 
         /**
@@ -98,7 +104,9 @@ public data class StreamColors(
             highlight = colorResource(R.color.stream_compose_highlight_dark),
             ownMessagesBackground = colorResource(R.color.stream_compose_borders_dark),
             otherMessagesBackground = colorResource(R.color.stream_compose_bars_background_dark),
-            deletedMessagesBackgroundColor = colorResource(R.color.stream_compose_input_background_dark),
+            deletedMessagesBackground = colorResource(R.color.stream_compose_input_background_dark),
+            threadSeparatorGradientStart = colorResource(R.color.stream_compose_input_background_dark),
+            threadSeparatorGradientEnd = colorResource(R.color.stream_compose_app_background_dark),
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
@@ -20,6 +20,8 @@ import androidx.compose.ui.unit.dp
  * @param attachmentsContentLinkWidth The with of link attachments in the message list.
  * @param attachmentsContentFileWidth The width of file attachments in the message list.
  * @param attachmentsContentFileUploadWidth The width of uploading file attachments in the message list.
+ * @param threadSeparatorVerticalPadding The vertical content padding inside thread separator item.
+ * @param threadSeparatorTextVerticalPadding The vertical padding inside thread separator text.
  */
 @Immutable
 public data class StreamDimens(
@@ -36,6 +38,8 @@ public data class StreamDimens(
     public val attachmentsContentLinkWidth: Dp,
     public val attachmentsContentFileWidth: Dp,
     public val attachmentsContentFileUploadWidth: Dp,
+    public val threadSeparatorVerticalPadding: Dp,
+    public val threadSeparatorTextVerticalPadding: Dp,
 ) {
     public companion object {
         public fun defaultDimens(): StreamDimens = StreamDimens(
@@ -52,6 +56,8 @@ public data class StreamDimens(
             attachmentsContentLinkWidth = 250.dp,
             attachmentsContentFileWidth = 250.dp,
             attachmentsContentFileUploadWidth = 250.dp,
+            threadSeparatorVerticalPadding = 8.dp,
+            threadSeparatorTextVerticalPadding = 2.dp
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPo
 import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPosition.None
 import io.getstream.chat.android.compose.state.messages.items.MessageItemGroupPosition.Top
 import io.getstream.chat.android.compose.state.messages.items.MessageListItem
+import io.getstream.chat.android.compose.state.messages.items.ThreadSeparator
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.model.ConnectionState
@@ -545,9 +546,14 @@ public class MessageListViewModel(
                     message = message,
                     groupPosition = position,
                     parentMessageId = parentMessageId,
-                    isMine = user.id == currentUser?.id
+                    isMine = user.id == currentUser?.id,
+                    isInThread = isInThread
                 )
             )
+
+            if (index == 0 && isInThread) {
+                groupedMessages.add(ThreadSeparator(message.replyCount))
+            }
         }
 
         return groupedMessages.reversed()

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -38,6 +38,14 @@
     <string name="stream_compose_user_status_last_seen_just_now">Last seen just now</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">Thread Reply</item>
+        <item quantity="other">%d Thread Replies</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d Reply</item>
+        <item quantity="other">%d Replies</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">No messages</string>
 
     <string name="stream_compose_message_label">Send a message</string>
@@ -62,7 +70,6 @@
     <string name="stream_compose_reply_to_message">Reply to message</string>
     <string name="stream_compose_message_deleted">Message deleted</string>
     <string name="stream_compose_only_visible_to_you">Only visible to you</string>
-    <string name="stream_compose_thread_footnote">Thread Reply</string>
     <string name="stream_compose_download">Download</string>
     <string name="stream_compose_share">Share</string>
     <string name="stream_compose_photos">Photos</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -38,5 +38,13 @@
     <string name="stream_compose_user_status_last_seen_just_now">Última vez visto justo ahora</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">Respuesta al hilo</item>
+        <item quantity="other">%1$d Respuestas en el hilo</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d Respuesta</item>
+        <item quantity="other">%d Respuestas</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">Sin mensajes</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -38,5 +38,13 @@
     <string name="stream_compose_user_status_last_seen_just_now">Dernière vue à l\'instant</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">%d Réponse au fil de discussion</item>
+        <item quantity="other">%d Réponses au fil de discussion</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d Réponse</item>
+        <item quantity="other">%d Réponses</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">Pas de messages</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -38,5 +38,13 @@
     <string name="stream_compose_user_status_last_seen_just_now">अंतिम बार अभी देखा</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">%d जवाब</item>
+        <item quantity="other">%d जवाब</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d जवाब</item>
+        <item quantity="other">%d जवाब</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">कोई मैसेज नहीं</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -38,5 +38,13 @@
     <string name="stream_compose_user_status_last_seen_just_now">Ultimo accesso di recente</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">%d Risposta nella Conversazione</item>
+        <item quantity="other">%d Risposte nella Conversazione</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d Risposta</item>
+        <item quantity="other">%d Risposte</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">Nessun messaggio</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -37,5 +37,11 @@
     <string name="stream_compose_user_status_last_seen_just_now">今見ました</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="other">%dスレッド返信</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="other">%dスレッド返信</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">メッセージはありません</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -37,5 +37,11 @@
     <string name="stream_compose_user_status_last_seen_just_now">방금 확인했습니다</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="other">%d개의 스레드 응답</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="other">%d개의 응답</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">메시지 없음</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -38,6 +38,14 @@
     <string name="stream_compose_user_status_last_seen_just_now">Last seen just now</string>
 
     <!-- Message List -->
+    <plurals name="stream_compose_message_list_thread_footnote">
+        <item quantity="one">Thread Reply</item>
+        <item quantity="other">%d Thread Replies</item>
+    </plurals>
+    <plurals name="stream_compose_message_list_thread_separator">
+        <item quantity="one">%d Reply</item>
+        <item quantity="other">%d Replies</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">No messages</string>
 
     <string name="stream_compose_message_label">Send a message</string>
@@ -62,7 +70,6 @@
     <string name="stream_compose_reply_to_message">Reply to message</string>
     <string name="stream_compose_message_deleted">Message deleted</string>
     <string name="stream_compose_only_visible_to_you">Only visible to you</string>
-    <string name="stream_compose_thread_footnote">Thread Reply</string>
     <string name="stream_compose_download">Download</string>
     <string name="stream_compose_share">Share</string>
     <string name="stream_compose_photos">Photos</string>


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2624

### 🎯 Goal

Improve thread design

### 🛠 Implementation details

- Added thread separator between parent message and replies
- Improved the footnote text shown in "normal" mode 
- Removed unnecessary thread footnote in "thread" mode

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2021-11-17 13 37 21](https://user-images.githubusercontent.com/9600921/142185109-3a0cc854-4933-4f16-9690-229cb87e7889.jpeg) | ![photo_2021-11-17 13 37 23](https://user-images.githubusercontent.com/9600921/142185103-448adee7-dc0e-4c64-a58d-2e390375533c.jpeg) |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
