### PR TITLE
[2733] Enable scrolling behavior in SelectedMessageOverlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ### ⬆️ Improved
 - Minor UI improvements to the message overlay
+- Enabled scrolling behavior in SelectedMessageOverlay
 
 ### ✅ Added
 - Added the mention suggestion popup to the `MessageComposer` component, that allows to autocomplete a mention from a list of users.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
@@ -17,15 +17,17 @@ import androidx.compose.foundation.layout.sizeIn
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Icon
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.End
@@ -78,6 +80,8 @@ public fun SelectedMessageOverlay(
     onMessageAction: (MessageAction) -> Unit,
     onDismiss: () -> Unit,
 ) {
+    val boxScrollState = rememberScrollState()
+
     val ownReactions = message.ownReactions
 
     val reactionOptions = reactionTypes.entries
@@ -93,6 +97,7 @@ public fun SelectedMessageOverlay(
         modifier = Modifier
             .fillMaxSize()
             .background(ChatTheme.colors.overlay)
+            .verticalScroll(boxScrollState)
             .clickable(
                 onClick = onDismiss,
                 indication = null,
@@ -281,19 +286,21 @@ public fun MessageOptions(
         shape = RoundedCornerShape(ChatTheme.dimens.messageOptionsRoundedCorners),
         color = ChatTheme.colors.barsBackground,
     ) {
-        LazyColumn(modifier) {
-            items(options) { option ->
-                Spacer(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(0.5.dp)
-                        .background(color = ChatTheme.colors.borders)
-                )
+        Column(modifier) {
+            options.forEach { option ->
+                key(option) {
+                    Spacer(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(0.5.dp)
+                            .background(color = ChatTheme.colors.borders)
+                    )
 
-                MessageOptionItem(
-                    option = option,
-                    onMessageOptionClick = { onMessageAction(it.action) }
-                )
+                    MessageOptionItem(
+                        option = option,
+                        onMessageOptionClick = { onMessageAction(it.action) }
+                    )
+                }
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Enable scrolling behavior in `SelectedMessageOverlay` in order to avoid clipping the message or clipping or fully excluding `MessageOptions` from the screen resulting in an inability to perform any actions over messages.

### 🛠 Implementation details

Enabled vertical Scrolling in `SelectedMessageOverlay` by applying `.verticalScroll(ScrollState)` to the `Box` `Modifier` inside `SelectedMessageOverlay`. 

Switched from implementing a `LazyColumn` for displaying `MessageOptionItem`s to using a `Column` so that nested scrolling would be avoided. Used key utility Composable to optimize recomposition since the Composables were called from the same call site.

### 🎨 UI Changes

Enabled vertical scrolling in `SelectedMessageOverlay`

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/37080097/144443377-a55b75a1-012f-46e4-baac-5632d2091f1e.png) | ![scroll_short](https://user-images.githubusercontent.com/37080097/144444849-86e3862c-aacf-4e4a-b847-a293a1734dd2.gif) |





### 🧪 Testing

Testing can be done manually by long pressing on a really long message and opening the aforementioned overlay. After that action is accomplished one should scroll down until all of `MessageOptions` is visible and test it by performing an action such as replying to a message, editing a message or deleting a message.

### ☑️ Checklist

- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

![scrolling](https://user-images.githubusercontent.com/37080097/144441958-94e9d84d-8af7-4cfa-b060-27f61e8478ee.gif)
