### PR TITLE
[CAS-1457] Fix - Disallowing empty giphys

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -709,7 +709,7 @@ public class MessageInputView : ConstraintLayout {
     private fun refreshControlsState() {
         with(binding) {
             val commandMode = messageInputFieldView.mode is MessageInputFieldView.Mode.CommandMode
-            val hasContent = messageInputFieldView.hasContent()
+            val hasContent = messageInputFieldView.hasValidContent()
             val hasValidContent = hasContent && !isMessageTooLong()
 
             attachmentsButton.isVisible = messageInputViewStyle.attachButtonEnabled && !commandMode

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -363,9 +363,11 @@ internal class MessageInputFieldView : FrameLayout {
         }
     }
 
-    private fun hasText(): Boolean = messageText.isNotBlank()
+    private fun hasValidText(): Boolean = isMessageTextValid(messageText)
 
-    fun hasContent(): Boolean = hasText() || selectedAttachments.isNotEmpty() || selectedCustomAttachments.isNotEmpty()
+    fun hasValidContent(): Boolean {
+        return hasValidText() || selectedAttachments.isNotEmpty() || selectedCustomAttachments.isNotEmpty()
+    }
 
     private fun onMessageTextChanged() {
         resetModeIfNecessary()
@@ -381,7 +383,7 @@ internal class MessageInputFieldView : FrameLayout {
     }
 
     private fun resetModeIfNecessary() {
-        if (!hasContent() && (mode is Mode.FileAttachmentMode || mode is Mode.MediaAttachmentMode)) {
+        if (!hasValidContent() && (mode is Mode.FileAttachmentMode || mode is Mode.MediaAttachmentMode)) {
             resetMode()
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidator.kt
@@ -1,0 +1,18 @@
+package io.getstream.chat.android.ui.message.input.internal
+
+internal fun isMessageTextValid(text: String): Boolean {
+    return text.isNotEmpty() && !emptyGiphy(text)
+}
+
+private fun emptyGiphy(text: String) : Boolean {
+    val giphyCommand = "/giphy"
+
+    if (text.startsWith(giphyCommand)) {
+        val giphyContent = text.removePrefix(giphyCommand)
+
+        return giphyContent.isEmpty() || giphyContent.isBlank()
+    }
+
+    return false
+}
+

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidatorTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidatorTest.kt
@@ -1,5 +1,7 @@
 package io.getstream.chat.android.ui.message.input.internal
 
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be`
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
@@ -10,7 +12,7 @@ internal class TextValidatorTest {
         val message = "/giphy"
         val result = isMessageTextValid(message)
 
-        assertFalse(result)
+        result `should be` (false)
     }
 
     @Test
@@ -18,7 +20,7 @@ internal class TextValidatorTest {
         val message = "/giphy      "
         val result = isMessageTextValid(message)
 
-        assertFalse(result)
+        result `should be` (false)
     }
 
     @Test
@@ -26,7 +28,7 @@ internal class TextValidatorTest {
         val message = "/giphy hi"
         val result = isMessageTextValid(message)
 
-        assertTrue(result)
+        result `should be` (true)
     }
 
     @Test
@@ -34,6 +36,6 @@ internal class TextValidatorTest {
         val message = "hi"
         val result = isMessageTextValid(message)
 
-        assertTrue(result)
+        result `should be` (true)
     }
 }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidatorTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/input/internal/TextValidatorTest.kt
@@ -1,0 +1,39 @@
+package io.getstream.chat.android.ui.message.input.internal
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+
+internal class TextValidatorTest {
+
+    @Test
+    fun `should not be possible to send empty giphys`() {
+        val message = "/giphy"
+        val result = isMessageTextValid(message)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should not be possible to send blank giphys`() {
+        val message = "/giphy      "
+        val result = isMessageTextValid(message)
+
+        assertFalse(result)
+    }
+
+    @Test
+    fun `should be possible to send giphys with content`() {
+        val message = "/giphy hi"
+        val result = isMessageTextValid(message)
+
+        assertTrue(result)
+    }
+
+    @Test
+    fun `should be possible to send text`() {
+        val message = "hi"
+        val result = isMessageTextValid(message)
+
+        assertTrue(result)
+    }
+}


### PR DESCRIPTION
[CAS-1457](https://stream-io.atlassian.net/browse/CAS-1457)

### 🎯 Goal

Fix a simple bug where is it possible to send giphys with empty screen. The check for valid message text is now outside of `MessageInputFieldView` and has unit tests for it, as it can grow in complexity as more logic is added in the SDK.

### 🛠 Implementation details

Created method to validate message text

### 🎨 UI Changes

| Before | After |
| --- | --- |
|![Screenshot_20211130-112900](https://user-images.githubusercontent.com/10619102/144067026-dd702e06-27ab-40a8-9fdc-fd59282f76c6.png) |  ![Screenshot_20211130-112820](https://user-images.githubusercontent.com/10619102/144067020-1d19df13-6ca8-42ca-896a-4b4c6f944997.png) |

### 🧪 Testing

Send giphys and messages with different data and don't forget to try to send a giphy with no text

### ☑️ Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [ ] Reviewers added

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/144062153-fd298164-5ec6-446c-882d-93ebb5219ffa.gif)



