### PR TITLE
[2707] Add support for message flagging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added support for Giphy command.
 - Added message pinning to the list of message options
 - Added pinned message UI
+- Added an option to flag a message to the message options overlay. 
 
 ### ⚠️ Changed
 - Changed the way focus state works for focused messages.

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1267,6 +1267,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Lio/getstream/chat/android/client/models/Message;ZILjava/lang/Object;)V
 	public final fun dismissAllMessageActions ()V
 	public final fun dismissMessageAction (Lio/getstream/chat/android/common/state/MessageAction;)V
+	public final fun flagMessage (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun focusMessage (Ljava/lang/String;)V
 	public final fun getChannel ()Lio/getstream/chat/android/client/models/Channel;
 	public final fun getChatClient ()Lio/getstream/chat/android/client/ChatClient;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/SimpleDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/common/SimpleDialog.kt
@@ -1,8 +1,9 @@
 package io.getstream.chat.android.compose.ui.common
 
 import androidx.compose.material.AlertDialog
-import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -44,12 +45,18 @@ public fun SimpleDialog(
             )
         },
         confirmButton = {
-            Button(onClick = { onPositiveAction() }) {
+            TextButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = ChatTheme.colors.primaryAccent),
+                onClick = { onPositiveAction() }
+            ) {
                 Text(text = stringResource(id = R.string.stream_compose_ok))
             }
         },
         dismissButton = {
-            Button(onClick = onDismiss) {
+            TextButton(
+                colors = ButtonDefaults.textButtonColors(contentColor = ChatTheme.colors.primaryAccent),
+                onClick = onDismiss
+            ) {
                 Text(text = stringResource(id = R.string.stream_compose_cancel))
             }
         },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.common.state.Delete
+import io.getstream.chat.android.common.state.Flag
 import io.getstream.chat.android.common.state.MessageMode
 import io.getstream.chat.android.common.state.Reply
 import io.getstream.chat.android.compose.R
@@ -222,6 +223,18 @@ public fun MessagesScreen(
                 message = stringResource(id = R.string.stream_compose_delete_message_text),
                 onPositiveAction = { listViewModel.deleteMessage(deleteAction.message) },
                 onDismiss = { listViewModel.dismissMessageAction(deleteAction) }
+            )
+        }
+
+        val flagAction = messageActions.firstOrNull { it is Flag }
+
+        if (flagAction != null) {
+            SimpleDialog(
+                modifier = Modifier.padding(16.dp),
+                title = stringResource(id = R.string.stream_compose_flag_message_title),
+                message = stringResource(id = R.string.stream_compose_flag_message_text),
+                onPositiveAction = { listViewModel.flagMessage(flagAction.message) },
+                onDismiss = { listViewModel.dismissMessageAction(flagAction) }
             )
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
@@ -20,12 +20,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Button
+import androidx.compose.material.ButtonDefaults
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
+import androidx.compose.material.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -253,7 +254,8 @@ private fun MissingPermissionContent(permissionState: PermissionState) {
 
         Spacer(modifier = Modifier.size(16.dp))
 
-        Button(
+        TextButton(
+            colors = ButtonDefaults.textButtonColors(contentColor = ChatTheme.colors.primaryAccent),
             onClick = {
                 // TODO pull this out into a utility function
                 val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
@@ -262,9 +264,10 @@ private fun MissingPermissionContent(permissionState: PermissionState) {
                     data = uri
                 }
                 context.startActivity(intent)
-            },
-            content = { Text(stringResource(id = R.string.stream_compose_grant_permission)) }
-        )
+            }
+        ) {
+            Text(stringResource(id = R.string.stream_compose_grant_permission))
+        }
     }
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlay.kt
@@ -41,6 +41,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.common.state.Copy
 import io.getstream.chat.android.common.state.Delete
 import io.getstream.chat.android.common.state.Edit
+import io.getstream.chat.android.common.state.Flag
 import io.getstream.chat.android.common.state.MessageAction
 import io.getstream.chat.android.common.state.MuteUser
 import io.getstream.chat.android.common.state.Pin
@@ -386,6 +387,15 @@ public fun defaultMessageOptionsState(
                 title = R.string.stream_compose_edit_message,
                 iconPainter = painterResource(R.drawable.stream_compose_ic_edit),
                 action = Edit(selectedMessage),
+                titleColor = ChatTheme.colors.textHighEmphasis,
+                iconColor = ChatTheme.colors.textLowEmphasis,
+            )
+        } else null,
+        if (!isOwnMessage) {
+            MessageOptionState(
+                title = R.string.stream_compose_flag_message,
+                iconPainter = painterResource(R.drawable.stream_compose_ic_flag),
+                action = Flag(selectedMessage),
                 titleColor = ChatTheme.colors.textHighEmphasis,
                 iconColor = ChatTheme.colors.textLowEmphasis,
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -617,6 +617,19 @@ public class MessageListViewModel(
     }
 
     /**
+     * Removes the flag actions from our [messageActions], as well as the overlay, before flagging
+     * the selected message.
+     *
+     * @param message Message to delete.
+     */
+    public fun flagMessage(message: Message) {
+        messageActions = messageActions - messageActions.filterIsInstance<Flag>()
+        removeOverlay()
+
+        chatClient.flagMessage(message.id).enqueue()
+    }
+
+    /**
      * Copies the message content using the [ClipboardHandler] we provide. This can copy both
      * attachment and text messages.
      *

--- a/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_flag.xml
+++ b/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_flag.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#000000"
+        android:fillType="evenOdd"
+        android:pathData="M5,2C4.4477,2 4,2.4477 4,3V4V14V21C4,21.5523 4.4477,22 5,22C5.5523,22 6,21.5523 6,21V14H20L18,9L20,4H6V3C6,2.4477 5.5523,2 5,2ZM6,6V12H17L16,9L17,6H6Z"
+        />
+</vector>

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -66,6 +66,13 @@
     <string name="stream_compose_edit_message">Edit Message</string>
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
+    <string name="stream_compose_flag_message">Flag Message</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">Delete message</string>
+    <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
+    <string name="stream_compose_flag_message_title">Flag Message</string>
+    <string name="stream_compose_flag_message_text">Do you want to send a copy of this message to a moderator for further investigation?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>
@@ -84,8 +91,6 @@
     <string name="stream_compose_recent_files">Recent Files</string>
     <string name="stream_compose_thread_title">Thread Reply</string>
     <string name="stream_compose_thread_subtitle">with %1$s</string>
-    <string name="stream_compose_delete_message_title">Delete message</string>
-    <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
     <string name="stream_compose_reply_to_message">Reply to message</string>
     <string name="stream_compose_message_deleted">Message deleted</string>
     <string name="stream_compose_only_visible_to_you">Only visible to you</string>

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -68,7 +68,7 @@
     <string name="stream_compose_mute_user">Mute User</string>
     <string name="stream_compose_flag_message">Flag Message</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Delete message</string>
     <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
     <string name="stream_compose_flag_message_title">Flag Message</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -66,6 +66,13 @@
     <string name="stream_compose_edit_message">Editar Mensaje</string>
     <string name="stream_compose_delete_message">Eliminar mensaje</string>
     <string name="stream_compose_mute_user">Silenciar usuario</string>
+    <string name="stream_compose_flag_message">Marcar Mensaje</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">Eliminar mensaje</string>
+    <string name="stream_compose_delete_message_text">¿Estás seguro de que quieres eliminar permanentemente el mensaje?</string>
+    <string name="stream_compose_flag_message_title">Marcar Mensaje</string>
+    <string name="stream_compose_flag_message_text">¿Quieres enviar una copia de este mensaje al moderador para una mejor investigación?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Tamaño máximo de mensaje (%1$d) excedido.</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -68,7 +68,7 @@
     <string name="stream_compose_mute_user">Silenciar usuario</string>
     <string name="stream_compose_flag_message">Marcar Mensaje</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Eliminar mensaje</string>
     <string name="stream_compose_delete_message_text">¿Estás seguro de que quieres eliminar permanentemente el mensaje?</string>
     <string name="stream_compose_flag_message_title">Marcar Mensaje</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -66,6 +66,13 @@
     <string name="stream_compose_edit_message">Modifier le message</string>
     <string name="stream_compose_delete_message">Supprimer le message</string>
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
+    <string name="stream_compose_flag_message">Signaler un message</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">Supprimer le message</string>
+    <string name="stream_compose_delete_message_text">Êtes-vous sûr de vouloir supprimer définitivement ce message ?</string>
+    <string name="stream_compose_flag_message_title">Signaler un message</string>
+    <string name="stream_compose_flag_message_text">Voulez-vous envoyer une copie de ce message à un nmodérateur pour une enquête plus approfondie?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Longueur maximale du message (%1$d) dépassée.</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -68,7 +68,7 @@
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
     <string name="stream_compose_flag_message">Signaler un message</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Supprimer le message</string>
     <string name="stream_compose_delete_message_text">Êtes-vous sûr de vouloir supprimer définitivement ce message ?</string>
     <string name="stream_compose_flag_message_title">Signaler un message</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -66,6 +66,13 @@
     <string name="stream_compose_edit_message">मैसेज एडिट करें</string>
     <string name="stream_compose_delete_message">मैसेज मिटायें</string>
     <string name="stream_compose_mute_user">यूजर को म्यूट करें</string>
+    <string name="stream_compose_flag_message">मैसेज चिह्नित करें</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">मैसेज मिटायें</string>
+    <string name="stream_compose_delete_message_text">क्या आप वाकई इस मैसेज को स्थायी रूप से मिटाना चाहते हैं?</string>
+    <string name="stream_compose_flag_message_title">मैसेज चिह्नित करें</string>
+    <string name="stream_compose_flag_message_text">क्या आप आगे की जांच के लिए इस संदेश की एक कॉपी मॉडरेटर को भेजना चाहते हैं?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">मैसेज की वर्ण सीमा (%1$d) पार हो गई है।</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -68,7 +68,7 @@
     <string name="stream_compose_mute_user">यूजर को म्यूट करें</string>
     <string name="stream_compose_flag_message">मैसेज चिह्नित करें</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">मैसेज मिटायें</string>
     <string name="stream_compose_delete_message_text">क्या आप वाकई इस मैसेज को स्थायी रूप से मिटाना चाहते हैं?</string>
     <string name="stream_compose_flag_message_title">मैसेज चिह्नित करें</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -66,6 +66,13 @@
     <string name="stream_compose_edit_message">Modifica messaggio</string>
     <string name="stream_compose_delete_message">Cancella messaggio</string>
     <string name="stream_compose_mute_user">Silenzia Utente</string>
+    <string name="stream_compose_flag_message">Segnala messaggio</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">Cancella messaggio</string>
+    <string name="stream_compose_delete_message_text">Sei sicuro di voler definitivamente cancellare questo messaggio?</string>
+    <string name="stream_compose_flag_message_title">Segnala messaggio</string>
+    <string name="stream_compose_flag_message_text">Vuoi mandare una copia di questo messaggio ad un moderatore?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">La lunghezza massima del messaggio (%1$d) è stata superata.</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -68,7 +68,7 @@
     <string name="stream_compose_mute_user">Silenzia Utente</string>
     <string name="stream_compose_flag_message">Segnala messaggio</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Cancella messaggio</string>
     <string name="stream_compose_delete_message_text">Sei sicuro di voler definitivamente cancellare questo messaggio?</string>
     <string name="stream_compose_flag_message_title">Segnala messaggio</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -65,7 +65,7 @@
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
     <string name="stream_compose_flag_message">メッセージをフラグする</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">メッセージを削除する</string>
     <string name="stream_compose_delete_message_text">このメッセージを完全に削除してもよろしいですか？</string>
     <string name="stream_compose_flag_message_title">メッセージをフラグする</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -63,6 +63,13 @@
     <string name="stream_compose_edit_message">メッセージを編集する</string>
     <string name="stream_compose_delete_message">メッセージを削除する</string>
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
+    <string name="stream_compose_flag_message">メッセージをフラグする</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">メッセージを削除する</string>
+    <string name="stream_compose_delete_message_text">このメッセージを完全に削除してもよろしいですか？</string>
+    <string name="stream_compose_flag_message_title">メッセージをフラグする</string>
+    <string name="stream_compose_flag_message_text">このメッセージのコピーをモデレーターに送って、さらに調査してもらいますか？</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">"最大メッセージ長（%1$d)字を超えました"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -65,7 +65,7 @@
     <string name="stream_compose_mute_user">사용자 무시</string>
     <string name="stream_compose_flag_message">메세지 신고</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">메시지를 삭제합니다</string>
     <string name="stream_compose_delete_message_text">이 메시지를 완전히 삭제하시겠습니까?</string>
     <string name="stream_compose_flag_message_title">메시지를 신고합니다</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -63,6 +63,13 @@
     <string name="stream_compose_edit_message">메세지 수정</string>
     <string name="stream_compose_delete_message">메시지 삭제</string>
     <string name="stream_compose_mute_user">사용자 무시</string>
+    <string name="stream_compose_flag_message">메세지 신고</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">메시지를 삭제합니다</string>
+    <string name="stream_compose_delete_message_text">이 메시지를 완전히 삭제하시겠습니까?</string>
+    <string name="stream_compose_flag_message_title">메시지를 신고합니다</string>
+    <string name="stream_compose_flag_message_text">추가 조사를 위해 관리자에게 해당 메시지의 복사본을 전송하시겠습니까?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">"최대 메시지 길이(%d)를 초과했습니다"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -70,7 +70,7 @@
     <string name="stream_compose_pin_message">Pin to this Chat</string>
     <string name="stream_compose_flag_message">Flag Message</string>
 
-    <!-- Message Action Confirmations -->
+    <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Delete message</string>
     <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
     <string name="stream_compose_flag_message_title">Flag Message</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -68,6 +68,13 @@
     <string name="stream_compose_mute_user">Mute User</string>
     <string name="stream_compose_unpin_message">Unpin from this Chat</string>
     <string name="stream_compose_pin_message">Pin to this Chat</string>
+    <string name="stream_compose_flag_message">Flag Message</string>
+
+    <!-- Message Action Confirmations -->
+    <string name="stream_compose_delete_message_title">Delete message</string>
+    <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
+    <string name="stream_compose_flag_message_title">Flag Message</string>
+    <string name="stream_compose_flag_message_text">Do you want to send a copy of this message to a moderator for further investigation?</string>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>
@@ -86,8 +93,6 @@
     <string name="stream_compose_recent_files">Recent Files</string>
     <string name="stream_compose_thread_title">Thread Reply</string>
     <string name="stream_compose_thread_subtitle">with %1$s</string>
-    <string name="stream_compose_delete_message_title">Delete message</string>
-    <string name="stream_compose_delete_message_text">Are you sure you want to delete this message?</string>
     <string name="stream_compose_reply_to_message">Reply to message</string>
     <string name="stream_compose_message_deleted">Message deleted</string>
     <string name="stream_compose_only_visible_to_you">Only visible to you</string>


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2707

### 🎯 Goal

Add an option to flag messages to the message options overlay.

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/144581828-a9288fe8-7db9-4638-a2c5-036d6c080e15.mov

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
