### PR TITLE
[CAS-1480] Fix background color setting in GiphyViewHolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed crash related with creation of MessageOptionsDialogFragment
+- Fixed `GiphyViewHolderStyle#cardBackgroundColor` not getting applied
+
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyViewHolder.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.content.res.ColorStateList
 import android.view.ViewGroup
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.enums.GiphyAction
@@ -60,7 +61,7 @@ internal class GiphyViewHolder(
 
     private fun applyStyle() {
         binding.apply {
-            cardView.setCardBackgroundColor(style.cardBackgroundColor)
+            cardView.backgroundTintList = ColorStateList.valueOf(style.cardBackgroundColor)
             cardView.elevation = style.cardElevation
 
             horizontalDivider.setBackgroundColor(style.cardButtonDividerColor)


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1480

### 🎯 Goal

Fix the style attribute not being applied correctly

### 🛠 Implementation details

Replaced the `setCardBackgroundColor` call with setting the `backgroundTintList` of the `MaterialCardView` instead. Not sure why exactly `setCardBackgroundColor` doesn't work, it works in three other places in our codebase just fine.

<details>
  <summary>Here's the patch to update the other three places too, in case we want to (or just for testing)</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt	(revision c4ff49e4273a18bbd7e2553662766dce131bf209)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt	(date 1638269690483)
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.ui.message.list.options.message.internal
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -52,7 +53,7 @@
                 isMessagePinned = isMessagePinned,
             )
         }
-        binding.messageOptionsContainer.setCardBackgroundColor(style.messageOptionsBackgroundColor)
+        binding.messageOptionsContainer.backgroundTintList = ColorStateList.valueOf(style.messageOptionsBackgroundColor)
     }
 
     private fun configureTheirsMessage(
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt	(revision c4ff49e4273a18bbd7e2553662766dce131bf209)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListView.kt	(date 1638269144414)
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.ui.suggestion.list
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.core.view.isVisible
@@ -60,7 +61,7 @@
     internal fun setSuggestionListViewStyle(style: SuggestionListViewStyle) {
         this.style = style
 
-        binding.suggestionsCardView.setCardBackgroundColor(style.suggestionsBackground)
+        binding.suggestionsCardView.backgroundTintList = ColorStateList.valueOf(style.suggestionsBackground)
         binding.commandsTitleTextView.setTextStyle(style.commandsTitleTextStyle)
         binding.commandsTitleTextView.setLeftDrawable(style.lightningIcon)
         viewHolderFactory.style = style
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/user/internal/UserReactionsView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/user/internal/UserReactionsView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/user/internal/UserReactionsView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/user/internal/UserReactionsView.kt	(revision c4ff49e4273a18bbd7e2553662766dce131bf209)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/user/internal/UserReactionsView.kt	(date 1638269020888)
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.ui.message.list.reactions.user.internal
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import androidx.recyclerview.widget.GridLayoutManager
@@ -51,7 +52,7 @@
     }
 
     internal fun configure(messageListViewStyle: MessageListViewStyle) {
-        binding.userReactionsContainer.setCardBackgroundColor(messageListViewStyle.userReactionsBackgroundColor)
+        binding.userReactionsContainer.backgroundTintList = ColorStateList.valueOf(messageListViewStyle.userReactionsBackgroundColor)
         messageListViewStyle.userReactionsTitleText.apply(binding.userReactionsTitleTextView)
     }
```
</details

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1638268301](https://user-images.githubusercontent.com/12054216/144034937-64d6af11-4b66-4311-ac06-3486250e69be.png) | ![Screenshot_1638268201](https://user-images.githubusercontent.com/12054216/144034941-7d29d8a2-a75c-4aa5-9620-71c642e6c2c0.png)| 

### 🧪 Testing

<details>
  <summary>Apply these changes temporarily</summary>
  
  
```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt	(revision c4ff49e4273a18bbd7e2553662766dce131bf209)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt	(date 1638268556386)
@@ -8,6 +8,8 @@
 import coil.decode.ImageDecoderDecoder
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.ui.StyleTransformer
+import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.ui.sample.BuildConfig
 import io.getstream.chat.ui.sample.data.user.SampleUser
 import io.getstream.chat.ui.sample.data.user.UserRepository
@@ -34,6 +36,19 @@
         )
         ApplicationConfigurator.configureApp(this)
         initializeToggleService()
+
+        TransformStyle.giphyViewHolderStyleTransformer = StyleTransformer { style ->
+            style.copy(cardBackgroundColor = 0xFFFF33F3.toInt())
+        }
+        TransformStyle.messageListStyleTransformer = StyleTransformer { style ->
+            style.copy(
+                messageOptionsBackgroundColor = 0xFFFF33F3.toInt(),
+                userReactionsBackgroundColor = 0xFFFF33F3.toInt()
+            )
+        }
+        TransformStyle.suggestionListStyleTransformer = StyleTransformer { style ->
+            style.copy(suggestionsBackground = 0xFFFF33F3.toInt())
+        }
     }
 
     private fun getApiKey(): String {

```
</details>

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added