### PR TITLE
[2674] Make NetworkLoadingView more customizable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added the `messageOverlayActionItemHeight` option to `StreamDimens`, to make it possible to customize the height of an action item on the selected message overlay via `ChatTheme`.
 - Added the `messageAlignmentProvider` field to the `ChatTheme` that allows to customize message horizontal alignment. 
 - Added the `maxAttachmentCount` and `maxAttachmentSize` parameters to the `MessagesViewModelFactory`, to make it possible to customize the allowed number and size of attachments that can be sent via the `MessageComposer` component.
+- Added the `textStyle` and `textColor` parameters to the `NetworkLoadingView` component, to make it possible to customize the text appearance of the inner text.
 
 ### ⚠️ Changed
 - Made the MessageMode subtypes to the parent class, to make it easier to understand when importing

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -546,7 +546,7 @@ public final class io/getstream/chat/android/compose/ui/common/MessageBubbleKt {
 }
 
 public final class io/getstream/chat/android/compose/ui/common/NetworkLoadingViewKt {
-	public static final fun NetworkLoadingView-rAjV9yQ (Landroidx/compose/ui/Modifier;FLandroidx/compose/runtime/Composer;II)V
+	public static final fun NetworkLoadingView-vlEVYhg (Landroidx/compose/ui/Modifier;FLandroidx/compose/ui/text/TextStyle;JLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/common/SearchInputKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/NetworkLoadingView.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/NetworkLoadingView.kt
@@ -9,7 +9,9 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
@@ -20,11 +22,15 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  *
  * @param modifier Styling for the [Row].
  * @param spinnerSize The size of the spinner.
+ * @param textStyle The text style of the inner text.
+ * @param textColor The text color of the inner text.
  */
 @Composable
 public fun NetworkLoadingView(
     modifier: Modifier = Modifier,
-    spinnerSize: Dp = 18.dp
+    spinnerSize: Dp = 18.dp,
+    textStyle: TextStyle = ChatTheme.typography.title3Bold,
+    textColor: Color = ChatTheme.colors.textHighEmphasis,
 ) {
     Row(
         modifier,
@@ -41,8 +47,8 @@ public fun NetworkLoadingView(
 
         Text(
             text = stringResource(id = R.string.stream_compose_waiting_for_network),
-            style = ChatTheme.typography.title3Bold,
-            color = ChatTheme.colors.textHighEmphasis,
+            style = textStyle,
+            color = textColor,
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/MessageListHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/MessageListHeader.kt
@@ -167,12 +167,15 @@ public fun DefaultMessageHeaderTitle(
             color = ChatTheme.colors.textHighEmphasis,
         )
 
+        val subtitleTextColor = ChatTheme.colors.textLowEmphasis
+        val subtitleTextStyle = ChatTheme.typography.footnote
+
         if (connectionState == ConnectionState.CONNECTED) {
             if (typingUsers.isEmpty()) {
                 Text(
                     text = subtitle,
-                    color = ChatTheme.colors.textLowEmphasis,
-                    style = ChatTheme.typography.footnote,
+                    color = subtitleTextColor,
+                    style = subtitleTextStyle,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
@@ -193,8 +196,8 @@ public fun DefaultMessageHeaderTitle(
 
                     Text(
                         text = typingUsersText,
-                        color = ChatTheme.colors.textLowEmphasis,
-                        style = ChatTheme.typography.footnote,
+                        color = subtitleTextColor,
+                        style = subtitleTextStyle,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
@@ -204,6 +207,8 @@ public fun DefaultMessageHeaderTitle(
             NetworkLoadingView(
                 modifier = Modifier.wrapContentHeight(),
                 spinnerSize = 12.dp,
+                textColor = subtitleTextColor,
+                textStyle = subtitleTextStyle
             )
         }
     }


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2674)](https://github.com/GetStream/stream-chat-android/issues/2674

### 🎯 Goal

Expose the `textStyle` and `textSize` params in the `NetworkLoadingView` component. Set them to the correct values for `ChannelListHeader` and `MessageListHeader`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![device-2021-11-25-084320](https://user-images.githubusercontent.com/9600921/143386458-c75787c6-6d5a-47a2-a601-c62bd2a1f9f3.png) | ![device-2021-11-25-084209](https://user-images.githubusercontent.com/9600921/143386207-c2cf1f4a-e8b5-4363-9b2b-d90834d6996d.png) |
| ![device-2021-11-25-084341](https://user-images.githubusercontent.com/9600921/143386456-378cfda6-0b64-41e0-977d-4d96df49fc48.png) | ![device-2021-11-25-084235](https://user-images.githubusercontent.com/9600921/143386198-31614117-c165-4264-9adf-c2cc959d1597.png) |

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
