### PR TITLE
[2720] Removed preemptive attachment loading that resulted in crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Removed preemptive attachment loading that was resulting in crashes on certain Android API versions
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
@@ -182,7 +182,7 @@ public fun AttachmentsPicker(
                     }
 
                     LaunchedEffect(storagePermissionState.hasPermission) {
-                        if (storagePermissionState.permissionRequested && storagePermissionState.hasPermission) {
+                        if (storagePermissionState.hasPermission) {
                             attachmentsPickerViewModel.loadData()
                         }
                     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModel.kt
@@ -58,10 +58,6 @@ public class AttachmentsPickerViewModel(
     public var isShowingAttachments: Boolean by mutableStateOf(false)
         private set
 
-    init {
-        loadData()
-    }
-
     /**
      * Loads all the items based on the current type.
      */
@@ -88,11 +84,8 @@ public class AttachmentsPickerViewModel(
     public fun changeAttachmentState(showAttachments: Boolean) {
         isShowingAttachments = showAttachments
 
-        if (!showAttachments) {
+        if (!showAttachments)
             dismissAttachments()
-        } else {
-            loadData()
-        }
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Preemptive loading of attachment data was done before permission `READ_EXTERNAL_STORAGE` was given leading to crashes on certain Android APIs (confirmed crashes on APIs 23,24,26 and 28) when `MessagesActivity` was open in the Compose Sample app. This PR aims to rectify said crashes.

### 🛠 Implementation details

Preemptive loading was removed from the init block of `AttachmentsPickerViewModel` and inside of the function body of `changeAttachmentState(showAttachments: Boolean)` inside `AttachmentsPickerViewModel`. 

`storagePermissionState.permissionRequested` was removed from the condition check because it would always return `false` even if permission had been previously requested.

### 🧪 Testing

Testing can be done manually by opening the sample app on emulators/ physical devices that had crashes occurring (APIs 23,24,26 and 28), opening `MessagesActivity`, showing `AttachmentsPicker` by clicking on the attachment integration and sending an attachment.

Please close `AttachmentsPicker` after sending an attachment once, reopen and send another attachment in order to confirm that the data is being loaded properly.

### ☑️ Checklist

- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![crash](https://user-images.githubusercontent.com/37080097/144233172-83abe931-c5bd-4324-a05e-b4463024f239.gif)