### PR TITLE
[CAS-1479] Fix/propagate user updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fix the issue when users' data can be outdated until restart SDK.
 
 ### ⬆️ Improved
 

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -79,6 +79,7 @@ object Versions {
     internal const val THREETENBP = "1.5.1"
     internal const val THREETENABP = "1.3.1"
     internal const val TIMBER = "5.0.0"
+    internal const val TURBINE = "0.7.0"
     internal const val WORK = "2.7.0"
 }
 
@@ -203,6 +204,7 @@ object Dependencies {
     const val threeTenBp = "org.threeten:threetenbp:${Versions.THREETENBP}"
     const val threeTenAbp = "com.jakewharton.threetenabp:threetenabp:${Versions.THREETENABP}"
     const val timber = "com.jakewharton.timber:timber:${Versions.TIMBER}"
+    const val turbine = "app.cash.turbine:turbine:${Versions.TURBINE}"
     const val workRuntimeKtx = "androidx.work:work-runtime-ktx:${Versions.WORK}"
     const val workTesting = "androidx.work:work-testing:${Versions.WORK}"
 

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -107,6 +107,7 @@ dependencies {
     testImplementation Dependencies.kluent
     testImplementation Dependencies.mockito
     testImplementation Dependencies.mockitoKotlin
+    testImplementation Dependencies.turbine
 
     // Instrumentation tests
     androidTestImplementation Dependencies.androidxTestJunit

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -149,7 +149,7 @@ internal class ChatDomainImpl internal constructor(
     override var userPresence: Boolean = false,
     internal var backgroundSyncEnabled: Boolean = false,
     internal var appContext: Context,
-    private val offlinePlugin: OfflinePlugin,
+    internal val offlinePlugin: OfflinePlugin,
     internal val uploadAttachmentsNetworkType: UploadAttachmentsNetworkType = UploadAttachmentsNetworkType.NOT_ROAMING,
     override val retryPolicy: RetryPolicy = DefaultRetryPolicy(),
 ) : ChatDomain {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -60,6 +60,7 @@ import io.getstream.chat.android.offline.querychannels.QueryChannelsController
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import io.getstream.chat.android.offline.repository.builder.RepositoryFacadeBuilder
 import io.getstream.chat.android.offline.repository.database.ChatDatabase
+import io.getstream.chat.android.offline.repository.domain.user.UserRepository
 import io.getstream.chat.android.offline.request.AnyChannelPaginationRequest
 import io.getstream.chat.android.offline.request.QueryChannelsPaginationRequest
 import io.getstream.chat.android.offline.request.toAnyChannelPaginationRequest
@@ -271,6 +272,7 @@ internal class ChatDomainImpl internal constructor(
 
     private val offlineSyncFirebaseMessagingHandler = OfflineSyncFirebaseMessagingHandler()
 
+    /** State flow of latest cached users. Usually it has size of 100 as max size of LRU cache in [UserRepository].*/
     internal var latestUsers: StateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
         private set
 
@@ -300,7 +302,7 @@ internal class ChatDomainImpl internal constructor(
             setOfflineEnabled(offlineEnabled)
         }.build()
 
-        latestUsers = repos.observeLastUsers()
+        latestUsers = repos.observeLatestUsers()
         // load channel configs from Room into memory
         initJob = scope.async {
             // fetch the configs for channels

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -271,6 +271,8 @@ internal class ChatDomainImpl internal constructor(
 
     private val offlineSyncFirebaseMessagingHandler = OfflineSyncFirebaseMessagingHandler()
 
+    private var latestUsers: StateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
+
     private fun clearState() {
         _initialized.value = false
         _connectionState.value = ConnectionState.OFFLINE
@@ -280,6 +282,7 @@ internal class ChatDomainImpl internal constructor(
         _mutedUsers.value = emptyList()
         activeChannelMapImpl.clear()
         activeQueryMapImpl.clear()
+        latestUsers = MutableStateFlow(emptyMap())
     }
 
     internal fun setUser(user: User) {
@@ -296,6 +299,7 @@ internal class ChatDomainImpl internal constructor(
             setOfflineEnabled(offlineEnabled)
         }.build()
 
+        latestUsers = repos.observeLastUsers()
         // load channel configs from Room into memory
         initJob = scope.async {
             // fetch the configs for channels

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -149,7 +149,7 @@ internal class ChatDomainImpl internal constructor(
     override var userPresence: Boolean = false,
     internal var backgroundSyncEnabled: Boolean = false,
     internal var appContext: Context,
-    internal val offlinePlugin: OfflinePlugin,
+    private val offlinePlugin: OfflinePlugin,
     internal val uploadAttachmentsNetworkType: UploadAttachmentsNetworkType = UploadAttachmentsNetworkType.NOT_ROAMING,
     override val retryPolicy: RetryPolicy = DefaultRetryPolicy(),
 ) : ChatDomain {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -271,7 +271,8 @@ internal class ChatDomainImpl internal constructor(
 
     private val offlineSyncFirebaseMessagingHandler = OfflineSyncFirebaseMessagingHandler()
 
-    private var latestUsers: StateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
+    internal var latestUsers: StateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
+        private set
 
     private fun clearState() {
         _initialized.value = false

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -103,8 +103,7 @@ import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(ExperimentalStreamChatApi::class)
 public class ChannelController internal constructor(
-    @VisibleForTesting
-    internal val mutableState: ChannelMutableState,
+    private val mutableState: ChannelMutableState,
     private val channelLogic: ChannelLogic,
     private val client: ChatClient,
     @VisibleForTesting

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -103,7 +103,8 @@ import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(ExperimentalStreamChatApi::class)
 public class ChannelController internal constructor(
-    private val mutableState: ChannelMutableState,
+    @VisibleForTesting
+    internal val mutableState: ChannelMutableState,
     private val channelLogic: ChannelLogic,
     private val client: ChatClient,
     @VisibleForTesting

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -131,7 +131,7 @@ public class ChannelController internal constructor(
     private val messageSendingService: MessageSendingService =
         messageSendingServiceFactory.create(domainImpl, this, client.channel(cid))
 
-    internal val unfilteredMessages by mutableState::unfilteredMessages
+    internal val unfilteredMessages by mutableState::messageList
     internal val hideMessagesBefore by mutableState::hideMessagesBefore
 
     public val messages: StateFlow<List<Message>> = mutableState.messages

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.extensions.incrementUnreadCount
 import io.getstream.chat.android.offline.extensions.updateLastMessage
+import io.getstream.chat.android.offline.extensions.updateUsers
 import io.getstream.chat.android.offline.extensions.users
 import io.getstream.chat.android.offline.message.shouldIncrementUnreadCount
 import io.getstream.chat.android.offline.message.users
@@ -78,8 +79,8 @@ internal class EventBatchUpdate private constructor(
 
         domainImpl.repos.storeStateForChannels(
             users = userMap.values.toList(),
-            channels = channelMap.values,
-            messages = messageMap.values.toList(),
+            channels = channelMap.values.updateUsers(userMap),
+            messages = messageMap.values.toList().updateUsers(userMap),
             cacheForMessages = true
         )
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -314,9 +314,6 @@ internal class EventHandlerImpl(
                 is NotificationChannelTruncatedEvent -> {
                     batch.addChannel(event.channel)
                 }
-                is UserPresenceChangedEvent -> {
-                    batch.addUser(event.user)
-                }
 
                 // we use syncState to store the last markAllRead date for a given
                 // user since it makes more sense to write to the database once instead of N times.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -314,6 +314,9 @@ internal class EventHandlerImpl(
                 is NotificationChannelTruncatedEvent -> {
                     batch.addChannel(event.channel)
                 }
+                is UserPresenceChangedEvent -> {
+                    batch.addUser(event.user)
+                }
 
                 // we use syncState to store the last markAllRead date for a given
                 // user since it makes more sense to write to the database once instead of N times.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -29,6 +29,7 @@ internal class ChannelMutableState(
     override val channelId: String,
     private val scope: CoroutineScope,
     private val userFlow: StateFlow<User?>,
+    private val latestUsers: StateFlow<Map<String, User>>,
 ) : ChannelState {
 
     override val cid: String = "%s:%s".format(channelType, channelId)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import java.util.Date
 
@@ -59,12 +58,10 @@ internal class ChannelMutableState(
 
     internal var hideMessagesBefore: Date? = null
 
-    var countTime = 0
-
     /** The raw message list updated by recent users value. */
-    internal val messageList: StateFlow<List<Message>> = _messages.combine(latestUsers) { messageMap, userMap ->
-        messageMap.values.updateUsers(userMap)
-    }.onEach { countTime += 1 }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+    internal val messageList: StateFlow<List<Message>> =
+        _messages.combine(latestUsers) { messageMap, userMap -> messageMap.values.updateUsers(userMap) }
+            .stateIn(scope, SharingStarted.Eagerly, emptyList())
 
     /** a list of messages sorted by message.createdAt */
     private val sortedVisibleMessages: StateFlow<List<Message>> =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/state/ThreadMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/state/ThreadMutableState.kt
@@ -26,7 +26,7 @@ internal class ThreadMutableState(
     override val oldestInThread: StateFlow<Message?> = _oldestInThread
 
     internal val threadMessages: Flow<List<Message>> =
-        channelMutableState.unfilteredMessages.map { messageList -> messageList.filter { it.id == parentId || it.parentId == parentId } }
+        channelMutableState.messageList.map { messageList -> messageList.filter { it.id == parentId || it.parentId == parentId } }
     internal val sortedVisibleMessages: StateFlow<List<Message>> = threadMessages.map { threadMessages ->
         threadMessages.sortedBy { m -> m.createdAt ?: m.createdLocallyAt }
             .filter {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
@@ -38,7 +38,13 @@ public class StateRegistry internal constructor(
 
     public fun channel(channelType: String, channelId: String): ChannelState {
         return channels.getOrPut(channelType to channelId) {
-            ChannelMutableState(channelType, channelId, chatDomainImpl.scope, chatDomainImpl.user)
+            ChannelMutableState(
+                channelType,
+                channelId,
+                chatDomainImpl.scope,
+                chatDomainImpl.user,
+                chatDomainImpl.latestUsers
+            )
         }
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
@@ -32,7 +32,7 @@ public class StateRegistry internal constructor(
 
     public fun queryChannels(filter: FilterObject, sort: QuerySort<Channel>): QueryChannelsState {
         return queryChannels.getOrPut(filter to sort) {
-            QueryChannelsMutableState(filter, sort, chatClient, chatDomainImpl.scope)
+            QueryChannelsMutableState(filter, sort, chatClient, chatDomainImpl.scope, chatDomainImpl.latestUsers)
         }
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
@@ -5,7 +5,9 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.offline.extensions.updateUsers
 import io.getstream.chat.android.offline.querychannels.ChatEventHandler
 import io.getstream.chat.android.offline.querychannels.DefaultChatEventHandler
 import io.getstream.chat.android.offline.querychannels.QueryChannelsSpec
@@ -23,6 +25,7 @@ internal class QueryChannelsMutableState(
     override val sort: QuerySort<Channel>,
     client: ChatClient,
     scope: CoroutineScope,
+    latestUsers: StateFlow<Map<String, User>>,
 ) : QueryChannelsState {
 
     internal val queryChannelsSpec: QueryChannelsSpec = QueryChannelsSpec(filter, sort)
@@ -32,7 +35,9 @@ internal class QueryChannelsMutableState(
     internal val _loadingMore = MutableStateFlow(false)
     internal val _endOfChannels = MutableStateFlow(false)
     internal val _sortedChannels =
-        _channels.map { it.values.sortedWith(sort.comparator) }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+        _channels.combine(latestUsers) { channelMap, userMap ->
+            channelMap.values.updateUsers(userMap)
+        }.map { it.sortedWith(sort.comparator) }.stateIn(scope, SharingStarted.Eagerly, emptyList())
     internal val _currentRequest = MutableStateFlow<QueryChannelsRequest?>(null)
     internal val recoveryNeeded: MutableStateFlow<Boolean> = MutableStateFlow(false)
     internal val channelsOffset: MutableStateFlow<Int> = MutableStateFlow(0)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Channel.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Channel.kt
@@ -65,3 +65,19 @@ internal fun Collection<Channel>.applyPagination(pagination: AnyChannelPaginatio
         .take(pagination.channelLimit)
         .toList()
 }
+
+internal fun Collection<Channel>.updateUsers(users: Map<String, User>) = map { it.updateUsers(users) }
+
+internal fun Channel.updateUsers(users: Map<String, User>): Channel {
+    return if (users().map(User::id).any(users::containsKey)) {
+        copy(
+            messages = messages.updateUsers(users),
+            members = members.updateUsers(users).toList(),
+            watchers = watchers.updateUsers(users),
+            createdBy = users[createdBy.id] ?: createdBy,
+            pinnedMessages = pinnedMessages.updateUsers(users),
+        )
+    } else {
+        this
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Channel.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Channel.kt
@@ -66,8 +66,13 @@ internal fun Collection<Channel>.applyPagination(pagination: AnyChannelPaginatio
         .toList()
 }
 
+/** Updates collection of channels with more recent data of [users]. */
 internal fun Collection<Channel>.updateUsers(users: Map<String, User>) = map { it.updateUsers(users) }
 
+/**
+ * Updates a channel with more recent data of [users]. It updates messages, members, watchers, createdBy and
+ * pinnedMessages of channel instance.
+ */
 internal fun Channel.updateUsers(users: Map<String, User>): Channel {
     return if (users().map(User::id).any(users::containsKey)) {
         copy(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Member.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Member.kt
@@ -1,0 +1,12 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.User
+
+internal fun Collection<Member>.updateUsers(userMap: Map<String, User>): Collection<Member> = map { member ->
+    if (userMap.containsKey(member.getUserId())) {
+        member.copy(user = userMap[member.getUserId()] ?: member.user)
+    } else {
+        member
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Member.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Member.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.offline.extensions
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.User
 
+/** Updates collection of members with more recent data of [users]. */
 internal fun Collection<Member>.updateUsers(userMap: Map<String, User>): Collection<Member> = map { member ->
     if (userMap.containsKey(member.getUserId())) {
         member.copy(user = userMap[member.getUserId()] ?: member.user)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
@@ -4,9 +4,13 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.offline.message.users
 
+/** Updates collection of messages with more recent data of [users]. */
 internal fun Collection<Message>.updateUsers(users: Map<String, User>) = map { it.updateUsers(users) }
 
-/** Updates a message with more recent data of [users]. */
+/**
+ * Updates a message with more recent data of [users]. It updates author user, latestReactions, replyTo message,
+ * mentionedUsers, threadParticipants and pinnedBy user of this instance.
+ */
 internal fun Message.updateUsers(users: Map<String, User>): Message =
     if (users().map(User::id).any(users::containsKey)) {
         copy(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
@@ -1,0 +1,24 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.offline.message.users
+
+internal fun Collection<Message>.updateUsers(users: Map<String, User>) = map { it.updateUsers(users) }
+
+/** Updates a message with more recent data of [users]. */
+internal fun Message.updateUsers(users: Map<String, User>): Message =
+    if (users().map(User::id).any(users::containsKey)) {
+        copy(
+            user = if (users.containsKey(user.id)) {
+                users[user.id] ?: user
+            } else user,
+            latestReactions = latestReactions.updateByUsers(users).toMutableList(),
+            replyTo = replyTo?.updateUsers(users),
+            mentionedUsers = mentionedUsers.updateUsers(users).toMutableList(),
+            threadParticipants = threadParticipants.updateUsers(users).toMutableList(),
+            pinnedBy = users[pinnedBy?.id ?: ""] ?: pinnedBy,
+        )
+    } else {
+        this
+    }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.offline.extensions
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 
+/** Updates collection of reactions with more recent data of [users]. */
 internal fun Collection<Reaction>.updateByUsers(userMap: Map<String, User>): Collection<Reaction> = if (mapNotNull { it.user?.id }.any(userMap::containsKey)) {
     map { reaction ->
         if (userMap.containsKey(reaction.user?.id ?: reaction.userId)) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
@@ -1,0 +1,16 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.client.models.Reaction
+import io.getstream.chat.android.client.models.User
+
+internal fun Collection<Reaction>.updateByUsers(userMap: Map<String, User>): Collection<Reaction> = if (mapNotNull { it.user?.id }.any(userMap::containsKey)) {
+    map { reaction ->
+        if (userMap.containsKey(reaction.user?.id ?: reaction.userId)) {
+            reaction.copy(user = userMap[reaction.userId] ?: reaction.user)
+        } else {
+            reaction
+        }
+    }
+} else {
+    this
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/User.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/User.kt
@@ -1,0 +1,6 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.client.models.User
+
+/** Updates a collection of users by more fresh value of [users]. */
+internal fun Collection<User>.updateUsers(users: Map<String, User>) = map { user -> users[user.id] ?: user }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/UserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/UserRepository.kt
@@ -16,10 +16,8 @@ internal interface UserRepository {
     suspend fun selectAllUsers(limit: Int, offset: Int): List<User>
     suspend fun selectUsersLikeName(searchString: String, limit: Int, offset: Int): List<User>
 
-    /**
-     * Returns flow of latest updated users.
-     */
-    fun observeLastUsers(): StateFlow<Map<String, User>>
+    /** Returns flow of latest updated users. */
+    fun observeLatestUsers(): StateFlow<Map<String, User>>
 }
 
 internal class UserRepositoryImpl(
@@ -31,9 +29,9 @@ internal class UserRepositoryImpl(
     private val userCache = LruCache<String, User>(cacheSize)
     private val currentUserMap: Map<String, User> = currentUser?.let { mapOf(it.id to it) } ?: emptyMap()
 
-    private val lastUsersFlow: MutableStateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
+    private val latestUsersFlow: MutableStateFlow<Map<String, User>> = MutableStateFlow(emptyMap())
 
-    override fun observeLastUsers(): StateFlow<Map<String, User>> = lastUsersFlow
+    override fun observeLatestUsers(): StateFlow<Map<String, User>> = latestUsersFlow
 
     override suspend fun insertUsers(users: Collection<User>) {
         if (users.isEmpty()) return
@@ -45,7 +43,7 @@ internal class UserRepositoryImpl(
         for (userEntity in users) {
             userCache.put(userEntity.id, userEntity)
         }
-        lastUsersFlow.value = userCache.snapshot()
+        latestUsersFlow.value = userCache.snapshot()
     }
 
     override suspend fun insertUser(user: User) {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.ReactionNewEvent
 import io.getstream.chat.android.client.events.TypingStartEvent
 import io.getstream.chat.android.client.events.TypingStopEvent
+import io.getstream.chat.android.client.events.UserStartWatchingEvent
 import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
@@ -60,6 +61,24 @@ import java.util.Date
 import java.util.concurrent.Executors
 
 private val fixture = JFixture()
+
+internal fun randomUserStartWatchingEvent(
+    type: String = randomString(),
+    createdAt: Date = randomDate(),
+    cid: String = randomString(),
+    watcherCount: Int = randomInt(),
+    channelType: String = randomString(),
+    channelId: String = randomString(),
+    user: User = randomUser(),
+) = UserStartWatchingEvent(
+    type = type,
+    createdAt = createdAt,
+    cid = cid,
+    watcherCount = watcherCount,
+    channelType = channelType,
+    channelId = channelId,
+    user = randomUser()
+)
 
 internal fun randomChannelDeletedEvent(
     type: String = randomString(),
@@ -291,7 +310,11 @@ internal fun randomMessageUpdateEvent(
 
 internal fun randomAttachmentsWithFile(
     size: Int = positiveRandomInt(10),
-    creationFunction: (Int) -> Attachment = { Attachment(upload = randomFile()).apply { uploadId = generateUploadId() } },
+    creationFunction: (Int) -> Attachment = {
+        Attachment(upload = randomFile()).apply {
+            uploadId = generateUploadId()
+        }
+    },
 ): List<Attachment> = (1..size).map(creationFunction)
 
 internal fun randomUser(
@@ -419,7 +442,7 @@ internal fun randomChannelInfo(
     id: String? = randomString(),
     type: String = randomString(),
     memberCount: Int = randomInt(),
-    name: String? = randomString()
+    name: String? = randomString(),
 ): ChannelInfo = ChannelInfo(
     cid = cid,
     id = id,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/SynchronizedCoroutineTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/SynchronizedCoroutineTest.kt
@@ -1,0 +1,23 @@
+package io.getstream.chat.android.offline
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
+
+/**
+ * Test interface that helps to synchronize test coroutine scope and test scope. Use only when [runBlockingTest] is not
+ * possible.
+ */
+@ExperimentalCoroutinesApi
+internal interface SynchronizedCoroutineTest {
+
+    /** Returns test scope. */
+    fun getTestScope(): TestCoroutineScope
+
+    /** Helper function that synchronize test scope and run your test in another scope blocking. */
+    fun coroutineTest(block: suspend CoroutineScope.() -> Unit): Unit = runBlocking {
+        getTestScope().launch(block = block).join()
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
@@ -17,6 +17,7 @@ import io.getstream.chat.android.offline.repository.RepositoryFacade
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScope
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 
 internal open class BaseChannelControllerTests {
@@ -31,12 +32,14 @@ internal open class BaseChannelControllerTests {
     protected lateinit var repos: RepositoryFacade
     protected lateinit var messageSendingService: MessageSendingService
     protected lateinit var mutableState: ChannelMutableState
+    protected lateinit var scope: TestCoroutineScope
 
     @OptIn(ExperimentalStreamChatApi::class)
     @ExperimentalCoroutinesApi
     @BeforeEach
     @CallSuper
     open fun before() {
+        scope = TestCoroutineScope()
         repos = mock()
         channelClient = mock()
         messageSendingService = mock()
@@ -46,7 +49,7 @@ internal open class BaseChannelControllerTests {
         }
         chatDomainImpl = mock {
             on(it.appContext) doReturn mock()
-            on { scope } doReturn TestCoroutineScope()
+            on { scope } doReturn scope
             on { repos } doReturn repos
         }
         mutableState =
@@ -63,5 +66,11 @@ internal open class BaseChannelControllerTests {
             chatClient,
             chatDomainImpl,
         )
+    }
+
+    @AfterEach
+    @CallSuper
+    open fun after() {
+        scope.cleanupTestCoroutines()
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/BaseChannelControllerTests.kt
@@ -50,7 +50,13 @@ internal open class BaseChannelControllerTests {
             on { repos } doReturn repos
         }
         mutableState =
-            ChannelMutableState(channelType, channelId, chatDomainImpl.scope, MutableStateFlow(randomUser()))
+            ChannelMutableState(
+                channelType,
+                channelId,
+                chatDomainImpl.scope,
+                MutableStateFlow(randomUser()),
+                MutableStateFlow(emptyMap())
+            )
         sut = ChannelController(
             mutableState,
             ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerImplTest.kt
@@ -19,6 +19,7 @@ import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutab
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.shouldBeEqualTo
@@ -36,7 +37,13 @@ internal class ChannelControllerImplTest : BaseDomainTest2() {
 
     override fun setup() {
         super.setup()
-        val mutableState = ChannelMutableState(channelType, channelId, chatDomainImpl.scope, chatDomainImpl.user)
+        val mutableState = ChannelMutableState(
+            channelType,
+            channelId,
+            chatDomainImpl.scope,
+            chatDomainImpl.user,
+            MutableStateFlow(emptyMap())
+        )
         channelController =
             ChannelController(
                 mutableState,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerIntegrationTest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 internal class ChannelControllerIntegrationTest : BaseConnectedMockedTest() {
 
     @Test
-    fun `When observing messages Should receive the correct number of events with messages`(): Unit = runBlocking {
+    fun `When observing messages Should receive the correct number of events with messages`(): Unit = coroutineTest {
         val counter = DiffUtilOperationCounter { old: List<Message>, new: List<Message> ->
             DiffUtil.calculateDiff(MessageDiffCallback(old, new), true)
         }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
@@ -251,7 +251,8 @@ internal class ChannelControllerReactionsTest {
             whenever(chatDomainImpl.job) doReturn Job()
             whenever(chatDomainImpl.scope) doReturn scope
             whenever(chatDomainImpl.repos) doReturn repos
-            val mutableState = ChannelMutableState("channelType", "channelId", scope, userFlow)
+            val mutableState =
+                ChannelMutableState("channelType", "channelId", scope, userFlow, MutableStateFlow(emptyMap()))
             channelControllerImpl = ChannelController(
                 mutableState,
                 ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
@@ -252,7 +252,7 @@ internal class ChannelControllerReactionsTest {
             whenever(chatDomainImpl.scope) doReturn scope
             whenever(chatDomainImpl.repos) doReturn repos
             val mutableState =
-                ChannelMutableState("channelType", "channelId", scope, userFlow, MutableStateFlow(emptyMap()))
+                ChannelMutableState("channelType", "channelId", scope, userFlow, MutableStateFlow(mapOf(user.id to user)))
             channelControllerImpl = ChannelController(
                 mutableState,
                 ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
@@ -77,7 +77,7 @@ internal class ChannelControllerReactionsTest {
 
             sut.sendReaction(newReaction, enforceUnique = false)
 
-            val result = sut.messages.value.first()
+            val result = sut.mutableState._messages.value.values.first()
             result.ownReactions.size `should be equal to` myReactions.size + 1
             result.ownReactions.contains(newReaction) `should be equal to` true
             result.latestReactions.size `should be equal to` myReactions.size + 1
@@ -94,7 +94,7 @@ internal class ChannelControllerReactionsTest {
 
             sut.sendReaction(newReaction, enforceUnique = true)
 
-            val result = sut.messages.value.first()
+            val result = sut.mutableState._messages.value.values.first()
             result.ownReactions.size `should be equal to` 1
             result.ownReactions.first() `should be equal to` newReaction
             result.latestReactions.size `should be equal to` 1
@@ -111,7 +111,7 @@ internal class ChannelControllerReactionsTest {
 
             sut.sendReaction(newReaction, enforceUnique = true)
 
-            val result = sut.messages.value.first()
+            val result = sut.mutableState._messages.value.values.first()
             result.reactionCounts[newReaction.type] `should be equal to` 1
         }
 
@@ -125,7 +125,7 @@ internal class ChannelControllerReactionsTest {
 
             sut.sendReaction(newReaction, enforceUnique = true)
 
-            val result = sut.messages.value.first()
+            val result = sut.mutableState._messages.value.values.first()
             result.reactionScores[newReaction.type] `should be equal to` newReaction.score
         }
 
@@ -141,7 +141,7 @@ internal class ChannelControllerReactionsTest {
 
             sut.deleteReaction(deletedReaction)
 
-            val result = sut.messages.value.first()
+            val result = sut.mutableState._messages.value.values.first()
             result.ownReactions.size `should be equal to` myReactions.size - 1
             result.ownReactions.contains(deletedReaction) `should be equal to` false
             result.latestReactions.contains(deletedReaction) `should be equal to` false

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
@@ -90,17 +90,16 @@ internal class ChannelControllerTypingTests {
         }
 
     @Test
-    fun `When a message is successfully marked as read Then the second invocation should be ignored`() =
-        runBlockingTest {
-            val sut = Fixture(testCoroutines.scope, randomUser())
-                .givenReadEventsEnabled()
-                .get()
+    fun `When a message is successfully marked as read Then the second invocation should be ignored`() = testCoroutines.scope.runBlockingTest {
+        val sut = Fixture(testCoroutines.scope, randomUser())
+            .givenReadEventsEnabled()
+            .get()
 
-            sut.upsertMessage(randomMessage())
+        sut.upsertMessage(randomMessage())
 
-            sut.markRead() `should be equal to` true
-            sut.markRead() `should be equal to` false
-        }
+        sut.markRead() `should be equal to` true
+        sut.markRead() `should be equal to` false
+    }
 
     private class Fixture(private val scope: CoroutineScope, user: User) {
         private val repos: RepositoryFacade = mock()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.channel.controller
 
+import app.cash.turbine.test
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -95,10 +96,15 @@ internal class ChannelControllerTypingTests {
             .givenReadEventsEnabled()
             .get()
 
-        sut.upsertMessage(randomMessage())
+        sut.mutableState.sortedMessages.test {
+            awaitItem()
 
-        sut.markRead() `should be equal to` true
-        sut.markRead() `should be equal to` false
+            sut.upsertMessage(randomMessage())
+
+            awaitItem()
+            sut.markRead() `should be equal to` true
+            sut.markRead() `should be equal to` false
+        }
     }
 
     private class Fixture(private val scope: CoroutineScope, user: User) {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
@@ -137,7 +137,8 @@ internal class ChannelControllerTypingTests {
         }
 
         fun get(): ChannelController {
-            val mutableState = ChannelMutableState("channelType", "channelId", scope, userFlow)
+            val mutableState =
+                ChannelMutableState("channelType", "channelId", scope, userFlow, MutableStateFlow(emptyMap()))
             return ChannelController(
                 mutableState,
                 ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerTypingTests.kt
@@ -1,6 +1,5 @@
 package io.getstream.chat.android.offline.channel.controller
 
-import app.cash.turbine.test
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
@@ -14,6 +13,7 @@ import io.getstream.chat.android.client.models.EventType
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.offline.ChatDomainImpl
+import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.experimental.channel.logic.ChannelLogic
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutableState
@@ -25,19 +25,22 @@ import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.util.Date
 
-internal class ChannelControllerTypingTests {
+internal class ChannelControllerTypingTests : SynchronizedCoroutineTest {
 
     companion object {
         @JvmField
         @RegisterExtension
         val testCoroutines = TestCoroutineExtension()
     }
+
+    override fun getTestScope(): TestCoroutineScope = testCoroutines.scope
 
     @Test
     fun `When clean is invoked Then old typing indicators should be removed`() = runBlockingTest {
@@ -91,20 +94,15 @@ internal class ChannelControllerTypingTests {
         }
 
     @Test
-    fun `When a message is successfully marked as read Then the second invocation should be ignored`() = testCoroutines.scope.runBlockingTest {
+    fun `When a message is successfully marked as read Then the second invocation should be ignored`() = coroutineTest {
         val sut = Fixture(testCoroutines.scope, randomUser())
             .givenReadEventsEnabled()
             .get()
 
-        sut.mutableState.sortedMessages.test {
-            awaitItem()
+        sut.upsertMessage(randomMessage())
 
-            sut.upsertMessage(randomMessage())
-
-            awaitItem()
-            sut.markRead() `should be equal to` true
-            sut.markRead() `should be equal to` false
-        }
+        sut.markRead() `should be equal to` true
+        sut.markRead() `should be equal to` false
     }
 
     private class Fixture(private val scope: CoroutineScope, user: User) {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/SendMessageOfflineTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/SendMessageOfflineTest.kt
@@ -102,7 +102,8 @@ internal class SendMessageOfflineTest {
         }
 
         fun get(): ChannelController {
-            val mutableState = ChannelMutableState("channelType", "channelId", scope, userFlow)
+            val mutableState =
+                ChannelMutableState("channelType", "channelId", scope, userFlow, MutableStateFlow(emptyMap()))
             return ChannelController(
                 mutableState,
                 ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenHandleEvent.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenHandleEvent.kt
@@ -72,7 +72,7 @@ internal class WhenHandleEvent {
             invocation.arguments[0] as List<Message>
         }
 
-        val mutableState = ChannelMutableState("type1", channelId, scope, userFlow)
+        val mutableState = ChannelMutableState("type1", channelId, scope, userFlow, MutableStateFlow(emptyMap()))
 
         channelController = ChannelController(
             mutableState,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenSendMessage.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenSendMessage.kt
@@ -84,7 +84,7 @@ internal class WhenSendMessage {
     @Before
     fun setup() {
         Shadows.shadowOf(MimeTypeMap.getSingleton())
-        val mutableState = ChannelMutableState(channelType, channelId, scope, userFlow)
+        val mutableState = ChannelMutableState(channelType, channelId, scope, userFlow, MutableStateFlow(emptyMap()))
         channelController = ChannelController(mutableState, ChannelLogic(mutableState, domainImpl), chatClient, domainImpl)
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenUploadAttachmentsTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/WhenUploadAttachmentsTests.kt
@@ -95,7 +95,14 @@ internal class WhenUploadAttachmentsTests {
     fun `Given uploaded and not uploaded attachments And failure when upload Should insert message with 2 attachments`() =
         runBlockingTest {
             val attachmentUploader = mock<AttachmentUploader> {
-                on(it.uploadAttachment(any(), any(), any(), any())) doReturn Result.error(IllegalArgumentException("Error:-)"))
+                on(
+                    it.uploadAttachment(
+                        any(),
+                        any(),
+                        any(),
+                        any()
+                    )
+                ) doReturn Result.error(IllegalArgumentException("Error:-)"))
             }
             val repository = mock<RepositoryFacade>()
             val message = randomMessage(
@@ -187,7 +194,13 @@ internal class WhenUploadAttachmentsTests {
         }
 
         fun get(): ChannelController {
-            val mutableState = ChannelMutableState("channelType", "channelId", scope, MutableStateFlow(randomUser()))
+            val mutableState = ChannelMutableState(
+                "channelType",
+                "channelId",
+                scope,
+                MutableStateFlow(randomUser()),
+                MutableStateFlow(emptyMap())
+            )
             return ChannelController(
                 mutableState = mutableState,
                 channelLogic = ChannelLogic(mutableState, chatDomainImpl),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -70,8 +70,10 @@ internal class UploadAttachmentsIntegrationTests : BaseRepositoryFacadeIntegrati
             on(it.client) doReturn chatClient
         }
 
-        val mutableState = ChannelMutableState(channelType, channelId, testCoroutines.scope, userFlow)
-        channelController = ChannelController(mutableState, ChannelLogic(mutableState, domainImpl), chatClient, domainImpl)
+        val mutableState =
+            ChannelMutableState(channelType, channelId, testCoroutines.scope, userFlow, MutableStateFlow(emptyMap()))
+        channelController =
+            ChannelController(mutableState, ChannelLogic(mutableState, domainImpl), chatClient, domainImpl)
     }
 
     @Test

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
+import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.createRoomDB
 import io.getstream.chat.android.offline.model.ChannelConfig
@@ -43,6 +44,7 @@ import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.After
@@ -50,7 +52,7 @@ import org.junit.Before
 import org.junit.Rule
 import java.util.Date
 
-internal open class BaseDomainTest {
+internal open class BaseDomainTest : SynchronizedCoroutineTest {
     lateinit var channelClientMock: ChannelClient
     lateinit var database: ChatDatabase
     lateinit var chatDomainImpl: ChatDomainImpl
@@ -84,6 +86,8 @@ internal open class BaseDomainTest {
 
     @get:Rule
     val testCoroutines = TestCoroutineRule()
+
+    override fun getTestScope(): TestCoroutineScope = testCoroutines.scope
 
     protected fun setupWorkManager() {
         val config = Configuration.Builder()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
+import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.model.ChannelConfig
 import io.getstream.chat.android.offline.querychannels.QueryChannelsController
@@ -42,6 +43,7 @@ import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineScope
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.After
@@ -54,7 +56,7 @@ import java.util.concurrent.Executors
  * Sets up a ChatDomain object with a mocked ChatClient.
  */
 @ExperimentalStreamChatApi
-internal open class BaseDomainTest2 {
+internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
 
     /** a realistic set of chat data, please only add to this, don't update */
     var data = TestDataHelper()
@@ -89,6 +91,8 @@ internal open class BaseDomainTest2 {
     /** single threaded coroutines via DispatcherProvider */
     @get:Rule
     val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    override fun getTestScope(): TestCoroutineScope = testCoroutines.scope
 
     @Before
     @CallSuper

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/ChatDomainEventDomainImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/ChatDomainEventDomainImplTest.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.offline.integration
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.querychannels.ChatEventHandler
 import io.getstream.chat.android.offline.querychannels.EventHandlingResult
 import kotlinx.coroutines.runBlocking
@@ -16,6 +17,7 @@ import org.junit.runner.RunWith
 /**
  * Verify that all events correctly update state in room.
  */
+@OptIn(ExperimentalStreamChatApi::class)
 @RunWith(AndroidJUnit4::class)
 internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
 
@@ -43,14 +45,12 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
     }
 
     @Test
-    fun `channel controller edit message event`(): Unit = runBlocking {
+    fun `channel controller edit message event`(): Unit = coroutineTest {
         // setup the queryControllerImpl
         queryControllerImpl.query(10)
 
         // update the last message
         chatDomainImpl.eventHandler.handleEvent(data.messageUpdatedEvent)
-        // channelControllerImpl.handleEvent(data.messageUpdatedEvent)
-        // queryControllerImpl.handleEvent(data.messageUpdatedEvent)
 
         // verify that the last message is now updated
         val channelMap = queryControllerImpl.channels.value.associateBy { it.cid }
@@ -101,7 +101,7 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
 
     @Test
     fun `verify that a channel is correctly deleted when channel deleted event is received`(): Unit =
-        runBlocking {
+        coroutineTest {
             queryControllerImpl.chatEventHandler = ChatEventHandler { _, _ -> EventHandlingResult.Skip }
             chatDomainImpl.eventHandler.handleEvent(data.newMessageEventNotification)
             chatDomainImpl.eventHandler.handleEvent(data.channelDeletedEvent)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerIntegratedMockTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerIntegratedMockTest.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.offline.integration.BaseConnectedMockedTest
 import io.getstream.chat.android.test.TestCall
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
@@ -21,7 +20,7 @@ internal class QueryChannelsControllerIntegratedMockTest : BaseConnectedMockedTe
 
     @Test
     fun `Given some channels When received new message event Should return the same channels with proper orderings`() {
-        runBlocking {
+        coroutineTest {
             val queryChannelsController =
                 chatDomainImpl.queryChannels(data.filter1, QuerySort.desc(Channel::lastMessageAt))
             val channel1 = data.channel1.copy(lastMessageAt = Date(10000L))

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
@@ -18,6 +18,7 @@ import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
+import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.experimental.querychannels.logic.QueryChannelsLogic
 import io.getstream.chat.android.offline.experimental.querychannels.state.QueryChannelsMutableState
@@ -43,17 +44,21 @@ import org.amshove.kluent.shouldNotContain
 import org.junit.jupiter.api.Test
 
 @ExperimentalCoroutinesApi
-internal class QueryChannelsControllerTest {
+internal class QueryChannelsControllerTest : SynchronizedCoroutineTest {
+
+    private val scope = TestCoroutineScope()
+
+    override fun getTestScope(): TestCoroutineScope = scope
 
     @Test
     fun `when add channel if filter matches should update LiveData from channel to channel controller`() =
-        runBlockingTest {
+        coroutineTest {
             val currentUser = randomUser()
             val newChannel = randomChannel(
                 members = List(positiveRandomInt(10)) { randomMember() } + randomMember(user = currentUser)
             )
             val channelController = mock<ChannelController>()
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenChannelFilterResponse(listOf(newChannel))
                 .givenCurrentUser(currentUser)
                 .givenNewChannelControllerForChannel(channelController)
@@ -66,7 +71,7 @@ internal class QueryChannelsControllerTest {
 
     @Test
     fun `when add channel if filter matches should post value to liveData with the same channel ID`() =
-        runBlockingTest {
+        coroutineTest {
             val currentUser = randomUser()
             val cid = randomCID()
             val newChannel = randomChannel(
@@ -75,7 +80,7 @@ internal class QueryChannelsControllerTest {
                 type = cid.substringBefore(":"),
                 members = List(positiveRandomInt(10)) { randomMember() } + randomMember(user = currentUser)
             )
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenChannelFilterResponse(listOf(newChannel))
                 .givenCurrentUser(currentUser)
                 .givenChannelType(newChannel.type)
@@ -91,7 +96,7 @@ internal class QueryChannelsControllerTest {
 
     @Test
     fun `when add channel twice if filter matches should post value to liveData only one value`() =
-        runBlockingTest {
+        coroutineTest {
             val currentUser = randomUser()
             val cid = randomCID()
             val newChannel = randomChannel(
@@ -100,7 +105,7 @@ internal class QueryChannelsControllerTest {
                 type = cid.substringBefore(":"),
                 members = List(positiveRandomInt(10)) { randomMember() } + randomMember(user = currentUser)
             )
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenChannelFilterResponse(listOf(newChannel))
                 .givenCurrentUser(currentUser)
                 .givenChannelType(newChannel.type)
@@ -119,7 +124,7 @@ internal class QueryChannelsControllerTest {
     fun `Given channel without current user as member When refresh channel Should not change flow value`() =
         runBlockingTest {
             val cid = "channelType:channelId"
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenChannelFilterResponse(emptyList())
                 .givenCurrentUser(randomUser())
                 .givenNewChannelControllerForChannel()
@@ -141,7 +146,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenNewChannelControllerForChannel(channelController)
                 .get()
 
@@ -157,7 +162,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenChatEventHandler { event, _ ->
                     when (event) {
                         is ChannelUpdatedEvent -> EventHandlingResult.Add(event.channel)
@@ -179,7 +184,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenChatEventHandler { _, _ -> EventHandlingResult.Skip }
                 .givenNewChannelControllerForChannel(channelController)
                 .get()
@@ -196,7 +201,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenChatEventHandler { event, _ ->
                     when (event) {
                         is ChannelUpdatedByUserEvent -> EventHandlingResult.Add(event.channel)
@@ -219,7 +224,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenChatEventHandler { _, _ -> EventHandlingResult.Skip }
                 .addInitialChannel(channel)
                 .givenNewChannelControllerForChannel(channelController)
@@ -237,7 +242,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenCurrentUser(randomUser())
                 .givenNewChannelControllerForChannel(channelController)
                 .addInitialChannel(channel)
@@ -255,7 +260,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .addInitialChannel(channel)
                 .givenChatEventHandler { _, _ -> EventHandlingResult.Skip }
                 .givenCurrentUser(randomUser())
@@ -274,7 +279,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .addInitialChannel(channel)
                 .givenCurrentUser(randomUser())
                 .givenNewChannelControllerForChannel(channelController)
@@ -292,7 +297,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .addInitialChannel(channel)
                 .givenNewChannelControllerForChannel(channelController)
                 .get()
@@ -309,7 +314,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .addInitialChannel(channel)
                 .givenNewChannelControllerForChannel(channelController)
                 .get()
@@ -326,7 +331,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .addInitialChannel(channel)
                 .givenCurrentUser(randomUser())
                 .givenNewChannelControllerForChannel(channelController)
@@ -344,7 +349,7 @@ internal class QueryChannelsControllerTest {
             val channelController: ChannelController = mock {
                 on(mock.toChannel()) doReturn channel
             }
-            val queryController = Fixture()
+            val queryController = Fixture(scope)
                 .givenChatEventHandler { event, _ ->
                     when (event) {
                         is NotificationAddedToChannelEvent -> EventHandlingResult.Add(event.channel)
@@ -360,11 +365,11 @@ internal class QueryChannelsControllerTest {
         }
 }
 
-private class Fixture {
+@OptIn(ExperimentalCoroutinesApi::class)
+private class Fixture constructor(testCoroutineScope: TestCoroutineScope) {
     private val chatClient: ChatClient = mock()
     private val chatDomainImpl: ChatDomainImpl = mock()
     private var querySort: QuerySort<Channel> = QuerySort()
-    private val testCoroutineScope = TestCoroutineScope()
 
     private var currentUser: User? = null
     private var channelType: String = ""

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsControllerTest.kt
@@ -422,7 +422,8 @@ private class Fixture {
     @OptIn(ExperimentalStreamChatApi::class)
     fun get(): QueryChannelsController {
         val filter = Filters.neutral()
-        val mutableState = QueryChannelsMutableState(filter, querySort, chatClient, chatDomainImpl.scope)
+        val mutableState =
+            QueryChannelsMutableState(filter, querySort, chatClient, chatDomainImpl.scope, MutableStateFlow(emptyMap()))
         return QueryChannelsController(
             chatDomainImpl,
             mutableState,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.offline.ChatDomainImpl
+import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.experimental.querychannels.logic.QueryChannelsLogic
 import io.getstream.chat.android.offline.experimental.querychannels.state.QueryChannelsMutableState
@@ -21,23 +22,25 @@ import io.getstream.chat.android.offline.randomUser
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.asCall
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestCoroutineScope
-import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.jupiter.api.Test
 import java.util.Date
 
 @ExperimentalCoroutinesApi
-internal class WhenQuery {
+internal class WhenQuery : SynchronizedCoroutineTest {
+
+    private val scope = TestCoroutineScope()
+
+    override fun getTestScope(): TestCoroutineScope = scope
 
     @Test
-    fun `Should request query channels spec in DB`() = runBlockingTest {
+    fun `Should request query channels spec in DB`() = coroutineTest {
         val repositories = mock<RepositoryFacade>()
-        val sut = Fixture()
+        val sut = Fixture(scope)
             .givenRepoFacade(repositories)
             .givenFailedNetworkRequest()
             .get()
@@ -48,9 +51,9 @@ internal class WhenQuery {
     }
 
     @Test
-    fun `Should request channels to chat client`() = runBlockingTest {
+    fun `Should request channels to chat client`() = coroutineTest {
         val chatClient = mock<ChatClient>()
-        val sut = Fixture()
+        val sut = Fixture(scope)
             .givenChatClient(chatClient)
             .givenFailedNetworkRequest()
             .get()
@@ -61,9 +64,9 @@ internal class WhenQuery {
     }
 
     @Test
-    fun `Given channels in DB and failed network request Should return channels from DB`() = runBlockingTest {
+    fun `Given channels in DB and failed network request Should return channels from DB`() = coroutineTest {
         val dbChannels = listOf(randomChannel(cid = "cid1"), randomChannel(cid = "cid2"))
-        val sut = Fixture()
+        val sut = Fixture(scope)
             .givenFailedNetworkRequest()
             .givenQueryChannelsSpec(QueryChannelsSpec(Filters.neutral(), QuerySort()))
             .givenDBChannels(dbChannels)
@@ -77,10 +80,10 @@ internal class WhenQuery {
 
     @Test
     fun `Given channels in DB and successful network request Should return channels from network response`() =
-        runBlockingTest {
+        coroutineTest {
             val dbChannel = randomChannel(cid = "cid", lastMessageAt = Date(1000L))
             val networkChannels = listOf(dbChannel.copy(lastMessageAt = Date(2000L)), randomChannel(cid = "cid2"))
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenQueryChannelsSpec(QueryChannelsSpec(Filters.neutral(), QuerySort()))
                 .givenDBChannels(listOf(dbChannel))
                 .givenNetworkChannels(networkChannels)
@@ -94,11 +97,11 @@ internal class WhenQuery {
 
     @Test
     fun `Given DB channels and failed network response Should set channels from db to channels flow in properly sorted order`() =
-        runBlockingTest {
+        coroutineTest {
             val dbChannel1 = randomChannel(cid = "cid1", lastMessageAt = Date(1000L))
             val dbChannel2 = randomChannel(cid = "cid2", lastMessageAt = Date(2000L))
             val querySort = QuerySort.desc(Channel::lastMessageAt)
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenFailedNetworkRequest()
                 .givenQuerySort(querySort)
                 .givenQueryChannelsSpec(
@@ -114,12 +117,12 @@ internal class WhenQuery {
 
     @Test
     fun `Given DB channels and network channels Should set channels from network to channels flow in properly sorted order`() =
-        runBlockingTest {
+        coroutineTest {
             val dbChannel = randomChannel(cid = "cid1", lastMessageAt = Date(1000L))
             val networkChannel1 = dbChannel.copy(lastMessageAt = Date(2000L))
             val networkChannel2 = randomChannel(cid = "cid2", lastMessageAt = Date(3000L))
             val querySort = QuerySort.desc(Channel::lastMessageAt)
-            val sut = Fixture()
+            val sut = Fixture(scope)
                 .givenQuerySort(querySort)
                 .givenQueryChannelsSpec(
                     QueryChannelsSpec(Filters.neutral(), QuerySort()).apply { cids = setOf("cid1", "cid2") }
@@ -133,10 +136,9 @@ internal class WhenQuery {
             sut.channels.value shouldBeEqualTo listOf(networkChannel2, networkChannel1)
         }
 
-    private class Fixture {
+    private class Fixture(val scope: TestCoroutineScope) {
         private var chatClient: ChatClient = mock()
         private var repositories: RepositoryFacade = mock()
-        private var scope: CoroutineScope = TestCoroutineScope()
         private var querySort: QuerySort<Channel> = QuerySort()
 
         private val user: User = randomUser()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
@@ -208,7 +208,12 @@ internal class WhenQuery {
             whenever(chatDomainImpl.repos) doReturn repositories
             whenever(chatDomainImpl.client) doReturn chatClient
             val filter = Filters.neutral()
-            val mutableState = QueryChannelsMutableState(filter, querySort, chatClient, chatDomainImpl.scope)
+            val mutableState = QueryChannelsMutableState(
+                filter, querySort, chatClient, chatDomainImpl.scope,
+                MutableStateFlow(
+                    mapOf(user.id to user)
+                )
+            )
 
             return QueryChannelsController(
                 chatDomainImpl,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
@@ -158,7 +158,7 @@ internal class UserRepositoryTests {
         }
 
     @Test
-    fun `Given users were inserted already When insert users Shouldn't be propagated value to flow again`() =
+    fun `Given users were inserted already When insert a user Shouldn't be propagated value to flow again`() =
         runBlockingTest {
             val newUser1 = randomUser()
             val newUser2 = randomUser()
@@ -173,6 +173,29 @@ internal class UserRepositoryTests {
                     sut.insertUser(newUser1)
 
                     observedTimes shouldBeEqualTo 1
+                    cancelAndConsumeRemainingEvents()
+                }
+        }
+
+    @Test
+    fun `Given users were inserted already When insert an updated user Should propagate value to flow`() =
+        runBlockingTest {
+            val newUser1 = randomUser()
+            val newUser2 = randomUser()
+            val updatedUser1 = newUser1.copy(extraData = mutableMapOf()).apply {
+                name = "newUserName"
+            }
+            var observedTimes = 0
+
+            sut.observeLastUsers()
+                .drop(1) // empty initial value
+                .onEach { observedTimes += 1 }
+                .test {
+                    sut.insertUsers(listOf(newUser1, newUser2))
+
+                    sut.insertUser(updatedUser1)
+
+                    observedTimes shouldBeEqualTo 2
                     cancelAndConsumeRemainingEvents()
                 }
         }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
@@ -113,7 +113,7 @@ internal class UserRepositoryTests {
     @Test
     fun `When insert user Should propagate updates to flow`() = runBlockingTest {
         val newUser = randomUser()
-        val flow = sut.observeLastUsers()
+        val flow = sut.observeLatestUsers()
 
         sut.insertUser(newUser)
 
@@ -126,7 +126,7 @@ internal class UserRepositoryTests {
     fun `When insert users Should propagate updates to flow`() = runBlockingTest {
         val newUser1 = randomUser()
         val newUser2 = randomUser()
-        val flow = sut.observeLastUsers()
+        val flow = sut.observeLatestUsers()
 
         sut.insertUsers(listOf(newUser1, newUser2))
 
@@ -144,7 +144,7 @@ internal class UserRepositoryTests {
             val newUser3 = randomUser()
             var observedTimes = 0
 
-            sut.observeLastUsers()
+            sut.observeLatestUsers()
                 .drop(1) // empty initial value
                 .onEach { observedTimes += 1 }
                 .test {
@@ -164,7 +164,7 @@ internal class UserRepositoryTests {
             val newUser2 = randomUser()
             var observedTimes = 0
 
-            sut.observeLastUsers()
+            sut.observeLatestUsers()
                 .drop(1) // empty initial value
                 .onEach { observedTimes += 1 }
                 .test {
@@ -187,7 +187,7 @@ internal class UserRepositoryTests {
             }
             var observedTimes = 0
 
-            sut.observeLastUsers()
+            sut.observeLatestUsers()
                 .drop(1) // empty initial value
                 .onEach { observedTimes += 1 }
                 .test {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.repository
 
+import app.cash.turbine.test
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.doReturn
@@ -14,6 +15,8 @@ import io.getstream.chat.android.offline.repository.domain.user.UserDao
 import io.getstream.chat.android.offline.repository.domain.user.UserRepository
 import io.getstream.chat.android.offline.repository.domain.user.UserRepositoryImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
@@ -132,4 +135,45 @@ internal class UserRepositoryTests {
         userMapFlow[newUser1.id] shouldBeEqualTo newUser1
         userMapFlow[newUser2.id] shouldBeEqualTo newUser2
     }
+
+    @Test
+    fun `Given users were inserted When insert a new user Should propagated new value to flow`() =
+        runBlockingTest {
+            val newUser1 = randomUser()
+            val newUser2 = randomUser()
+            val newUser3 = randomUser()
+            var observedTimes = 0
+
+            sut.observeLastUsers()
+                .drop(1) // empty initial value
+                .onEach { observedTimes += 1 }
+                .test {
+                    sut.insertUsers(listOf(newUser1, newUser2))
+
+                    sut.insertUser(newUser3)
+
+                    observedTimes shouldBeEqualTo 2
+                    cancelAndConsumeRemainingEvents()
+                }
+        }
+
+    @Test
+    fun `Given users were inserted already When insert users Shouldn't be propagated value to flow again`() =
+        runBlockingTest {
+            val newUser1 = randomUser()
+            val newUser2 = randomUser()
+            var observedTimes = 0
+
+            sut.observeLastUsers()
+                .drop(1) // empty initial value
+                .onEach { observedTimes += 1 }
+                .test {
+                    sut.insertUsers(listOf(newUser1, newUser2))
+
+                    sut.insertUser(newUser1)
+
+                    observedTimes shouldBeEqualTo 1
+                    cancelAndConsumeRemainingEvents()
+                }
+        }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
@@ -106,4 +106,30 @@ internal class UserRepositoryTests {
         result.shouldNotBeNull()
         result.id shouldBeEqualTo "userId"
     }
+
+    @Test
+    fun `When insert user Should propagate updates to flow`() = runBlockingTest {
+        val newUser = randomUser()
+        val flow = sut.observeLastUsers()
+
+        sut.insertUser(newUser)
+
+        val userMapFlow = flow.value
+        userMapFlow.size shouldBeEqualTo 1
+        userMapFlow[newUser.id] shouldBeEqualTo newUser
+    }
+
+    @Test
+    fun `When insert users Should propagate updates to flow`() = runBlockingTest {
+        val newUser1 = randomUser()
+        val newUser2 = randomUser()
+        val flow = sut.observeLastUsers()
+
+        sut.insertUsers(listOf(newUser1, newUser2))
+
+        val userMapFlow = flow.value
+        userMapFlow.size shouldBeEqualTo 2
+        userMapFlow[newUser1.id] shouldBeEqualTo newUser1
+        userMapFlow[newUser2.id] shouldBeEqualTo newUser2
+    }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/thread/ThreadControllerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/thread/ThreadControllerImplTest.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.offline.thread
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import app.cash.turbine.test
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
@@ -59,35 +60,38 @@ internal class ThreadControllerImplTest : BaseDomainTest2() {
     @Test
     fun `the correct messages on the channelController should be shown on the thread`() =
         testCoroutines.scope.runBlockingTest {
-            val messages = threadController.messages.value
-
-            // verify we see the correct 2 messages
-            val expectedMessages = listOf(threadMessage, threadReply)
-            messages shouldBeEqualTo expectedMessages
+            threadController.messages.test {
+                awaitItem()
+                // verify we see the correct 2 messages
+                val expectedMessages = listOf(threadMessage, threadReply)
+                awaitItem() shouldBeEqualTo expectedMessages
+            }
         }
 
     @Test
     fun `new messages on the channel controller should show up on the thread`() = testCoroutines.scope.runBlockingTest {
         // add an extra message
         val threadReply2 = data.createMessage().apply { parentId = threadId }
-        setMessages(listOf(data.message1, threadMessage, threadReply, threadReply2))
-        val messages = threadController.messages.value
-
-        // verify we see the correct 3 messages
-        val expectedMessages = listOf(threadMessage, threadReply, threadReply2)
-        messages shouldBeEqualTo expectedMessages
+        threadController.messages.test {
+            awaitItem()
+            setMessages(listOf(data.message1, threadMessage, threadReply, threadReply2))
+            // verify we see the correct 3 messages
+            val expectedMessages = listOf(threadMessage, threadReply, threadReply2)
+            awaitItem() shouldBeEqualTo expectedMessages
+        }
     }
 
     @Test
     fun `removing messages on the channel controller should remove them from the thread`() =
         testCoroutines.scope.runBlockingTest {
             // remove a message
-            setMessages(listOf(data.message1, threadMessage))
-            val messages = threadController.messages.value
-
-            // verify we see the correct message
-            val expectedMessages = listOf(threadMessage)
-            messages shouldBeEqualTo expectedMessages
+            threadController.messages.test {
+                awaitItem()
+                setMessages(listOf(data.message1, threadMessage))
+                // verify we see the correct message
+                val expectedMessages = listOf(threadMessage)
+                awaitItem() shouldBeEqualTo expectedMessages
+            }
         }
 
     @Test

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/thread/ThreadControllerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/thread/ThreadControllerImplTest.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.offline.experimental.channel.thread.state.Threa
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Before
@@ -38,9 +39,15 @@ internal class ThreadControllerImplTest : BaseDomainTest2() {
         threadMessage = data.createMessage().apply { id = threadId }
         threadReply = data.createMessage().apply { parentId = threadId }
         channelMessages = listOf(data.message1, threadMessage, threadReply)
-        channelMutableState = ChannelMutableState("channelType", "channelId", chatDomainImpl.scope, chatDomainImpl.user).apply {
-            hideMessagesBefore = null
-        }
+        channelMutableState =
+            ChannelMutableState(
+                "channelType", "channelId", chatDomainImpl.scope, chatDomainImpl.user,
+                MutableStateFlow(
+                    emptyMap()
+                )
+            ).apply {
+                hideMessagesBefore = null
+            }
         setMessages(channelMessages)
 
         val channelLogic = ChannelLogic(channelMutableState, chatDomainImpl)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteMessageTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteMessageTest.kt
@@ -13,7 +13,6 @@ import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.integration.BaseConnectedIntegrationTest.Companion.data
 import io.getstream.chat.android.offline.integration.BaseConnectedMockedTest
 import io.getstream.chat.android.test.TestCall
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should not be`
 import org.junit.Test
@@ -24,7 +23,7 @@ internal class DeleteMessageTest : BaseConnectedMockedTest() {
 
     @Test
     fun `Given a message was sent When deleting the message Should return the deleted message`() {
-        runBlocking {
+        coroutineTest {
             val message = data.createMessage()
             val channelController = Fixture(client, chatDomain)
                 .givenMockedSendMessageResponse(channelClientMock, message)
@@ -34,7 +33,7 @@ internal class DeleteMessageTest : BaseConnectedMockedTest() {
             chatDomain.sendMessage(message).execute()
             chatDomain.deleteMessage(message).execute()
 
-            val deletedMessage = channelController.mutableState._messages.value.values.last()
+            val deletedMessage = channelController.messages.value.last()
 
             deletedMessage.id `should be equal to` message.id
             deletedMessage.deletedAt `should not be` null

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteMessageTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteMessageTest.kt
@@ -34,7 +34,7 @@ internal class DeleteMessageTest : BaseConnectedMockedTest() {
             chatDomain.sendMessage(message).execute()
             chatDomain.deleteMessage(message).execute()
 
-            val deletedMessage = channelController.messages.value.last()
+            val deletedMessage = channelController.mutableState._messages.value.values.last()
 
             deletedMessage.id `should be equal to` message.id
             deletedMessage.deletedAt `should not be` null

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/EditMessageUseCaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/EditMessageUseCaseTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.test.TestCall
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldContainAll
 import org.amshove.kluent.shouldNotBe
@@ -18,7 +17,7 @@ import org.junit.runner.RunWith
 internal class EditMessageUseCaseTest : BaseDomainTest2() {
 
     @Test
-    fun `edit message use case full example`(): Unit = runBlocking {
+    fun `edit message use case full example`(): Unit = coroutineTest {
         // TODO: this test is slow for unknown reasons
         val originalMessage = data.createMessage()
 
@@ -26,7 +25,7 @@ internal class EditMessageUseCaseTest : BaseDomainTest2() {
         val result = channelControllerImpl.sendMessage(originalMessage)
         assertSuccess(result)
 
-        var messages = channelControllerImpl.mutableState._messages.value.values
+        var messages = channelControllerImpl.messages.value
         val lastMessage = messages.last()
         lastMessage.id shouldBeEqualTo originalMessage.id
 
@@ -37,7 +36,7 @@ internal class EditMessageUseCaseTest : BaseDomainTest2() {
         val result2 = channelControllerImpl.editMessage(updatedMessage)
 
         assertSuccess(result2)
-        messages = channelControllerImpl.mutableState._messages.value.values
+        messages = channelControllerImpl.messages.value
         val liveLastMessage = messages.last()
         liveLastMessage.id shouldBeEqualTo originalMessage.id
         liveLastMessage.extraData shouldContainAll updatedMessage.extraData

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/EditMessageUseCaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/EditMessageUseCaseTest.kt
@@ -26,7 +26,7 @@ internal class EditMessageUseCaseTest : BaseDomainTest2() {
         val result = channelControllerImpl.sendMessage(originalMessage)
         assertSuccess(result)
 
-        var messages = channelControllerImpl.messages.value
+        var messages = channelControllerImpl.mutableState._messages.value.values
         val lastMessage = messages.last()
         lastMessage.id shouldBeEqualTo originalMessage.id
 
@@ -37,7 +37,7 @@ internal class EditMessageUseCaseTest : BaseDomainTest2() {
         val result2 = channelControllerImpl.editMessage(updatedMessage)
 
         assertSuccess(result2)
-        messages = channelControllerImpl.messages.value
+        messages = channelControllerImpl.mutableState._messages.value.values
         val liveLastMessage = messages.last()
         liveLastMessage.id shouldBeEqualTo originalMessage.id
         liveLastMessage.extraData shouldContainAll updatedMessage.extraData

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
@@ -35,13 +35,13 @@ internal class LoadOldMessagesTest : BaseDomainTest2() {
 
         whenever(channelClientMock.sendMessage(any())) doReturn newMessage.asCall()
 
-        val channelState = chatDomain.watchChannel(data.channel1.cid, 0).execute().data()
-        val result = chatDomainImpl.loadOlderMessages(data.channel1.cid, 10).execute()
+        val channelController = chatDomain.watchChannel(data.channel1.cid, 0).execute().data()
+        chatDomainImpl.loadOlderMessages(data.channel1.cid, 10).execute()
 
-        val messages1: List<Message> = channelState.messages.value
+        val messages1: Collection<Message> = channelController.mutableState._messages.value.values
         chatDomain.sendMessage(newMessage).execute()
 
-        val messages2 = channelState.messages.value
+        val messages2 = channelController.mutableState._messages.value.values
 
         messages2 shouldNotBeEqualTo messages1
         messages2.last() shouldBeEqualTo newMessage

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
@@ -30,7 +30,7 @@ internal class LoadOldMessagesTest : BaseDomainTest2() {
     }
 
     @Test
-    fun `when watching a channel, new messages are updated correctly for the watcher`() = runBlockingTest {
+    fun `when watching a channel, new messages are updated correctly for the watcher`() = coroutineTest {
         val newMessage = data.createMessage()
 
         whenever(channelClientMock.sendMessage(any())) doReturn newMessage.asCall()
@@ -38,10 +38,10 @@ internal class LoadOldMessagesTest : BaseDomainTest2() {
         val channelController = chatDomain.watchChannel(data.channel1.cid, 0).execute().data()
         chatDomainImpl.loadOlderMessages(data.channel1.cid, 10).execute()
 
-        val messages1: Collection<Message> = channelController.mutableState._messages.value.values
+        val messages1: Collection<Message> = channelController.messages.value
         chatDomain.sendMessage(newMessage).execute()
 
-        val messages2 = channelController.mutableState._messages.value.values
+        val messages2 = channelController.messages.value
 
         messages2 shouldNotBeEqualTo messages1
         messages2.last() shouldBeEqualTo newMessage

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendMessageTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendMessageTest.kt
@@ -28,11 +28,11 @@ internal class SendMessageTest : BaseConnectedMockedTest() {
                 .get()
 
             // check that current state is empty
-            channelController.messages.value.size `should be equal to` 0
+            channelController.mutableState._messages.value.size `should be equal to` 0
 
             chatDomain.sendMessage(message).execute()
 
-            channelController.messages.value.last() `should be equal to` message
+            channelController.mutableState._messages.value.values.last() `should be equal to` message
         }
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendMessageTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendMessageTest.kt
@@ -11,7 +11,6 @@ import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.integration.BaseConnectedIntegrationTest.Companion.data
 import io.getstream.chat.android.offline.integration.BaseConnectedMockedTest
 import io.getstream.chat.android.test.TestCall
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -20,20 +19,18 @@ import org.junit.runner.RunWith
 internal class SendMessageTest : BaseConnectedMockedTest() {
 
     @Test
-    fun `Given a message was sent When subscribing message updates Should emit the sent message`() {
-        runBlocking {
-            val message = data.createMessage().apply { extraData = mutableMapOf("location" to "Amsterdam") }
-            val channelController = Fixture(chatDomain)
-                .givenMockedSendMessageResponse(channelClientMock, message)
-                .get()
+    fun `Given a message was sent When subscribing message updates Should emit the sent message`() = coroutineTest {
+        val message = data.createMessage().apply { extraData = mutableMapOf("location" to "Amsterdam") }
+        val channelController = Fixture(chatDomain)
+            .givenMockedSendMessageResponse(channelClientMock, message)
+            .get()
 
-            // check that current state is empty
-            channelController.mutableState._messages.value.size `should be equal to` 0
+        // check that current state is empty
+        channelController.messages.value.size `should be equal to` 0
 
-            chatDomain.sendMessage(message).execute()
+        chatDomain.sendMessage(message).execute()
 
-            channelController.mutableState._messages.value.values.last() `should be equal to` message
-        }
+        channelController.messages.value.last() `should be equal to` message
     }
 
     private class Fixture(private val chatDomain: ChatDomain) {

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
@@ -27,10 +27,10 @@ public class TestCoroutineExtension : BeforeAllCallback, AfterEachCallback, Afte
 
     override fun afterEach(context: ExtensionContext) {
         check(beforeAllCalled) { "TestCoroutineExtension field must be static" }
-        scope.cleanupTestCoroutines()
     }
 
     override fun afterAll(context: ExtensionContext) {
         DispatcherProvider.reset()
+        dispatcher.cleanupTestCoroutines()
     }
 }

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
@@ -23,7 +23,6 @@ public class TestCoroutineRule : TestWatcher() {
 
     override fun finished(description: Description) {
         super.finished(description)
-        scope.cleanupTestCoroutines()
         DispatcherProvider.reset()
     }
 }

--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -74,6 +74,13 @@ object AppConfig {
         ),
         SampleUser(
             apiKey = apiKey,
+            id = "oleg",
+            name = "NotOleg Kuzmin",
+            image = "https://ca.slack-edge.com/T02RM6X6B-U019BEATNCD-bad2dcf654ef-128",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2xlZyJ9.ZucjlxjiNewCORdCLwpKwZw2nNtRC_Bv17TjHlitdLU"
+        ),
+        SampleUser(
+            apiKey = apiKey,
             id = "rafal",
             name = "Rafal Adasiewicz",
             image = "https://ca.slack-edge.com/T02RM6X6B-U0177N46AFN-a4e664d1960d-128",

--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -74,13 +74,6 @@ object AppConfig {
         ),
         SampleUser(
             apiKey = apiKey,
-            id = "oleg",
-            name = "NotOleg Kuzmin",
-            image = "https://ca.slack-edge.com/T02RM6X6B-U019BEATNCD-bad2dcf654ef-128",
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2xlZyJ9.ZucjlxjiNewCORdCLwpKwZw2nNtRC_Bv17TjHlitdLU"
-        ),
-        SampleUser(
-            apiKey = apiKey,
             id = "rafal",
             name = "Rafal Adasiewicz",
             image = "https://ca.slack-edge.com/T02RM6X6B-U0177N46AFN-a4e664d1960d-128",


### PR DESCRIPTION
### 🎯 Goal

Update our VMs data of channels/messages/users with last recent user data

### 🛠 Implementation details

1. Expose in `UserRepository` flow with latest users
2. Provide this flow to `ChannelMutableState`, `QueryChannelsControllerState`
3. Retrigger channels, messages with updated users values

### 🧪 Testing

1. Log with a user1 and send a message to channel 1
2. Log from another device with another user and observe the message from user1 in channel 1
3. On first device log out and log in with user1 but with a changed name

Check: user2 sees updated message with new user name of user1

https://user-images.githubusercontent.com/11807573/145237938-88c73208-c5fc-46ff-94d2-8f8b27b5d042.mov

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [ ] Reviewers added

### 🎉 GIF

<img src="https://media0.giphy.com/media/AvMJCeu1EMmhG/giphy.gif"/>
