### PR TITLE
Preprocess ownReactions for currentUser when event arrives

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -457,7 +457,7 @@ internal class EventHandlerImpl(
             batch.getCurrentMessage(id)?.ownReactions ?: mutableListOf()
         } else {
             mergeReactions(
-                latestReactions.filter { it.userId == user!!.id },
+                latestReactions.filter { it.userId == domainImpl.user.value?.id ?: "" },
                 batch.getCurrentMessage(id)?.ownReactions ?: mutableListOf()
             ).toMutableList()
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Reaction.kt
@@ -4,14 +4,33 @@ import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 
 /** Updates collection of reactions with more recent data of [users]. */
-internal fun Collection<Reaction>.updateByUsers(userMap: Map<String, User>): Collection<Reaction> = if (mapNotNull { it.user?.id }.any(userMap::containsKey)) {
-    map { reaction ->
-        if (userMap.containsKey(reaction.user?.id ?: reaction.userId)) {
-            reaction.copy(user = userMap[reaction.userId] ?: reaction.user)
-        } else {
-            reaction
+internal fun Collection<Reaction>.updateByUsers(userMap: Map<String, User>): Collection<Reaction> =
+    if (mapNotNull { it.user?.id }.any(userMap::containsKey)) {
+        map { reaction ->
+            if (userMap.containsKey(reaction.user?.id ?: reaction.userId)) {
+                reaction.copy(user = userMap[reaction.userId] ?: reaction.user)
+            } else {
+                reaction
+            }
         }
+    } else {
+        this
     }
-} else {
-    this
+
+/**
+ * Merges two collections of reactions by their [Reaction.type].
+ *
+ * @param recentReactions More recent collection of reactions.
+ * @param cachedReactions More outdated collection of reactions.
+ *
+ * @return Collection of reactions where cached data is substituted by more recent one if they have same [Reaction.type].
+ */
+internal fun mergeReactions(
+    recentReactions: Collection<Reaction>,
+    cachedReactions: Collection<Reaction>,
+): Collection<Reaction> {
+    return (
+        cachedReactions.associateBy(Reaction::type) +
+            recentReactions.associateBy(Reaction::type)
+        ).values
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/extensions/ReactionExtensionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/extensions/ReactionExtensionsTest.kt
@@ -1,0 +1,22 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.offline.randomReaction
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should contain`
+import org.junit.jupiter.api.Test
+
+internal class ReactionExtensionsTest {
+
+    @Test
+    fun `Should merge correctly`() {
+        val reaction1 = randomReaction(type = "type1")
+        val reaction1Update = randomReaction(type = "type1")
+        val reaction2 = randomReaction(type = "type2")
+
+        val mergedResult = mergeReactions(listOf(reaction1Update), listOf(reaction1, reaction2))
+
+        mergedResult.size `should be equal to` 2
+        mergedResult `should contain` reaction1Update
+        mergedResult `should contain` reaction2
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Update `Message::ownReactions` for current user when WS event arrives

### 🛠 Implementation details

Set field as merge of lates reactions for this user and own cached reactions

### 🧪 Testing

UI Comp Sample App:

1. Enter channel X
2. Open message overlay and leave a reaction (everything is fine)
3. After that open the message overlay and react using a different reaction without removing the previous one. 
4. Reactions should be shown accordingly

### ☑️ Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] PR targets the `develop` branch
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (docusaurus, tutorial, CMS (task created))
- [x] Reviewers added

### 🎉 GIF

<img src="https://media0.giphy.com/media/3o6MbaH4zqUQ3wydlC/giphy.gif"/>
