### PR TITLE
[CAS-1482] Fix - Query controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Fixed crash related with creation of MessageOptionsDialogFragment
 - Removed cut from text when text end with Italic
 - Fixed `GiphyViewHolderStyle#cardBackgroundColor` not getting applied
+- Fixed bug related of not removing channels when filter selects channels where the the current user is not a member
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1525,18 +1525,20 @@ public final class io/getstream/chat/android/client/events/NotificationMutesUpda
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasMember {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;)V
+public final class io/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasChannel, io/getstream/chat/android/client/events/HasMember {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/Member;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun component7 ()Lio/getstream/chat/android/client/models/Member;
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;)Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;
+	public final fun component7 ()Lio/getstream/chat/android/client/models/Channel;
+	public final fun component8 ()Lio/getstream/chat/android/client/models/Member;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/Member;)Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/Member;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChannel ()Lio/getstream/chat/android/client/models/Channel;
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -458,6 +458,7 @@ private fun NotificationRemovedFromChannelEventDto.toDomain(): NotificationRemov
         cid = cid,
         channelType = channel_type,
         channelId = channel_id,
+        channel = channel.toDomain(),
         member = member.toDomain()
     )
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -285,6 +285,7 @@ internal data class NotificationRemovedFromChannelEventDto(
     val cid: String,
     val channel_type: String,
     val channel_id: String,
+    val channel: DownstreamChannelDto,
     val member: DownstreamMemberDto,
 ) : ChatEventDto()
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -405,8 +405,9 @@ public data class NotificationRemovedFromChannelEvent(
     override val cid: String,
     override val channelType: String,
     override val channelId: String,
+    override val channel: Channel,
     override val member: Member,
-) : CidEvent(), HasMember
+) : CidEvent(), HasMember, HasChannel
 
 /**
  * Triggered when a message reaction is deleted

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -280,6 +280,7 @@ internal fun createNotificationRemovedFromChannelEventStringJson() =
             "channel_type": "channelType",
             "channel_id": "channelId",
             "cid": "channelType:channelId",
+            "channel": ${createChannelJsonString()},
             "user": ${createUserJsonString()},
             "member": ${createMemberJsonString()}
         """.trimIndent()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -201,7 +201,7 @@ internal object EventArguments {
     private val notificationInvitedEvent = NotificationInvitedEvent(EventType.NOTIFICATION_INVITED, date, cid, channelType, channelId, user, member)
     private val notificationMarkReadEvent = NotificationMarkReadEvent(EventType.NOTIFICATION_MARK_READ, date, user, cid, channelType, channelId, totalUnreadCount, unreadChannels)
     private val notificationMessageNewEvent = NotificationMessageNewEvent(EventType.NOTIFICATION_MESSAGE_NEW, date, cid, channelType, channelId, channel, message, totalUnreadCount, unreadChannels)
-    private val notificationRemovedFromChannelEvent = NotificationRemovedFromChannelEvent(EventType.NOTIFICATION_REMOVED_FROM_CHANNEL, date, user, cid, channelType, channelId, member)
+    private val notificationRemovedFromChannelEvent = NotificationRemovedFromChannelEvent(EventType.NOTIFICATION_REMOVED_FROM_CHANNEL, date, user, cid, channelType, channelId, channel, member)
     private val reactionDeletedEvent = ReactionDeletedEvent(EventType.REACTION_DELETED, date, user, cid, channelType, channelId, message, reaction)
     private val reactionNewEvent = ReactionNewEvent(EventType.REACTION_NEW, date, user, cid, channelType, channelId, message, reaction)
     private val reactionUpdateEvent = ReactionUpdateEvent(EventType.REACTION_UPDATED, date, user, cid, channelType, channelId, message, reaction)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -399,6 +399,10 @@ internal class EventHandlerImpl(
     }
 
     internal suspend fun handleEventsInternal(events: List<ChatEvent>) {
+        events.forEach { chatEvent ->
+            logger.logD("Received event: $chatEvent")
+        }
+
         val sortedEvents = events.sortedBy { it.createdAt }
         updateOfflineStorageFromEvents(sortedEvents)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChatEventHandler.kt
@@ -88,6 +88,7 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
     public open fun handleChannelEvent(event: HasChannel, filter: FilterObject): EventHandlingResult {
         return when (event) {
             is NotificationAddedToChannelEvent -> handleNotificationAddedToChannelEvent(event, filter)
+            is NotificationRemovedFromChannelEvent -> handleNotificationRemovedFromChannelEvent(event, filter)
             is ChannelDeletedEvent -> EventHandlingResult.Remove(event.cid)
             is NotificationChannelDeletedEvent -> EventHandlingResult.Remove(event.cid)
             is ChannelUpdatedByUserEvent -> handleChannelUpdatedByUserEvent(event, filter)
@@ -99,7 +100,6 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
 
     public open fun handleCidEvent(event: CidEvent, filter: FilterObject): EventHandlingResult {
         return when (event) {
-            is NotificationRemovedFromChannelEvent -> handleNotificationRemovedFromChannelEvent(event, filter)
             is ChannelHiddenEvent -> EventHandlingResult.Remove(event.cid)
             else -> EventHandlingResult.Skip
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.events.ChannelUpdatedByUserEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedEvent
+import io.getstream.chat.android.client.events.HasChannel
 import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
@@ -47,12 +48,16 @@ internal class DefaultChatEventHandler(private val client: ChatClient, private v
     override fun handleNotificationAddedToChannelEvent(
         event: NotificationAddedToChannelEvent,
         filter: FilterObject,
-    ): EventHandlingResult = fireRequestIfChannelIsAbsent(event.channel, filter)
+    ): EventHandlingResult {
+        return handleMemberUpdate(event, event.cid, filter)
+    }
 
     override fun handleChannelUpdatedByUserEvent(
         event: ChannelUpdatedByUserEvent,
         filter: FilterObject,
-    ): EventHandlingResult = EventHandlingResult.Skip
+    ): EventHandlingResult {
+        return handleMemberUpdate(event, event.cid, filter)
+    }
 
     override fun handleChannelUpdatedEvent(event: ChannelUpdatedEvent, filter: FilterObject): EventHandlingResult =
         EventHandlingResult.Skip
@@ -90,17 +95,39 @@ internal class DefaultChatEventHandler(private val client: ChatClient, private v
         event: NotificationRemovedFromChannelEvent,
         filter: FilterObject,
     ): EventHandlingResult {
-        return if (channels.value.any { it.cid == event.cid }.not()) {
-            EventHandlingResult.Skip
-        } else {
-            checkCidByChannelFilter(event.cid, filter, EventHandlingResult.Skip)
+        return handleMemberUpdate(event, event.cid, filter)
+    }
+
+    private fun handleMemberUpdate(
+        event: HasChannel,
+        cid: String,
+        filter: FilterObject,
+    ): EventHandlingResult {
+        val channel = event.channel
+
+        return runBlocking {
+            val hasChannel = channels.value.any { it.cid == channel.cid }
+            val filterPassed = channelFilter(channel.cid, filter)
+
+            when {
+                filterPassed && !hasChannel -> EventHandlingResult.Add(channel)
+
+                !filterPassed && hasChannel -> EventHandlingResult.Remove(cid)
+
+                else -> EventHandlingResult.Skip
+            }
         }
     }
 
+
     /**
-     * Run filter request. If filter is passed then it returns [filterPositiveResult], otherwise it returns [EventHandlingResult.Skip].
+     * Run filter request. If filter is passed then it returns [filterPositiveResult], otherwise it returns [EventHandlingResult.Remove].
      */
-    private fun checkCidByChannelFilter(cid: String, filter: FilterObject, filterPositiveResult: EventHandlingResult): EventHandlingResult {
+    private fun checkCidByChannelFilter(
+        cid: String,
+        filter: FilterObject,
+        filterPositiveResult: EventHandlingResult,
+    ): EventHandlingResult {
         return runBlocking {
             if (channelFilter(cid, filter)) {
                 filterPositiveResult

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
@@ -48,16 +48,12 @@ internal class DefaultChatEventHandler(private val client: ChatClient, private v
     override fun handleNotificationAddedToChannelEvent(
         event: NotificationAddedToChannelEvent,
         filter: FilterObject,
-    ): EventHandlingResult {
-        return handleMemberUpdate(event, event.cid, filter)
-    }
+    ): EventHandlingResult = handleMemberUpdate(event, event.cid, filter)
 
     override fun handleChannelUpdatedByUserEvent(
         event: ChannelUpdatedByUserEvent,
         filter: FilterObject,
-    ): EventHandlingResult {
-        return handleMemberUpdate(event, event.cid, filter)
-    }
+    ): EventHandlingResult = EventHandlingResult.Skip
 
     override fun handleChannelUpdatedEvent(event: ChannelUpdatedEvent, filter: FilterObject): EventHandlingResult =
         EventHandlingResult.Skip
@@ -94,9 +90,7 @@ internal class DefaultChatEventHandler(private val client: ChatClient, private v
     override fun handleNotificationRemovedFromChannelEvent(
         event: NotificationRemovedFromChannelEvent,
         filter: FilterObject,
-    ): EventHandlingResult {
-        return handleMemberUpdate(event, event.cid, filter)
-    }
+    ): EventHandlingResult = handleMemberUpdate(event, event.cid, filter)
 
     private fun handleMemberUpdate(
         event: HasChannel,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
@@ -119,7 +119,6 @@ internal class DefaultChatEventHandler(private val client: ChatClient, private v
         }
     }
 
-
     /**
      * Run filter request. If filter is passed then it returns [filterPositiveResult], otherwise it returns [EventHandlingResult.Remove].
      */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/QueryChannelsController.kt
@@ -114,7 +114,11 @@ public class QueryChannelsController internal constructor(
 
     /** Handles updates by WS events. Keeps synchronized data of [QueryChannelsMutableState]. */
     internal suspend fun handleEvent(event: ChatEvent) {
-        when (val handlingResult = mutableState.eventHandler.handleChatEvent(event, filter)) {
+        // update the info for that channel from the channel repo
+        logger.logI("received channel event $event")
+
+        val handlingResult = mutableState.eventHandler.handleChatEvent(event, filter)
+        when (handlingResult) {
             is EventHandlingResult.Add -> addChannel(handlingResult.channel)
             is EventHandlingResult.Remove -> removeChannel(handlingResult.cid)
             is EventHandlingResult.Skip -> Unit
@@ -129,8 +133,6 @@ public class QueryChannelsController internal constructor(
             if (event is UserStartWatchingEvent || event is UserStopWatchingEvent) {
                 return
             }
-            // update the info for that channel from the channel repo
-            logger.logI("received channel event $event")
             refreshChannel(event.cid)
         }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
@@ -410,6 +410,7 @@ internal class TestDataHelper {
             channel1.cid,
             channel1.type,
             channel1.id,
+            channel1,
             member1
         )
 


### PR DESCRIPTION
[CAS-1482](https://stream-io.atlassian.net/browse/CAS-1482)

### 🎯 Goal

Fix of channels not being updated when the filter is requesting channels that the user is **not** a member. 

### 🛠 Implementation details

Removing or adding the user depends on the filter, not the event that arrived. If the channel fails if the filter, it must be removed, if it passes, it must be added. 

### 🎨 UI Changes

Left side - Normal filtering. 
Right side - Displaying only channels where the user is not a member
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/144480750-5b3ce670-815f-4752-adef-e8e4b0b6d5e9.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/144480611-b859b562-1d86-41d5-b767-0bdbbaf16919.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Change the filter to 
```
filter = Filters.and(
    Filters.eq("type", "messaging"),
    Filters.nin("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
    Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
)
```
instead of:
```
filter = Filters.and(
    Filters.eq("type", "messaging"),
    Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
    Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
)
```

Please try other filters aswell.
### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes. 
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes.
- ~[ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))~
- [x] Reviewers added.

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
