### PR TITLE
[2653] Implement input validation errors in the message composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Improved the subtitle text in the `MessageListHeader` component.
 - Now, the `MessageComposer` component supports sending `typing.start` and `typing.stop` events when a user starts or stops typing.
 - Made the `ChannelNameFormatter`, `ClipboardHandler` and `MessagePreviewFormatter` interfaces functional for ease of use.
-- Now, a error Toast is shown when the input in the `MessageComposer` does not pass validation.
+- Now, an error Toast is shown when the input in the `MessageComposer` does not pass validation.
 
 ### ✅ Added
 - Added the "mute" option to the `ChannelInfo` action dialog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Improved the subtitle text in the `MessageListHeader` component.
 - Now, the `MessageComposer` component supports sending `typing.start` and `typing.stop` events when a user starts or stops typing.
 - Made the `ChannelNameFormatter`, `ClipboardHandler` and `MessagePreviewFormatter` interfaces functional for ease of use.
+- Now, a error Toast is shown when the input in the `MessageComposer` does not pass validation.
 
 ### ✅ Added
 - Added the "mute" option to the `ChannelInfo` action dialog.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -201,9 +201,9 @@ internal fun DefaultComposerLabel() {
 /**
  * Shows a [Toast] with an error if one of the following constraints are violated:
  *
- * - The message length exceed the maximum allowed message length.
+ * - The message length exceeds the maximum allowed message length.
  * - The number of selected attachments is too big.
- * - One of the attachments is too big.
+ * - At least one of the attachments is too big.
  *
  * @param validationErrors The list of validation errors for the current user input.
  */

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -213,19 +213,19 @@ private fun showValidationErrorIfNecessary(validationErrors: List<ValidationErro
         val errorMessage = when (val validationError = validationErrors.first()) {
             is ValidationError.MessageLengthExceeded -> {
                 stringResource(
-                    R.string.stream_compose_message_composer_error_max_length,
+                    R.string.stream_compose_message_composer_error_message_length,
                     validationError.maxMessageLength
                 )
             }
             is ValidationError.AttachmentCountExceeded -> {
                 stringResource(
-                    R.string.stream_compose_message_composer_error_max_attachments_count_exceeded,
+                    R.string.stream_compose_message_composer_error_attachment_count,
                     validationError.maxAttachmentCount
                 )
             }
             is ValidationError.AttachmentSizeExceeded -> {
                 stringResource(
-                    R.string.stream_compose_message_composer_error_file_large_size,
+                    R.string.stream_compose_message_composer_error_file_size,
                     MediaStringUtil.convertFileSizeByteCount(validationError.maxAttachmentSize)
                 )
             }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.compose.ui.messages.composer
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -12,16 +13,20 @@ import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.getstream.sdk.chat.utils.MediaStringUtil
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.common.state.Edit
+import io.getstream.chat.android.common.state.ValidationError
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.composer.MessageInputState
 import io.getstream.chat.android.compose.ui.messages.composer.components.DefaultComposerIntegrations
@@ -124,6 +129,8 @@ public fun MessageComposer(
 ) {
     val (value, attachments, activeAction, validationErrors) = messageInputState
 
+    showValidationErrorIfNecessary(validationErrors)
+
     Surface(
         modifier = modifier,
         elevation = 4.dp,
@@ -189,4 +196,44 @@ internal fun DefaultComposerLabel() {
         text = stringResource(id = R.string.stream_compose_message_label),
         color = ChatTheme.colors.textLowEmphasis
     )
+}
+
+/**
+ * Shows a [Toast] with an error if one of the following constraints are violated:
+ *
+ * - The message length exceed the maximum allowed message length.
+ * - The number of selected attachments is too big.
+ * - One of the attachments is too big.
+ *
+ * @param validationErrors The list of validation errors for the current user input.
+ */
+@Composable
+private fun showValidationErrorIfNecessary(validationErrors: List<ValidationError>) {
+    if (validationErrors.isNotEmpty()) {
+        val errorMessage = when (val validationError = validationErrors.first()) {
+            is ValidationError.MessageLengthExceeded -> {
+                stringResource(
+                    R.string.stream_compose_message_composer_error_max_length,
+                    validationError.maxMessageLength
+                )
+            }
+            is ValidationError.AttachmentCountExceeded -> {
+                stringResource(
+                    R.string.stream_compose_message_composer_error_max_attachments_count_exceeded,
+                    validationError.maxAttachmentCount
+                )
+            }
+            is ValidationError.AttachmentSizeExceeded -> {
+                stringResource(
+                    R.string.stream_compose_message_composer_error_file_large_size,
+                    MediaStringUtil.convertFileSizeByteCount(validationError.maxAttachmentSize)
+                )
+            }
+        }
+
+        val context = LocalContext.current
+        LaunchedEffect(validationErrors.size) {
+            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
+        }
+    }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StorageHelperWrapper.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StorageHelperWrapper.kt
@@ -58,7 +58,7 @@ public class StorageHelperWrapper(
                 upload = fileFromUri,
                 type = it.type,
                 name = it.title ?: fileFromUri.name ?: "",
-                fileSize = metaData.size,
+                fileSize = it.size.toInt(),
                 mimeType = it.mimeType
             )
         }

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -63,6 +63,11 @@
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
 
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">Max message length (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_file_large_size">File is too large - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attachments count (%1$d) exceeded.</string>
+
     <string name="stream_compose_message_label">Send a message</string>
     <string name="stream_compose_send_message">Send</string>
     <string name="stream_compose_attachments">Attachments</string>

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -64,9 +64,9 @@
     <string name="stream_compose_mute_user">Mute User</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">Max message length (%1$d) exceeded.</string>
-    <string name="stream_compose_message_composer_error_file_large_size">File is too large - max %1$s.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attachments count (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_file_size">File is too large - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">Attachments count (%1$d) exceeded.</string>
 
     <string name="stream_compose_message_label">Send a message</string>
     <string name="stream_compose_send_message">Send</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -62,4 +62,9 @@
     <string name="stream_compose_edit_message">Editar Mensaje</string>
     <string name="stream_compose_delete_message">Eliminar mensaje</string>
     <string name="stream_compose_mute_user">Silenciar usuario</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">Tamaño máximo de mensaje (%1$d) excedido.</string>
+    <string name="stream_compose_message_composer_error_file_large_size">El fichero es demasiado grande - Máximo %1$s.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">No es posible añadir más de %1$d archivos adjuntos.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -64,7 +64,7 @@
     <string name="stream_compose_mute_user">Silenciar usuario</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">Tamaño máximo de mensaje (%1$d) excedido.</string>
-    <string name="stream_compose_message_composer_error_file_large_size">El fichero es demasiado grande - Máximo %1$s.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">No es posible añadir más de %1$d archivos adjuntos.</string>
+    <string name="stream_compose_message_composer_error_message_length">Tamaño máximo de mensaje (%1$d) excedido.</string>
+    <string name="stream_compose_message_composer_error_file_size">El fichero es demasiado grande - Máximo %1$s.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">No es posible añadir más de %1$d archivos adjuntos.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -62,4 +62,9 @@
     <string name="stream_compose_edit_message">Modifier le message</string>
     <string name="stream_compose_delete_message">Supprimer le message</string>
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">Longueur maximale du message (%1$d) dépassée.</string>
+    <string name="stream_compose_message_composer_error_file_large_size">Le fichier est trop volumineux - %1$s maximum.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Limite de pièces jointes dépassée : il n\'est pas possible d\'ajouter plus de %1$d pièces jointes</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -64,7 +64,7 @@
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">Longueur maximale du message (%1$d) dépassée.</string>
-    <string name="stream_compose_message_composer_error_file_large_size">Le fichier est trop volumineux - %1$s maximum.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Limite de pièces jointes dépassée : il n\'est pas possible d\'ajouter plus de %1$d pièces jointes</string>
+    <string name="stream_compose_message_composer_error_message_length">Longueur maximale du message (%1$d) dépassée.</string>
+    <string name="stream_compose_message_composer_error_file_size">Le fichier est trop volumineux - %1$s maximum.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">Limite de pièces jointes dépassée : il n\'est pas possible d\'ajouter plus de %1$d pièces jointes</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -62,4 +62,9 @@
     <string name="stream_compose_edit_message">मैसेज एडिट करें</string>
     <string name="stream_compose_delete_message">मैसेज मिटायें</string>
     <string name="stream_compose_mute_user">यूजर को म्यूट करें</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">मैसेज की वर्ण सीमा (%1$d) पार हो गई है।</string>
+    <string name="stream_compose_message_composer_error_file_large_size">फ़ाइल बहुत बड़ी है - अधिकतम %1$s एमबी.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">अटैचमेंट्स संख्या (%1$d) पार हो गयी</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -64,7 +64,7 @@
     <string name="stream_compose_mute_user">यूजर को म्यूट करें</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">मैसेज की वर्ण सीमा (%1$d) पार हो गई है।</string>
-    <string name="stream_compose_message_composer_error_file_large_size">फ़ाइल बहुत बड़ी है - अधिकतम %1$s एमबी.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">अटैचमेंट्स संख्या (%1$d) पार हो गयी</string>
+    <string name="stream_compose_message_composer_error_message_length">मैसेज की वर्ण सीमा (%1$d) पार हो गई है।</string>
+    <string name="stream_compose_message_composer_error_file_size">फ़ाइल बहुत बड़ी है - अधिकतम %1$s एमबी.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">अटैचमेंट्स संख्या (%1$d) पार हो गयी</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -64,7 +64,7 @@
     <string name="stream_compose_mute_user">Silenzia Utente</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">La lunghezza massima del messaggio (%1$d) è stata superata.</string>
-    <string name="stream_compose_message_composer_error_file_large_size">File troppo grande - max %1$s.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attenzione: il limite massimo di %1$d file è stato superato.</string>
+    <string name="stream_compose_message_composer_error_message_length">La lunghezza massima del messaggio (%1$d) è stata superata.</string>
+    <string name="stream_compose_message_composer_error_file_size">File troppo grande - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">Attenzione: il limite massimo di %1$d file è stato superato.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -62,4 +62,9 @@
     <string name="stream_compose_edit_message">Modifica messaggio</string>
     <string name="stream_compose_delete_message">Cancella messaggio</string>
     <string name="stream_compose_mute_user">Silenzia Utente</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">La lunghezza massima del messaggio (%1$d) è stata superata.</string>
+    <string name="stream_compose_message_composer_error_file_large_size">File troppo grande - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attenzione: il limite massimo di %1$d file è stato superato.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -61,7 +61,7 @@
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">"最大メッセージ長（%1$d)字を超えました"</string>
-    <string name="stream_compose_message_composer_error_file_large_size">ファイルが大きすぎます- 最大%1$s。</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">添付ファイルの制限を超えました：%1$d個のファイル以上を添付することはできません</string>
+    <string name="stream_compose_message_composer_error_message_length">"最大メッセージ長（%1$d)字を超えました"</string>
+    <string name="stream_compose_message_composer_error_file_size">ファイルが大きすぎます- 最大%1$s。</string>
+    <string name="stream_compose_message_composer_error_attachment_count">添付ファイルの制限を超えました：%1$d個のファイル以上を添付することはできません</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -59,4 +59,9 @@
     <string name="stream_compose_edit_message">メッセージを編集する</string>
     <string name="stream_compose_delete_message">メッセージを削除する</string>
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">"最大メッセージ長（%1$d)字を超えました"</string>
+    <string name="stream_compose_message_composer_error_file_large_size">ファイルが大きすぎます- 最大%1$s。</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">添付ファイルの制限を超えました：%1$d個のファイル以上を添付することはできません</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -61,7 +61,7 @@
     <string name="stream_compose_mute_user">사용자 무시</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">"최대 메시지 길이(%d)를 초과했습니다"</string>
-    <string name="stream_compose_message_composer_error_file_large_size">파일이 너무 큽니다 - 최대 %1$s입니다</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">첨부파일 개수가 (%1$d) 개를 초과하였습니다.</string>
+    <string name="stream_compose_message_composer_error_message_length">"최대 메시지 길이(%d)를 초과했습니다"</string>
+    <string name="stream_compose_message_composer_error_file_size">파일이 너무 큽니다 - 최대 %1$s입니다</string>
+    <string name="stream_compose_message_composer_error_attachment_count">첨부파일 개수가 (%1$d) 개를 초과하였습니다.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -59,4 +59,9 @@
     <string name="stream_compose_edit_message">메세지 수정</string>
     <string name="stream_compose_delete_message">메시지 삭제</string>
     <string name="stream_compose_mute_user">사용자 무시</string>
+
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">"최대 메시지 길이(%d)를 초과했습니다"</string>
+    <string name="stream_compose_message_composer_error_file_large_size">파일이 너무 큽니다 - 최대 %1$s입니다</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">첨부파일 개수가 (%1$d) 개를 초과하였습니다.</string>
 </resources>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -63,6 +63,10 @@
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
 
+    <!-- Message Composer -->
+    <string name="stream_compose_message_composer_error_max_length">Max message length (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_file_large_size">File is too large - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attachments count (%1$d) exceeded.</string>
 
     <string name="stream_compose_message_label">Send a message</string>
     <string name="stream_compose_send_message">Send</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -64,9 +64,9 @@
     <string name="stream_compose_mute_user">Mute User</string>
 
     <!-- Message Composer -->
-    <string name="stream_compose_message_composer_error_max_length">Max message length (%1$d) exceeded.</string>
-    <string name="stream_compose_message_composer_error_file_large_size">File is too large - max %1$s.</string>
-    <string name="stream_compose_message_composer_error_max_attachments_count_exceeded">Attachments count (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>
+    <string name="stream_compose_message_composer_error_file_size">File is too large - max %1$s.</string>
+    <string name="stream_compose_message_composer_error_attachment_count">Attachments count (%1$d) exceeded.</string>
 
     <string name="stream_compose_message_label">Send a message</string>
     <string name="stream_compose_send_message">Send</string>

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/MediaStringUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/MediaStringUtil.kt
@@ -16,7 +16,7 @@ public object MediaStringUtil {
 
     @JvmStatic
     public fun convertFileSizeByteCount(bytes: Long): String {
-        val unit = 1000
+        val unit = 1024
         if (bytes <= 0) return 0.toString() + " B"
         if (bytes < unit) return "$bytes B"
         val exp = (ln(bytes.toDouble()) / ln(unit.toDouble())).toInt()

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/GetDeletedOrMentionedTextTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/GetDeletedOrMentionedTextTest.kt
@@ -64,10 +64,10 @@ internal class GetDeletedOrMentionedTextTest {
         var fileSize: Long = 999
         convertFileSizeByteCount(fileSize) shouldBeEqualTo "999 B"
         fileSize = 110592
-        convertFileSizeByteCount(fileSize) shouldBeEqualTo "110.59 KB"
+        convertFileSizeByteCount(fileSize) shouldBeEqualTo "108 KB"
         fileSize = 452984832
-        convertFileSizeByteCount(fileSize) shouldBeEqualTo "452.98 MB"
-        fileSize = 900000
+        convertFileSizeByteCount(fileSize) shouldBeEqualTo "432 MB"
+        fileSize = 921600
         convertFileSizeByteCount(fileSize) shouldBeEqualTo "900 KB"
         fileSize = 0
         convertFileSizeByteCount(fileSize) shouldBeEqualTo "0 B"


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2653

### 🎯 Goal

Give users visual feedback when a validation error happens.

### 🛠 Implementation details

For now, adding a simple to`Toast` to display validation errors as in Compose it is impossible to show a `Snackbar` above an achor.

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/143227759-bc122e40-d1b8-494f-bca2-c4152dd23ef3.mp4

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
