### PR TITLE
Fix broken Dokka links in our documentation

### DIFF
--- a/docusaurus/docs/Android/01-basics/05-logging.mdx
+++ b/docusaurus/docs/Android/01-basics/05-logging.mdx
@@ -47,5 +47,5 @@ adb logcat com.your.package | grep "Chat:"
 Here's a set of useful tags for debugging network communication:
 
 - `Chat:Http` to see HTTP requests made from the `ChatClient` and the responses returned by Stream.
-- `Chat:Events` to see a list of [events](https://getstream.github.io/stream-chat-android/stream-chat-android-client/stream-chat-android-client/io.getstream.chat.android.client.events/-chat-event/index.html) that the `ChatClient` emits.
+- `Chat:Events` to see a list of [events](https://getstream.github.io/stream-chat-android/stream-chat-android-client/io.getstream.chat.android.client.events/-chat-event/) that the `ChatClient` emits.
 - `Chat:SocketService` to see socket related events.

--- a/docusaurus/docs/Android/02-client/06-guides/06-working-with-offline.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/06-working-with-offline.mdx
@@ -74,7 +74,7 @@ Some other basic functions available on `ChatDomain`:
 - markRead()
 
 :::note
-See the [API documentation for `ChatDomain`](https://getstream.github.io/stream-chat-android/stream-chat-android-offline/stream-chat-android-offline/io.getstream.chat.android.offline/-chat-domain/index.html) for the full list of available features and more info about them.
+See the [API documentation for `ChatDomain`](https://getstream.github.io/stream-chat-android/stream-chat-android-offline/io.getstream.chat.android.offline/-chat-domain/) for the full list of available features and more info about them.
 :::
 
 Let's see how some of the most common operations work.

--- a/docusaurus/docs/Android/03-ui/04-components/02-channel-list.mdx
+++ b/docusaurus/docs/Android/03-ui/04-components/02-channel-list.mdx
@@ -75,7 +75,7 @@ channelListView.setUserClickListener { user ->
 }
 ```
 
-The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.channel.list/-channel-list-view/index.html).
+The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.channel.list/-channel-list-view/).
 
 ## Customization
 

--- a/docusaurus/docs/Android/03-ui/04-components/05-message-list.mdx
+++ b/docusaurus/docs/Android/03-ui/04-components/05-message-list.mdx
@@ -145,7 +145,7 @@ setUserReactionClickListener{ message: Message, user: User, reaction: Reaction -
 }
 ```
 
-Other available listeners for `MessageListView` can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list.adapter/-message-list-listener-container/index.html).
+Other available listeners for `MessageListView` can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list.adapter/-message-list-listener-container/).
 
 ## Customization
 
@@ -183,7 +183,7 @@ In order to do that, we need to add additional attributes to `MessageListView`:
 
 ### Using Style Transformations
 
-Both `MessageListView` and its ViewHolders can be configured programmatically (a list of supported customizations can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list/-message-list-view-style/index.html) and [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list/-message-list-item-style/index.html)).
+Both `MessageListView` and its ViewHolders can be configured programmatically (a list of supported customizations can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list/-message-list-view-style/) and [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.message.list/-message-list-item-style/)).
 
 As an example, let's apply the green style from the previous section, but this time programmatically:
 

--- a/docusaurus/docs/Android/03-ui/04-components/08-mention-list-view.mdx
+++ b/docusaurus/docs/Android/03-ui/04-components/08-mention-list-view.mdx
@@ -56,4 +56,4 @@ mentionListView.setMentionSelectedListener { message ->
 }
 ```
 
-The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.mention.list/-mention-list-view/index.html).
+The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.mention.list/-mention-list-view/).

--- a/docusaurus/docs/Android/03-ui/04-components/09-pinned-message-list-view.mdx
+++ b/docusaurus/docs/Android/03-ui/04-components/09-pinned-message-list-view.mdx
@@ -58,4 +58,4 @@ pinnedMessageListView.setPinnedMessageSelectedListener { message ->
 }
 ```
 
-The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.pinned.list/-pinned-message-list-view/index.html).
+The full list of available listeners is available [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.pinned.list/-pinned-message-list-view/).

--- a/docusaurus/docs/Android/03-ui/04-components/10-search-view.mdx
+++ b/docusaurus/docs/Android/03-ui/04-components/10-search-view.mdx
@@ -84,7 +84,7 @@ searchResultView.setSearchResultSelectedListener { message ->
 }
 ```
 
-The full list of listeners available for `SearchInputView` can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.search/-search-input-view/index.html), and for `SearchResultListView` [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/stream-chat-android-ui-components/io.getstream.chat.android.ui.search.list/-search-result-list-view/index.html).
+The full list of listeners available for `SearchInputView` can be found [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.search/-search-input-view/), and for `SearchResultListView` [here](https://getstream.github.io/stream-chat-android/stream-chat-android-ui-components/io.getstream.chat.android.ui.search.list/-search-result-list-view/).
 
 ## Updating the Search Query Programmatically
 


### PR DESCRIPTION
### 🎯 Goal

Fix a bunch of broken links in our documentation, caused by Dokka changing its generated URLs.

### 🧪 Testing

Open the new links.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (docusaurus, tutorial, CMS (task created)) ✅✅✅✅✅✅✅✅
- [x] Reviewers added

### 🎉 GIF

![](https://media.giphy.com/media/6IanN6Nqj0JFK/giphy.gif)