### PR TITLE
[CAS-1503] Fix/user updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed a bug when hard deleted messages still remain in the UI.
+- Stabilized behavior of users' updates propagation across values of the channels and the messages. [#2803](https://github.com/GetStream/stream-chat-android/pull/2803)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -892,7 +892,7 @@ internal class ChatDomainImpl internal constructor(
     private suspend fun selectAndEnrichChannels(
         channelIds: List<String>,
         pagination: AnyChannelPaginationRequest,
-    ): List<Channel> = repos.selectChannels(channelIds = channelIds, forceCache = false, pagination = pagination).applyPagination(pagination)
+    ): List<Channel> = repos.selectChannels(channelIds, pagination).applyPagination(pagination)
 
     override fun clean() {
         for (channelController in activeChannelMapImpl.values.toList()) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -892,7 +892,7 @@ internal class ChatDomainImpl internal constructor(
     private suspend fun selectAndEnrichChannels(
         channelIds: List<String>,
         pagination: AnyChannelPaginationRequest,
-    ): List<Channel> = repos.selectChannels(channelIds, pagination).applyPagination(pagination)
+    ): List<Channel> = repos.selectChannels(channelIds = channelIds, forceCache = false, pagination = pagination).applyPagination(pagination)
 
     override fun clean() {
         for (channelController in activeChannelMapImpl.values.toList()) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -595,7 +595,6 @@ public class ChannelController internal constructor(
     // This one needs to be public for flows such as running a message action
 
     internal fun upsertMessage(message: Message) {
-        android.util.Log.w("USER_UPDATES", "upsertMessage")
         channelLogic.upsertMessages(listOf(message))
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -800,10 +800,10 @@ public class ChannelController internal constructor(
     private fun upsertUserPresence(user: User) {
         val userId = user.id
         // members and watchers have users
-        val members = mutableState._members.value
-        val watchers = mutableState._watchers.value
-        val member = members[userId]?.copy()
-        val watcher = watchers[userId]
+        val members = mutableState.members.value
+        val watchers = mutableState.watchers.value
+        val member = members.firstOrNull { it.getUserId() == userId }?.copy()
+        val watcher = watchers.firstOrNull { it.id == userId }
         if (member != null) {
             member.user = user
             upsertMember(member)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/channel/ChannelController.kt
@@ -970,25 +970,7 @@ public class ChannelController internal constructor(
         return Result(messageToBeDeleted)
     }
 
-    public fun toChannel(): Channel {
-        // recreate a channel object from the various observables.
-        val channelData = mutableState._channelData.value ?: ChannelData(channelType, channelId)
-
-        val messages = mutableState.sortedMessages.value
-        val members = mutableState._members.value.values.toList()
-        val watchers = mutableState._watchers.value.values.toList()
-        val reads = mutableState._reads.value.values.toList()
-        val watcherCount = mutableState._watcherCount.value
-
-        val channel = channelData.toChannel(messages, members, reads, watchers, watcherCount)
-        channel.config = mutableState.channelConfig.value
-        channel.unreadCount = mutableState._unreadCount.value
-        channel.lastMessageAt =
-            mutableState.lastMessageAt.value ?: messages.lastOrNull()?.let { it.createdAt ?: it.createdLocallyAt }
-        channel.hidden = mutableState._hidden.value
-
-        return channel
-    }
+    public fun toChannel(): Channel = mutableState.toChannel()
 
     internal suspend fun loadMessageById(
         messageId: String,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
@@ -66,7 +66,11 @@ internal class EventBatchUpdate private constructor(
     }
 
     fun addUsers(newUsers: List<User>) {
-        userMap += newUsers.associateBy(User::id)
+        newUsers.forEach { user ->
+            if (userMap.containsKey(user.id).not()) {
+                userMap[user.id] = user
+            }
+        }
     }
 
     fun addUser(newUser: User) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventBatchUpdate.kt
@@ -115,10 +115,12 @@ internal class EventBatchUpdate private constructor(
         }
 
         suspend fun build(domainImpl: ChatDomainImpl): EventBatchUpdate {
+            // Update users in DB in order to fetch channels and messages with sync data.
+            domainImpl.repos.insertUsers(users)
             val messageMap: Map<String, Message> =
-                domainImpl.repos.selectMessages(messagesToFetch.toList()).associateBy(Message::id)
+                domainImpl.repos.selectMessages(messagesToFetch.toList(), forceCache = true).associateBy(Message::id)
             val channelMap: Map<String, Channel> =
-                domainImpl.repos.selectChannels(channelsToFetch.toList()).associateBy(Channel::cid)
+                domainImpl.repos.selectChannels(channelsToFetch.toList(), forceCache = true).associateBy(Channel::cid)
             return EventBatchUpdate(
                 domainImpl,
                 channelMap.toMutableMap(),

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -25,7 +25,6 @@ import io.getstream.chat.android.offline.extensions.isPermanent
 import io.getstream.chat.android.offline.message.NEVER
 import io.getstream.chat.android.offline.message.attachment.AttachmentUrlValidator
 import io.getstream.chat.android.offline.message.shouldIncrementUnreadCount
-import io.getstream.chat.android.offline.message.users
 import io.getstream.chat.android.offline.model.ChannelConfig
 import io.getstream.chat.android.offline.request.QueryChannelPaginationRequest
 import java.util.Date

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.offline.extensions.isPermanent
 import io.getstream.chat.android.offline.message.NEVER
 import io.getstream.chat.android.offline.message.attachment.AttachmentUrlValidator
 import io.getstream.chat.android.offline.message.shouldIncrementUnreadCount
+import io.getstream.chat.android.offline.message.users
 import io.getstream.chat.android.offline.model.ChannelConfig
 import io.getstream.chat.android.offline.request.QueryChannelPaginationRequest
 import java.util.Date
@@ -235,7 +236,7 @@ internal class ChannelLogic(
     }
 
     private fun parseMessages(messages: List<Message>): Map<String, Message> {
-        val currentMessages = mutableState._messages.value
+        val currentMessages = mutableState.messageList.value.associateBy(Message::id)
         return currentMessages + attachmentUrlValidator.updateValidAttachmentsUrl(messages, currentMessages)
             .filter { newMessage -> isMessageNewerThanCurrent(currentMessages[newMessage.id], newMessage) }
             .associateBy(Message::id)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -31,7 +31,7 @@ internal class ChannelMutableState(
     override val channelId: String,
     private val scope: CoroutineScope,
     private val userFlow: StateFlow<User?>,
-    private val latestUsers: StateFlow<Map<String, User>>,
+    latestUsers: StateFlow<Map<String, User>>,
 ) : ChannelState {
 
     override val cid: String = "%s:%s".format(channelType, channelId)
@@ -164,7 +164,7 @@ internal class ChannelMutableState(
 
     override fun toChannel(): Channel {
         // recreate a channel object from the various observables.
-        val channelData = channelData.value ?: ChannelData(channelType, channelId)
+        val channelData = channelData.value
 
         val messages = sortedMessages.value
         val members = members.value

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -31,7 +31,7 @@ internal class ChannelMutableState(
     override val channelId: String,
     private val scope: CoroutineScope,
     private val userFlow: StateFlow<User?>,
-    latestUsers: StateFlow<Map<String, User>>,
+    private val latestUsers: StateFlow<Map<String, User>>,
 ) : ChannelState {
 
     override val cid: String = "%s:%s".format(channelType, channelId)
@@ -164,11 +164,11 @@ internal class ChannelMutableState(
 
     override fun toChannel(): Channel {
         // recreate a channel object from the various observables.
-        val channelData = _channelData.value ?: ChannelData(channelType, channelId)
+        val channelData = channelData.value ?: ChannelData(channelType, channelId)
 
         val messages = sortedMessages.value
-        val members = _members.value.values.toList()
-        val watchers = _watchers.value.values.toList()
+        val members = _members.value.values.updateUsers(latestUsers.value).toList()
+        val watchers = _watchers.value.values.toList().updateUsers(latestUsers.value)
         val reads = _reads.value.values.toList()
         val watcherCount = _watcherCount.value
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -167,8 +167,8 @@ internal class ChannelMutableState(
         val channelData = channelData.value ?: ChannelData(channelType, channelId)
 
         val messages = sortedMessages.value
-        val members = _members.value.values.updateUsers(latestUsers.value).toList()
-        val watchers = _watchers.value.values.toList().updateUsers(latestUsers.value)
+        val members = members.value
+        val watchers = watchers.value
         val reads = _reads.value.values.toList()
         val watcherCount = _watcherCount.value
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
@@ -61,11 +61,7 @@ internal class QueryChannelsLogic(
         val query =
             chatDomainImpl.repos.selectBy(queryChannelsSpec.filter, queryChannelsSpec.querySort) ?: return emptyList()
 
-        return chatDomainImpl.repos.selectChannels(
-            channelIds = query.cids.toList(),
-            forceCache = false,
-            pagination = pagination
-        )
+        return chatDomainImpl.repos.selectChannels(query.cids.toList(), pagination)
             .applyPagination(pagination)
             .also { logger.logI("found ${it.size} channels in offline storage") }
             .also { addChannels(it) }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
@@ -61,7 +61,11 @@ internal class QueryChannelsLogic(
         val query =
             chatDomainImpl.repos.selectBy(queryChannelsSpec.filter, queryChannelsSpec.querySort) ?: return emptyList()
 
-        return chatDomainImpl.repos.selectChannels(query.cids.toList(), pagination)
+        return chatDomainImpl.repos.selectChannels(
+            channelIds = query.cids.toList(),
+            forceCache = false,
+            pagination = pagination
+        )
             .applyPagination(pagination)
             .also { logger.logI("found ${it.size} channels in offline storage") }
             .also { addChannels(it) }
@@ -120,11 +124,10 @@ internal class QueryChannelsLogic(
     }
 
     /**
-     * Updates the state on the channelController based on the channel object we received from the API.
+     * Updates the state based on the channels collection we received from the API.
      *
      * @param channels The list of channels to update.
      * @param isFirstPage If it's the first page we set/replace the list of results. if it's not the first page we add to the list.
-     *
      */
     internal suspend fun updateOnlineChannels(
         channels: List<Channel>,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
@@ -85,12 +85,7 @@ internal class RepositoryFacade constructor(
     }
 
     override suspend fun insertChannels(channels: Collection<Channel>) {
-        val users = channels.flatMap(Channel::users)
-        val olegUser = users.firstOrNull { it.id == "oleg" }
-        if (olegUser != null) {
-            android.util.Log.w("USER_UPDATES", "RepoFacade insertChannels, with Oleg's name is ${olegUser.name}")
-        }
-        insertUsers(users)
+        insertUsers(channels.flatMap(Channel::users))
         channelsRepository.insertChannels(channels)
     }
 
@@ -124,12 +119,6 @@ internal class RepositoryFacade constructor(
         cacheForMessages: Boolean = false,
     ) {
         configs?.let { insertChannelConfigs(it) }
-        val olegUser = users.firstOrNull { it.id == "oleg" }
-        if (olegUser != null) {
-            android.util.Log.w("USER_UPDATES", "Store channels state with Oleg's name is ${olegUser.name}")
-        } else {
-            android.util.Log.w("USER_UPDATES", "Store channels state without Oleg")
-        }
         insertUsers(users)
         insertChannels(channels)
         insertMessages(messages, cacheForMessages)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
@@ -45,12 +45,12 @@ internal class RepositoryFacade constructor(
     SyncStateRepository by syncStateRepository,
     AttachmentRepository by attachmentRepository {
 
-    override suspend fun selectChannels(channelCIDs: List<String>, forceCache: Boolean): List<Channel> = selectChannels(channelCIDs, forceCache, null)
+    override suspend fun selectChannels(channelCIDs: List<String>, forceCache: Boolean): List<Channel> = selectChannels(channelCIDs, null, forceCache)
 
     internal suspend fun selectChannels(
         channelIds: List<String>,
-        forceCache: Boolean,
         pagination: AnyChannelPaginationRequest?,
+        forceCache: Boolean = false,
     ): List<Channel> {
         // fetch the channel entities from room
         val channels = channelsRepository.selectChannels(channelIds, forceCache)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/builder/RepositoryFacadeBuilder.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/builder/RepositoryFacadeBuilder.kt
@@ -65,7 +65,7 @@ internal class RepositoryFacadeBuilder {
         val getMessage: suspend (messageId: String) -> Message? = messageRepository::selectMessage
 
         return RepositoryFacade(
-            userRepository = factory.createUserRepository(),
+            userRepository = userRepository,
             configsRepository = factory.createChannelConfigRepository(),
             channelsRepository = factory.createChannelRepository(getUser, getMessage),
             queryChannelsRepository = factory.createQueryChannelsRepository(),

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelRepository.kt
@@ -15,6 +15,16 @@ internal interface ChannelRepository {
     suspend fun insertChannels(channels: Collection<Channel>)
     suspend fun deleteChannel(cid: String)
     suspend fun selectChannelWithoutMessages(cid: String): Channel?
+
+    /**
+     * Select channels by full channel IDs [Channel.cid]
+     *
+     * @param channelCIDs A list of [Channel.cid] as query specification.
+     * @param forceCache A boolean flag that forces cache in repository and fetches data directly in database if passed
+     * value is true.
+     *
+     * @return A list of channels found in repository.
+     */
     suspend fun selectChannels(channelCIDs: List<String>, forceCache: Boolean = false): List<Channel>
     suspend fun selectChannelsSyncNeeded(): List<Channel>
     suspend fun setChannelDeletedAt(cid: String, deletedAt: Date)
@@ -23,6 +33,7 @@ internal interface ChannelRepository {
     suspend fun selectMembersForChannel(cid: String): List<Member>
     suspend fun updateMembersForChannel(cid: String, members: List<Member>)
     suspend fun evictChannel(cid: String)
+
     @VisibleForTesting
     fun clearChannelCache()
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/MessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/MessageRepository.kt
@@ -13,6 +13,15 @@ internal interface MessageRepository {
         pagination: AnyChannelPaginationRequest?,
     ): List<Message>
 
+    /**
+     * Selects messages by IDs.
+     *
+     * @param messageIds A list of [Message.id] as query specification.
+     * @param forceCache A boolean flag that forces cache in repository and fetches data directly in database if passed
+     * value is true.
+     *
+     * @return A list of messages found in repository.
+     */
     suspend fun selectMessages(messageIds: List<String>, forceCache: Boolean = false): List<Message>
     suspend fun selectMessage(messageId: String): Message?
     suspend fun insertMessages(messages: List<Message>, cache: Boolean = false)
@@ -82,6 +91,7 @@ internal class MessageRepositoryImpl(
         }
     }
 
+    /** Fetches messages from [MessageDao] and cache values in [LruCache]. */
     private suspend fun fetchMessages(messageIds: List<String>): List<Message> {
         return messageDao.select(messageIds)
             .map { entity ->

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/ChannelControllerReactionsTest.kt
@@ -153,7 +153,7 @@ internal class ChannelControllerReactionsTest : SynchronizedCoroutineTest {
 
     @Test
     fun `when deleting a reaction while offline, status must be right and reaction inserted`() =
-        runBlockingTest {
+        coroutineTest {
             val sut = Fixture(testCoroutines.scope, currentUser)
                 .givenMockedRepositories()
                 .givenMessageWithReactions(myReactions)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/event/TotalUnreadCountTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/event/TotalUnreadCountTest.kt
@@ -100,8 +100,8 @@ internal class TotalUnreadCountTest {
 
         fun givenMockedRepositories(): Fixture {
             runBlocking {
-                whenever(repos.selectMessages(any())) doReturn emptyList()
-                whenever(repos.selectChannels(any())) doReturn emptyList()
+                whenever(repos.selectMessages(any(), any())) doReturn emptyList()
+                whenever(repos.selectChannels(any<List<String>>(), any<Boolean>())) doReturn emptyList()
             }
             return this
         }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/extensions/MemberExtensionsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/extensions/MemberExtensionsTest.kt
@@ -1,0 +1,22 @@
+package io.getstream.chat.android.offline.extensions
+
+import io.getstream.chat.android.offline.randomMember
+import io.getstream.chat.android.offline.randomUser
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+
+internal class MemberExtensionsTest {
+
+    @Test
+    fun `Should update members correctly`() {
+        val user1 = randomUser(id = "userId1").apply { name = "userName1" }
+        val member1 = randomMember(user = user1)
+        val member2 = randomMember()
+        val user1Updated = randomUser(id = "userId1").apply { name = "userName2" }
+
+        val result = listOf(member1, member2).updateUsers(mapOf(user1Updated.id to user1Updated))
+
+        result.any { it.user == user1 } shouldBeEqualTo false
+        result.any { it.user == user1Updated } shouldBeEqualTo true
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/WhenQuery.kt
@@ -185,7 +185,7 @@ internal class WhenQuery : SynchronizedCoroutineTest {
                     on { toChannel() } doReturn channel
                 }
             }
-            whenever(repositories.selectChannels(any(), any())) doReturn dbChannels
+            whenever(repositories.selectChannels(any(), any(), any())) doReturn dbChannels
         }
 
         fun givenNetworkChannels(channels: List<Channel>) = apply {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.repository.facade
 
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -40,9 +41,9 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
             whenever(users.selectUser("userId")) doReturn user
             val channel1 = randomChannel(messages = emptyList(), cid = "cid1", createdBy = user)
             val channel2 = randomChannel(messages = emptyList(), cid = "cid2", createdBy = user)
-            whenever(channels.selectChannels(eq(listOf("cid1", "cid2")))) doReturn listOf(channel1, channel2)
+            whenever(channels.selectChannels(eq(listOf("cid1", "cid2")), any())) doReturn listOf(channel1, channel2)
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), false, paginationRequest)
+            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.isEmpty() } shouldBeEqualTo true
@@ -65,12 +66,12 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
             )
             val channel1 = randomChannel(messages = emptyList(), cid = "cid1", createdBy = user)
             val channelEntity2 = randomChannel(messages = emptyList(), cid = "cid2", createdBy = user)
-            whenever(channels.selectChannels(eq(listOf("cid1", "cid2")))) doReturn listOf(
+            whenever(channels.selectChannels(eq(listOf("cid1", "cid2")), any())) doReturn listOf(
                 channel1,
                 channelEntity2
             )
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), false, paginationRequest)
+            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.size == 1 && it.messages.first().id == "messageId1" } shouldBeEqualTo true
@@ -81,7 +82,7 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
     fun `Given Db contains all required data When select messages Should return message list`() = runBlockingTest {
         val message1 = randomMessage()
         val message2 = randomMessage()
-        whenever(messages.selectMessages(eq(listOf("messageId1", "messageId2")))) doReturn listOf(message1, message2)
+        whenever(messages.selectMessages(eq(listOf("messageId1", "messageId2")), any())) doReturn listOf(message1, message2)
 
         val result = sut.selectMessages(listOf("messageId1", "messageId2"))
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
@@ -42,7 +42,7 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
             val channel2 = randomChannel(messages = emptyList(), cid = "cid2", createdBy = user)
             whenever(channels.selectChannels(eq(listOf("cid1", "cid2")))) doReturn listOf(channel1, channel2)
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest)
+            val result = sut.selectChannels(listOf("cid1", "cid2"), false, paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.isEmpty() } shouldBeEqualTo true
@@ -70,7 +70,7 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
                 channelEntity2
             )
 
-            val result = sut.selectChannels(listOf("cid1", "cid2"), paginationRequest)
+            val result = sut.selectChannels(listOf("cid1", "cid2"), false, paginationRequest)
 
             result.size shouldBeEqualTo 2
             result.any { it.cid == "cid1" && it.messages.size == 1 && it.messages.first().id == "messageId1" } shouldBeEqualTo true

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteReactionTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/DeleteReactionTest.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.offline.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.offline.integration.BaseConnectedIntegrationTest
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldNotBeNull
 import org.junit.Test
@@ -12,7 +11,7 @@ import org.junit.runner.RunWith
 internal class DeleteReactionTest : BaseConnectedIntegrationTest() {
 
     @Test
-    fun reactionUseCase(): Unit = runBlocking {
+    fun reactionUseCase(): Unit = coroutineTest {
         val channelController =
             chatDomain.watchChannel(data.channel1.cid, 10).execute().data()
         val message1 = data.createMessage()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendReactionTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendReactionTest.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.offline.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.offline.integration.BaseConnectedIntegrationTest
-import kotlinx.coroutines.runBlocking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBe
@@ -13,7 +12,7 @@ import org.junit.runner.RunWith
 internal class SendReactionTest : BaseConnectedIntegrationTest() {
 
     @Test
-    fun reactionUseCase(): Unit = runBlocking {
+    fun reactionUseCase(): Unit = coroutineTest {
         val channelState = chatDomain.watchChannel(data.channel1.cid, 10).execute().data()
         val message1 = data.createMessage()
         val result = chatDomain.sendMessage(message1).execute()

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/BaseMessageListHeaderViewModel.kt
@@ -42,6 +42,9 @@ public abstract class BaseMessageListHeaderViewModel @InternalStreamChatApi cons
                 _channelState.addSource(map(channelController.offlineChannelData) { channelController.toChannel() }) {
                     _channelState.value = it
                 }
+                _channelState.addSource(map(channelController.members) { channelController.toChannel() }) {
+                    _channelState.value = it
+                }
                 _anyOtherUsersOnline.addSource(
                     map(channelController.members) { members ->
                         members.asSequence()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -464,15 +464,16 @@ public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelList
 }
 
 public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff {
-	public fun <init> (ZZZZZZ)V
+	public fun <init> (ZZZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
 	public final fun component5 ()Z
 	public final fun component6 ()Z
-	public final fun copy (ZZZZZZ)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;ZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
+	public final fun component7 ()Z
+	public final fun copy (ZZZZZZZ)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;ZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarViewChanged ()Z
 	public final fun getExtraDataChanged ()Z
@@ -480,6 +481,7 @@ public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelList
 	public final fun getNameChanged ()Z
 	public final fun getReadStateChanged ()Z
 	public final fun getUnreadCountChanged ()Z
+	public final fun getUsersChanged ()Z
 	public final fun hasDifference ()Z
 	public fun hashCode ()I
 	public final fun plus (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff.kt
@@ -3,19 +3,21 @@ package io.getstream.chat.android.ui.channel.list.adapter
 public data class ChannelListPayloadDiff(
     val nameChanged: Boolean,
     val avatarViewChanged: Boolean,
+    val usersChanged: Boolean,
     val lastMessageChanged: Boolean,
     val readStateChanged: Boolean,
     val unreadCountChanged: Boolean,
     val extraDataChanged: Boolean,
 ) {
     public fun hasDifference(): Boolean {
-        return nameChanged || avatarViewChanged || lastMessageChanged || readStateChanged || unreadCountChanged || extraDataChanged
+        return nameChanged || avatarViewChanged || usersChanged || lastMessageChanged || readStateChanged || unreadCountChanged || extraDataChanged
     }
 
     public operator fun plus(other: ChannelListPayloadDiff): ChannelListPayloadDiff =
         copy(
             nameChanged = nameChanged || other.nameChanged,
             avatarViewChanged = avatarViewChanged || other.avatarViewChanged,
+            usersChanged = usersChanged || other.usersChanged,
             lastMessageChanged = lastMessageChanged || other.lastMessageChanged,
             readStateChanged = readStateChanged || other.readStateChanged,
             unreadCountChanged = unreadCountChanged || other.unreadCountChanged,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
@@ -7,6 +7,7 @@ import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
+import okhttp3.internal.userAgent
 
 internal class ChannelListItemAdapter(
     private val viewHolderFactory: ChannelListItemViewHolderFactory,
@@ -54,6 +55,7 @@ internal class ChannelListItemAdapter(
         private val FULL_CHANNEL_LIST_ITEM_PAYLOAD_DIFF: ChannelListPayloadDiff = ChannelListPayloadDiff(
             nameChanged = true,
             avatarViewChanged = true,
+            usersChanged = true,
             lastMessageChanged = true,
             readStateChanged = true,
             unreadCountChanged = true,
@@ -63,6 +65,7 @@ internal class ChannelListItemAdapter(
         val EMPTY_CHANNEL_LIST_ITEM_PAYLOAD_DIFF: ChannelListPayloadDiff = ChannelListPayloadDiff(
             nameChanged = false,
             avatarViewChanged = false,
+            usersChanged = false,
             lastMessageChanged = false,
             readStateChanged = false,
             unreadCountChanged = false,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -8,6 +8,7 @@ import androidx.core.view.isVisible
 import com.getstream.sdk.chat.utils.DateFormatter
 import com.getstream.sdk.chat.utils.extensions.isDirectMessaging
 import com.getstream.sdk.chat.utils.formatDate
+import io.getstream.chat.android.client.extensions.isAnonymousChannel
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -162,7 +163,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
     private fun configureForeground(diff: ChannelListPayloadDiff, channel: Channel) {
         binding.itemForegroundView.apply {
             diff.run {
-                if (nameChanged) {
+                if (nameChanged || (channel.isAnonymousChannel() && diff.usersChanged)) {
                     configureChannelNameLabel()
                 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -12,15 +12,18 @@ import io.getstream.chat.android.ui.common.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.ui.common.extensions.getLastMessage
 import io.getstream.chat.android.ui.common.extensions.isSystem
 
-internal fun Channel.diff(other: Channel): ChannelListPayloadDiff =
-    ChannelListPayloadDiff(
+internal fun Channel.diff(other: Channel): ChannelListPayloadDiff {
+    val usersChanged = getUsersExcludingCurrent() != other.getUsersExcludingCurrent()
+    return ChannelListPayloadDiff(
         nameChanged = name != other.name,
-        avatarViewChanged = getUsersExcludingCurrent() != other.getUsersExcludingCurrent(),
+        avatarViewChanged = usersChanged,
+        usersChanged = usersChanged,
         readStateChanged = read != other.read,
         lastMessageChanged = getLastMessage() != other.getLastMessage(),
         unreadCountChanged = unreadCount != other.unreadCount,
         extraDataChanged = extraData != other.extraData
     )
+}
 
 internal fun Channel.isMessageRead(message: Message): Boolean {
     val currentUser = ChatDomain.instance().user.value

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModelTest.kt
@@ -6,6 +6,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.getstream.chat.android.client.models.Channel
@@ -53,7 +54,7 @@ internal class MessageListHeaderViewModelTest {
         val mockObserver: Observer<Channel> = spy()
 
         channelHeaderViewModel.channelState.observeForever(mockObserver)
-        verify(mockObserver).onChanged(eq(channel))
+        verify(mockObserver, times(2)).onChanged(eq(channel))
     }
 
     @Test

--- a/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModelTest.kt
+++ b/stream-chat-android/src/test/java/com/getstream/sdk/chat/viewmodel/ChannelHeaderViewModelTest.kt
@@ -10,6 +10,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import io.getstream.chat.android.client.models.Channel
@@ -54,7 +55,7 @@ internal class ChannelHeaderViewModelTest {
         val mockObserver: Observer<Channel> = spy()
 
         channelHeaderViewModel.channelState.observeForever(mockObserver)
-        verify(mockObserver).onChanged(eq(channel))
+        verify(mockObserver, times(2)).onChanged(eq(channel))
     }
 
     @Test


### PR DESCRIPTION
### 🎯 Goal

We need to propagate user updates received in runtime. We had several bugs that lead to inconsistent behavior. This PR fixes them

### 🛠 Implementation details

1. Eliminate two instances of `UserRepository`. Each had a different in-memory cache that lead to inconsistent data.
2. In `EventBatchUpdate` when we fetch channels and messages we need to take data directly from DB, because some cached values can be outdated
3. Eliminate doubling of `ChannelController::toChannel` and `ChannelState::toChannel`
4. Some minor improvements

### 🧪 Testing
Have two samples running. Log in from the second device with changed name and observer on first device updates. Try to do some actions and be sure the updated value doesn't get reset to the previous.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

<img src="https://media2.giphy.com/media/yx4Hg5zO2q7Pf1cCBN/giphy.gif"/>
