### PR TITLE
Propagate current user updates to `MessageListView`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Users' updates done in runtime are now propagated in the MessageListView component. [#2769](https://github.com/GetStream/stream-chat-android/pull/2769)
 
 ### ⬆️ Improved
 - Improved Korean 🇰🇷 and Japanese 🇯🇵 translation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Users' updates done in runtime are now propagated in the MessageListView component. [#2769](https://github.com/GetStream/stream-chat-android/pull/2769)
+- Users' updates done in runtime are now propagated to the `MessageListView` component. [#2769](https://github.com/GetStream/stream-chat-android/pull/2769)
 
 ### ⬆️ Improved
 - Improved Korean 🇰🇷 and Japanese 🇯🇵 translation.

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -192,4 +192,13 @@ internal class ChatClientTest {
 
         result shouldBeEqualTo listOf(eventA)
     }
+
+    @Test
+    fun `Given connected user When handle event with updated user Should updated user value`() {
+        val updateUser = user.copy(extraData = mutableMapOf()).apply { name = "updateUserName" }
+
+        socket.sendEvent(Mother.randomUserPresenceChangedEvent(updateUser))
+
+        client.getCurrentUser() shouldBeEqualTo updateUser
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.client
 import com.flextrade.jfixture.JFixture
 import com.flextrade.kfixture.KFixture
 import com.nhaarman.mockitokotlin2.mock
+import io.getstream.chat.android.client.events.UserPresenceChangedEvent
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Device
@@ -45,4 +46,10 @@ internal object Mother {
             token = token,
             pushProvider = pushProvider,
         )
+
+    fun randomUserPresenceChangedEvent(user: User = randomUser()): UserPresenceChangedEvent {
+        return KFixture(fixture) {
+            sameInstance(User::class.java, user)
+        }()
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -14,7 +14,8 @@ import io.getstream.chat.android.client.models.User
 import java.util.UUID
 
 internal object Mother {
-    private val fixture = JFixture()
+    private val fixture: JFixture
+        get() = JFixture()
 
     fun randomAttachment(attachmentBuilder: Attachment.() -> Unit = { }): Attachment {
         return KFixture(fixture) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/UserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/UserRepository.kt
@@ -52,6 +52,7 @@ internal class UserRepositoryImpl(
     }
 
     override suspend fun insertCurrentUser(user: User) {
+        insertUser(user)
         val userEntity = toEntity(user).copy(id = ME_ID)
         userDao.insert(userEntity)
     }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1978,7 +1978,7 @@ public abstract class io/getstream/chat/android/ui/message/list/adapter/BaseMess
 }
 
 public final class io/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff {
-	public fun <init> (ZZZZZZZZ)V
+	public fun <init> (ZZZZZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -1987,8 +1987,9 @@ public final class io/getstream/chat/android/ui/message/list/adapter/MessageList
 	public final fun component6 ()Z
 	public final fun component7 ()Z
 	public final fun component8 ()Z
-	public final fun copy (ZZZZZZZZ)Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;ZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;
+	public final fun component9 ()Z
+	public final fun copy (ZZZZZZZZZ)Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;ZZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachments ()Z
 	public final fun getDeleted ()Z
@@ -1998,6 +1999,7 @@ public final class io/getstream/chat/android/ui/message/list/adapter/MessageList
 	public final fun getReplies ()Z
 	public final fun getSyncStatus ()Z
 	public final fun getText ()Z
+	public final fun getUser ()Z
 	public fun hashCode ()I
 	public final fun plus (Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;)Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff.kt
@@ -9,6 +9,7 @@ public data class MessageListItemPayloadDiff(
     val deleted: Boolean,
     val positions: Boolean,
     val pinned: Boolean,
+    val user: Boolean,
 ) {
     public operator fun plus(other: MessageListItemPayloadDiff): MessageListItemPayloadDiff {
         return MessageListItemPayloadDiff(
@@ -20,6 +21,7 @@ public data class MessageListItemPayloadDiff(
             deleted = deleted || other.deleted,
             positions = positions || other.positions,
             pinned = pinned || other.pinned,
+            user = user || other.user,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemAdapter.kt
@@ -85,6 +85,7 @@ internal class MessageListItemAdapter(
             deleted = true,
             positions = true,
             pinned = true,
+            user = true,
         )
         private val EMPTY_MESSAGE_LIST_ITEM_PAYLOAD_DIFF = MessageListItemPayloadDiff(
             text = false,
@@ -95,6 +96,7 @@ internal class MessageListItemAdapter(
             deleted = false,
             positions = false,
             pinned = false,
+            user = false,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/internal/MessageListItemDiffCallback.kt
@@ -25,7 +25,8 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                     oldItem.isMessageRead == newItem.isMessageRead &&
                     oldItem.isThreadMode == newItem.isThreadMode &&
                     oldItem.message.extraData == newItem.message.extraData &&
-                    oldItem.message.pinned == newItem.message.pinned
+                    oldItem.message.pinned == newItem.message.pinned &&
+                    oldItem.message.user == newItem.message.user
             }
             is MessageListItem.DateSeparatorItem -> oldItem.date == (newItem as? MessageListItem.DateSeparatorItem)?.date
             is MessageListItem.ThreadSeparatorItem -> oldItem == (newItem as? MessageListItem.ThreadSeparatorItem)
@@ -48,6 +49,7 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
                 deleted = oldItem.message.deletedAt != newItem.message.deletedAt,
                 positions = oldItem.positions != newItem.positions,
                 pinned = oldItem.message.pinned != newItem.message.pinned,
+                user = oldItem.message.user != newItem.message.user,
             )
         } else {
             null


### PR DESCRIPTION
### 🎯 Goal

When users' updates happen in runtime it's not reflected in `MessageListView`. Because we don't calculate `Message::user` in diff callback.
Also, we keep the outdated users in LLC

### 🛠 Implementation details

1. Consider `Message::user` field when calculate diff for `MessageListView`
2. Update user in LLC when an event with current user arrives.

### 🧪 Testing

Open some conversation
Change name (login from another device with a different name e.g. Dashboard update doesn't trigger event, can't be used here) of some user
Be sure the new name is shown in the conversation

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [x] UI Components sample runs & works
- [ ] Compose sample runs & works
- [x] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [x] New feature tested and works
- [x] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
<img src="https://media2.giphy.com/media/vRfD1XbxzLtYI/giphy.gif"/>
