### PR TITLE
Fixing border bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### 🐞 Fixed
 - Users' updates done in runtime are now propagated to the `MessageListView` component. [#2769](https://github.com/GetStream/stream-chat-android/pull/2769)
 - Fixed the display of image attachments on the pinned message list screen. [#2792](https://github.com/GetStream/stream-chat-android/pull/2792)
+- Small bug fix for borders of attachments
 
 ### ⬆️ Improved
 - Improved Korean 🇰🇷 and Japanese 🇯🇵 translation.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/TextAndAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/TextAndAttachmentsViewHolder.kt
@@ -100,7 +100,7 @@ internal class TextAndAttachmentsViewHolder(
         binding.messageText.isVisible = data.message.text.isNotEmpty()
         markdown.setText(binding.messageText, data.message.text)
 
-        if (diff?.attachments != false) {
+        if (diff?.attachments != false || diff.positions) {
             setupAttachment(data)
         }
 


### PR DESCRIPTION
### 🎯 Goal

Fixing a little bug with borders of attachments when position change. 

### 🛠 Implementation details

The setup is redone when positions change. This allows the attachments to redraw their borders and change them accordingly. 

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_20211222-170441](https://user-images.githubusercontent.com/10619102/147149534-a9cf58ea-6c2d-4c4d-9223-51e849e7ff5a.png) | ![Screenshot_20211222-170534](https://user-images.githubusercontent.com/10619102/147149545-0855db4c-2cb1-44e2-86a1-d28f767cde27.png) |

### 🧪 Testing

- Send a giphy 
- Expected: Check that the border is sharp
- Send another message
- Expected: Check that the border of the first giphy is no longer shard. It becomes round. 
### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/147150134-d998faae-2b1c-478d-9bcc-846c375282df.gif)

