### PR TITLE
Provide title for attachment with file name if it is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Deprecated `QueryChannelsController::mutedChannelsIds`. Use `ChatDomain.mutedChannels` instead
+- Fix issue when sent attachments from Android SDK don't show title in iOS.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUploader.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/attachment/AttachmentUploader.kt
@@ -47,6 +47,15 @@ internal class AttachmentUploader(
         }
     }
 
+    /**
+     * Augment an attachment instance with data from uploaded file, mimeType, attachmentType and obtained from backend
+     * url.
+     *
+     * @param file A file that has been uploaded.
+     * @param mimeType MimeType of uploaded attachment.
+     * @param attachmentType File, video or picture enum instance.
+     * @param url URL obtained from BE.
+     */
     private fun Attachment.augmentAttachmentOnSuccess(
         file: File,
         mimeType: String,
@@ -69,6 +78,9 @@ internal class AttachmentUploader(
                 imageUrl = url
             } else {
                 assetUrl = url
+            }
+            if (title.isNullOrBlank()) {
+                title = file.name
             }
         }
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/AttachmentUploaderTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/AttachmentUploaderTests.kt
@@ -103,6 +103,7 @@ internal class AttachmentUploaderTests {
                 type = "file",
                 mimeType = "",
                 name = attachment.upload!!.name,
+                title = attachment.upload!!.name,
                 uploadState = Attachment.UploadState.Success
             )
             val result = sut.uploadAttachment(channelType, channelId, attachment)
@@ -128,6 +129,7 @@ internal class AttachmentUploaderTests {
                 type = "file",
                 mimeType = "",
                 name = attachment.upload!!.name,
+                title = attachment.upload!!.name,
                 uploadState = Attachment.UploadState.Success
             )
             val result = sut.uploadAttachment(


### PR DESCRIPTION
### 🎯 Goal

Other SDKs use title property instead of name to show the display name.

### 🛠 Implementation details

Set title when file was uploaded


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
