### PR TITLE
[Compose] - 2656 - Do not rely on channel members to display message list header subtitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ### ⬆️ Improved
 - Updated a lot of documentation around the Messages features
+- Improved the subtitle text in the `MessageListHeader` component.
 
 ### ✅ Added
 - Added the "mute" option to the `ChannelInfo` action dialog.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfo.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfo.kt
@@ -51,6 +51,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.getMembersStatusText
 import io.getstream.chat.android.compose.ui.util.isDistinct
 import io.getstream.chat.android.compose.ui.util.isMuted
+import io.getstream.chat.android.compose.ui.util.isOneToOne
 
 /**
  * Shows special UI when an item is selected.
@@ -78,8 +79,11 @@ public fun ChannelInfo(
         ?.role
         ?.let { it == "admin" || it == "owner" }
         ?: false
-
-    val otherMembers = channelMembers.filter { it.user.id != currentUser?.id }
+    val membersToDisplay = if (selectedChannel.isOneToOne(currentUser)) {
+        channelMembers.filter { it.user.id != currentUser?.id }
+    } else {
+        channelMembers
+    }
 
     val channelOptions = listOfNotNull(
         ChannelOption(
@@ -174,7 +178,7 @@ public fun ChannelInfo(
                     color = ChatTheme.colors.textLowEmphasis,
                 )
 
-                ChannelMembers(otherMembers)
+                ChannelMembers(membersToDisplay)
 
                 ChannelOptions(channelOptions, onChannelOptionClick)
             }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ChannelUtils.kt
@@ -84,21 +84,26 @@ public fun Channel.isOneToOne(currentUser: User?): Boolean {
  * @return The text that represent the member status of the channel.
  */
 public fun Channel.getMembersStatusText(context: Context, currentUser: User?): String {
-    val otherMembers = members.filter { it.user.id != currentUser?.id }
-
     return when {
-        otherMembers.isEmpty() -> ""
-        isOneToOne(currentUser) -> otherMembers.first()
+        isOneToOne(currentUser) -> members.first { it.user.id != currentUser?.id }
             .user
             .getLastSeenText(context)
         else -> {
-            val count = otherMembers.count()
-            context.resources.getQuantityString(
-                R.plurals.stream_compose_channel_members,
-                count,
-                count,
-                otherMembers.count { it.user.online }
+            val memberCountString = context.resources.getQuantityString(
+                R.plurals.stream_compose_member_count,
+                memberCount,
+                memberCount
             )
+
+            return if (watcherCount > 0) {
+                context.getString(
+                    R.string.stream_compose_member_count_online,
+                    memberCountString,
+                    watcherCount
+                )
+            } else {
+                memberCountString
+            }
         }
     }
 }

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">Cancel</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d Member, %2d Online</item>
-        <item quantity="other">%1d Members, %2d Online</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d Online</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d Member</item>
+        <item quantity="other">%1d Members</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Cancel</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">Cancelar</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d Miembro, %2d Conectados</item>
-        <item quantity="other">%1d Miembros, %2d Conectados</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d Conectados</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d Miembro</item>
+        <item quantity="other">%1d Miembros</item>
     </plurals>
     <string name="stream_compose_ok">Vale</string>
     <string name="stream_compose_cancel">Cancelar</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">Annuler</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d Membre, %2d En ligne</item>
-        <item quantity="other">%1d Membres, %2d En ligne</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d En ligne</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d Membre</item>
+        <item quantity="other">%1d Membres</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Annuler</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">रद्द करें</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d सदस्य, %2d ऑनलाइन</item>
-        <item quantity="other">%1d सदस्य, %2d ऑनलाइन</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d ऑनलाइन</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d सदस्य</item>
+        <item quantity="other">%1d सदस्य</item>
     </plurals>
     <string name="stream_compose_ok">ठीक</string>
     <string name="stream_compose_cancel">रद्द करें</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">Annulla</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d Membro, %2d Online</item>
-        <item quantity="other">%1d Membri, %2d Online</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d Online</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d Membro</item>
+        <item quantity="other">%1d Membri</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Annulla</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -25,8 +25,9 @@
     <string name="stream_compose_channel_info_dismiss">キャンセル</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="other">%1d人のメンバー, %2d人がオンライン</item>
+    <string name="stream_compose_member_count_online">%s, %d人がオンライン</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="other">%1d人のメンバー</item>
     </plurals>
     <string name="stream_compose_ok">よし</string>
     <string name="stream_compose_cancel">キャンセル</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -25,8 +25,9 @@
     <string name="stream_compose_channel_info_dismiss">취소</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="other">%1d명, %2d명이 온라인</item>
+    <string name="stream_compose_member_count_online">%s, %d온라인</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="other">%1d명</item>
     </plurals>
     <string name="stream_compose_ok">확인</string>
     <string name="stream_compose_cancel">취소</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -25,9 +25,10 @@
     <string name="stream_compose_channel_info_dismiss">Cancel</string>
 
     <!-- Common -->
-    <plurals name="stream_compose_channel_members">
-        <item quantity="one">%1d Member, %2d Online</item>
-        <item quantity="other">%1d Members, %2d Online</item>
+    <string name="stream_compose_member_count_online">%1$s, %2$d Online</string>
+    <plurals name="stream_compose_member_count">
+        <item quantity="one">%1d Member</item>
+        <item quantity="other">%1d Members</item>
     </plurals>
     <string name="stream_compose_ok">OK</string>
     <string name="stream_compose_cancel">Cancel</string>


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2656

### 🎯 Goal

We rely on the `Channel.members` field to show the number of members in a channel. Also, we use it to count and display the number online users. But the `Channel.members` is unreliable as it only contains the first 30 members of a channel, that's why we need to find another way.

### 🛠 Implementation details

We need to use `Channel.member_count` and `Channel.watcher_count` fields to display the `MessageListHeader` subtitle.

### 🎨 UI Changes

<img src="https://user-images.githubusercontent.com/9600921/142863965-3376b723-61ad-4bf9-9461-4d998162f6ef.png" width="40%">

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
