### PR TITLE
Cleaned up base message UI around footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved the UI for message footers to be more respective of thread replies [#2765](https://github.com/GetStream/stream-chat-android/pull/2765)
+- Fixed the orientation and UI of ThreadParticipants [#2765](https://github.com/GetStream/stream-chat-android/pull/2765)
 
 ### ✅ Added
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -796,6 +796,10 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Mess
 	public static final fun MessageText (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooterKt {
+	public static final fun MessageThreadFooter (Ljava/util/List;Ljava/lang/String;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+}
+
 public final class io/getstream/chat/android/compose/ui/components/messages/MessageThreadSeparatorKt {
 	public static final fun MessageThreadSeparator (Lio/getstream/chat/android/compose/state/messages/list/ThreadSeparatorState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
@@ -809,7 +813,7 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Syst
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ThreadParticipantsKt {
-	public static final fun ThreadParticipants (Ljava/util/List;Landroidx/compose/ui/Modifier;Ljava/lang/String;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ThreadParticipants (Ljava/util/List;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/UploadingFooterKt {
@@ -1079,7 +1083,7 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors$Compa
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamDimens$Companion;
-	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
 	public final fun component10-D9Ej5fM ()F
 	public final fun component11-D9Ej5fM ()F
@@ -1101,6 +1105,7 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun component26-D9Ej5fM ()F
 	public final fun component27-D9Ej5fM ()F
 	public final fun component28-D9Ej5fM ()F
+	public final fun component29-D9Ej5fM ()F
 	public final fun component3-D9Ej5fM ()F
 	public final fun component4-D9Ej5fM ()F
 	public final fun component5-D9Ej5fM ()F
@@ -1108,8 +1113,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun component7-D9Ej5fM ()F
 	public final fun component8-D9Ej5fM ()F
 	public final fun component9-D9Ej5fM ()F
-	public final fun copy-b3hfcmU (FFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
-	public static synthetic fun copy-b3hfcmU$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public final fun copy-VSRLDhc (FFFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public static synthetic fun copy-VSRLDhc$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachmentsContentFileUploadWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentFileWidth-D9Ej5fM ()F
@@ -1137,6 +1142,7 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun getSuggestionListElevation-D9Ej5fM ()F
 	public final fun getSuggestionListMaxHeight-D9Ej5fM ()F
 	public final fun getSuggestionListPadding-D9Ej5fM ()F
+	public final fun getThreadParticipantItemSize-D9Ej5fM ()F
 	public final fun getThreadSeparatorTextVerticalPadding-D9Ej5fM ()F
 	public final fun getThreadSeparatorVerticalPadding-D9Ej5fM ()F
 	public fun hashCode ()I

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -813,7 +813,7 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Syst
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ThreadParticipantsKt {
-	public static final fun ThreadParticipants (Ljava/util/List;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V
+	public static final fun ThreadParticipants (Ljava/util/List;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/BorderStroke;ILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/UploadingFooterKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -15,7 +15,7 @@ import io.getstream.chat.android.compose.ui.components.Timestamp
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
 /**
- * Default message footer, which contains either [ThreadParticipants] or the default footer, which
+ * Default message footer, which contains either [MessageThreadFooter] or the default footer, which
  * holds the sender name and the timestamp.
  *
  * @param messageItem Message to show.
@@ -28,18 +28,22 @@ public fun MessageFooter(
 ) {
     val (message, position) = messageItem
     val hasThread = message.threadParticipants.isNotEmpty()
+    val alignment = ChatTheme.messageAlignmentProvider.provideMessageAlignment(messageItem)
 
     if (hasThread && !messageItem.isInThread) {
         val replyCount = message.replyCount
-        ThreadParticipants(
+        MessageThreadFooter(
             modifier = modifier,
             participants = message.threadParticipants,
+            messageAlignment = alignment,
             text = LocalContext.current.resources.getQuantityString(
                 R.plurals.stream_compose_message_list_thread_footnote,
                 replyCount,
                 replyCount
             )
         )
+
+        Timestamp(date = message.updatedAt ?: message.createdAt)
     } else if (!hasThread && (position == MessageItemGroupPosition.Bottom || position == MessageItemGroupPosition.None)) {
         Row(
             modifier = modifier.padding(top = 4.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -42,9 +42,9 @@ public fun MessageFooter(
                 replyCount
             )
         )
+    }
 
-        Timestamp(date = message.updatedAt ?: message.createdAt)
-    } else if (!hasThread && (position == MessageItemGroupPosition.Bottom || position == MessageItemGroupPosition.None)) {
+    if (position == MessageItemGroupPosition.Bottom || position == MessageItemGroupPosition.None) {
         Row(
             modifier = modifier.padding(top = 4.dp),
             verticalAlignment = Alignment.CenterVertically

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
@@ -1,0 +1,53 @@
+package io.getstream.chat.android.compose.ui.components.messages
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.compose.state.messages.MessageAlignment
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+
+/**
+ * Shows a row of participants in the message thread, if they exist.
+ *
+ * @param participants List of users in the thread.
+ * @param text Text of the label.
+ * @param messageAlignment The alignment of the message, used for the content orientation.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+public fun MessageThreadFooter(
+    participants: List<User>,
+    text: String,
+    messageAlignment: MessageAlignment,
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier.padding(top = 4.dp)) {
+        if (messageAlignment == MessageAlignment.Start) {
+            ThreadParticipants(
+                modifier = Modifier
+                    .padding(end = 4.dp),
+                participants = participants,
+                alignment = messageAlignment
+            )
+        }
+
+        Text(
+            text = text,
+            style = ChatTheme.typography.footnoteBold,
+            color = ChatTheme.colors.primaryAccent
+        )
+
+        if (messageAlignment == MessageAlignment.End) {
+            ThreadParticipants(
+                modifier = Modifier
+                    .padding(start = 4.dp),
+                participants = participants,
+                alignment = messageAlignment
+            )
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ThreadParticipants.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ThreadParticipants.kt
@@ -1,5 +1,7 @@
 package io.getstream.chat.android.compose.ui.components.messages
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -13,14 +15,13 @@ import io.getstream.chat.android.compose.state.messages.MessageAlignment
 import io.getstream.chat.android.compose.ui.components.avatar.Avatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
-private const val DEFAULT_PARTICIPANTS_LIMIT = 4
-
 /**
- * Represents the last two participants in the thread.
+ * Represents a number of participants in the thread.
  *
  * @param participants The list of participants in the thread.
  * @param alignment The alignment of the parent message.
  * @param modifier Modifier for styling.
+ * @param borderStroke The border of user avatars, for visibility.
  * @param participantsLimit The limit of the number of participants shown in the component.
  */
 @Composable
@@ -28,13 +29,10 @@ public fun ThreadParticipants(
     participants: List<User>,
     alignment: MessageAlignment,
     modifier: Modifier = Modifier,
+    borderStroke: BorderStroke = BorderStroke(width = 1.dp, color = ChatTheme.colors.appBackground),
     participantsLimit: Int = DEFAULT_PARTICIPANTS_LIMIT,
 ) {
     Box(modifier) {
-        /**
-         * If we're aligning the message to the start, we just show items as they are, if we are showing them from the
-         * end, then we need to reverse the order.
-         */
         /**
          * If we're aligning the message to the start, we just show items as they are, if we are showing them from the
          * end, then we need to reverse the order.
@@ -58,12 +56,6 @@ public fun ThreadParticipants(
              *
              * If we're aligned to the end, then the last item should be the upper most.
              */
-            /**
-             * Calculates the visual position of the item to define its zIndex. If we're aligned to the start of the screen,
-             * the first item should be the upper most.
-             *
-             * If we're aligned to the end, then the last item should be the upper most.
-             */
             val itemPosition = if (alignment == MessageAlignment.Start) {
                 participantsLimit - index
             } else {
@@ -73,9 +65,12 @@ public fun ThreadParticipants(
             Avatar(
                 modifier = itemPadding
                     .zIndex(itemPosition)
-                    .size(itemSize),
+                    .size(itemSize)
+                    .border(border = borderStroke, shape = ChatTheme.shapes.avatar),
                 painter = painter
             )
         }
     }
 }
+
+private const val DEFAULT_PARTICIPANTS_LIMIT = 4

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ThreadParticipants.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ThreadParticipants.kt
@@ -1,44 +1,79 @@
 package io.getstream.chat.android.compose.ui.components.messages
 
-import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import coil.compose.rememberImagePainter
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.compose.state.messages.MessageAlignment
 import io.getstream.chat.android.compose.ui.components.avatar.Avatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
+private const val DEFAULT_PARTICIPANTS_LIMIT = 4
+
 /**
- * Shows a row of participants in the message thread, if they exist.
+ * Represents the last two participants in the thread.
  *
- * @param participants List of users in the thread.
+ * @param participants The list of participants in the thread.
+ * @param alignment The alignment of the parent message.
  * @param modifier Modifier for styling.
- * @param text Text of the label.
+ * @param participantsLimit The limit of the number of participants shown in the component.
  */
 @Composable
 public fun ThreadParticipants(
     participants: List<User>,
+    alignment: MessageAlignment,
     modifier: Modifier = Modifier,
-    text: String,
+    participantsLimit: Int = DEFAULT_PARTICIPANTS_LIMIT,
 ) {
-    Row(modifier = modifier.padding(start = 4.dp, end = 4.dp, top = 4.dp)) {
-        Text(
-            modifier = Modifier.padding(end = 4.dp),
-            text = text,
-            style = ChatTheme.typography.footnoteBold,
-            color = ChatTheme.colors.primaryAccent
-        )
+    Box(modifier) {
+        /**
+         * If we're aligning the message to the start, we just show items as they are, if we are showing them from the
+         * end, then we need to reverse the order.
+         */
+        /**
+         * If we're aligning the message to the start, we just show items as they are, if we are showing them from the
+         * end, then we need to reverse the order.
+         */
+        val participantsToShow = participants.take(participantsLimit).let {
+            if (alignment == MessageAlignment.End) {
+                it.reversed()
+            } else {
+                it
+            }
+        }
+        val itemSize = ChatTheme.dimens.threadParticipantItemSize
 
-        for (user in participants) {
+        participantsToShow.forEachIndexed { index, user ->
             val painter = rememberImagePainter(data = user.image)
+            val itemPadding = Modifier.padding(start = (index * (itemSize.value / 2)).dp)
+
+            /**
+             * Calculates the visual position of the item to define its zIndex. If we're aligned to the start of the screen,
+             * the first item should be the upper most.
+             *
+             * If we're aligned to the end, then the last item should be the upper most.
+             */
+            /**
+             * Calculates the visual position of the item to define its zIndex. If we're aligned to the start of the screen,
+             * the first item should be the upper most.
+             *
+             * If we're aligned to the end, then the last item should be the upper most.
+             */
+            val itemPosition = if (alignment == MessageAlignment.Start) {
+                participantsLimit - index
+            } else {
+                index + 1
+            }.toFloat()
+
             Avatar(
-                modifier = Modifier
-                    .padding(2.dp)
-                    .size(16.dp),
+                modifier = itemPadding
+                    .zIndex(itemPosition)
+                    .size(itemSize),
                 painter = painter
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.unit.dp
  * @param messageOptionsMaxHeight The max height of the message options section when we select a message in the list.
  * @param messageOptionsMaxWidth The max width of the message options section when we select a message in the list.
  * @param messageOptionsRoundedCorners The rounded corners size of the message options shape.
+ * @param threadParticipantItemSize The size of thread participant avatar items.
  */
 @Immutable
 public data class StreamDimens(
@@ -66,6 +67,7 @@ public data class StreamDimens(
     public val messageOptionsMaxWidth: Dp,
     public val messageOptionsMaxHeight: Dp,
     public val messageOptionsRoundedCorners: Dp,
+    public val threadParticipantItemSize: Dp,
 ) {
     public companion object {
         public fun defaultDimens(): StreamDimens = StreamDimens(
@@ -96,7 +98,8 @@ public data class StreamDimens(
             commandSuggestionItemIconSize = 24.dp,
             messageOptionsMaxWidth = 200.dp,
             messageOptionsMaxHeight = 300.dp,
-            messageOptionsRoundedCorners = 16.dp
+            messageOptionsRoundedCorners = 16.dp,
+            threadParticipantItemSize = 16.dp
         )
     }
 }


### PR DESCRIPTION
Fixes #2687.

### 🛠 Implementation details

Fixed the logic around MessageFooter and the ThreadParticipants components.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/17215808/145860969-0206a6d2-342f-4e9a-be8f-75d38e159dde.png) | ![after](https://user-images.githubusercontent.com/17215808/145860991-f6f2b9a9-1311-4703-a811-631c71faa313.png) |

### 🧪 Testing

Start a thread or observe existing threads - the message should have both a thread participants footer and a timestamp, if it's at the end.

Also fixed the orientation of the participants component and made it more design-friendly.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
~~- [ ] New code is covered by unit tests~~
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![footer](https://user-images.githubusercontent.com/17215808/145859070-1b2f1d2c-9d62-4670-83f7-6dd89d06945a.gif)
