### PR TITLE
[2745] Fix user mute/unmute behavior

### DIFF
--- a/.idea/inspectionProfiles/ktlint.xml
+++ b/.idea/inspectionProfiles/ktlint.xml
@@ -5,6 +5,21 @@
       <scope name="Library modules" level="WARNING" enabled="true" />
     </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
+    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="previewFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SuspiciousCollectionReassignment" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>

--- a/.idea/inspectionProfiles/ktlint.xml
+++ b/.idea/inspectionProfiles/ktlint.xml
@@ -5,21 +5,6 @@
       <scope name="Library modules" level="WARNING" enabled="true" />
     </inspection_tool>
     <inspection_tool class="KotlinUnusedImport" enabled="true" level="ERROR" enabled_by_default="true" />
-    <inspection_tool class="PreviewAnnotationInFunctionWithParameters" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewDimensionRespectsLimit" enabled="true" level="WARNING" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewMustBeTopLevelFunction" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
-    <inspection_tool class="PreviewNeedsComposableAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
-      <option name="previewFile" value="true" />
-    </inspection_tool>
     <inspection_tool class="RedundantSemicolon" enabled="true" level="ERROR" enabled_by_default="true" />
     <inspection_tool class="SuspiciousCollectionReassignment" enabled="false" level="WARNING" enabled_by_default="false" />
   </profile>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,7 +103,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added site name labels to link attachments for websites using the Open Graph protocol [#2785](https://github.com/GetStream/stream-chat-android/pull/2785)
 - Added preview screens for file attachments [#2764](https://github.com/GetStream/stream-chat-android/pull/2764)
 - Added a way to disable date separator and system message items in the message list [#2770](https://github.com/GetStream/stream-chat-android/pull/2770)
-- Added an option to the message options menu to unmute a user that sent the message. [#](https://github.com/GetStream/stream-chat-android/pull/)
+- Added an option to the message options menu to unmute a user that sent the message. [#2787](https://github.com/GetStream/stream-chat-android/pull/2787)
 
 ### ⚠️ Changed
 - Removed SelectedMessageOverlay and replaced it with SelectedMessageMenu - [#2768](https://github.com/GetStream/stream-chat-android/pull/2768)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added site name labels to link attachments for websites using the Open Graph protocol [#2785](https://github.com/GetStream/stream-chat-android/pull/2785)
 - Added preview screens for file attachments [#2764](https://github.com/GetStream/stream-chat-android/pull/2764)
 - Added a way to disable date separator and system message items in the message list [#2770](https://github.com/GetStream/stream-chat-android/pull/2770)
+- Added an option to the message options menu to unmute a user that sent the message. [#](https://github.com/GetStream/stream-chat-android/pull/)
 
 ### ⚠️ Changed
 - Removed SelectedMessageOverlay and replaced it with SelectedMessageMenu - [#2768](https://github.com/GetStream/stream-chat-android/pull/2768)

--- a/docusaurus/docs/Android/04-compose/04-message-components/06-selected-message-overlay.mdx
+++ b/docusaurus/docs/Android/04-compose/04-message-components/06-selected-message-overlay.mdx
@@ -5,7 +5,7 @@ The `SelectedMessageMenu` component allows you to show different message options
 This is a **stateless component** that you can easily add to your UI if you're building a custom Messages screen. Internally, it sets up the following components:
 
 * Reaction options: Shows a list of reactions the user can use to react to the message. Those reactions are shown as `ReactionOptionItem`s.
-* Message options: Shows a list of actions the user can take with the selected message, such as **delete**, **edit**, **reply to** and **start a thread** actions.
+* Message options: Shows a list of actions the user can take with the selected message, such as **delete**, **edit**, **reply to**, **flag message**, **copy message**, **mute user** and **start a thread** actions.
 
 Let's see how to use it!
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -91,8 +91,11 @@ public fun defaultMessageOptionsState(
     currentUser: User?,
     isInThread: Boolean,
 ): List<MessageOptionItemState> {
+    val selectedMessageUserId = selectedMessage.user.id
+
     val isTextOnlyMessage = selectedMessage.text.isNotEmpty() && selectedMessage.attachments.isEmpty()
-    val isOwnMessage = selectedMessage.user.id == currentUser?.id
+    val isOwnMessage = selectedMessageUserId == currentUser?.id
+    val isUserMuted = currentUser?.mutes?.any { it.target.id == selectedMessageUserId } ?: true
 
     return listOfNotNull(
         MessageOptionItemState(
@@ -156,8 +159,8 @@ public fun defaultMessageOptionsState(
         } else null,
         if (!isOwnMessage) {
             MessageOptionItemState(
-                title = R.string.stream_compose_mute_user,
-                iconPainter = painterResource(R.drawable.stream_compose_ic_mute),
+                title = if (isUserMuted) R.string.stream_compose_unmute_user else R.string.stream_compose_mute_user,
+                iconPainter = painterResource(id = if (isUserMuted) R.drawable.stream_compose_ic_unmute else R.drawable.stream_compose_ic_mute),
                 action = MuteUser(selectedMessage),
                 titleColor = ChatTheme.colors.textHighEmphasis,
                 iconColor = ChatTheme.colors.textLowEmphasis,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -95,7 +95,7 @@ public fun defaultMessageOptionsState(
 
     val isTextOnlyMessage = selectedMessage.text.isNotEmpty() && selectedMessage.attachments.isEmpty()
     val isOwnMessage = selectedMessageUserId == currentUser?.id
-    val isUserMuted = currentUser?.mutes?.any { it.target.id == selectedMessageUserId } ?: true
+    val isUserMuted = currentUser?.mutes?.any { it.target.id == selectedMessageUserId } ?: false
 
     return listOfNotNull(
         MessageOptionItemState(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -505,7 +505,7 @@ public class MessageListViewModel(
                 messageActions = messageActions + messageAction
             }
             is Copy -> copyMessage(messageAction.message)
-            is MuteUser -> muteUser(messageAction.message.user)
+            is MuteUser -> updateUserMute(messageAction.message.user)
             is React -> reactToMessage(messageAction.reaction, messageAction.message)
             is Pin -> updateMessagePin(messageAction.message)
             else -> {
@@ -699,12 +699,18 @@ public class MessageListViewModel(
     }
 
     /**
-     * Mutes the user that sent a particular message.
+     * Mutes or unmutes the user that sent a particular message.
      *
-     * @param user The user to mute.
+     * @param user The user to mute or unmute.
      */
-    private fun muteUser(user: User) {
-        chatClient.muteUser(user.id).enqueue()
+    private fun updateUserMute(user: User) {
+        val isUserMuted = chatDomain.muted.value.any { it.target.id == user.id }
+
+        if (isUserMuted) {
+            chatClient.unmuteUser(user.id)
+        } else {
+            chatClient.muteUser(user.id)
+        }.enqueue()
     }
 
     /**

--- a/stream-chat-android-compose/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-en/strings.xml
@@ -66,6 +66,7 @@
     <string name="stream_compose_edit_message">Edit Message</string>
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
+    <string name="stream_compose_unmute_user">Unmute User</string>
     <string name="stream_compose_flag_message">Flag Message</string>
 
     <!-- Message Action Prompts -->

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -50,6 +50,7 @@
     <string name="stream_compose_edit_message">Editar Mensaje</string>
     <string name="stream_compose_delete_message">Eliminar mensaje</string>
     <string name="stream_compose_mute_user">Silenciar usuario</string>
+    <string name="stream_compose_unmute_user">Dejar de silenciar al usuario</string>
     <string name="stream_compose_flag_message">Marcar Mensaje</string>
     <string name="stream_compose_delete_message_title">Eliminar mensaje</string>
     <string name="stream_compose_delete_message_text">¿Estás seguro de que quieres eliminar permanentemente el mensaje?</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -52,6 +52,7 @@
     <string name="stream_compose_edit_message">Modifier le message</string>
     <string name="stream_compose_delete_message">Supprimer le message</string>
     <string name="stream_compose_mute_user">Mettre en sourdine l\'utilisateur</string>
+    <string name="stream_compose_unmute_user">Désactiver la mise en sourdine de l\'utilisateur</string>
     <string name="stream_compose_flag_message">Signaler un message</string>
     <string name="stream_compose_delete_message_title">Supprimer le message</string>
     <string name="stream_compose_delete_message_text">Êtes-vous sûr de vouloir supprimer définitivement ce message ?</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -45,6 +45,7 @@
     <string name="stream_compose_message_label">"मेसेज भेजें"</string>
     <string name="stream_compose_message_list_empty_messages">"कोई मैसेज नहीं"</string>
     <string name="stream_compose_mute_user">"यूजर को म्यूट करें"</string>
+    <string name="stream_compose_unmute_user">"यूजर को म्यूट से हटायें"</string>
     <string name="stream_compose_new_message">"नया मैसेज़"</string>
     <string name="stream_compose_ok">"ठीक"</string>
     <string name="stream_compose_only_visible_to_you">"केवल आपको दिखाई दे रहा है"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -55,6 +55,7 @@
     <string name="stream_compose_edit_message">Modifica messaggio</string>
     <string name="stream_compose_delete_message">Cancella messaggio</string>
     <string name="stream_compose_mute_user">Silenzia Utente</string>
+    <string name="stream_compose_unmute_user">Riattiva Utente</string>
     <string name="stream_compose_flag_message">Segnala messaggio</string>
     <string name="stream_compose_delete_message_title">Cancella messaggio</string>
     <string name="stream_compose_delete_message_text">Sei sicuro di voler definitivamente cancellare questo messaggio?</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -42,6 +42,7 @@
     <string name="stream_compose_edit_message">メッセージを編集する</string>
     <string name="stream_compose_delete_message">メッセージを削除する</string>
     <string name="stream_compose_mute_user">ユーザーをミュートする</string>
+    <string name="stream_compose_unmute_user">ユーザーのミュートを解除する</string>
     <string name="stream_compose_flag_message">メッセージをフラグする</string>
     <string name="stream_compose_delete_message_title">メッセージを削除する</string>
     <string name="stream_compose_delete_message_text">このメッセージを完全に削除してもよろしいですか？</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -42,6 +42,7 @@
     <string name="stream_compose_edit_message">메세지 수정</string>
     <string name="stream_compose_delete_message">메시지 삭제</string>
     <string name="stream_compose_mute_user">사용자 무시</string>
+    <string name="stream_compose_unmute_user">사용자 음소거 해제</string>
     <string name="stream_compose_flag_message">메세지 신고</string>
     <string name="stream_compose_delete_message_title">메시지를 삭제합니다</string>
     <string name="stream_compose_delete_message_text">이 메시지를 완전히 삭제하시겠습니까?</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -66,6 +66,7 @@
     <string name="stream_compose_edit_message">Edit Message</string>
     <string name="stream_compose_delete_message">Delete Message</string>
     <string name="stream_compose_mute_user">Mute User</string>
+    <string name="stream_compose_unmute_user">Unmute User</string>
     <string name="stream_compose_unpin_message">Unpin from this Chat</string>
     <string name="stream_compose_pin_message">Pin to this Chat</string>
     <string name="stream_compose_flag_message">Flag Message</string>

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageAction.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageAction.kt
@@ -56,7 +56,7 @@ public class Delete(message: Message) : MessageAction(message)
 public class Flag(message: Message) : MessageAction(message)
 
 /**
- * Show a mute user dialog, for another user.
+ * Mutes or unmutes the user who sent the message.
  */
 public class MuteUser(message: Message) : MessageAction(message)
 


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2745

### 🎯 Goal

The goal is to add a message option to unmute the user that sent the message. Also, to properly reflect the muted state of the user in the UI.

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/146725813-49ba9945-3280-4bb4-81fe-63b641d6c4c3.mov

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

Monday

![photo_2021-12-20 10 11 48](https://user-images.githubusercontent.com/9600921/146726695-438f048a-a162-4384-9df9-cff4d476d2a8.jpeg)
