### PR TITLE
[Compose] Add tint to mute icon

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/list/ChannelItem.kt
@@ -181,6 +181,7 @@ public fun ChannelDetails(
                         .size(16.dp),
                     painter = painterResource(id = R.drawable.stream_compose_ic_mute),
                     contentDescription = null,
+                    tint = ChatTheme.colors.textLowEmphasis,
                 )
             }
         } else {


### PR DESCRIPTION
### 🎯 Goal

Make icon color dynamic (adapt to dark mode, use colors from `ChatTheme` when they're customized)

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1637751183](https://user-images.githubusercontent.com/12054216/143225630-d7b83915-00cf-41fd-9105-66c3eaa4a7ec.png) |  ![Screenshot_1637751193](https://user-images.githubusercontent.com/12054216/143225667-b49827cb-a05d-4f04-8b23-31d60e4eb77b.png) |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added
