### PR TITLE
[Compose] - 2621 - Add message length limitation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added the `threadSeparatorVerticalPadding` and `threadSeparatorTextVerticalPadding` options to `StreamDimens`, to make it possible to customize the dimensions of thread separator via `ChatTheme`.
 - Added a typing indicator to the `MessageListHeader` component. 
 - Added the `messageOverlayActionItemHeight` option to `StreamDimens`, to make it possible to customize the height of an action item on the selected message overlay via `ChatTheme`.
+- Added the maximum allowed message length validation in the `MessageComposer` component. Now the send button becomes disabled when the message length exceed the maximum message length defined in channel config.
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added the `threadSeparatorVerticalPadding` and `threadSeparatorTextVerticalPadding` options to `StreamDimens`, to make it possible to customize the dimensions of thread separator via `ChatTheme`.
 - Added a typing indicator to the `MessageListHeader` component. 
 - Added the `messageOverlayActionItemHeight` option to `StreamDimens`, to make it possible to customize the height of an action item on the selected message overlay via `ChatTheme`.
-- Added the maximum allowed message length validation in the `MessageComposer` component. Now the send button becomes disabled when the message length exceed the maximum message length defined in channel config.
+- Added the `maxAttachmentCount` and `maxAttachmentSize` parameters to the `MessagesViewModelFactory`, to make it possible to customize the allowed number and size of attachments that can be sent via the `MessageComposer` component.
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -226,19 +226,19 @@ public final class io/getstream/chat/android/compose/state/messages/attachments/
 public final class io/getstream/chat/android/compose/state/messages/composer/MessageInputState {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;I)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Lio/getstream/chat/android/common/state/MessageAction;
-	public final fun component4 ()I
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;I)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;IILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
+	public final fun component4 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;Ljava/util/List;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lio/getstream/chat/android/common/state/MessageAction;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getInputValue ()Ljava/lang/String;
-	public final fun getMaxMessageLength ()I
+	public final fun getValidationErrors ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1072,8 +1072,8 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageC
 	public final fun dismissMessageActions ()V
 	public final fun getInput ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getLastActiveAction ()Lkotlinx/coroutines/flow/Flow;
-	public final fun getMaxMessageLength ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getSelectedAttachments ()Lkotlinx/coroutines/flow/MutableStateFlow;
+	public final fun getValidationErrors ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun leaveThread ()V
 	public final fun performMessageAction (Lio/getstream/chat/android/common/state/MessageAction;)V
 	public final fun removeSelectedAttachment (Lio/getstream/chat/android/client/models/Attachment;)V
@@ -1117,8 +1117,8 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZI)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZIIJ)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/offline/ChatDomain;ZIIJILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -226,17 +226,19 @@ public final class io/getstream/chat/android/compose/state/messages/attachments/
 public final class io/getstream/chat/android/compose/state/messages/composer/MessageInputState {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;I)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Lio/getstream/chat/android/common/state/MessageAction;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
+	public final fun component4 ()I
+	public final fun copy (Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;I)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Ljava/lang/String;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageAction;IILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lio/getstream/chat/android/common/state/MessageAction;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getInputValue ()Ljava/lang/String;
+	public final fun getMaxMessageLength ()I
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1070,6 +1072,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageC
 	public final fun dismissMessageActions ()V
 	public final fun getInput ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getLastActiveAction ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getMaxMessageLength ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getSelectedAttachments ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun leaveThread ()V
 	public final fun performMessageAction (Lio/getstream/chat/android/common/state/MessageAction;)V

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -678,7 +678,7 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/compon
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/components/MessageInputKt {
-	public static final fun MessageInput (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageInput (Lio/getstream/chat/android/compose/state/messages/composer/MessageInputState;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;ILkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageInputOptions (Lio/getstream/chat/android/common/state/MessageAction;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
@@ -9,9 +9,11 @@ import io.getstream.chat.android.common.state.MessageAction
  * @param inputValue The current text value that's within the input.
  * @param attachments The currently selected attachments.
  * @param action The currently active [MessageAction].
+ * @param maxMessageLength The maximum allowed message length.
  */
 public data class MessageInputState(
     val inputValue: String = "",
     val attachments: List<Attachment> = emptyList(),
     val action: MessageAction? = null,
+    val maxMessageLength: Int = Integer.MAX_VALUE,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
@@ -4,6 +4,11 @@ import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.common.state.MessageAction
 
 /**
+ * The default allowed number of characters in a message.
+ */
+private const val DEFAULT_MAX_MESSAGE_LENGTH: Int = 5000
+
+/**
  * Represents the state within the message input.
  *
  * @param inputValue The current text value that's within the input.
@@ -15,5 +20,5 @@ public data class MessageInputState(
     val inputValue: String = "",
     val attachments: List<Attachment> = emptyList(),
     val action: MessageAction? = null,
-    val maxMessageLength: Int = Integer.MAX_VALUE,
+    val maxMessageLength: Int = DEFAULT_MAX_MESSAGE_LENGTH,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/composer/MessageInputState.kt
@@ -2,11 +2,7 @@ package io.getstream.chat.android.compose.state.messages.composer
 
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.common.state.MessageAction
-
-/**
- * The default allowed number of characters in a message.
- */
-private const val DEFAULT_MAX_MESSAGE_LENGTH: Int = 5000
+import io.getstream.chat.android.common.state.ValidationError
 
 /**
  * Represents the state within the message input.
@@ -14,11 +10,11 @@ private const val DEFAULT_MAX_MESSAGE_LENGTH: Int = 5000
  * @param inputValue The current text value that's within the input.
  * @param attachments The currently selected attachments.
  * @param action The currently active [MessageAction].
- * @param maxMessageLength The maximum allowed message length.
+ * @param validationErrors The list of validation errors.
  */
 public data class MessageInputState(
     val inputValue: String = "",
     val attachments: List<Attachment> = emptyList(),
     val action: MessageAction? = null,
-    val maxMessageLength: Int = DEFAULT_MAX_MESSAGE_LENGTH,
+    val validationErrors: List<ValidationError> = emptyList(),
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -14,7 +14,7 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.Alignment.Companion.CenterVertically
+import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -66,6 +66,7 @@ public fun MessageComposer(
         MessageInput(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(vertical = 8.dp)
                 .weight(1f),
             label = label,
             messageInputState = inputState,
@@ -77,6 +78,7 @@ public fun MessageComposer(
     val value by viewModel.input.collectAsState()
     val selectedAttachments by viewModel.selectedAttachments.collectAsState()
     val activeAction by viewModel.lastActiveAction.collectAsState(null)
+    val maxMessageLength by viewModel.maxMessageLength.collectAsState()
 
     MessageComposer(
         modifier = modifier,
@@ -87,7 +89,12 @@ public fun MessageComposer(
         },
         integrations = integrations,
         input = input,
-        messageInputState = MessageInputState(value, selectedAttachments, activeAction),
+        messageInputState = MessageInputState(
+            inputValue = value,
+            attachments = selectedAttachments,
+            action = activeAction,
+            maxMessageLength = maxMessageLength
+        ),
         shouldShowIntegrations = true,
         onCancelAction = onCancelAction
     )
@@ -115,7 +122,7 @@ public fun MessageComposer(
     integrations: @Composable RowScope.() -> Unit,
     input: @Composable RowScope.(MessageInputState) -> Unit,
 ) {
-    val (value, attachments, activeAction) = messageInputState
+    val (value, attachments, activeAction, maxMessageLength) = messageInputState
 
     Surface(
         modifier = modifier,
@@ -137,24 +144,21 @@ public fun MessageComposer(
             }
 
             Row(
-                Modifier
-                    .fillMaxWidth(),
-                verticalAlignment = CenterVertically
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Bottom
             ) {
 
                 if (shouldShowIntegrations && activeAction !is Edit) {
                     integrations()
                 } else {
                     Spacer(
-                        modifier = Modifier
-                            .size(48.dp)
-                            .align(CenterVertically)
+                        modifier = Modifier.size(48.dp)
                     )
                 }
 
                 input(messageInputState)
 
-                val isInputValid = value.isNotEmpty() || attachments.isNotEmpty()
+                val isInputValid = (value.isNotEmpty() || attachments.isNotEmpty()) && value.length < maxMessageLength
 
                 IconButton(
                     enabled = isInputValid,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -152,7 +152,7 @@ public fun MessageComposer(
                     integrations()
                 } else {
                     Spacer(
-                        modifier = Modifier.size(48.dp)
+                        modifier = Modifier.size(16.dp)
                     )
                 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -78,7 +78,7 @@ public fun MessageComposer(
     val value by viewModel.input.collectAsState()
     val selectedAttachments by viewModel.selectedAttachments.collectAsState()
     val activeAction by viewModel.lastActiveAction.collectAsState(null)
-    val maxMessageLength by viewModel.maxMessageLength.collectAsState()
+    val validationErrors by viewModel.validationErrors.collectAsState()
 
     MessageComposer(
         modifier = modifier,
@@ -93,7 +93,7 @@ public fun MessageComposer(
             inputValue = value,
             attachments = selectedAttachments,
             action = activeAction,
-            maxMessageLength = maxMessageLength
+            validationErrors = validationErrors
         ),
         shouldShowIntegrations = true,
         onCancelAction = onCancelAction
@@ -122,7 +122,7 @@ public fun MessageComposer(
     integrations: @Composable RowScope.() -> Unit,
     input: @Composable RowScope.(MessageInputState) -> Unit,
 ) {
-    val (value, attachments, activeAction, maxMessageLength) = messageInputState
+    val (value, attachments, activeAction, validationErrors) = messageInputState
 
     Surface(
         modifier = modifier,
@@ -158,7 +158,7 @@ public fun MessageComposer(
 
                 input(messageInputState)
 
-                val isInputValid = (value.isNotEmpty() || attachments.isNotEmpty()) && value.length < maxMessageLength
+                val isInputValid = (value.isNotEmpty() || attachments.isNotEmpty()) && validationErrors.isEmpty()
 
                 IconButton(
                     enabled = isInputValid,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/ComposerIntegrations.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/ComposerIntegrations.kt
@@ -1,10 +1,8 @@
 package io.getstream.chat.android.compose.ui.messages.composer.components
 
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -20,13 +18,12 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param modifier Modifier for styling.
  */
 @Composable
-internal fun RowScope.DefaultComposerIntegrations(
+internal fun DefaultComposerIntegrations(
     onAttachmentsClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     IconButton(
-        modifier = modifier
-            .align(CenterVertically),
+        modifier = modifier,
         content = {
             Icon(
                 painter = painterResource(id = R.drawable.stream_compose_ic_attachments),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
@@ -166,4 +166,8 @@ private fun MessageInputAttachments(
     previewFactory?.previewContent?.invoke(modifier, attachments, onAttachmentRemoved)
 }
 
+/**
+ * The default number of lines allowed in the input. The message input will become scrollable after
+ * this threshold is exceeded.
+ */
 private const val DEFAULT_MESSAGE_INPUT_MAX_LINES = 6

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
@@ -109,6 +109,7 @@ public fun MessageInput(
     InputField(
         modifier = modifier,
         value = value,
+        maxLines = 6,
         onValueChange = onValueChange,
         decorationBox = { innerTextField ->
             Column {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/components/MessageInput.kt
@@ -94,6 +94,7 @@ public fun MessageInputOptions(
  * @param onValueChange Handler when the value changes.
  * @param onAttachmentRemoved Handler when the user removes a selected attachment.
  * @param modifier Modifier for styling.
+ * @param maxLines The number of lines that are allowed in the input.
  * @param label Composable function that represents the label UI, when there's no input/focus.
  */
 @Composable
@@ -102,6 +103,7 @@ public fun MessageInput(
     onValueChange: (String) -> Unit,
     onAttachmentRemoved: (Attachment) -> Unit,
     modifier: Modifier = Modifier,
+    maxLines: Int = DEFAULT_MESSAGE_INPUT_MAX_LINES,
     label: @Composable () -> Unit = { DefaultComposerLabel() },
 ) {
     val (value, attachments, activeAction) = messageInputState
@@ -109,7 +111,7 @@ public fun MessageInput(
     InputField(
         modifier = modifier,
         value = value,
-        maxLines = 6,
+        maxLines = maxLines,
         onValueChange = onValueChange,
         decorationBox = { innerTextField ->
             Column {
@@ -163,3 +165,5 @@ private fun MessageInputAttachments(
 
     previewFactory?.previewContent?.invoke(modifier, attachments, onAttachmentRemoved)
 }
+
+private const val DEFAULT_MESSAGE_INPUT_MAX_LINES = 6

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -40,7 +40,6 @@ public class MessageComposerViewModel(
      */
     public val validationErrors: MutableStateFlow<List<ValidationError>> = messageComposerController.validationErrors
 
-
     /**
      * Gets the active [Edit] or [Reply] action, whichever is last, to show on the UI.
      */

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -35,6 +35,11 @@ public class MessageComposerViewModel(
     public val selectedAttachments: MutableStateFlow<List<Attachment>> = messageComposerController.selectedAttachments
 
     /**
+     * Represents the maximum allowed message length.
+     */
+    public val maxMessageLength: MutableStateFlow<Int> = messageComposerController.maxMessageLength
+
+    /**
      * Gets the active [Edit] or [Reply] action, whichever is last, to show on the UI.
      */
     public val lastActiveAction: Flow<MessageAction?> = messageComposerController.lastActiveAction
@@ -122,4 +127,12 @@ public class MessageComposerViewModel(
      * user left the relevant thread.
      */
     public fun leaveThread(): Unit = messageComposerController.leaveThread()
+
+    /**
+     * Disposes the inner [MessageComposerController].
+     */
+    override fun onCleared() {
+        super.onCleared()
+        messageComposerController.onCleared()
+    }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -8,6 +8,7 @@ import io.getstream.chat.android.common.state.Edit
 import io.getstream.chat.android.common.state.MessageAction
 import io.getstream.chat.android.common.state.MessageMode
 import io.getstream.chat.android.common.state.Reply
+import io.getstream.chat.android.common.state.ValidationError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
@@ -35,9 +36,10 @@ public class MessageComposerViewModel(
     public val selectedAttachments: MutableStateFlow<List<Attachment>> = messageComposerController.selectedAttachments
 
     /**
-     * Represents the maximum allowed message length.
+     * Represents the list of validation errors for the current text input and the currently selected attachments.
      */
-    public val maxMessageLength: MutableStateFlow<Int> = messageComposerController.maxMessageLength
+    public val validationErrors: MutableStateFlow<List<ValidationError>> = messageComposerController.validationErrors
+
 
     /**
      * Gets the active [Edit] or [Reply] action, whichever is last, to show on the UI.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -4,6 +4,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import com.getstream.sdk.chat.utils.AttachmentConstants
 import com.getstream.sdk.chat.utils.StorageHelper
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.common.composer.MessageComposerController
@@ -20,6 +21,8 @@ import io.getstream.chat.android.offline.ChatDomain
  * @param chatDomain The domain used to fetch data.
  * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
  * @param messageLimit The limit when loading messages.
+ * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
+ * @param maxAttachmentSize Tne maximum file size of each attachment in bytes. By default, 20mb for Stream CDN.
  */
 public class MessagesViewModelFactory(
     private val context: Context,
@@ -28,6 +31,8 @@ public class MessagesViewModelFactory(
     private val chatDomain: ChatDomain = ChatDomain.instance(),
     private val enforceUniqueReactions: Boolean = true,
     private val messageLimit: Int = 30,
+    private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
+    private val maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(
@@ -36,7 +41,9 @@ public class MessagesViewModelFactory(
                 MessageComposerController(
                     chatClient = chatClient,
                     chatDomain = chatDomain,
-                    channelId = channelId
+                    channelId = channelId,
+                    maxAttachmentCount = maxAttachmentCount,
+                    maxAttachmentSize = maxAttachmentSize
                 )
             )
         },

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -317,6 +317,7 @@ public final class io/getstream/chat/android/offline/ChatDomain$DefaultImpls {
 
 public final class io/getstream/chat/android/offline/channel/ChannelController {
 	public final fun clean ()V
+	public final fun getChannelConfig ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getChannelData ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getChannelId ()Ljava/lang/String;
 	public final fun getChannelType ()Ljava/lang/String;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -59,6 +59,7 @@ import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelUserRead
+import io.getstream.chat.android.client.models.Config
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
@@ -160,6 +161,7 @@ public class ChannelController internal constructor(
     public val loadingNewerMessages: StateFlow<Boolean> by mutableState::loadingNewerMessages
     public val endOfOlderMessages: StateFlow<Boolean> by mutableState::endOfOlderMessages
     public val endOfNewerMessages: StateFlow<Boolean> by mutableState::endOfNewerMessages
+    public val channelConfig: StateFlow<Config> by mutableState::channelConfig
     public val recoveryNeeded: Boolean by mutableState::recoveryNeeded
 
     internal fun getThread(threadId: String): ThreadController = threadControllerMap.getOrPut(threadId) {

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -819,6 +819,48 @@ public final class io/getstream/chat/android/common/state/ThreadReply : io/getst
 	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
 }
 
+public abstract class io/getstream/chat/android/common/state/ValidationError {
+}
+
+public final class io/getstream/chat/android/common/state/ValidationError$AttachmentCountExceeded : io/getstream/chat/android/common/state/ValidationError {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lio/getstream/chat/android/common/state/ValidationError$AttachmentCountExceeded;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/common/state/ValidationError$AttachmentCountExceeded;IIILjava/lang/Object;)Lio/getstream/chat/android/common/state/ValidationError$AttachmentCountExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachmentCount ()I
+	public final fun getMaxAttachmentCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/common/state/ValidationError$AttachmentSizeExceeded : io/getstream/chat/android/common/state/ValidationError {
+	public fun <init> (Ljava/util/List;J)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()J
+	public final fun copy (Ljava/util/List;J)Lio/getstream/chat/android/common/state/ValidationError$AttachmentSizeExceeded;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/common/state/ValidationError$AttachmentSizeExceeded;Ljava/util/List;JILjava/lang/Object;)Lio/getstream/chat/android/common/state/ValidationError$AttachmentSizeExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttachments ()Ljava/util/List;
+	public final fun getMaxAttachmentSize ()J
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/common/state/ValidationError$MessageLengthExceeded : io/getstream/chat/android/common/state/ValidationError {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lio/getstream/chat/android/common/state/ValidationError$MessageLengthExceeded;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/common/state/ValidationError$MessageLengthExceeded;IIILjava/lang/Object;)Lio/getstream/chat/android/common/state/ValidationError$MessageLengthExceeded;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxMessageLength ()I
+	public final fun getMessageLength ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/common/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -60,8 +60,7 @@ public class MessageComposerController(
     public val maxMessageLength: MutableStateFlow<Int> = MutableStateFlow(Integer.MAX_VALUE)
 
     /**
-     * Sets up the core data loading operations - such as observing the current channel and loading
-     * messages and other pieces of information.
+     * Sets up the data loading operations such as observing the maximum allowed message length.
      */
     init {
         scope.launch {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -57,7 +57,7 @@ public class MessageComposerController(
     /**
      * Represents the maximum allowed message length.
      */
-    public val maxMessageLength: MutableStateFlow<Int> = MutableStateFlow(Integer.MAX_VALUE)
+    public val maxMessageLength: MutableStateFlow<Int> = MutableStateFlow(DEFAULT_MAX_MESSAGE_LENGTH)
 
     /**
      * Sets up the data loading operations such as observing the maximum allowed message length.
@@ -281,5 +281,12 @@ public class MessageComposerController(
      */
     public fun onCleared() {
         scope.cancel()
+    }
+
+    private companion object {
+        /**
+         * The default allowed number of characters in a message.
+         */
+        private const val DEFAULT_MAX_MESSAGE_LENGTH: Int = 5000
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -301,7 +301,7 @@ public class MessageComposerController(
     }
 
     /**
-     *
+     * Checks the current input for validation errors.
      */
     private fun validateInput() {
         validationErrors.value = mutableListOf<ValidationError>().apply {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -33,12 +33,16 @@ import kotlinx.coroutines.launch
  * @param channelId The ID of the channel we're chatting in.
  * @param chatClient The client used to communicate to the API.
  * @param chatDomain The domain used to communicate to the API and store data offline.
+ * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
+ * @param maxAttachmentSize Tne maximum file size of each attachment in bytes. By default, 20mb for Stream CDN.
  */
 @InternalStreamChatApi
 public class MessageComposerController(
     private val channelId: String,
     private val chatClient: ChatClient = ChatClient.instance(),
     private val chatDomain: ChatDomain = ChatDomain.instance(),
+    private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
+    private val maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE,
 ) {
     /**
      * Creates a [CoroutineScope] that allows us to cancel the ongoing work when the parent
@@ -62,19 +66,9 @@ public class MessageComposerController(
     public val validationErrors: MutableStateFlow<List<ValidationError>> = MutableStateFlow(emptyList())
 
     /**
-     *
+     * Represents the maximum allowed message length in the message input.
      */
     private var maxMessageLength: Int = DEFAULT_MAX_MESSAGE_LENGTH
-
-    /**
-     *
-     */
-    private var maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT
-
-    /**
-     *
-     */
-    private var maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE
 
     /**
      * Sets up the data loading operations such as observing the maximum allowed message length.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
@@ -3,7 +3,7 @@ package io.getstream.chat.android.common.state
 import io.getstream.chat.android.client.models.Attachment
 
 /**
- * Represents the list of validation errors for the current text input and currently selected attachments.
+ * Represents a validation error for the user input.
  */
 public sealed class ValidationError {
     /**

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
@@ -1,0 +1,32 @@
+package io.getstream.chat.android.common.state
+
+import io.getstream.chat.android.client.models.Attachment
+
+/**
+ * Represents the list of validation errors for the current text input and currently selected attachments.
+ */
+public sealed class ValidationError {
+    /**
+     *
+     */
+    public data class MessageLengthExceeded(
+        val messageLength: Int,
+        val maxMessageLength: Int,
+    ) : ValidationError()
+
+    /**
+     *
+     */
+    public data class AttachmentSizeExceeded(
+        val attachments: List<Attachment>,
+        val maxAttachmentSize: Long,
+    ) : ValidationError()
+
+    /**
+     *
+     */
+    public data class AttachmentCountExceeded(
+        val attachmentCount: Int,
+        val maxAttachmentCount: Int,
+    ) : ValidationError()
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/ValidationError.kt
@@ -7,7 +7,11 @@ import io.getstream.chat.android.client.models.Attachment
  */
 public sealed class ValidationError {
     /**
+     * Represents a validation error that happens when the message length in the message input
+     * exceed the maximum allowed message length.
      *
+     * @param messageLength The current message length in the message input.
+     * @param maxMessageLength The maximum allowed message length that we exceeded.
      */
     public data class MessageLengthExceeded(
         val messageLength: Int,
@@ -15,7 +19,11 @@ public sealed class ValidationError {
     ) : ValidationError()
 
     /**
+     * Represents a validation error that happens when one or several attachments are too big
+     * to be handled by the server.
      *
+     * @param attachments The list of attachments that are bigger than the server can handle.
+     * @param maxAttachmentSize The maximum allowed attachment file size in bytes.
      */
     public data class AttachmentSizeExceeded(
         val attachments: List<Attachment>,
@@ -23,7 +31,11 @@ public sealed class ValidationError {
     ) : ValidationError()
 
     /**
+     * Represents a validation error that happens when the number of selected attachments is too
+     * big to be sent in a single message.
      *
+     * @param attachmentCount The number of selected attachments.
+     * @param maxAttachmentCount The maximum allowed number of attachments in a single message.
      */
     public data class AttachmentCountExceeded(
         val attachmentCount: Int,


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2621

### 🎯 Goal

Add message length limitation.

### 🛠 Implementation details

This PR only introduces message length limitation. The rest of the limitation will be covered in different PRs.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![device-2021-11-19-182347](https://user-images.githubusercontent.com/9600921/142647394-8a06dc2e-a4b4-4b20-8b4e-2057e563e9e8.png) | ![device-2021-11-19-182238](https://user-images.githubusercontent.com/9600921/142647293-ce751d23-6b0b-4467-8bf6-bf7929d86146.png) |
| ![device-2021-11-19-181733](https://user-images.githubusercontent.com/9600921/142646847-75a1f666-0caf-4771-a69a-22851e6c66ff.png) | ![device-2021-11-19-181921](https://user-images.githubusercontent.com/9600921/142646834-f2f4e0da-3656-4f2c-b591-067772c5b9a2.png) |

### 🧪 Testing

Modify the message limitation in the dashboard or test with the default value - 5000 chars.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
