### PR TITLE
Bug: `MessageInputFieldView#mode` not being reset after clearing custom attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Fixed `MessageInputFieldView#mode` not being reset after custom attachments were cleared
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -383,7 +383,7 @@ internal class MessageInputFieldView : FrameLayout {
     }
 
     private fun resetModeIfNecessary() {
-        if (!hasValidContent() && (mode is Mode.FileAttachmentMode || mode is Mode.MediaAttachmentMode)) {
+        if (!hasValidContent() && (mode is Mode.CustomAttachmentMode || mode is Mode.FileAttachmentMode || mode is Mode.MediaAttachmentMode)) {
             resetMode()
         }
     }


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1489

### 🎯 Goal

`MessageInputFieldView#mode` was not reset after custom attachments were cleared

### 🧪 Testing

Add custom attachment, and remove it. Debug the `MessageInputField#mode` value.

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

