### PR TITLE
CAS-1468 `MessageComposerView` slow mode 

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -809,7 +809,7 @@ public final class io/getstream/chat/android/common/state/MessageInputState {
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAction ()Lio/getstream/chat/android/common/state/MessageAction;
 	public final fun getAttachments ()Ljava/util/List;
-	public final fun getCooldownTimer ()I
+	public final fun getCoolDownTimer ()I
 	public final fun getInputValue ()Ljava/lang/String;
 	public final fun getMentionSuggestions ()Ljava/util/List;
 	public final fun getValidationErrors ()Ljava/util/List;

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageInputState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageInputState.kt
@@ -11,7 +11,7 @@ import io.getstream.chat.android.client.models.User
  * @param action The currently active [MessageAction].
  * @param validationErrors The list of validation errors.
  * @param mentionSuggestions The list of users that can be used to autocomplete the mention.
- * @param cooldownTimer The amount of time left until the user is allowed to send the next message.
+ * @param coolDownTimer The amount of time left until the user is allowed to send the next message.
  */
 public data class MessageInputState(
     val inputValue: String = "",
@@ -19,5 +19,5 @@ public data class MessageInputState(
     val action: MessageAction? = null,
     val validationErrors: List<ValidationError> = emptyList(),
     val mentionSuggestions: List<User> = emptyList(),
-    val cooldownTimer: Int = 0,
+    val coolDownTimer: Int = 0,
 )

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1143,6 +1143,7 @@ public final class io/getstream/chat/android/ui/message/composer/MessageComposer
 	public final fun buildNewMessage (Ljava/lang/String;Ljava/util/List;)Lio/getstream/chat/android/client/models/Message;
 	public static synthetic fun buildNewMessage$default (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewModel;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/Message;
 	public final fun dismissMessageActions ()V
+	public final fun getCooldownTimer ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getInput ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getLastActiveAction ()Lkotlinx/coroutines/flow/Flow;
 	public final fun getMessageInputState ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
@@ -46,12 +46,13 @@ internal class MessageComposerDefaultTrailingContent : FrameLayout, MessageCompo
      * Re-rendering the UI according to the new state.
      */
     override fun renderState(state: MessageInputState) {
-        val sendButtonVisible = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
         binding.apply {
+            val sendButtonVisible = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
             sendMessageButtonDisabled.isVisible = !sendButtonVisible
             sendMessageButtonEnabled.isVisible = sendButtonVisible
-            coolDownBadge.isVisible = state.cooldownTimer > 0
-            coolDownBadge.text = state.cooldownTimer.toString()
+            val coolDownTimerVisible = state.cooldownTimer > 0
+            coolDownBadge.isVisible = coolDownTimerVisible
+            if (coolDownTimerVisible) coolDownBadge.text = state.cooldownTimer.toString()
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
@@ -47,12 +47,12 @@ internal class MessageComposerDefaultTrailingContent : FrameLayout, MessageCompo
      */
     override fun renderState(state: MessageInputState) {
         binding.apply {
-            val sendButtonVisible = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
+            val sendButtonVisible = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.coolDownTimer == 0
             sendMessageButtonDisabled.isVisible = !sendButtonVisible
             sendMessageButtonEnabled.isVisible = sendButtonVisible
-            val coolDownTimerVisible = state.cooldownTimer > 0
+            val coolDownTimerVisible = state.coolDownTimer > 0
             coolDownBadge.isVisible = coolDownTimerVisible
-            if (coolDownTimerVisible) coolDownBadge.text = state.cooldownTimer.toString()
+            if (coolDownTimerVisible) coolDownBadge.text = state.coolDownTimer.toString()
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
@@ -46,10 +46,12 @@ internal class MessageComposerDefaultTrailingContent : FrameLayout, MessageCompo
      * Re-rendering the UI according to the new state.
      */
     override fun renderState(state: MessageInputState) {
-        val sendButtonEnabled = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
+        val sendButtonVisible = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
         binding.apply {
-            sendMessageButtonDisabled.isVisible = !sendButtonEnabled
-            sendMessageButtonEnabled.isVisible = sendButtonEnabled
+            sendMessageButtonDisabled.isVisible = !sendButtonVisible
+            sendMessageButtonEnabled.isVisible = sendButtonVisible
+            coolDownBadge.isVisible = state.cooldownTimer > 0
+            coolDownBadge.text = state.cooldownTimer.toString()
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerDefaultTrailingContent.kt
@@ -46,7 +46,7 @@ internal class MessageComposerDefaultTrailingContent : FrameLayout, MessageCompo
      * Re-rendering the UI according to the new state.
      */
     override fun renderState(state: MessageInputState) {
-        val sendButtonEnabled = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty()
+        val sendButtonEnabled = (state.inputValue.isNotEmpty() || state.attachments.isNotEmpty()) && state.validationErrors.isEmpty() && state.cooldownTimer == 0
         binding.apply {
             sendMessageButtonDisabled.isVisible = !sendButtonEnabled
             sendMessageButtonEnabled.isVisible = sendButtonEnabled

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
@@ -198,7 +198,7 @@ public class MessageComposerViewModel(
             attachments = messageComposerController.selectedAttachments.value,
             validationErrors = messageComposerController.validationErrors.value,
             mentionSuggestions = messageComposerController.mentionSuggestions.value,
-            cooldownTimer = messageComposerController.cooldownTimer.value
+            coolDownTimer = messageComposerController.cooldownTimer.value
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
@@ -60,6 +60,10 @@ public class MessageComposerViewModel(
      */
     public val lastActiveAction: Flow<MessageAction?> = messageComposerController.lastActiveAction
 
+    /**
+     * Initializing properties:
+     * - Listening to cooldownTimer value's updates and propagating the update to messageInputState.
+     */
     init {
         viewModelScope.launch {
             cooldownTimer.collect {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewModel.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.ui.message.composer
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
@@ -13,6 +14,8 @@ import io.getstream.chat.android.common.state.Reply
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel responsible for handling the composing and sending of messages.
@@ -38,6 +41,11 @@ public class MessageComposerViewModel(
     public val messageInputState: StateFlow<MessageInputState> = _messageInputState
 
     /**
+     * Represents the remaining time until the user is allowed to send the next message.
+     */
+    public val cooldownTimer: MutableStateFlow<Int> = messageComposerController.cooldownTimer
+
+    /**
      * UI state of the current composer input.
      */
     public val input: MutableStateFlow<String> = messageComposerController.input
@@ -51,6 +59,14 @@ public class MessageComposerViewModel(
      * Gets the active [Edit] or [Reply] action, whichever is last, to show on the UI.
      */
     public val lastActiveAction: Flow<MessageAction?> = messageComposerController.lastActiveAction
+
+    init {
+        viewModelScope.launch {
+            cooldownTimer.collect {
+                updateMessageInputState()
+            }
+        }
+    }
 
     /**
      * Called when the input changes and the internal state needs to be updated.
@@ -182,6 +198,7 @@ public class MessageComposerViewModel(
             attachments = messageComposerController.selectedAttachments.value,
             validationErrors = messageComposerController.validationErrors.value,
             mentionSuggestions = messageComposerController.mentionSuggestions.value,
+            cooldownTimer = messageComposerController.cooldownTimer.value
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_trailing_content.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_trailing_content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <merge xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     >
 
     <FrameLayout
@@ -29,6 +30,18 @@
             android:layout_gravity="center_vertical"
             android:padding="@dimen/stream_ui_spacing_tiny"
             android:src="@drawable/stream_ui_ic_filled_up_arrow"
+            />
+
+        <TextView
+            android:id="@+id/coolDownBadge"
+            style="@style/StreamUiCooldownBadgeStyle"
+            android:layout_gravity="center_vertical|end"
+            android:layout_marginEnd="@dimen/stream_ui_spacing_tiny"
+            android:clickable="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toTopOf="@+id/lastMessageTimeLabel"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="99"
             />
     </FrameLayout>
 </merge>


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1468

### 🎯 Goal

Adding slow mode support to `MessageComposerView`.

### 🛠 Implementation details

1. Propagating current `coolDownTimer` value in `MessageInputState`
2. Disabling send button when `coolDownTimer` is > 0
3. Displaying remaining cooldown seconds at `coolDownBadge` `TextView` displayed in front of send button.

### 🎨 UI Changes

https://user-images.githubusercontent.com/4527432/147079587-3816c85d-1f9a-4572-87bd-0cf4b2e6c695.mp4

### 🧪 Testing

Run ui-components sample app on the `feature/cas-1468-composer-slow-mode` branch. Open a channel with slow mode enabled and test sending messages.

### 🚧 Note
This PR is related to `MessageComposerView` development and targets the `feature/cas-1466-message-composer-attachments` working branch