### PR TITLE
[2679] Implement reactions info feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added support for Giphy command.
 - Added message pinning to the list of message options
 - Added pinned message UI
+- Added the `ReactionsInfo` component that shows a list of reactions for a particular message.
 
 ### ⚠️ Changed
 - Changed the way focus state works for focused messages.

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/MessagesActivity.kt
@@ -32,12 +32,15 @@ import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import io.getstream.chat.android.common.state.MessageMode
 import io.getstream.chat.android.common.state.Reply
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResultType
+import io.getstream.chat.android.compose.state.messages.SelectedMessageOptionsState
+import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsState
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.messages.attachments.AttachmentsPicker
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.composer.components.MessageInput
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
-import io.getstream.chat.android.compose.ui.messages.overlay.SelectedMessageOverlay
+import io.getstream.chat.android.compose.ui.messages.overlay.MessageOptionsOverlay
+import io.getstream.chat.android.compose.ui.messages.overlay.MessageReactionsOverlay
 import io.getstream.chat.android.compose.ui.messages.overlay.defaultMessageOptionsState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
@@ -83,7 +86,7 @@ class MessagesActivity : AppCompatActivity() {
     @Composable
     fun MyCustomUi() {
         val isShowingAttachments = attachmentsPickerViewModel.isShowingAttachments
-        val selectedMessage = listViewModel.currentMessagesState.selectedMessage
+        val selectedMessageState = listViewModel.currentMessagesState.selectedMessageState
         val user by listViewModel.user.collectAsState()
 
         Box(modifier = Modifier.fillMaxSize()) {
@@ -138,17 +141,34 @@ class MessagesActivity : AppCompatActivity() {
                 )
             }
 
-            if (selectedMessage != null) {
-                SelectedMessageOverlay(
-                    messageOptions = defaultMessageOptionsState(selectedMessage, user, listViewModel.isInThread),
-                    message = selectedMessage,
-                    currentUser = user,
-                    onMessageAction = { action ->
-                        composerViewModel.performMessageAction(action)
-                        listViewModel.performMessageAction(action)
-                    },
-                    onDismiss = { listViewModel.removeOverlay() }
-                )
+            if (selectedMessageState != null) {
+                val selectedMessage = selectedMessageState.message
+                if (selectedMessageState is SelectedMessageOptionsState) {
+                    MessageOptionsOverlay(
+                        messageOptions = defaultMessageOptionsState(
+                            selectedMessage = selectedMessage,
+                            currentUser = user,
+                            isInThread = listViewModel.isInThread
+                        ),
+                        message = selectedMessage,
+                        currentUser = user,
+                        onMessageAction = { action ->
+                            composerViewModel.performMessageAction(action)
+                            listViewModel.performMessageAction(action)
+                        },
+                        onDismiss = { listViewModel.removeOverlay() }
+                    )
+                } else if (selectedMessageState is SelectedMessageReactionsState) {
+                    MessageReactionsOverlay(
+                        message = selectedMessage,
+                        currentUser = user,
+                        onMessageAction = { action ->
+                            composerViewModel.performMessageAction(action)
+                            listViewModel.performMessageAction(action)
+                        },
+                        onDismiss = { listViewModel.removeOverlay() }
+                    )
+                }
             }
         }
     }

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -146,26 +146,26 @@ public final class io/getstream/chat/android/compose/state/imagepreview/ImagePre
 public final class io/getstream/chat/android/compose/state/messages/MessagesState {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (ZZZLjava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;I)V
-	public synthetic fun <init> (ZZZLjava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ZZZLjava/util/List;Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;I)V
+	public synthetic fun <init> (ZZZLjava/util/List;Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/util/List;
-	public final fun component5 ()Lio/getstream/chat/android/client/models/Message;
+	public final fun component5 ()Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;
 	public final fun component6 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component7 ()Lio/getstream/chat/android/compose/state/messages/NewMessageState;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()I
-	public final fun copy (ZZZLjava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;I)Lio/getstream/chat/android/compose/state/messages/MessagesState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/MessagesState;ZZZLjava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;IILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/MessagesState;
+	public final fun copy (ZZZLjava/util/List;Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;I)Lio/getstream/chat/android/compose/state/messages/MessagesState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/MessagesState;ZZZLjava/util/List;Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/compose/state/messages/NewMessageState;Ljava/lang/String;IILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/MessagesState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentUser ()Lio/getstream/chat/android/client/models/User;
 	public final fun getEndOfMessages ()Z
 	public final fun getMessageItems ()Ljava/util/List;
 	public final fun getNewMessageState ()Lio/getstream/chat/android/compose/state/messages/NewMessageState;
 	public final fun getParentMessageId ()Ljava/lang/String;
-	public final fun getSelectedMessage ()Lio/getstream/chat/android/client/models/Message;
+	public final fun getSelectedMessageState ()Lio/getstream/chat/android/compose/state/messages/SelectedMessageState;
 	public final fun getUnreadCount ()I
 	public fun hashCode ()I
 	public final fun isLoading ()Z
@@ -185,6 +185,22 @@ public abstract class io/getstream/chat/android/compose/state/messages/NewMessag
 public final class io/getstream/chat/android/compose/state/messages/Other : io/getstream/chat/android/compose/state/messages/NewMessageState {
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/compose/state/messages/Other;
+}
+
+public final class io/getstream/chat/android/compose/state/messages/SelectedMessageOptionsState : io/getstream/chat/android/compose/state/messages/SelectedMessageState {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
+}
+
+public final class io/getstream/chat/android/compose/state/messages/SelectedMessageReactionsState : io/getstream/chat/android/compose/state/messages/SelectedMessageState {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
+}
+
+public abstract class io/getstream/chat/android/compose/state/messages/SelectedMessageState {
+	public static final field $stable I
+	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getMessage ()Lio/getstream/chat/android/client/models/Message;
 }
 
 public final class io/getstream/chat/android/compose/state/messages/attachments/AttachmentPickerItemState {
@@ -748,9 +764,7 @@ public final class io/getstream/chat/android/compose/ui/messages/header/MessageL
 public final class io/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageItemKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-10 Lkotlin/jvm/functions/Function4;
-	public static field lambda-11 Lkotlin/jvm/functions/Function2;
-	public static field lambda-12 Lkotlin/jvm/functions/Function2;
+	public static field lambda-10 Lkotlin/jvm/functions/Function2;
 	public static field lambda-2 Lkotlin/jvm/functions/Function4;
 	public static field lambda-3 Lkotlin/jvm/functions/Function4;
 	public static field lambda-4 Lkotlin/jvm/functions/Function4;
@@ -758,12 +772,10 @@ public final class io/getstream/chat/android/compose/ui/messages/list/Composable
 	public static field lambda-6 Lkotlin/jvm/functions/Function4;
 	public static field lambda-7 Lkotlin/jvm/functions/Function4;
 	public static field lambda-8 Lkotlin/jvm/functions/Function4;
-	public static field lambda-9 Lkotlin/jvm/functions/Function4;
+	public static field lambda-9 Lkotlin/jvm/functions/Function2;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-10$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-11$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda-12$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-10$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 	public final fun getLambda-3$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 	public final fun getLambda-4$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
@@ -771,7 +783,7 @@ public final class io/getstream/chat/android/compose/ui/messages/list/Composable
 	public final fun getLambda-6$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 	public final fun getLambda-7$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 	public final fun getLambda-8$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-9$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
+	public final fun getLambda-9$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageListKt {
@@ -794,11 +806,11 @@ public final class io/getstream/chat/android/compose/ui/messages/list/MessageAli
 
 public final class io/getstream/chat/android/compose/ui/messages/list/MessageItemKt {
 	public static final field HIGHLIGHT_FADE_OUT_DURATION_MILLIS I
-	public static final fun DefaultMessageContainer (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
-	public static final fun DefaultMessageItem (Lio/getstream/chat/android/compose/state/messages/list/MessageListItemState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DefaultMessageContainer (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
+	public static final fun DefaultMessageItem (Lio/getstream/chat/android/compose/state/messages/list/MessageListItemState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;III)V
 	public static final fun DefaultMessageItemContent (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DefaultMessageItemFooterContent (Landroidx/compose/foundation/layout/ColumnScope;Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DefaultMessageItemHeaderContent (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/runtime/Composer;I)V
+	public static final fun DefaultMessageItemHeaderContent (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DefaultMessageItemLeadingContent (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun DefaultMessageItemTrailingContent (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageDateSeparator (Lio/getstream/chat/android/compose/state/messages/list/DateSeparatorState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
@@ -811,13 +823,13 @@ public final class io/getstream/chat/android/compose/ui/messages/list/MessageIte
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/list/MessageListKt {
-	public static final fun MessageList (Lio/getstream/chat/android/compose/state/messages/MessagesState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
-	public static final fun MessageList (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MessageList (Lio/getstream/chat/android/compose/state/messages/MessagesState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun MessageList (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 	public static final fun Messages (Lio/getstream/chat/android/compose/state/messages/MessagesState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
-public final class io/getstream/chat/android/compose/ui/messages/overlay/ComposableSingletons$SelectedMessageOverlayKt {
-	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/overlay/ComposableSingletons$SelectedMessageOverlayKt;
+public final class io/getstream/chat/android/compose/ui/messages/overlay/ComposableSingletons$MessageOverlayKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/overlay/ComposableSingletons$MessageOverlayKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
 	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
@@ -825,11 +837,20 @@ public final class io/getstream/chat/android/compose/ui/messages/overlay/Composa
 	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
-public final class io/getstream/chat/android/compose/ui/messages/overlay/SelectedMessageOverlayKt {
+public final class io/getstream/chat/android/compose/ui/messages/overlay/MessageOptionsOverlayKt {
 	public static final fun MessageOptions (Ljava/util/List;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun ReactionOptions (Ljava/util/List;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
-	public static final fun SelectedMessageOverlay (Ljava/util/Map;Ljava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageOptionsOverlay (Ljava/util/List;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static final fun defaultMessageOptionsState (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;ZLandroidx/compose/runtime/Composer;I)Ljava/util/List;
+}
+
+public final class io/getstream/chat/android/compose/ui/messages/overlay/MessageOverlayKt {
+	public static final fun MessageOverlay (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Alignment$Horizontal;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;I)V
+}
+
+public final class io/getstream/chat/android/compose/ui/messages/overlay/MessageReactionsOverlayKt {
+	public static final fun MessageReactionsOverlay (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
+	public static final fun ReactionsInfo (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V
+	public static final fun UserReactionItem (Lio/getstream/chat/android/client/models/Reaction;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/suggestions/ComposableSingletons$SuggestionListKt {
@@ -967,7 +988,7 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors$Compa
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamDimens$Companion;
-	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
 	public final fun component10-D9Ej5fM ()F
 	public final fun component11-D9Ej5fM ()F
@@ -989,15 +1010,18 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun component26-D9Ej5fM ()F
 	public final fun component27-D9Ej5fM ()F
 	public final fun component28-D9Ej5fM ()F
+	public final fun component29-D9Ej5fM ()F
 	public final fun component3-D9Ej5fM ()F
+	public final fun component30-D9Ej5fM ()F
+	public final fun component31-D9Ej5fM ()F
 	public final fun component4-D9Ej5fM ()F
 	public final fun component5-D9Ej5fM ()F
 	public final fun component6-D9Ej5fM ()F
 	public final fun component7-D9Ej5fM ()F
 	public final fun component8-D9Ej5fM ()F
 	public final fun component9-D9Ej5fM ()F
-	public final fun copy-b3hfcmU (FFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
-	public static synthetic fun copy-b3hfcmU$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public final fun copy-04wMkAg (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public static synthetic fun copy-04wMkAg$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachmentsContentFileUploadWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentFileWidth-D9Ej5fM ()F
@@ -1022,6 +1046,9 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun getMessageOptionsMaxWidth-D9Ej5fM ()F
 	public final fun getMessageOptionsRoundedCorners-D9Ej5fM ()F
 	public final fun getMessageOverlayActionItemHeight-D9Ej5fM ()F
+	public final fun getMessageReactionItemWidth-D9Ej5fM ()F
+	public final fun getMessageReactionsMaxHeight-D9Ej5fM ()F
+	public final fun getMessageReactionsRoundedCorners-D9Ej5fM ()F
 	public final fun getSuggestionListElevation-D9Ej5fM ()F
 	public final fun getSuggestionListMaxHeight-D9Ej5fM ()F
 	public final fun getSuggestionListPadding-D9Ej5fM ()F
@@ -1288,6 +1315,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public final fun performMessageAction (Lio/getstream/chat/android/common/state/MessageAction;)V
 	public final fun removeOverlay ()V
 	public final fun selectMessage (Lio/getstream/chat/android/client/models/Message;)V
+	public final fun selectReactions (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun updateLastSeenMessage (Lio/getstream/chat/android/client/models/Message;)V
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/MessagesState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/MessagesState.kt
@@ -1,6 +1,5 @@
 package io.getstream.chat.android.compose.state.messages
 
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.compose.state.messages.list.MessageListItemState
 
@@ -11,7 +10,7 @@ import io.getstream.chat.android.compose.state.messages.list.MessageListItemStat
  * @param isLoadingMore If we're loading more data (pagination).
  * @param endOfMessages If we're at the end of messages (to stop pagination).
  * @param messageItems Message items to represent in the list.
- * @param selectedMessage Currently selected message, to show the overlay.
+ * @param selectedMessageState Currently selected message, to show the overlay.
  * @param currentUser The data of the current user, required for various UI states.
  * @param newMessageState The state that represents any new messages.
  * @param parentMessageId The id of the parent message - if we're in a thread.
@@ -22,7 +21,7 @@ public data class MessagesState(
     val isLoadingMore: Boolean = false,
     val endOfMessages: Boolean = false,
     val messageItems: List<MessageListItemState> = emptyList(),
-    val selectedMessage: Message? = null,
+    val selectedMessageState: SelectedMessageState? = null,
     val currentUser: User? = null,
     val newMessageState: NewMessageState? = null,
     val parentMessageId: String? = null,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/MessagesState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/MessagesState.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.compose.state.messages.list.MessageListItemStat
  * @param isLoadingMore If we're loading more data (pagination).
  * @param endOfMessages If we're at the end of messages (to stop pagination).
  * @param messageItems Message items to represent in the list.
- * @param selectedMessageState Currently selected message, to show the overlay.
+ * @param selectedMessageState The state that represents currently selected message, to show the overlay.
  * @param currentUser The data of the current user, required for various UI states.
  * @param newMessageState The state that represents any new messages.
  * @param parentMessageId The id of the parent message - if we're in a thread.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/SelectedMessageState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/SelectedMessageState.kt
@@ -3,18 +3,18 @@ package io.getstream.chat.android.compose.state.messages
 import io.getstream.chat.android.client.models.Message
 
 /**
- * Represents a state when a message component was selected.
+ * Represents a state when a message or its reactions were clicked.
  *
  * @param message The selected message.
  */
 public sealed class SelectedMessageState(public val message: Message)
 
 /**
- * Represents a state when a user clicked on a message item in the message list.
+ * Represents a state when a message was clicked.
  */
 public class SelectedMessageOptionsState(message: Message) : SelectedMessageState(message)
 
 /**
- * Represents a state when a user clicked on message reactions in the message list.
+ * Represents a state when message reactions were clicked.
  */
 public class SelectedMessageReactionsState(message: Message) : SelectedMessageState(message)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/SelectedMessageState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/SelectedMessageState.kt
@@ -1,0 +1,20 @@
+package io.getstream.chat.android.compose.state.messages
+
+import io.getstream.chat.android.client.models.Message
+
+/**
+ * Represents a state when a message component was selected.
+ *
+ * @param message The selected message.
+ */
+public sealed class SelectedMessageState(public val message: Message)
+
+/**
+ * Represents a state when a user clicked on a message item in the message list.
+ */
+public class SelectedMessageOptionsState(message: Message) : SelectedMessageState(message)
+
+/**
+ * Represents a state when a user clicked on message reactions in the message list.
+ */
+public class SelectedMessageReactionsState(message: Message) : SelectedMessageState(message)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -34,12 +34,15 @@ import io.getstream.chat.android.common.state.Reply
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.handlers.SystemBackPressedHandler
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResultType
+import io.getstream.chat.android.compose.state.messages.SelectedMessageOptionsState
+import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsState
 import io.getstream.chat.android.compose.ui.common.SimpleDialog
 import io.getstream.chat.android.compose.ui.messages.attachments.AttachmentsPicker
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.header.MessageListHeader
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
-import io.getstream.chat.android.compose.ui.messages.overlay.SelectedMessageOverlay
+import io.getstream.chat.android.compose.ui.messages.overlay.MessageOptionsOverlay
+import io.getstream.chat.android.compose.ui.messages.overlay.MessageReactionsOverlay
 import io.getstream.chat.android.compose.ui.messages.overlay.defaultMessageOptionsState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
@@ -82,7 +85,7 @@ public fun MessagesScreen(
     val currentState = listViewModel.currentMessagesState
     val messageActions = listViewModel.messageActions
 
-    val selectedMessage = currentState.selectedMessage
+    val selectedMessageState = currentState.selectedMessageState
     val messageMode = listViewModel.messageMode
     val isShowingAttachments = attachmentsPickerViewModel.isShowingAttachments
 
@@ -169,17 +172,34 @@ public fun MessagesScreen(
             )
         }
 
-        if (selectedMessage != null) {
-            SelectedMessageOverlay(
-                messageOptions = defaultMessageOptionsState(selectedMessage, user, listViewModel.isInThread),
-                message = selectedMessage,
-                currentUser = user,
-                onMessageAction = { action ->
-                    composerViewModel.performMessageAction(action)
-                    listViewModel.performMessageAction(action)
-                },
-                onDismiss = { listViewModel.removeOverlay() }
-            )
+        if (selectedMessageState != null) {
+            val selectedMessage = selectedMessageState.message
+            if (selectedMessageState is SelectedMessageOptionsState) {
+                MessageOptionsOverlay(
+                    messageOptions = defaultMessageOptionsState(
+                        selectedMessage = selectedMessage,
+                        currentUser = user,
+                        isInThread = listViewModel.isInThread
+                    ),
+                    message = selectedMessage,
+                    currentUser = user,
+                    onMessageAction = { action ->
+                        composerViewModel.performMessageAction(action)
+                        listViewModel.performMessageAction(action)
+                    },
+                    onDismiss = { listViewModel.removeOverlay() }
+                )
+            } else if (selectedMessageState is SelectedMessageReactionsState) {
+                MessageReactionsOverlay(
+                    message = selectedMessage,
+                    currentUser = user,
+                    onMessageAction = { action ->
+                        composerViewModel.performMessageAction(action)
+                        listViewModel.performMessageAction(action)
+                    },
+                    onDismiss = { listViewModel.removeOverlay() }
+                )
+            }
         }
 
         AnimatedVisibility(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -106,6 +106,7 @@ public const val HIGHLIGHT_FADE_OUT_DURATION_MILLIS: Int = 1000
  * @param modifier Modifier for styling.
  * @param onLongItemClick Handler when the user long taps on an item.
  * @param onThreadClick Handler when the user taps on a thread in a message item.
+ * @param onReactionsClick Handler when the user taps on message reactions.
  * @param onGiphyActionClick Handler when the user taps on an action button in a giphy message item.
  * @param onImagePreviewResult Handler when the user receives a result from previewing message attachments.
  * @param systemMessageContent Customizable composable function that represents the system message item.
@@ -127,6 +128,7 @@ public fun DefaultMessageItem(
     modifier: Modifier = Modifier,
     onLongItemClick: (Message) -> Unit = {},
     onThreadClick: (Message) -> Unit = {},
+    onReactionsClick: (Message) -> Unit = {},
     onGiphyActionClick: (GiphyAction) -> Unit = {},
     onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
     systemMessageContent: @Composable (SystemMessageState) -> Unit = {
@@ -147,7 +149,10 @@ public fun DefaultMessageItem(
         )
     },
     headerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
-        DefaultMessageItemHeaderContent(messageItem = it)
+        DefaultMessageItemHeaderContent(
+            messageItem = it,
+            onReactionsClick = onReactionsClick
+        )
     },
     footerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
         DefaultMessageItemFooterContent(
@@ -187,6 +192,7 @@ public fun DefaultMessageItem(
             messageItem = messageListItem,
             onLongItemClick = onLongItemClick,
             onThreadClick = onThreadClick,
+            onReactionsClick = onReactionsClick,
             onImagePreviewResult = onImagePreviewResult,
             leadingContent = leadingContent,
             headerContent = headerContent,
@@ -303,6 +309,7 @@ public fun MessageThreadSeparator(
  * @param onLongItemClick Handler when the user selects a message, on long tap.
  * @param modifier Modifier for styling.
  * @param onThreadClick Handler for thread clicks, if this message has a thread going.
+ * @param onReactionsClick Handler when the user taps on message reactions.
  * @param onGiphyActionClick Handler when the user taps on an action button in a giphy message item.
  * @param onImagePreviewResult Handler when the user selects an option in the Image Preview screen.
  * @param leadingContent The content shown at the start of a message list item. By default, we provide
@@ -324,6 +331,7 @@ public fun DefaultMessageContainer(
     onLongItemClick: (Message) -> Unit,
     modifier: Modifier = Modifier,
     onThreadClick: (Message) -> Unit = {},
+    onReactionsClick: (Message) -> Unit,
     onGiphyActionClick: (GiphyAction) -> Unit = {},
     onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
     leadingContent: @Composable RowScope.(MessageItemState) -> Unit = {
@@ -336,7 +344,10 @@ public fun DefaultMessageContainer(
         )
     },
     headerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
-        DefaultMessageItemHeaderContent(messageItem = it)
+        DefaultMessageItemHeaderContent(
+            messageItem = it,
+            onReactionsClick = onReactionsClick
+        )
     },
     footerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
         DefaultMessageItemFooterContent(
@@ -452,9 +463,13 @@ public fun DefaultMessageItemLeadingContent(
  * By default, we show if the message is pinned and a list of reactions for the message.
  *
  * @param messageItem The message item to show the content for.
+ * @param onReactionsClick Handler when the user taps on message reactions.
  */
 @Composable
-public fun DefaultMessageItemHeaderContent(messageItem: MessageItemState) {
+public fun DefaultMessageItemHeaderContent(
+    messageItem: MessageItemState,
+    onReactionsClick: (Message) -> Unit = {},
+) {
     val message = messageItem.message
     val currentUser = messageItem.currentUser
 
@@ -503,7 +518,9 @@ public fun DefaultMessageItemHeaderContent(messageItem: MessageItemState) {
             }
             ?.let { options ->
                 MessageReactions(
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 2.dp),
+                    modifier = Modifier
+                        .clickable(onClick = { onReactionsClick(message) })
+                        .padding(horizontal = 4.dp, vertical = 2.dp),
                     options = options
                 )
             }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
@@ -59,6 +59,7 @@ import kotlin.math.abs
  * @param modifier Modifier for styling.
  * @param onThreadClick Handler when the user taps on the message, while there's a thread going.
  * @param onLongItemClick Handler for when the user long taps on a message and selects it.
+ * @param onReactionsClick Handler when the user taps on message reactions.
  * @param onMessagesStartReached Handler for pagination.
  * @param onLastVisibleMessageChanged Handler that notifies us when the user scrolls and the last visible message changes.
  * @param onScrollToBottom Handler when the user reaches the bottom.
@@ -75,6 +76,7 @@ public fun MessageList(
     modifier: Modifier = Modifier,
     onThreadClick: (Message) -> Unit = { viewModel.openMessageThread(it) },
     onLongItemClick: (Message) -> Unit = { viewModel.selectMessage(it) },
+    onReactionsClick: (Message) -> Unit = { viewModel.selectReactions(it) },
     onMessagesStartReached: () -> Unit = { viewModel.loadMore() },
     onLastVisibleMessageChanged: (Message) -> Unit = { viewModel.updateLastSeenMessage(it) },
     onScrollToBottom: () -> Unit = { viewModel.clearNewMessageState() },
@@ -91,6 +93,7 @@ public fun MessageList(
             messageListItem = it,
             onLongItemClick = onLongItemClick,
             onThreadClick = onThreadClick,
+            onReactionsClick = onReactionsClick,
             onGiphyActionClick = onGiphyActionClick,
             onImagePreviewResult = onImagePreviewResult
         )
@@ -102,6 +105,7 @@ public fun MessageList(
         onMessagesStartReached = onMessagesStartReached,
         onLastVisibleMessageChanged = onLastVisibleMessageChanged,
         onLongItemClick = onLongItemClick,
+        onReactionsClick = onReactionsClick,
         onScrolledToBottom = onScrollToBottom,
         onImagePreviewResult = onImagePreviewResult,
         itemContent = itemContent,
@@ -121,6 +125,7 @@ public fun MessageList(
  * @param onScrolledToBottom Handler when the user scrolls to the bottom.
  * @param onThreadClick Handler for when the user taps on a message with an active thread.
  * @param onLongItemClick Handler for when the user long taps on an item.
+ * @param onReactionsClick Handler when the user taps on message reactions.
  * @param onImagePreviewResult Handler when the user selects an option in the Image Preview screen.
  * @param loadingContent Composable that represents the loading content, when we're loading the initial data.
  * @param emptyContent Composable that represents the empty content if there are no messages.
@@ -136,6 +141,7 @@ public fun MessageList(
     onScrolledToBottom: () -> Unit = {},
     onThreadClick: (Message) -> Unit = {},
     onLongItemClick: (Message) -> Unit = {},
+    onReactionsClick: (Message) -> Unit = {},
     onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
     onGiphyActionClick: (GiphyAction) -> Unit = {},
     loadingContent: @Composable () -> Unit = { LoadingView(modifier) },
@@ -145,6 +151,7 @@ public fun MessageList(
             messageListItem = it,
             onLongItemClick = onLongItemClick,
             onThreadClick = onThreadClick,
+            onReactionsClick = onReactionsClick,
             onGiphyActionClick = onGiphyActionClick,
             onImagePreviewResult = onImagePreviewResult
         )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageOptionsOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageOptionsOverlay.kt
@@ -155,7 +155,7 @@ public fun MessageOptions(
  * @param onMessageOptionClick Handler when the user selects the option.
  */
 @Composable
-internal fun MessageOptionItem(
+private fun MessageOptionItem(
     option: MessageOptionState,
     onMessageOptionClick: (MessageOptionState) -> Unit,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageOverlay.kt
@@ -1,0 +1,280 @@
+package io.getstream.chat.android.compose.ui.messages.overlay
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
+import androidx.compose.material.ripple.rememberRipple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import coil.compose.rememberImagePainter
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Reaction
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.common.state.MessageAction
+import io.getstream.chat.android.common.state.React
+import io.getstream.chat.android.compose.state.messages.reaction.ReactionOptionItemState
+import io.getstream.chat.android.compose.ui.attachments.content.MessageAttachmentsContent
+import io.getstream.chat.android.compose.ui.common.MessageBubble
+import io.getstream.chat.android.compose.ui.common.avatar.Avatar
+import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageContent
+import io.getstream.chat.android.compose.ui.messages.list.DeletedMessageContent
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatTheme.reactionTypes
+
+/**
+ * The overlays that's shown for a message on the message list screen.
+ *
+ * @param message The message we are showing the overlay for.
+ * @param horizontalAlignment The horizontal alignment of the composable slots.
+ * @param onDismiss Handler when the user dismisses the UI.
+ * @param headerContent The content shown at the top of a message overlay.
+ * @param centerContent The content shown at the center of a message overlay.
+ * @param footerContent The content shown at the bottom of a message overlay.
+ */
+@Composable
+public fun MessageOverlay(
+    message: Message,
+    horizontalAlignment: Alignment.Horizontal,
+    onDismiss: () -> Unit,
+    headerContent: @Composable ColumnScope.(Message) -> Unit,
+    centerContent: @Composable ColumnScope.(Message) -> Unit,
+    footerContent: @Composable ColumnScope.(Message) -> Unit,
+) {
+    val boxScrollState = rememberScrollState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(ChatTheme.colors.overlay)
+            .verticalScroll(boxScrollState)
+            .clickable(
+                onClick = onDismiss,
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() }
+            ),
+        contentAlignment = Alignment.CenterStart
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = horizontalAlignment
+        ) {
+            headerContent(message)
+
+            centerContent(message)
+
+            footerContent(message)
+        }
+    }
+}
+
+/**
+ * Represents the default header content of the message overlay.
+ *
+ * @param message The message we are showing the overlay for.
+ * @param onMessageAction Handler for reaction actions.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+internal fun DefaultMessageOverlayHeaderContent(
+    message: Message,
+    onMessageAction: (MessageAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val ownReactions = message.ownReactions
+
+    val reactionOptions = reactionTypes.entries
+        .map { (type, drawable) ->
+            ReactionOptionItemState(
+                painter = painterResource(drawable),
+                isSelected = ownReactions.any { it.type == type },
+                type = type
+            )
+        }
+
+    ReactionOptions(
+        modifier = modifier,
+        options = reactionOptions,
+        onReactionClick = {
+            onMessageAction(
+                React(
+                    Reaction(
+                        messageId = message.id,
+                        type = it.type,
+                    ),
+                    message
+                )
+            )
+        }
+    )
+
+    Spacer(modifier = Modifier.size(8.dp))
+}
+
+/**
+ * Represent the default center content of the message overlay.
+ *
+ * @param message The message we are showing the overlay for.
+ * @param currentUser The currently logged in user.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+internal fun DefaultMessageOverlayCenterContent(
+    message: Message,
+    currentUser: User?,
+    modifier: Modifier = Modifier,
+) {
+    val isMine = message.user.id == currentUser?.id
+
+    SelectedMessage(
+        modifier = modifier,
+        message = message,
+        isMine = isMine
+    )
+}
+
+/**
+ * A row of selectable reactions on a message. Users can provide their own, or use the default.
+ *
+ * @param options The options to show.
+ * @param onReactionClick Handler when the user clicks on any reaction.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+private fun ReactionOptions(
+    options: List<ReactionOptionItemState>,
+    onReactionClick: (ReactionOptionItemState) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Surface(
+        shape = RoundedCornerShape(16.dp),
+        color = ChatTheme.colors.barsBackground,
+    ) {
+        LazyRow(
+            modifier = modifier
+                .wrapContentWidth()
+                .padding(vertical = 4.dp),
+            horizontalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            item { Spacer(modifier = Modifier.width(2.dp)) }
+            items(options) { option ->
+                ReactionOptionItem(option = option, onReactionClick = onReactionClick)
+            }
+
+            item { Spacer(modifier = Modifier.width(2.dp)) }
+        }
+    }
+}
+
+/**
+ * Each reaction item in the row of reactions.
+ *
+ * @param option The reaction to show.
+ * @param onReactionClick Handler when the user clicks on the reaction.
+ */
+@Composable
+private fun ReactionOptionItem(
+    option: ReactionOptionItemState,
+    onReactionClick: (ReactionOptionItemState) -> Unit,
+) {
+    Icon(
+        modifier = Modifier
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = rememberRipple(bounded = false),
+                onClick = { onReactionClick(option) }
+            )
+            .padding(2.dp),
+        painter = option.painter,
+        contentDescription = option.type,
+        tint = if (option.isSelected) ChatTheme.colors.primaryAccent else ChatTheme.colors.textLowEmphasis
+    )
+}
+
+/**
+ * The UI for a basic text message that's selected. It doesn't have all the components as a message
+ * in the list, as those are not as important.
+ *
+ * @param message The message to show.
+ * @param isMine If the message is owned by the current user.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+private fun SelectedMessage(
+    message: Message,
+    isMine: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier.widthIn(max = 300.dp)
+    ) {
+        val authorImage = rememberImagePainter(data = message.user.image)
+
+        if (!isMine) {
+            Avatar(
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp)
+                    .size(24.dp)
+                    .align(Alignment.Bottom),
+                painter = authorImage
+            )
+        }
+
+        val messageBubbleShape = if (isMine) ChatTheme.shapes.myMessageBubble else ChatTheme.shapes.otherMessageBubble
+        val messageBubbleColor =
+            if (isMine) ChatTheme.colors.ownMessagesBackground else ChatTheme.colors.otherMessagesBackground
+
+        MessageBubble(
+            shape = messageBubbleShape,
+            color = messageBubbleColor,
+            content = {
+                if (message.deletedAt != null) {
+                    DeletedMessageContent()
+                } else {
+                    Column {
+                        MessageAttachmentsContent(message = message, onLongItemClick = {})
+
+                        if (message.text.isNotEmpty()) {
+                            DefaultMessageContent(message = message)
+                        }
+                    }
+                }
+            }
+        )
+
+        if (isMine) {
+            Avatar(
+                modifier = Modifier
+                    .padding(start = 8.dp, end = 8.dp)
+                    .size(24.dp)
+                    .align(Alignment.Bottom),
+                painter = authorImage
+            )
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageReactionsOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageReactionsOverlay.kt
@@ -118,7 +118,7 @@ public fun ReactionsInfo(
     val reactions = message.latestReactions
     val reactionCount = reactions.size
 
-    val title = LocalContext.current.resources.getQuantityString(
+    val reactionCountText = LocalContext.current.resources.getQuantityString(
         R.plurals.stream_compose_message_reactions,
         reactionCount,
         reactionCount
@@ -136,7 +136,7 @@ public fun ReactionsInfo(
             modifier = Modifier.padding(vertical = 16.dp)
         ) {
             Text(
-                text = title,
+                text = reactionCountText,
                 style = ChatTheme.typography.title3Bold,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageReactionsOverlay.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/overlay/MessageReactionsOverlay.kt
@@ -1,0 +1,222 @@
+package io.getstream.chat.android.compose.ui.messages.overlay
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.Icon
+import androidx.compose.material.Surface
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Reaction
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.common.state.MessageAction
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.common.avatar.UserAvatar
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+
+/**
+ * The message reactions overlays that's shown when the user taps on message reactions.
+ *
+ * It shows the list of users reacted to this message, as well as reactions, that the user can take.
+ * It also shows the currently selected message in the middle of these options.
+ *
+ * @param message Selected message.
+ * @param currentUser The currently logged in user.
+ * @param onMessageAction Handler for any of the available message actions (options + reactions).
+ * @param onDismiss Handler when the user dismisses the UI.
+ */
+@Composable
+public fun MessageReactionsOverlay(
+    message: Message,
+    currentUser: User?,
+    onMessageAction: (MessageAction) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val isMine = message.user.id == currentUser?.id
+
+    MessageOverlay(
+        message = message,
+        horizontalAlignment = if (isMine) Alignment.End else Alignment.Start,
+        onDismiss = onDismiss,
+        headerContent = {
+            DefaultMessageOverlayHeaderContent(
+                message = message,
+                onMessageAction = onMessageAction
+            )
+        },
+        centerContent = {
+            DefaultMessageOverlayCenterContent(
+                message = message,
+                currentUser = currentUser
+            )
+        },
+        footerContent = {
+            DefaultMessageReactionsOverlayFooterContent(
+                message = message,
+                currentUser = currentUser
+            )
+        }
+    )
+}
+
+/**
+ * Represent the default footer content of the message reactions overlay.
+ *
+ * @param message The message that contains the reactions.
+ * @param currentUser The currently logged in user.
+ */
+@Composable
+private fun DefaultMessageReactionsOverlayFooterContent(
+    message: Message,
+    currentUser: User?,
+) {
+    Spacer(modifier = Modifier.size(8.dp))
+
+    ReactionsInfo(
+        message = message,
+        currentUser = currentUser
+    )
+}
+
+/**
+ *
+ * Represent a section with a list of reactions left for the message.
+ *
+ * @param message The message that contains the reactions.
+ * @param currentUser The currently logged in user.
+ * @param modifier Modifier for styling.
+ * @param maxColumns The maximum number of columns in the user reactions grid.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+public fun ReactionsInfo(
+    message: Message,
+    currentUser: User?,
+    modifier: Modifier = Modifier,
+    maxColumns: Int = 4,
+) {
+    val reactions = message.latestReactions
+    val reactionCount = reactions.size
+
+    val title = LocalContext.current.resources.getQuantityString(
+        R.plurals.stream_compose_message_reactions,
+        reactionCount,
+        reactionCount
+    )
+
+    Surface(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(max = ChatTheme.dimens.messageReactionsMaxHeight),
+        shape = RoundedCornerShape(ChatTheme.dimens.messageReactionsRoundedCorners),
+        color = ChatTheme.colors.barsBackground,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier.padding(vertical = 16.dp)
+        ) {
+            Text(
+                text = title,
+                style = ChatTheme.typography.title3Bold,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                color = ChatTheme.colors.textHighEmphasis
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            val columns = reactionCount.coerceAtMost(maxColumns)
+            val reactionItemWidth = ChatTheme.dimens.messageReactionItemWidth
+            val reactionGridWidth = reactionItemWidth * columns
+
+            LazyVerticalGrid(
+                modifier = Modifier.width(reactionGridWidth),
+                cells = GridCells.Fixed(reactionCount.coerceAtMost(columns))
+            ) {
+                items(reactions) { reaction ->
+                    UserReactionItem(
+                        modifier = Modifier
+                            .width(reactionItemWidth)
+                            .padding(8.dp),
+                        reaction = reaction,
+                        currentUser = currentUser
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Represent a reaction with the user who left it.
+ *
+ * @param reaction The user reaction to display.
+ * @param currentUser The currently logged in user.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+public fun UserReactionItem(
+    reaction: Reaction,
+    currentUser: User?,
+    modifier: Modifier = Modifier,
+) {
+    val user = reaction.user!!
+
+    val isCurrentUser = currentUser?.id == user.id
+
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+
+        Box(modifier = Modifier.width(64.dp)) {
+            UserAvatar(
+                user = user,
+                showOnlineIndicator = false,
+                modifier = Modifier.size(64.dp)
+            )
+
+            Icon(
+                modifier = Modifier
+                    .background(shape = RoundedCornerShape(16.dp), color = ChatTheme.colors.barsBackground)
+                    .size(24.dp)
+                    .padding(4.dp)
+                    .align(Alignment.BottomEnd),
+                painter = painterResource(requireNotNull(ChatTheme.reactionTypes[reaction.type])),
+                contentDescription = reaction.type,
+                tint = if (isCurrentUser) ChatTheme.colors.primaryAccent else ChatTheme.colors.textLowEmphasis,
+            )
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = user.name,
+            style = ChatTheme.typography.footnoteBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            color = ChatTheme.colors.textHighEmphasis,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
@@ -35,6 +35,9 @@ import androidx.compose.ui.unit.dp
  * @param messageOptionsMaxHeight The max height of the message options section when we select a message in the list.
  * @param messageOptionsMaxWidth The max width of the message options section when we select a message in the list.
  * @param messageOptionsRoundedCorners The rounded corners size of the message options shape.
+ * @param messageReactionsRoundedCorners The rounded corners size of the message reactions shape.
+ * @param messageReactionsMaxHeight The max height of the message reactions section when we click on message reactions.
+ * @param messageReactionItemWidth The width of the user reaction item on the message reaction overlay.
  */
 @Immutable
 public data class StreamDimens(
@@ -66,6 +69,9 @@ public data class StreamDimens(
     public val messageOptionsMaxWidth: Dp,
     public val messageOptionsMaxHeight: Dp,
     public val messageOptionsRoundedCorners: Dp,
+    public val messageReactionsRoundedCorners: Dp,
+    public val messageReactionsMaxHeight: Dp,
+    public val messageReactionItemWidth: Dp,
 ) {
     public companion object {
         public fun defaultDimens(): StreamDimens = StreamDimens(
@@ -96,7 +102,10 @@ public data class StreamDimens(
             commandSuggestionItemIconSize = 24.dp,
             messageOptionsMaxWidth = 200.dp,
             messageOptionsMaxHeight = 300.dp,
-            messageOptionsRoundedCorners = 16.dp
+            messageOptionsRoundedCorners = 16.dp,
+            messageReactionsRoundedCorners = 16.dp,
+            messageReactionsMaxHeight = 300.dp,
+            messageReactionItemWidth = 80.dp,
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -27,6 +27,8 @@ import io.getstream.chat.android.compose.state.messages.MessagesState
 import io.getstream.chat.android.compose.state.messages.MyOwn
 import io.getstream.chat.android.compose.state.messages.NewMessageState
 import io.getstream.chat.android.compose.state.messages.Other
+import io.getstream.chat.android.compose.state.messages.SelectedMessageOptionsState
+import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsState
 import io.getstream.chat.android.compose.state.messages.list.CancelGiphy
 import io.getstream.chat.android.compose.state.messages.list.DateSeparatorState
 import io.getstream.chat.android.compose.state.messages.list.GiphyAction
@@ -129,7 +131,7 @@ public class MessageListViewModel(
      * Gives us information if we're showing the selected message overlay.
      */
     public val isShowingOverlay: Boolean
-        get() = messagesState.selectedMessage != null || threadMessagesState.selectedMessage != null
+        get() = messagesState.selectedMessageState != null || threadMessagesState.selectedMessageState != null
 
     /**
      * Gives us information about the online state of the device.
@@ -425,10 +427,26 @@ public class MessageListViewModel(
      * @param message The selected message.
      */
     public fun selectMessage(message: Message?) {
+        val selectedMessageState = message?.let(::SelectedMessageOptionsState)
         if (isInThread) {
-            threadMessagesState = threadMessagesState.copy(selectedMessage = message)
+            threadMessagesState = threadMessagesState.copy(selectedMessageState = selectedMessageState)
         } else {
-            messagesState = messagesState.copy(selectedMessage = message)
+            messagesState = messagesState.copy(selectedMessageState = selectedMessageState)
+        }
+    }
+
+    /**
+     * Triggered when the user taps on message reactions. This updates the internal state
+     * and allows our UI to re-render it and show an overlay.
+     *
+     * @param message The message that contains the reactions.
+     */
+    public fun selectReactions(message: Message?) {
+        val selectedMessageState = message?.let(::SelectedMessageReactionsState)
+        if (isInThread) {
+            threadMessagesState = threadMessagesState.copy(selectedMessageState = selectedMessageState)
+        } else {
+            messagesState = messagesState.copy(selectedMessageState = selectedMessageState)
         }
     }
 
@@ -673,7 +691,7 @@ public class MessageListViewModel(
      */
     public fun leaveThread() {
         messageMode = MessageMode.Normal
-        messagesState = messagesState.copy(selectedMessage = null)
+        messagesState = messagesState.copy(selectedMessageState = null)
         threadMessagesState = MessagesState()
         lastSeenThreadMessage = null
         threadJob?.cancel()
@@ -683,8 +701,8 @@ public class MessageListViewModel(
      * Resets the [MessagesState]s, to remove the message overlay, by setting 'selectedMessage' to null.
      */
     public fun removeOverlay() {
-        threadMessagesState = threadMessagesState.copy(selectedMessage = null)
-        messagesState = messagesState.copy(selectedMessage = null)
+        threadMessagesState = threadMessagesState.copy(selectedMessageState = null)
+        messagesState = messagesState.copy(selectedMessageState = null)
     }
 
     /**

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -66,6 +66,10 @@
     <string name="stream_compose_edit_message">Edit Message</string>
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d Message Reaction</item>
+        <item quantity="other">%d Message Reactions</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -66,6 +66,10 @@
     <string name="stream_compose_edit_message">Editar Mensaje</string>
     <string name="stream_compose_delete_message">Eliminar mensaje</string>
     <string name="stream_compose_mute_user">Silenciar usuario</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d Reación de mensaje</item>
+        <item quantity="other">%d Reaciones de mensaje</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Tamaño máximo de mensaje (%1$d) excedido.</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -66,6 +66,11 @@
     <string name="stream_compose_edit_message">Modifier le message</string>
     <string name="stream_compose_delete_message">Supprimer le message</string>
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d Réaction aux messages</item>
+        <item quantity="other">%d Réactions aux messages</item>
+    </plurals>
+
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Longueur maximale du message (%1$d) dépassée.</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -66,6 +66,10 @@
     <string name="stream_compose_edit_message">मैसेज एडिट करें</string>
     <string name="stream_compose_delete_message">मैसेज मिटायें</string>
     <string name="stream_compose_mute_user">यूजर को म्यूट करें</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d प्रतिक्रिया</item>
+        <item quantity="other">%d प्रतिक्रियायें</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">मैसेज की वर्ण सीमा (%1$d) पार हो गई है।</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -66,6 +66,10 @@
     <string name="stream_compose_edit_message">Modifica messaggio</string>
     <string name="stream_compose_delete_message">Cancella messaggio</string>
     <string name="stream_compose_mute_user">Silenzia Utente</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d Reazione al messaggio</item>
+        <item quantity="other">%d Reazioni al messaggio</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">La lunghezza massima del messaggio (%1$d) è stata superata.</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -63,6 +63,9 @@
     <string name="stream_compose_edit_message">メッセージを編集する</string>
     <string name="stream_compose_delete_message">メッセージを削除する</string>
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="other">%dメッセージのリアクション</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">"最大メッセージ長（%1$d)字を超えました"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -63,6 +63,9 @@
     <string name="stream_compose_edit_message">메세지 수정</string>
     <string name="stream_compose_delete_message">메시지 삭제</string>
     <string name="stream_compose_mute_user">사용자 무시</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="other">%d개의 공감</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">"최대 메시지 길이(%d)를 초과했습니다"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -68,6 +68,10 @@
     <string name="stream_compose_mute_user">Mute User</string>
     <string name="stream_compose_unpin_message">Unpin from this Chat</string>
     <string name="stream_compose_pin_message">Pin to this Chat</string>
+    <plurals name="stream_compose_message_reactions">
+        <item quantity="one">%d Message Reaction</item>
+        <item quantity="other">%d Message Reactions</item>
+    </plurals>
 
     <!-- Message Composer -->
     <string name="stream_compose_message_composer_error_message_length">Max message length (%1$d) exceeded.</string>


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2679

### 🎯 Goal

Add the `ReactionsInfo` component that shows a list of reactions for a particular message.

### 🛠 Implementation details

Ended up with a single `SelectedMessageState` and 3 overlays:
- MessageOverlay - an abstract message overlay with 3 slots
  - MessageOptionsOverlay - the message options overlay with action list footer
  - MessageReactionsOverlay  - the message reaction overlay with reaction list footer

### 🎨 UI Changes

#### 1 reaction

<img src="https://user-images.githubusercontent.com/9600921/144900399-15978cfa-b683-4fef-bde8-f50cf13db3f9.jpeg" width="40%">

#### 2 reactions

<img src="https://user-images.githubusercontent.com/9600921/144900394-c10b5ada-c34d-4a22-a695-13514de98012.jpeg" width="40%">

#### 5 reactions

<img src="https://user-images.githubusercontent.com/9600921/144900402-80b5cb84-1be4-491d-b570-45c6701e3dea.jpeg" width="40%">

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added
