### PR TITLE
Crash fix for message options dialog fragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-
+- Fixed crash related with creation of MessageOptionsDialogFragment
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2075,7 +2075,7 @@ public class io/getstream/chat/android/ui/message/list/adapter/viewholder/attach
 	protected final fun createLinkContent (Lio/getstream/chat/android/client/models/Attachment;ZLio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Landroid/view/View;)Landroid/view/View;
 }
 
-public abstract interface class io/getstream/chat/android/ui/message/list/background/MessageBackgroundFactory : java/io/Serializable {
+public abstract interface class io/getstream/chat/android/ui/message/list/background/MessageBackgroundFactory {
 	public abstract fun deletedMessageBackground (Landroid/content/Context;Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;)Landroid/graphics/drawable/Drawable;
 	public abstract fun giphyAppearanceModel (Landroid/content/Context;)Landroid/graphics/drawable/Drawable;
 	public abstract fun plainTextMessageBackground (Landroid/content/Context;Lcom/getstream/sdk/chat/adapter/MessageListItem$MessageItem;)Landroid/graphics/drawable/Drawable;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/background/MessageBackgroundFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/background/MessageBackgroundFactory.kt
@@ -3,12 +3,11 @@ package io.getstream.chat.android.ui.message.list.background
 import android.content.Context
 import android.graphics.drawable.Drawable
 import com.getstream.sdk.chat.adapter.MessageListItem
-import java.io.Serializable
 
 /**
  * Drawer of background of message items
  */
-public interface MessageBackgroundFactory : Serializable {
+public interface MessageBackgroundFactory {
 
     /**
      * Background for message of plain text

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.ui.message.list.MessageListView
 import io.getstream.chat.android.ui.message.list.MessageListViewStyle
 import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
-import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainerImpl
 import io.getstream.chat.android.ui.message.list.adapter.internal.MessageListItemViewTypeMapper
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.TextAndAttachmentsViewHolder
@@ -374,7 +373,6 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
 
         private const val ARG_OPTIONS_MODE = "optionsMode"
         private const val ARG_OPTIONS_CONFIG = "optionsConfig"
-        private const val ARG_OPTIONS_BACKGROUND_FACTORY = "backgroundFactory"
 
         internal var messageListViewStyle: MessageListViewStyle? = null
 
@@ -437,7 +435,6 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                 arguments = bundleOf(
                     ARG_OPTIONS_MODE to optionsMode,
                     ARG_OPTIONS_CONFIG to configuration,
-                    ARG_OPTIONS_BACKGROUND_FACTORY to messageBackgroundFactory
                 )
                 // pass message via static field
                 messageArg = message


### PR DESCRIPTION
### 🎯 Goal

Fix crash related to serialization of `MessageBackgroundFactoryImpl`

### 🛠 Implementation details

Using only the static instance of `messageViewHolderFactory` inside `MessageOptionsDialogFragment`

### 🧪 Testing

Change the background of messages and check that it is still applied an not crashes occur.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
