### PR TITLE
[2810] Align the naming of Slot API parameters

### DIFF
--- a/docusaurus/docs/Android/04-compose/03-channel-components/02-channel-list-header.mdx
+++ b/docusaurus/docs/Android/04-compose/03-channel-components/02-channel-list-header.mdx
@@ -3,7 +3,7 @@
 The `ChannelListHeader` component allows you to display a header for the channel screen. It sets up the following:
 
 * `leadingContent`: Shows the current user image. The style is applied from the `ChatTheme` wrapper. <!-- TODO WIP PAGE -->
-* `ChannelHeaderTitle`: A component that shows the title of the header, or a loading view if there's no network available.
+* `centerContent`: A component that shows the title of the header, or a loading view if there's no network available.
 * `trailingContent`: A customizable trailing action shown at the end of the header, exposed as a parameter.  `DefaultChannelListHeaderAction` by default.
 
 Let's see how to use the header.
@@ -83,15 +83,19 @@ fun ChannelListHeader(
     title: String = "",
     currentUser: User? = ChatClient.instance().getCurrentUser(),
     connectionState = ConnectionState.CONNECTED,
-    leadingContent: @Composable RowScope.() -> Unit = { DefaultChannelHeaderLeadingContent(currentUser, onAvatarClick) },
-    titleContent: @Composable RowScope.() -> Unit = {
-        ChannelHeaderTitle(
+    leadingContent: @Composable RowScope.() -> Unit = {
+        DefaultChannelListHeaderLeadingContent(currentUser, onAvatarClick) 
+    },
+    centerContent: @Composable RowScope.() -> Unit = {
+        DefaultChannelListHeaderCenterContent(
             modifier = Modifier.weight(1f),
             connectionState = connectionState,
             title = title
         )
     },
-    trailingContent: @Composable RowScope.() -> Unit = { DefaultChannelListHeaderAction(onHeaderActionClick) },
+    trailingContent: @Composable RowScope.() -> Unit = {
+        DefaultChannelListHeaderTrailingContent(onHeaderActionClick) 
+    },
     ... // Action handlers
 )
 ```
@@ -103,7 +107,7 @@ fun ChannelListHeader(
 * `leadingContent`: Customizable composable function parameter that overrides the leading action. This allows you to either:
     * override the default behavior but keep the UI by overriding `onAvatarClick`,
     * or override both the UI and behavior by changing the `leadingContent` parameter from the default to your own.
-* `titleContent`: Customizable composable function parameter that overrides the title content. This allows you to either:
+* `centerContent`: Customizable composable function parameter that overrides the center content. This allows you to either:
     * override the shown data but keep the UI, by passing in the `title` and `connectionState`.
     * or override both the UI and behavior by changing the `titleContent` parameter from the default to your own.
 * `trailingContent`: Customizable composable function parameter that overrides the trailing action. This allows you to either:

--- a/docusaurus/docs/Android/04-compose/03-channel-components/04-default-channel-item.mdx
+++ b/docusaurus/docs/Android/04-compose/03-channel-components/04-default-channel-item.mdx
@@ -108,7 +108,7 @@ fun DefaultChannelItem(
             currentUser = currentUser
         )
     },
-    detailsContent: @Composable RowScope.(ChannelItem) -> Unit = {
+    centerContent: @Composable RowScope.(ChannelItem) -> Unit = {
         ChannelDetails(
             channel = it.channel,
             isMuted = it.isMuted,
@@ -141,7 +141,7 @@ fun DefaultChannelItem(
 
 * `modifier`: The modifier parameter for the root component. You can apply a background, elevation, padding, shape, touch handlers and much more.
 * `leadingContent`: Customizable composable function that allows you to override the content that appears at the start of the list item. By default, it represents a `ChannelAvatar`.
-* `detailsContent`: Customizable composable function that allows you to override the center part of the list item. By default, it represents the `ChannelDetails` that show its name and the last message preview.
+* `centerConent`: Customizable composable function that allows you to override the center part of the list item. By default, it represents the `ChannelDetails` that show its name and the last message preview.
 * `trailingContent`: Customizable composable function that allows you to override the content that appears at the end of the list item. By default, it represents the `ChannelLastMessageInfo` that shows the unread message indicator if there are unread messages and the last message read state.
 * `divider`: Customizable composable function that allows you to override the content that appears at the bottom of the list item, as a divider.
 

--- a/docusaurus/docs/Android/04-compose/04-message-components/02-message-list-header.mdx
+++ b/docusaurus/docs/Android/04-compose/04-message-components/02-message-list-header.mdx
@@ -121,8 +121,8 @@ fun MessageListHeader(
         )
     },
 
-    titleContent: @Composable RowScope.() -> Unit = {
-        DefaultMessageHeaderTitle(
+    centerContent: @Composable RowScope.() -> Unit = {
+        DefaultMessageListHeaderCenterContent(
             modifier = Modifier.weight(6f),
             channel = channel,
             messageMode = messageMode,
@@ -142,7 +142,7 @@ fun MessageListHeader(
 ```
 
 * `leadingContent`: Represents the leading content part of the header. By default the `BackButton`.
-* `titleContent`: Represents the core and center part of the header. Shows either more information about the channel using a `DefaultMessageHeaderTitle`, or a `NetworkLoadingView`, based on whether the network is available or not.
+* `centerContent`: Represents the core and center part of the header. Shows either more information about the channel using a `DefaultMessageHeaderTitle`, or a `NetworkLoadingView`, based on whether the network is available or not.
 * `trailingContent`: Represents the content at the end of the header. By default the 'ChannelAvatar'.
 
 You can override each of these parameters that represent different slots in the header.

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChannelActivity.kt
@@ -138,7 +138,7 @@ class ChannelActivity : AppCompatActivity() {
             trailingContent = {
                 Spacer(modifier = Modifier.width(8.dp))
             },
-            detailsContent = {
+            centerContent = {
                 Text(
                     text = ChatTheme.channelNameFormatter.formatChannelName(it.channel, user),
                     style = ChatTheme.typography.bodyBold,

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -595,7 +595,6 @@ public final class io/getstream/chat/android/compose/ui/channels/info/ChannelInf
 
 public final class io/getstream/chat/android/compose/ui/channels/list/ChannelItemKt {
 	public static final fun ChannelItem (Lio/getstream/chat/android/compose/state/channel/list/ChannelItemState;Lio/getstream/chat/android/client/models/User;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
-	public static final fun DefaultChannelTrailingContent (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/list/ChannelListKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1168,7 +1168,7 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/Messag
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/header/MessageListHeaderKt {
-	public static final fun DefaultMessageHeaderTitle (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageMode;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/offline/model/ConnectionState;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DefaultMessageListHeaderCenterContent (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageMode;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/offline/model/ConnectionState;Landroidx/compose/runtime/Composer;II)V
 	public static final fun MessageListHeader (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Ljava/util/List;Lio/getstream/chat/android/common/state/MessageMode;Lio/getstream/chat/android/offline/model/ConnectionState;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/header/ChannelListHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/header/ChannelListHeader.kt
@@ -44,9 +44,10 @@ import io.getstream.chat.android.offline.model.ConnectionState
  * @param onHeaderActionClick Action handler when the user taps on the header action.
  * @param leadingContent Custom composable that allows the user to replace the default header leading content.
  * By default it shows a [UserAvatar].
- * @param trailingContent Custom composable that allows the user to completely replace the default header
- * action. If nothing is passed in, the default element will be built, using the [onHeaderActionClick]
- * parameter as its handler, and it will represent [DefaultChannelListHeaderAction].
+ * @param centerContent Custom composable that allows the user to replace the default header center content.
+ * By default it either shows a text with [title] or [connectionState].
+ * @param trailingContent Custom composable that allows the user to replace the default leading content.
+ * By default it shows an action icon.
  */
 @Composable
 public fun ChannelListHeader(
@@ -62,14 +63,16 @@ public fun ChannelListHeader(
             onAvatarClick
         )
     },
-    titleContent: @Composable RowScope.() -> Unit = {
-        DefaultChannelHeaderTitle(
+    centerContent: @Composable RowScope.() -> Unit = {
+        DefaultChannelListHeaderCenterContent(
             modifier = Modifier.weight(1f),
             connectionState = connectionState,
             title = title
         )
     },
-    trailingContent: @Composable RowScope.() -> Unit = { DefaultChannelListHeaderAction(onHeaderActionClick) },
+    trailingContent: @Composable RowScope.() -> Unit = {
+        DefaultChannelListHeaderTrailingContent(onHeaderActionClick)
+    },
 ) {
     Surface(
         modifier = modifier
@@ -86,7 +89,7 @@ public fun ChannelListHeader(
 
             leadingContent()
 
-            titleContent()
+            centerContent()
 
             trailingContent()
         }
@@ -119,7 +122,7 @@ internal fun DefaultChannelHeaderLeadingContent(
 }
 
 /**
- * Represents the channel header's title slot. It either shows a [Text] if [connectionState] is
+ * Represents the channel header's center slot. It either shows a [Text] if [connectionState] is
  * [ConnectionState.CONNECTED], or a [NetworkLoadingIndicator] if there is no connections.
  *
  * @param connectionState The state of WebSocket connection.
@@ -127,7 +130,7 @@ internal fun DefaultChannelHeaderLeadingContent(
  * @param modifier Modifier for styling.
  */
 @Composable
-internal fun DefaultChannelHeaderTitle(
+internal fun DefaultChannelListHeaderCenterContent(
     connectionState: ConnectionState,
     title: String,
     modifier: Modifier = Modifier,
@@ -148,14 +151,14 @@ internal fun DefaultChannelHeaderTitle(
 }
 
 /**
- * Represents the default action for the ChannelList header.
+ * Represents the default trailing content for the [ChannelListHeader], which is an action icon.
  *
  * @param onHeaderActionClick Handler for when the user taps on the action.
  * @param modifier Modifier for styling.
  */
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
-internal fun DefaultChannelListHeaderAction(
+internal fun DefaultChannelListHeaderTrailingContent(
     onHeaderActionClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -63,10 +63,10 @@ public fun ChannelItem(
     onChannelLongClick: (Channel) -> Unit,
     modifier: Modifier = Modifier,
     leadingContent: @Composable RowScope.(ChannelItemState) -> Unit = {
-        DefaultChannelAvatar(channelItem = it, currentUser = currentUser)
+        DefaultChannelItemLeadingContent(channelItem = it, currentUser = currentUser)
     },
     centerContent: @Composable RowScope.(ChannelItemState) -> Unit = {
-        DefaultChannelCenterContent(
+        DefaultChannelItemCenterContent(
             channel = it.channel,
             isMuted = it.isMuted,
             currentUser = currentUser,
@@ -76,7 +76,7 @@ public fun ChannelItem(
         )
     },
     trailingContent: @Composable RowScope.(ChannelItemState) -> Unit = {
-        DefaultChannelTrailingContent(
+        DefaultChannelItemTrailingContent(
             channel = it.channel,
             currentUser = currentUser,
             modifier = Modifier
@@ -119,13 +119,13 @@ public fun ChannelItem(
 }
 
 /**
- * Represents the default channel avatar.
+ * Represents the default leading content of [ChannelItem].
  *
  * @param channelItem The channel to show the avatar of.
  * @param currentUser The currently logged in user.
  */
 @Composable
-internal fun DefaultChannelAvatar(
+internal fun DefaultChannelItemLeadingContent(
     channelItem: ChannelItemState,
     currentUser: User?,
 ) {
@@ -148,7 +148,7 @@ internal fun DefaultChannelAvatar(
  * @param modifier Modifier for styling.
  */
 @Composable
-internal fun DefaultChannelCenterContent(
+internal fun DefaultChannelItemCenterContent(
     channel: Channel,
     isMuted: Boolean,
     currentUser: User?,
@@ -212,7 +212,7 @@ internal fun DefaultChannelCenterContent(
  * @param modifier Modifier for styling.
  */
 @Composable
-public fun DefaultChannelTrailingContent(
+internal fun DefaultChannelItemTrailingContent(
     channel: Channel,
     currentUser: User?,
     modifier: Modifier = Modifier,
@@ -250,7 +250,7 @@ public fun DefaultChannelTrailingContent(
 }
 
 /**
- * Preview of [DefaultChannelCenterContent] component for one-to-one conversation.
+ * Preview of [DefaultChannelItemCenterContent] component for one-to-one conversation.
  *
  * Should show a user name and the last message in the channel.
  */
@@ -265,7 +265,7 @@ private fun DefaultChannelCenterContentOneToOnePreview() {
 }
 
 /**
- * Preview of [DefaultChannelCenterContent] for muted channel.
+ * Preview of [DefaultChannelItemCenterContent] for muted channel.
  *
  * Should show a muted icon next to the channel name.
  */
@@ -279,7 +279,7 @@ private fun DefaultChannelCenterContentMutedPreview() {
 }
 
 /**
- * Preview of [DefaultChannelCenterContent] for a channel without messages.
+ * Preview of [DefaultChannelItemCenterContent] for a channel without messages.
  *
  * Should show only channel name that is centered vertically.
  */
@@ -290,7 +290,7 @@ private fun DefaultChannelCenterContentWithMessagePreview() {
 }
 
 /**
- * Shows [DefaultChannelCenterContent] preview for the provided parameters.
+ * Shows [DefaultChannelItemCenterContent] preview for the provided parameters.
  *
  * @param channel The channel used to show the preview.
  * @param isMuted If the channel is muted.
@@ -303,7 +303,7 @@ private fun DefaultChannelDetailsPreview(
     currentUser: User? = null,
 ) {
     ChatTheme {
-        DefaultChannelCenterContent(
+        DefaultChannelItemCenterContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(64.dp),
@@ -315,7 +315,7 @@ private fun DefaultChannelDetailsPreview(
 }
 
 /**
- * Preview of [DefaultChannelTrailingContent].
+ * Preview of [DefaultChannelItemTrailingContent].
  *
  * Should show unread count badge, delivery indicator and timestamp.
  */
@@ -323,7 +323,7 @@ private fun DefaultChannelDetailsPreview(
 @Composable
 private fun DefaultChannelTrailingContentPreview() {
     ChatTheme {
-        DefaultChannelTrailingContent(
+        DefaultChannelItemTrailingContent(
             channel = PreviewChannelData.channelWithMessages,
             currentUser = PreviewUserData.user1,
         )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -49,7 +49,7 @@ import io.getstream.chat.android.compose.ui.util.getLastMessage
  * @param modifier Modifier for styling.
  * @param leadingContent Customizable composable function that represents the leading content of a channel item, usually
  * the avatar that holds an image of the channel or its members.
- * @param detailsContent Customizable composable function that represents the center content of a channel item, usually
+ * @param centerContent Customizable composable function that represents the center content of a channel item, usually
  * holding information about its name and the last message.
  * @param trailingContent Customizable composable function that represents the trailing content of the a channel item,
  * usually information about the last message and the number of unread messages.
@@ -65,8 +65,8 @@ public fun ChannelItem(
     leadingContent: @Composable RowScope.(ChannelItemState) -> Unit = {
         DefaultChannelAvatar(channelItem = it, currentUser = currentUser)
     },
-    detailsContent: @Composable RowScope.(ChannelItemState) -> Unit = {
-        DefaultChannelDetails(
+    centerContent: @Composable RowScope.(ChannelItemState) -> Unit = {
+        DefaultChannelCenterContent(
             channel = it.channel,
             isMuted = it.isMuted,
             currentUser = currentUser,
@@ -111,7 +111,7 @@ public fun ChannelItem(
         ) {
             leadingContent(channelItem)
 
-            detailsContent(channelItem)
+            centerContent(channelItem)
 
             trailingContent(channelItem)
         }
@@ -139,7 +139,7 @@ internal fun DefaultChannelAvatar(
 }
 
 /**
- * Represents the details portion of the channel item, that shows the channel display name and the last message text
+ * Represents the center portion of the channel item, that shows the channel display name and the last message text
  * preview.
  *
  * @param channel The channel to show the info for.
@@ -148,7 +148,7 @@ internal fun DefaultChannelAvatar(
  * @param modifier Modifier for styling.
  */
 @Composable
-internal fun DefaultChannelDetails(
+internal fun DefaultChannelCenterContent(
     channel: Channel,
     isMuted: Boolean,
     currentUser: User?,
@@ -250,13 +250,13 @@ public fun DefaultChannelTrailingContent(
 }
 
 /**
- * Preview of [DefaultChannelDetails] component for one-to-one conversation.
+ * Preview of [DefaultChannelCenterContent] component for one-to-one conversation.
  *
  * Should show a user name and the last message in the channel.
  */
 @Preview(showBackground = true, name = "ChannelDetails Preview (One-to-one conversation)")
 @Composable
-private fun DefaultChannelDetailsOneToOnePreview() {
+private fun DefaultChannelCenterContentOneToOnePreview() {
     DefaultChannelDetailsPreview(
         channel = PreviewChannelData.channelWithMessages,
         isMuted = false,
@@ -265,13 +265,13 @@ private fun DefaultChannelDetailsOneToOnePreview() {
 }
 
 /**
- * Preview of [DefaultChannelDetails] for muted channel.
+ * Preview of [DefaultChannelCenterContent] for muted channel.
  *
  * Should show a muted icon next to the channel name.
  */
 @Preview(showBackground = true, name = "ChannelDetails Preview (Muted channel)")
 @Composable
-private fun DefaultChannelDetailsMutedPreview() {
+private fun DefaultChannelCenterContentMutedPreview() {
     DefaultChannelDetailsPreview(
         channel = PreviewChannelData.channelWithMessages,
         isMuted = true
@@ -279,18 +279,18 @@ private fun DefaultChannelDetailsMutedPreview() {
 }
 
 /**
- * Preview of [DefaultChannelDetails] for a channel without messages.
+ * Preview of [DefaultChannelCenterContent] for a channel without messages.
  *
  * Should show only channel name that is centered vertically.
  */
 @Preview(showBackground = true, name = "ChannelDetails Preview (Without message)")
 @Composable
-private fun DefaultChannelDetailsWithMessagePreview() {
+private fun DefaultChannelCenterContentWithMessagePreview() {
     DefaultChannelDetailsPreview(channel = PreviewChannelData.channelWithImage)
 }
 
 /**
- * Shows [DefaultChannelDetails] preview for the provided parameters.
+ * Shows [DefaultChannelCenterContent] preview for the provided parameters.
  *
  * @param channel The channel used to show the preview.
  * @param isMuted If the channel is muted.
@@ -303,7 +303,7 @@ private fun DefaultChannelDetailsPreview(
     currentUser: User? = null,
 ) {
     ChatTheme {
-        DefaultChannelDetails(
+        DefaultChannelCenterContent(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(64.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageDialog.kt
@@ -26,7 +26,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param overlayColor The color applied to the overlay.
  * @param onDismiss Handler called when the dialog is dismissed.
  * @param headerContent The content shown at the top of the dialog.
- * @param bodyContent The content shown in the dialog.
+ * @param centerContent The content shown in the dialog.
  */
 @Composable
 internal fun SelectedMessageDialog(
@@ -35,7 +35,7 @@ internal fun SelectedMessageDialog(
     overlayColor: Color = ChatTheme.colors.overlay,
     onDismiss: () -> Unit = {},
     headerContent: @Composable ColumnScope.() -> Unit = {},
-    bodyContent: @Composable ColumnScope.() -> Unit = {},
+    centerContent: @Composable ColumnScope.() -> Unit = {},
 ) {
     Box(
         modifier = Modifier
@@ -60,7 +60,7 @@ internal fun SelectedMessageDialog(
             Column(modifier = Modifier.padding(top = 12.dp)) {
                 headerContent()
 
-                bodyContent()
+                centerContent()
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param reactionTypes The available reactions within the menu.
  * @param onDismiss Handler called when the menu is dismissed.
  * @param headerContent The content shown at the top of the [SelectedMessageMenu] dialog. By default [ReactionOptions].
- * @param bodyContent The content shown in the [SelectedMessageMenu] dialog. By Default [MessageOptions].
+ * @param centerContent The content shown at the center of the [SelectedMessageMenu] dialog. By Default [MessageOptions].
  */
 @Composable
 public fun SelectedMessageMenu(
@@ -51,7 +51,7 @@ public fun SelectedMessageMenu(
             onMessageAction = onMessageAction
         )
     },
-    bodyContent: @Composable ColumnScope.() -> Unit = {
+    centerContent: @Composable ColumnScope.() -> Unit = {
         DefaultSelectedMessageOptions(
             messageOptions = messageOptions,
             onMessageAction = onMessageAction
@@ -64,7 +64,7 @@ public fun SelectedMessageMenu(
         overlayColor = overlayColor,
         onDismiss = onDismiss,
         headerContent = headerContent,
-        bodyContent = bodyContent
+        centerContent = centerContent
     )
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedReactionsMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedReactionsMenu.kt
@@ -35,7 +35,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param reactionTypes The available reactions within the menu.
  * @param onDismiss Handler called when the menu is dismissed.
  * @param headerContent The content shown at the top of the [SelectedReactionsMenu] dialog. By default [ReactionOptions].
- * @param bodyContent The content shown in the [SelectedReactionsMenu] dialog. By Default [UserReactions].
+ * @param centerContent The content shown in the [SelectedReactionsMenu] dialog. By Default [UserReactions].
  */
 @Composable
 public fun SelectedReactionsMenu(
@@ -54,8 +54,8 @@ public fun SelectedReactionsMenu(
             onMessageAction = onMessageAction
         )
     },
-    bodyContent: @Composable ColumnScope.() -> Unit = {
-        DefaultSelectedReactionsBodyContent(
+    centerContent: @Composable ColumnScope.() -> Unit = {
+        DefaultSelectedReactionsCenterContent(
             message = message,
             currentUser = currentUser
         )
@@ -67,7 +67,7 @@ public fun SelectedReactionsMenu(
         overlayColor = overlayColor,
         onDismiss = onDismiss,
         headerContent = headerContent,
-        bodyContent = bodyContent
+        centerContent = centerContent
     )
 }
 
@@ -102,13 +102,13 @@ internal fun DefaultSelectedReactionsHeaderContent(
 }
 
 /**
- * Default body content for the selected reactions menu.
+ * Default center content for the selected reactions menu.
  *
  * @param message The selected message.
  * @param currentUser The currently logged in user.
  */
 @Composable
-internal fun DefaultSelectedReactionsBodyContent(
+internal fun DefaultSelectedReactionsCenterContent(
     message: Message,
     currentUser: User?,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/SuggestionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/SuggestionList.kt
@@ -22,7 +22,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param shape The shape of suggestion list popup.
  * @param contentPadding The inner content padding inside the popup.
  * @param headerContent The content shown at the top of a suggestion list popup.
- * @param content The content shown inside the suggestion list popup.
+ * @param centerContent The content shown inside the suggestion list popup.
  */
 @Composable
 public fun SuggestionList(
@@ -30,7 +30,7 @@ public fun SuggestionList(
     shape: Shape = ChatTheme.shapes.suggestionList,
     contentPadding: PaddingValues = PaddingValues(vertical = ChatTheme.dimens.suggestionListPadding),
     headerContent: @Composable () -> Unit = {},
-    content: @Composable () -> Unit,
+    centerContent: @Composable () -> Unit,
 ) {
     Popup(popupPositionProvider = SuggestionListPositionProvider()) {
         Card(
@@ -42,7 +42,7 @@ public fun SuggestionList(
             Column(Modifier.padding(contentPadding)) {
                 headerContent()
 
-                content()
+                centerContent()
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/commands/CommandSuggestionItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/commands/CommandSuggestionItem.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param modifier Modifier for styling.
  * @param onCommandSelected Handler when the user taps on an item.
  * @param leadingContent Customizable composable function that represents the leading content of a command item.
- * @param detailsContent Customizable composable function that represents the details content of a command item.
+ * @param centerContent Customizable composable function that represents the center content of a command item.
  */
 @Composable
 public fun CommandSuggestionItem(
@@ -42,8 +42,8 @@ public fun CommandSuggestionItem(
     leadingContent: @Composable RowScope.(Command) -> Unit = {
         DefaultCommandSuggestionItemLeadingContent()
     },
-    detailsContent: @Composable RowScope.(Command) -> Unit = {
-        DefaultCommandSuggestionItemDetailsContent(command = it)
+    centerContent: @Composable RowScope.(Command) -> Unit = {
+        DefaultCommandSuggestionItemCenterContent(command = it)
     },
 ) {
     Row(
@@ -63,7 +63,7 @@ public fun CommandSuggestionItem(
     ) {
         leadingContent(command)
 
-        detailsContent(command)
+        centerContent(command)
     }
 }
 
@@ -82,13 +82,13 @@ internal fun DefaultCommandSuggestionItemLeadingContent() {
 }
 
 /**
- *  Represents the details portion of the command item, that show the user name and the user ID.
+ *  Represents the center portion of the command item, that show the user name and the user ID.
  *
  *  @param command The user to show the info for.
  *  @param modifier Modifier for styling.
  */
 @Composable
-internal fun RowScope.DefaultCommandSuggestionItemDetailsContent(
+internal fun RowScope.DefaultCommandSuggestionItemCenterContent(
     command: Command,
     modifier: Modifier = Modifier,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/mentions/MentionSuggestionItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/mentions/MentionSuggestionItem.kt
@@ -31,7 +31,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * @param modifier Modifier for styling.
  * @param onMentionSelected Handler when the user taps on an item.
  * @param leadingContent Customizable composable function that represents the leading content of a mention item.
- * @param detailsContent Customizable composable function that represents the center content of a mention item.
+ * @param centerContent Customizable composable function that represents the center content of a mention item.
  * @param trailingContent Customizable composable function that represents the trailing content of the a mention item.
  */
 @Composable
@@ -42,8 +42,8 @@ public fun MentionSuggestionItem(
     leadingContent: @Composable RowScope.(User) -> Unit = {
         DefaultMentionSuggestionItemLeadingContent(user = it)
     },
-    detailsContent: @Composable RowScope.(User) -> Unit = {
-        DefaultMentionSuggestionItemDetailsContent(user = it)
+    centerContent: @Composable RowScope.(User) -> Unit = {
+        DefaultMentionSuggestionItemCenterContent(user = it)
     },
     trailingContent: @Composable RowScope.(User) -> Unit = {
         DefaultMentionSuggestionItemTrailingContent()
@@ -67,7 +67,7 @@ public fun MentionSuggestionItem(
 
         leadingContent(user)
 
-        detailsContent(user)
+        centerContent(user)
 
         trailingContent(user)
     }
@@ -90,12 +90,12 @@ internal fun DefaultMentionSuggestionItemLeadingContent(user: User) {
 }
 
 /**
- *  Represents the details portion of the mention item, that show the user name and the user ID.
+ *  Represents the center portion of the mention item, that show the user name and the user ID.
  *
  *  @param user The user to show the info for.
  */
 @Composable
-internal fun RowScope.DefaultMentionSuggestionItemDetailsContent(user: User) {
+internal fun RowScope.DefaultMentionSuggestionItemCenterContent(user: User) {
     Column(
         modifier = Modifier
             .weight(1f)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/MessageListHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/MessageListHeader.kt
@@ -49,8 +49,8 @@ import io.getstream.chat.android.offline.model.ConnectionState
  * @param onBackPressed Handler that propagates the back button click event.
  * @param onHeaderActionClick Action handler when the user taps on the header action.
  * @param leadingContent The content shown at the start of the header, by default a [BackButton].
- * @param titleContent The content shown in the middle of the header and represents the core information, by default
- * [DefaultMessageHeaderTitle].
+ * @param centerContent The content shown in the middle of the header and represents the core information, by default
+ * [DefaultMessageHeaderCenterContent].
  * @param trailingContent The content shown at the end of the header, by default a [ChannelAvatar].
  */
 @Composable
@@ -72,8 +72,8 @@ public fun MessageListHeader(
         )
     },
 
-    titleContent: @Composable RowScope.() -> Unit = {
-        DefaultMessageHeaderTitle(
+    centerContent: @Composable RowScope.() -> Unit = {
+        DefaultMessageListHeaderCenterContent(
             modifier = Modifier.weight(1f),
             channel = channel,
             currentUser = currentUser,
@@ -106,7 +106,7 @@ public fun MessageListHeader(
 
             leadingContent()
 
-            titleContent()
+            centerContent()
 
             trailingContent()
         }
@@ -114,8 +114,8 @@ public fun MessageListHeader(
 }
 
 /**
- * Default header title, that handles if we should show a loading view for network,
- * or the channel information.
+ * Represents the center content of [MessageListHeader]. By default shows header title, that handles
+ * if we should show a loading view for network, or the channel information.
  *
  * @param channel The channel used for the title information.
  * @param modifier Modifier for styling.
@@ -125,7 +125,7 @@ public fun MessageListHeader(
  * @param connectionState A flag that governs if we show the subtitle or the network loading view.
  */
 @Composable
-public fun DefaultMessageHeaderTitle(
+public fun DefaultMessageListHeaderCenterContent(
     channel: Channel,
     currentUser: User?,
     modifier: Modifier = Modifier,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -82,12 +82,12 @@ import io.getstream.chat.android.compose.ui.util.isUploading
  * current user.
  * @param headerContent The content shown at the top of a message list item. By default, we provide
  * [DefaultMessageItemHeaderContent], which shows a list of reactions for the message.
+ *  @param centerContent The content shown at the center of a message list item. By default, we provide
+ * [DefaultMessageItemCenterContent], which shows the message bubble with text and attachments.
  * @param footerContent The content shown at the bottom of a message list item. By default, we provide
  * [DefaultMessageItemFooterContent], which shows the information like thread participants, upload status, etc.
  * @param trailingContent The content shown at the end of a message list item. By default, we provide
  * [DefaultMessageItemTrailingContent], which adds an extra spacing to the end of the message list item.
- * @param content The content shown at the center of a message list item. By default, we provide
- * [DefaultMessageItemContent], which shows the message bubble with text and attachments.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -108,19 +108,19 @@ public fun MessageItem(
             onReactionsClick = onReactionsClick
         )
     },
-    footerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
-        DefaultMessageItemFooterContent(messageItem = it)
-    },
-    trailingContent: @Composable RowScope.(MessageItemState) -> Unit = {
-        DefaultMessageItemTrailingContent(messageItem = it)
-    },
-    content: @Composable ColumnScope.(MessageItemState) -> Unit = {
-        DefaultMessageItemContent(
+    centerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
+        DefaultMessageItemCenterContent(
             messageItem = it,
             onLongItemClick = onLongItemClick,
             onImagePreviewResult = onImagePreviewResult,
             onGiphyActionClick = onGiphyActionClick
         )
+    },
+    footerContent: @Composable ColumnScope.(MessageItemState) -> Unit = {
+        DefaultMessageItemFooterContent(messageItem = it)
+    },
+    trailingContent: @Composable RowScope.(MessageItemState) -> Unit = {
+        DefaultMessageItemTrailingContent(messageItem = it)
     },
 ) {
     val (message, _, _, _, focusState) = messageItem
@@ -175,7 +175,7 @@ public fun MessageItem(
             Column(horizontalAlignment = messageAlignment.contentAlignment) {
                 headerContent(messageItem)
 
-                content(messageItem)
+                centerContent(messageItem)
 
                 footerContent(messageItem)
             }
@@ -354,7 +354,7 @@ internal fun DefaultMessageItemTrailingContent(
  * @param onImagePreviewResult Handler when the user selects an option in the Image Preview screen.
  */
 @Composable
-internal fun DefaultMessageItemContent(
+internal fun DefaultMessageItemCenterContent(
     messageItem: MessageItemState,
     onLongItemClick: (Message) -> Unit = {},
     onGiphyActionClick: (GiphyAction) -> Unit = {},


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2810

### 🎯 Goal

Align the naming of Slot API parameters.

### 🛠 Implementation details

The parameters were aligned according to the rules below:

For 1 slot (like wrapping something): content
For 3 horizontal slots: leadingContent / centerContent / trailingContent
For 3 vertical slots: headerContent / centerContent / footerContent
For 5 slots: leadingContent / headerContent / centerContent / footerContent/ trailingContent
For 2 vertical slots: headerContent / centerContent OR centerContent / footerContent

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
~~- [ ] Changelog is updated with client-facing changes~~
~~- [ ] New code is covered by unit tests~~
~~- [ ] Comparison screenshots added for visual changes~~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
