### PR TITLE
[2677] Fix muted channel icon with long title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fixed the information about channel members shown in the `MessageListHeader` subtitle.
+- Fixed the bug where the channel icon did not appear because of a lengthy title.
 
 ### ⬆️ Improved
 - Updated a lot of documentation around the Messages features

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/list/ChannelItem.kt
@@ -160,8 +160,9 @@ public fun ChannelDetails(
         modifier = modifier,
         verticalArrangement = Arrangement.Center
     ) {
-        val channelName: (@Composable () -> Unit) = @Composable {
+        val channelName: (@Composable (modifier: Modifier) -> Unit) = @Composable {
             Text(
+                modifier = it,
                 text = ChatTheme.channelNameFormatter.formatChannelName(channel),
                 style = ChatTheme.typography.bodyBold,
                 fontSize = 16.sp,
@@ -173,7 +174,7 @@ public fun ChannelDetails(
 
         if (channel.isMuted) {
             Row(verticalAlignment = CenterVertically) {
-                channelName()
+                channelName(Modifier.weight(weight = 1f, fill = false))
 
                 Icon(
                     modifier = Modifier
@@ -185,7 +186,7 @@ public fun ChannelDetails(
                 )
             }
         } else {
-            channelName()
+            channelName(Modifier)
         }
 
         val lastMessageText = channel.getLastMessage(currentUser)?.let { lastMessage ->


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2677

### 🎯 Goal

 Fix the bug where the channel icon doesn't appear because of a lengthy title.

### 🎨 UI Changes

#### Short channel name
<img src="https://user-images.githubusercontent.com/9600921/143463602-cc1a1106-bc43-43e1-bf7f-a1b20e353dce.png" width="40%">

#### Long channel name
<img src="https://user-images.githubusercontent.com/9600921/143463623-44160db0-5c87-4021-8258-76416b0a2429.png" width="40%">


### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
