### PR TITLE
Fix block user textview behvaviour

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -52,7 +52,6 @@ internal class MessageOptionsView : FrameLayout {
                 isMessagePinned = isMessagePinned,
             )
         }
-        binding.blockTV.isVisible = false
         binding.messageOptionsContainer.setCardBackgroundColor(style.messageOptionsBackgroundColor)
     }
 
@@ -79,7 +78,7 @@ internal class MessageOptionsView : FrameLayout {
         binding.blockTV.configureListItem(textStyle, style.blockIcon)
         binding.editTV.isVisible = false
         binding.deleteTV.isVisible = false
-        configureBlock(configuration = configuration, style = style)
+        binding.blockTV.isVisible = true
         configureMute(
             configuration = configuration,
             style = style,
@@ -200,11 +199,7 @@ internal class MessageOptionsView : FrameLayout {
     }
 
     private fun configureBlock(configuration: Configuration, style: MessageListViewStyle) {
-        if (configuration.blockEnabled) {
-            binding.blockTV.configureListItem(style.messageOptionsText, style.replyIcon)
-        } else {
-            binding.blockTV.isVisible = false
-        }
+        binding.blockTV.isVisible = configuration.blockEnabled
     }
 
     private fun configureCopyMessage(configuration: Configuration, style: MessageListViewStyle) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -75,10 +75,8 @@ internal class MessageOptionsView : FrameLayout {
 
         binding.flagTV.configureListItem(textStyle, style.flagIcon)
         binding.muteTV.configureListItem(textStyle, style.muteIcon)
-        binding.blockTV.configureListItem(textStyle, style.blockIcon)
         binding.editTV.isVisible = false
         binding.deleteTV.isVisible = false
-        binding.blockTV.isVisible = true
         configureMute(
             configuration = configuration,
             style = style,
@@ -90,6 +88,7 @@ internal class MessageOptionsView : FrameLayout {
             style = style,
             isMessagePinned = isMessagePinned
         )
+        configureBlock(configuration = configuration, style = style)
     }
 
     private fun configureMineMessage(
@@ -200,6 +199,9 @@ internal class MessageOptionsView : FrameLayout {
 
     private fun configureBlock(configuration: Configuration, style: MessageListViewStyle) {
         binding.blockTV.isVisible = configuration.blockEnabled
+        if(configuration.blockEnabled) {
+            binding.blockTV.configureListItem(style.messageOptionsText, style.blockIcon)
+        }
     }
 
     private fun configureCopyMessage(configuration: Configuration, style: MessageListViewStyle) {


### PR DESCRIPTION
### 🎯 Goal

The block user textview was never visible even if developer has enabled `blockEnabled` property.

### 🛠 Implementation details

Simply, removed the line which was changing its visibility.

### 🧪 Testing

- Enable block user either with the help of style attribute `blockEnabled`.
- Block user options should be visible when tapping long on any message.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
