### PR TITLE
Minor fix of recomposition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fixed the message grouping logic to now include date separators when splitting message groups [#2770](https://github.com/GetStream/stream-chat-android/pull/2770)
+- Fixed a small issue with user avatars flickering [#2822](https://github.com/GetStream/stream-chat-android/pull/2822)
 
 ### ⬆️ Improved
 - Improved the UI for message footers to be more respective of thread replies [#2765](https://github.com/GetStream/stream-chat-android/pull/2765)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
@@ -47,7 +47,7 @@ public fun UserAvatar(
     },
     onClick: (() -> Unit)? = null,
 ) {
-    val avatarContent: (@Composable (modifier: Modifier) -> Unit) = @Composable { innerModifier ->
+    Box(modifier = modifier) {
         if (user.image.isNotBlank()) {
             val authorImage = if (LocalInspectionMode.current) {
                 // Show hardcoded avatar from resources when rendering preview
@@ -57,7 +57,7 @@ public fun UserAvatar(
             }
 
             Avatar(
-                modifier = innerModifier,
+                modifier = Modifier.fillMaxSize(),
                 shape = shape,
                 painter = authorImage,
                 contentDescription = contentDescription,
@@ -65,16 +65,12 @@ public fun UserAvatar(
             )
         } else {
             InitialsAvatar(
-                modifier = innerModifier,
+                modifier = Modifier.fillMaxSize(),
                 initials = user.initials,
                 shape = shape,
                 onClick = onClick
             )
         }
-    }
-
-    Box(modifier = modifier) {
-        avatarContent(modifier = Modifier.fillMaxSize())
 
         if (showOnlineIndicator && user.online) {
             onlineIndicator()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
@@ -73,16 +73,12 @@ public fun UserAvatar(
         }
     }
 
-    if (showOnlineIndicator && user.online) {
-        // Apply modifier to the outer box
-        Box(modifier = modifier) {
-            avatarContent(modifier = Modifier.fillMaxSize())
+    Box(modifier = modifier) {
+        avatarContent(modifier = Modifier.fillMaxSize())
 
+        if (showOnlineIndicator && user.online) {
             onlineIndicator()
         }
-    } else {
-        // Apply modifier to the avatar itself
-        avatarContent(modifier = modifier)
     }
 }
 


### PR DESCRIPTION
Fixes #2821 

### 🎯 Goal

Had to reorder the elements in a way that we always use a box and only add the indicator if needed instead of the previous logic.

### 🧪 Testing

Open the ChannelsScreen, shouldn't see flickering of avatars around online status updates.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
