### PR TITLE
[CAS-1292] Deprecate ChatDomain::showChannel, remove side effects

### DIFF
--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,7 +4,8 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `ChatDomain#loadOlderMessages` | 2021.12.20<br/>4.25.0 | 2022.01.20<br/>⌛ | 2022.02.20 ⌛ | Use `ChatClient#loadOlderMessages` instead |
+| `ChatDomain#showChannel` | 2021.12.21<br/>4.25.0 | 2022.01.21<br/>⌛ | 2022.02.21 ⌛ | Use `ChatClient#showChannel` instead |
+| `ChatDomain#loadOlderMessages` | 2021.12.21<br/>4.25.0 | 2022.01.21<br/>⌛ | 2022.02.21 ⌛ | Use `ChatClient#loadOlderMessages` instead |
 | `ChatDomain#stopTyping` | 2021.11.29<br/>4.24.0 | 2021.12.29<br/>⌛ | 2022.01.29 ⌛ | Use `ChatClient#stopTyping` instead |
 | `ChatDomain#keystroke` | 2021.11.29<br/>4.24.0 | 2021.12.29<br/>⌛ | 2022.01.29 ⌛ | Use `ChatClient#keystroke` instead |
 | `QueryChannelsController#mutedChannelIds` | 2021.11.23<br/>4.23.0 | 2021.12.09<br/>4.24.0 | 2022.12.21 ⌛ | Use ChatDomain.mutedChannels instead |

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -517,6 +517,14 @@ public sealed interface ChatDomain {
      * @return Executable async [Call] responsible for hiding a channel.
      */
     @CheckResult
+    @Deprecated(
+        message = "Deprecated. Use ChatClient::showChannel instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().showChannel(channelType, channelId)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun showChannel(cid: String): Call<Unit>
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -521,6 +521,14 @@ public sealed interface ChatDomain {
      * @return Executable async [Call] responsible for hiding a channel.
      */
     @CheckResult
+    @Deprecated(
+        message = "Deprecated. Use ChatClient::showChannel instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().showChannel(channelType, channelId)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun showChannel(cid: String): Call<Unit>
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -271,12 +271,7 @@ public class ChannelController internal constructor(
     }
 
     internal suspend fun show(): Result<Unit> {
-        channelLogic.setHidden(false)
-        val result = channelClient.show().await()
-        if (result.isSuccess) {
-            domainImpl.repos.setHiddenForChannel(cid, false)
-        }
-        return result
+        return channelClient.show().await()
     }
 
     /** Leave the channel action. Fires an API request. */

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.events.ChannelDeletedEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedByUserEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedEvent
+import io.getstream.chat.android.client.events.ChannelVisibleEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
 import io.getstream.chat.android.client.events.MessageReadEvent
@@ -64,8 +65,22 @@ import java.util.concurrent.Executors
 
 private val fixture = JFixture()
 
+internal fun randomChannelVisibleEvent(
+    createdAt: Date = randomDate(),
+    cid: String = randomCID(),
+    channelType: String = randomString(),
+    channelId: String = randomString(),
+    user: User = randomUser(),
+) = ChannelVisibleEvent(
+    type = EventType.CHANNEL_VISIBLE,
+    createdAt = createdAt,
+    cid = cid,
+    channelType = channelType,
+    channelId = channelId,
+    user = user
+)
+
 internal fun randomUserStartWatchingEvent(
-    type: String = randomString(),
     createdAt: Date = randomDate(),
     cid: String = randomString(),
     watcherCount: Int = randomInt(),
@@ -73,7 +88,7 @@ internal fun randomUserStartWatchingEvent(
     channelId: String = randomString(),
     user: User = randomUser(),
 ) = UserStartWatchingEvent(
-    type = type,
+    type = EventType.USER_WATCHING_START,
     createdAt = createdAt,
     cid = cid,
     watcherCount = watcherCount,

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/ChatDomainEventDomainImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/ChatDomainEventDomainImplTest.kt
@@ -4,6 +4,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.querychannels.ChatEventHandler
 import io.getstream.chat.android.offline.querychannels.EventHandlingResult
+import io.getstream.chat.android.offline.randomChannel
+import io.getstream.chat.android.offline.randomChannelVisibleEvent
 import io.getstream.chat.android.offline.randomMember
 import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.offline.randomUser
@@ -281,4 +283,17 @@ internal class ChatDomainEventDomainImplTest : BaseDomainTest2() {
             val messages = channelController.messages.value
             messages.shouldBeEmpty()
         }
+
+    @Test
+    fun `Given a hidden channel in DB When handle ChannelVisibleEvent Should update value in DB and in controller`() = coroutineTest {
+        val channel = randomChannel(cid = "cid123", hidden = true)
+        chatDomainImpl.repos.insertChannel(channel)
+        val channelController = chatDomainImpl.channel(channel).also { it.watch() }
+        channelController.hidden.value shouldBeEqualTo true
+
+        chatDomainImpl.eventHandler.handleEvent(randomChannelVisibleEvent(cid = "cid123"))
+
+        channelController.hidden.value shouldBeEqualTo false
+        chatDomainImpl.repos.selectChannels(listOf("cid123")).first().hidden shouldBeEqualTo false
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

In order to merge ChatDomain into ChatClient we need to eliminate direct usage of ChatDomain and substitute it with the usage of ChatClient. 
This PR deprecates usage of `ChatDomain::showChannel`

### 🛠 Implementation details

1. Deprecate `ChatDomain::showChannel`
2. Remove side effects from `ChannelController::showChannel` (it should be handled via events)
3. Write a test that checks that event handling updates required data

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
<img src="https://media2.giphy.com/media/daIVWn5q3HIeGHpbh2/giphy.gif"/>
