### PR TITLE
[Compose] - 2461 - Add support for message alignment customization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added the `threadSeparatorVerticalPadding` and `threadSeparatorTextVerticalPadding` options to `StreamDimens`, to make it possible to customize the dimensions of thread separator via `ChatTheme`.
 - Added a typing indicator to the `MessageListHeader` component. 
 - Added the `messageOverlayActionItemHeight` option to `StreamDimens`, to make it possible to customize the height of an action item on the selected message overlay via `ChatTheme`.
+- Added the `messageAlignmentProvider` field to the `ChatTheme` that allows to customize message horizontal alignment. 
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/docusaurus/docs/Android/04-compose/02-general-customization/01-chat-theme.mdx
+++ b/docusaurus/docs/Android/04-compose/02-general-customization/01-chat-theme.mdx
@@ -10,6 +10,7 @@ The `ChatTheme` component is a wrapper that **you should use as the root** of al
 * **DateFormatter**: Used to define the timestamp formatting in the app. You can use the default formatting, or customize it to your needs.
 * **ChannelNameFormatter**: Used to define the channel name formatting in the app. You can use the default implementation, or customize it according to your needs.
 * **MessagePreviewFormatter**: Used to define the message preview formatting in the app. You can use the default implementation, or customize the display of message previews according to your needs.
+* **MessageAlignmentProvider** Used to provide an alignment for a particular message. You can use the default implementation, which aligns the messages of the current user to the right, or customize it according to your needs.
 
 :::note
 In case any of these properties are not provided, because you're not using the `ChatTheme` to wrap our Compose UI Components, you'll get an exception saying that required properties are missing. 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -724,8 +724,8 @@ public final class io/getstream/chat/android/compose/ui/messages/list/Composable
 public final class io/getstream/chat/android/compose/ui/messages/list/MessageAlignment : java/lang/Enum {
 	public static final field End Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
 	public static final field Start Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
-	public final fun getMessageAlignment ()Landroidx/compose/ui/Alignment;
-	public final fun getMessageContentAlignment ()Landroidx/compose/ui/Alignment$Horizontal;
+	public final fun getContentAlignment ()Landroidx/compose/ui/Alignment$Horizontal;
+	public final fun getItemAlignment ()Landroidx/compose/ui/Alignment;
 	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
 	public static fun values ()[Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
 }

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -721,6 +721,15 @@ public final class io/getstream/chat/android/compose/ui/messages/list/Composable
 	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class io/getstream/chat/android/compose/ui/messages/list/MessageAlignment : java/lang/Enum {
+	public static final field End Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
+	public static final field Start Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
+	public final fun getMessageAlignment ()Landroidx/compose/ui/Alignment;
+	public final fun getMessageContentAlignment ()Landroidx/compose/ui/Alignment$Horizontal;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
+	public static fun values ()[Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
+}
+
 public final class io/getstream/chat/android/compose/ui/messages/list/MessageItemKt {
 	public static final field HIGHLIGHT_FADE_OUT_DURATION_MILLIS I
 	public static final fun DefaultMessageContainer (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
@@ -766,6 +775,7 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatTheme {
 	public final fun getColors (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public final fun getDateFormatter (Landroidx/compose/runtime/Composer;I)Lcom/getstream/sdk/chat/utils/DateFormatter;
 	public final fun getDimens (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public final fun getMessageAlignmentProvider (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;
 	public final fun getMessagePreviewFormatter (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;
 	public final fun getReactionTypes (Landroidx/compose/runtime/Composer;I)Ljava/util/Map;
 	public final fun getShapes (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/theme/StreamShapes;
@@ -773,7 +783,7 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatTheme {
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
-	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Ljava/util/List;Ljava/util/Map;Lcom/getstream/sdk/chat/utils/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Ljava/util/List;Ljava/util/Map;Lcom/getstream/sdk/chat/utils/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
@@ -968,6 +978,15 @@ public final class io/getstream/chat/android/compose/ui/util/DefaultReactionType
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/util/DefaultReactionTypes;
 	public final fun defaultReactionTypes ()Ljava/util/Map;
+}
+
+public abstract interface class io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider {
+	public static final field Companion Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider$Companion;
+	public abstract fun provideMessageAlignment (Lio/getstream/chat/android/compose/state/messages/items/MessageItem;)Lio/getstream/chat/android/compose/ui/messages/list/MessageAlignment;
+}
+
+public final class io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider$Companion {
+	public final fun defaultMessageAlignmentProvider ()Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;
 }
 
 public abstract interface class io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.Alignment.Companion.CenterEnd
 import androidx.compose.ui.Alignment.Companion.CenterStart
 import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Alignment.Companion.End
-import androidx.compose.ui.Alignment.Companion.Start
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.platform.LocalContext
@@ -317,7 +316,7 @@ public fun DefaultMessageContainer(
         )
     },
 ) {
-    val (message, _, _, ownsMessage, isFocused) = messageItem
+    val (message, _, _, _, isFocused) = messageItem
 
     val clickModifier = if (message.isDeleted()) {
         Modifier
@@ -345,12 +344,14 @@ public fun DefaultMessageContainer(
         )
     )
 
+    val messageAlignment = ChatTheme.messageAlignmentProvider.provideMessageAlignment(messageItem)
+
     Box(
         modifier = Modifier
             .fillMaxWidth()
             .wrapContentHeight()
             .background(color = backgroundColor),
-        contentAlignment = if (ownsMessage) CenterEnd else CenterStart
+        contentAlignment = messageAlignment.messageAlignment
     ) {
         Row(
             modifier
@@ -360,7 +361,7 @@ public fun DefaultMessageContainer(
 
             leadingContent(messageItem)
 
-            Column(horizontalAlignment = if (ownsMessage) End else Start) {
+            Column(horizontalAlignment = messageAlignment.messageContentAlignment) {
                 headerContent(messageItem)
 
                 content(messageItem)
@@ -386,17 +387,15 @@ public fun DefaultMessageItemLeadingContent(
     messageItem: MessageItem,
     modifier: Modifier = Modifier,
 ) {
-    if (!messageItem.isMine) {
-        val position = messageItem.groupPosition
-        if (position == Bottom || position == None) {
-            UserAvatar(
-                modifier = modifier,
-                user = messageItem.message.user,
-                showOnlineIndicator = false
-            )
-        } else {
-            Spacer(modifier = modifier)
-        }
+    val position = messageItem.groupPosition
+    if (!messageItem.isMine && (position == Bottom || position == None)) {
+        UserAvatar(
+            modifier = modifier,
+            user = messageItem.message.user,
+            showOnlineIndicator = false
+        )
+    } else {
+        Spacer(modifier = modifier)
     }
 }
 
@@ -960,6 +959,20 @@ private fun OwnedMessageVisibilityContent(
             date = message.updatedAt ?: message.createdAt ?: Date()
         )
     }
+}
+
+/**
+ * Represents the horizontal alignment of messages in the message list.
+ *
+ * @param messageAlignment The alignment of message.
+ * @param messageContentAlignment The alignment of the inner content.
+ */
+public enum class MessageAlignment(
+    public val messageAlignment: Alignment,
+    public val messageContentAlignment: Alignment.Horizontal,
+) {
+    Start(CenterStart, Alignment.Start),
+    End(CenterEnd, Alignment.End),
 }
 
 @Preview

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -351,7 +351,7 @@ public fun DefaultMessageContainer(
             .fillMaxWidth()
             .wrapContentHeight()
             .background(color = backgroundColor),
-        contentAlignment = messageAlignment.messageAlignment
+        contentAlignment = messageAlignment.itemAlignment
     ) {
         Row(
             modifier
@@ -361,7 +361,7 @@ public fun DefaultMessageContainer(
 
             leadingContent(messageItem)
 
-            Column(horizontalAlignment = messageAlignment.messageContentAlignment) {
+            Column(horizontalAlignment = messageAlignment.contentAlignment) {
                 headerContent(messageItem)
 
                 content(messageItem)
@@ -964,12 +964,12 @@ private fun OwnedMessageVisibilityContent(
 /**
  * Represents the horizontal alignment of messages in the message list.
  *
- * @param messageAlignment The alignment of message.
- * @param messageContentAlignment The alignment of the inner content.
+ * @param itemAlignment The alignment of the message item.
+ * @param contentAlignment The alignment of the inner content.
  */
 public enum class MessageAlignment(
-    public val messageAlignment: Alignment,
-    public val messageContentAlignment: Alignment.Horizontal,
+    public val itemAlignment: Alignment,
+    public val contentAlignment: Alignment.Horizontal,
 ) {
     Start(CenterStart, Alignment.Start),
     End(CenterEnd, Alignment.End),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -15,6 +15,7 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.StreamAttachmentFactories
 import io.getstream.chat.android.compose.ui.util.ChannelNameFormatter
 import io.getstream.chat.android.compose.ui.util.DefaultReactionTypes
+import io.getstream.chat.android.compose.ui.util.MessageAlignmentProvider
 import io.getstream.chat.android.compose.ui.util.MessagePreviewFormatter
 import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoader
 
@@ -39,17 +40,17 @@ private val LocalAttachmentFactories = compositionLocalOf<List<AttachmentFactory
 private val LocalReactionTypes = compositionLocalOf<Map<String, Int>> {
     error("No reactions provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
 }
-
 private val LocalDateFormatter = compositionLocalOf<DateFormatter> {
     error("No DateFormatter provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
 }
-
 private val LocalChannelNameFormatter = compositionLocalOf<ChannelNameFormatter> {
     error("No ChannelNameFormatter provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
 }
-
 private val LocalMessagePreviewFormatter = compositionLocalOf<MessagePreviewFormatter> {
     error("No MessagePreviewFormatter provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
+}
+private val LocalMessageAlignmentProvider = compositionLocalOf<MessageAlignmentProvider> {
+    error("No MessageAlignmentProvider provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
 }
 
 /**
@@ -66,6 +67,7 @@ private val LocalMessagePreviewFormatter = compositionLocalOf<MessagePreviewForm
  * @param dateFormatter [DateFormatter] used throughout the app for date and time information.
  * @param channelNameFormatter [ChannelNameFormatter] used throughout the app for channel names.
  * @param messagePreviewFormatter [MessagePreviewFormatter] used to generate a string preview for the given message.
+ * @param messageAlignmentProvider [MessageAlignmentProvider] used to provide message alignment for the given message.
  * @param content The content shown within the theme wrapper.
  */
 @Composable
@@ -80,6 +82,7 @@ public fun ChatTheme(
     dateFormatter: DateFormatter = DateFormatter.from(LocalContext.current),
     channelNameFormatter: ChannelNameFormatter = ChannelNameFormatter.defaultFormatter(LocalContext.current),
     messagePreviewFormatter: MessagePreviewFormatter = MessagePreviewFormatter.defaultFormatter(LocalContext.current),
+    messageAlignmentProvider: MessageAlignmentProvider = MessageAlignmentProvider.defaultMessageAlignmentProvider(),
     content: @Composable () -> Unit,
 ) {
     LaunchedEffect(Unit) {
@@ -96,7 +99,8 @@ public fun ChatTheme(
         LocalDateFormatter provides dateFormatter,
         LocalChannelNameFormatter provides channelNameFormatter,
         LocalMessagePreviewFormatter provides messagePreviewFormatter,
-        LocalImageLoader provides StreamCoilImageLoader.imageLoader(LocalContext.current)
+        LocalImageLoader provides StreamCoilImageLoader.imageLoader(LocalContext.current),
+        LocalMessageAlignmentProvider provides MessageAlignmentProvider.defaultMessageAlignmentProvider()
     ) {
         content()
     }
@@ -152,4 +156,9 @@ public object ChatTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalMessagePreviewFormatter.current
+
+    public val messageAlignmentProvider: MessageAlignmentProvider
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalMessageAlignmentProvider.current
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -100,7 +100,7 @@ public fun ChatTheme(
         LocalChannelNameFormatter provides channelNameFormatter,
         LocalMessagePreviewFormatter provides messagePreviewFormatter,
         LocalImageLoader provides StreamCoilImageLoader.imageLoader(LocalContext.current),
-        LocalMessageAlignmentProvider provides MessageAlignmentProvider.defaultMessageAlignmentProvider()
+        LocalMessageAlignmentProvider provides messageAlignmentProvider
     ) {
         content()
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider.kt
@@ -6,7 +6,7 @@ import io.getstream.chat.android.compose.ui.messages.list.MessageAlignment
 /**
  *  An interface that allows to return the desired horizontal alignment for a particular [MessageItem].
  */
-public interface MessageAlignmentProvider {
+public fun interface MessageAlignmentProvider {
 
     /**
      * Returns [MessageAlignment] for a particular [MessageItem].

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageAlignmentProvider.kt
@@ -1,0 +1,47 @@
+package io.getstream.chat.android.compose.ui.util
+
+import io.getstream.chat.android.compose.state.messages.items.MessageItem
+import io.getstream.chat.android.compose.ui.messages.list.MessageAlignment
+
+/**
+ *  An interface that allows to return the desired horizontal alignment for a particular [MessageItem].
+ */
+public interface MessageAlignmentProvider {
+
+    /**
+     * Returns [MessageAlignment] for a particular [MessageItem].
+     *
+     * @param messageItem The message whose data is used to decide which alignment to use.
+     * @return The [MessageAlignment] for the provided message.
+     */
+    public fun provideMessageAlignment(messageItem: MessageItem): MessageAlignment
+
+    public companion object {
+        /**
+         * Builds the default message alignment provider.
+         *
+         * @see [DefaultMessageAlignmentProvider]
+         */
+        public fun defaultMessageAlignmentProvider(): MessageAlignmentProvider {
+            return DefaultMessageAlignmentProvider()
+        }
+    }
+}
+
+/**
+ * A simple implementation of [MessageAlignmentProvider] that returns [MessageAlignment.End]
+ * for the messages of the current user and [MessageAlignment.Start] for the messages of
+ * other users.
+ */
+private class DefaultMessageAlignmentProvider : MessageAlignmentProvider {
+
+    /**
+     * Returns [MessageAlignment] for a particular [MessageItem].
+     *
+     * @param messageItem The message whose data is used to decide which alignment to use.
+     * @return The [MessageAlignment] for the provided message.
+     */
+    override fun provideMessageAlignment(messageItem: MessageItem): MessageAlignment {
+        return if (messageItem.isMine) MessageAlignment.End else MessageAlignment.Start
+    }
+}


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2461

### 🎯 Goal

Provide a way to customize message alignment.

### 🎨 UI Changes

The resulting UI after applying the patch below:

<img src="https://user-images.githubusercontent.com/9600921/142429419-b54fb307-4cd9-49b5-b820-ecb406593196.jpeg" width="40%">

### 🧪 Testing

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt	(revision 1f2b6969cd3c063b16540ba35d969f4bd1c60fc4)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt	(date 1637243847821)
@@ -36,6 +36,7 @@
 import io.getstream.chat.android.compose.ui.messages.attachments.AttachmentsPicker
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.composer.components.MessageInput
+import io.getstream.chat.android.compose.ui.messages.list.MessageAlignment
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
 import io.getstream.chat.android.compose.ui.messages.overlay.SelectedMessageOverlay
 import io.getstream.chat.android.compose.ui.messages.overlay.defaultMessageOptions
@@ -67,7 +68,10 @@
         val channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: return
 
         setContent {
-            ChatTheme(dateFormatter = ChatApp.dateFormatter) {
+            ChatTheme(
+                dateFormatter = ChatApp.dateFormatter,
+                messageAlignmentProvider = { MessageAlignment.Start }
+            ) {
                 MessagesScreen(
                     channelId = channelId,
                     messageLimit = 30,                 
```
</details>

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
