### PR TITLE
[Compose] - 2647 - Send typing events when the current user is typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,6 +91,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ### ⬆️ Improved
 - Updated a lot of documentation around the Messages features
+- Now, the `MessageComposer` component supports sending `typing.start` and `typing.stop` events when a user starts or stops typing.
 
 ### ✅ Added
 - Added the "mute" option to the `ChannelInfo` action dialog.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -75,12 +75,20 @@ public class MessageComposerController(
         get() = activeAction is Edit
 
     /**
+     * Gets the parent message id if we are in thread mode, or null otherwise.
+     */
+    private val parentMessageId: String?
+        get() = (messageMode as? MessageMode.MessageThread)?.parentMessage?.id
+
+    /**
      * Called when the input changes and the internal state needs to be updated.
      *
      * @param value Current state value.
      */
     public fun setMessageInput(value: String) {
         this.input.value = value
+
+        setTyping(value.isNotEmpty())
     }
 
     /**
@@ -190,6 +198,7 @@ public class MessageComposerController(
 
         dismissMessageActions()
         clearData()
+        setTyping(false)
 
         sendMessageCall.enqueue()
     }
@@ -210,11 +219,9 @@ public class MessageComposerController(
         attachments: List<Attachment> = emptyList(),
     ): Message {
         val activeAction = activeAction
-        val messageMode = messageMode
 
         val actionMessage = activeAction?.message ?: Message()
         val replyMessageId = (activeAction as? Reply)?.message?.id
-        val parentMessageId = (messageMode as? MessageMode.MessageThread)?.parentMessage?.id
 
         return if (isInEditMode) {
             actionMessage.copy(
@@ -242,5 +249,18 @@ public class MessageComposerController(
     public fun leaveThread() {
         setMessageMode(MessageMode.Normal)
         dismissMessageActions()
+    }
+
+    /**
+     * Sends the `typing.start` or `typing.stop` event depending on the [isTyping] parameter.
+     *
+     * @param isTyping If the user is currently typing.
+     */
+    private fun setTyping(isTyping: Boolean) {
+        if (isTyping) {
+            chatDomain.keystroke(channelId, parentMessageId)
+        } else {
+            chatDomain.stopTyping(channelId, parentMessageId)
+        }.enqueue()
     }
 }


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2647

### 🎯 Goal

Currently, we only handle incoming typing events. We need also to send typing events from the Compose SDK.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
