### PR TITLE
[CAS-1505] Add support for pinned messages endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added support to paginate messages pinned in a channel. [#2841](https://github.com/GetStream/stream-chat-android/pull/2841).
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -52,6 +52,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun getMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun getMessagesWithAttachments (Ljava/lang/String;Ljava/lang/String;IILjava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public final fun getNotifications ()Lio/getstream/chat/android/client/notifications/ChatNotifications;
+	public final fun getPinnedMessages (Ljava/lang/String;Ljava/lang/String;ILio/getstream/chat/android/client/api/models/QuerySort;Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination;)Lio/getstream/chat/android/client/call/Call;
 	public final fun getPlugins ()Ljava/util/Collection;
 	public final fun getPreSetUserListeners ()Ljava/util/List;
 	public final fun getReactions (Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
@@ -399,6 +400,83 @@ public final class io/getstream/chat/android/client/api/models/Pagination : java
 	public static fun values ()[Lio/getstream/chat/android/client/api/models/Pagination;
 }
 
+public abstract class io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterDate : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/util/Date;Z)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/Date;Z)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterDate;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterDate;Ljava/util/Date;ZILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterDate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/util/Date;
+	public final fun getInclusive ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterMessage : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterMessage;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AfterMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInclusive ()Z
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundDate : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/util/Date;)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun copy (Ljava/util/Date;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundDate;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundDate;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundDate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/util/Date;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundMessage : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundMessage;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$AroundMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeDate : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/util/Date;Z)V
+	public final fun component1 ()Ljava/util/Date;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/util/Date;Z)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeDate;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeDate;Ljava/util/Date;ZILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeDate;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDate ()Ljava/util/Date;
+	public final fun getInclusive ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeMessage : io/getstream/chat/android/client/api/models/PinnedMessagesPagination {
+	public fun <init> (Ljava/lang/String;Z)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Z
+	public final fun copy (Ljava/lang/String;Z)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeMessage;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination$BeforeMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getInclusive ()Z
+	public final fun getMessageId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public class io/getstream/chat/android/client/api/models/QueryChannelRequest : io/getstream/chat/android/client/api/models/ChannelRequest {
 	public fun <init> ()V
 	public final fun filteringOlderMessages ()Z
@@ -626,6 +704,7 @@ public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public final fun getImageAttachments (II)Lio/getstream/chat/android/client/call/Call;
 	public final fun getMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun getMessagesWithAttachments (IILjava/util/List;)Lio/getstream/chat/android/client/call/Call;
+	public final fun getPinnedMessages (ILio/getstream/chat/android/client/api/models/QuerySort;Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination;)Lio/getstream/chat/android/client/call/Call;
 	public final fun getReactions (Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
 	public final fun getReactions (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun hide (Z)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ChatClientConfig
 import io.getstream.chat.android.client.api.ErrorCall
 import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
@@ -771,6 +772,39 @@ public class ChatClient internal constructor(
             limit = limit,
             next = next,
             sort = sort,
+        )
+    }
+
+    /**
+     * Returns a list of message pinned in the channel.
+     * You can sort the list by specifying [sort] parameter.
+     * Keep in mind that for now we only support sorting by [Message.pinnedAt]
+     * The list can be paginated in a few different ways using [limit] and [pagination]
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param limit Max limit messages to be fetched.
+     * @param sort Desired attachment's types list.
+     * @param pagination Provides different options for pagination.
+     *
+     * @return Executable async [Call] responsible for getting pinned messages.
+     *
+     * @see [PinnedMessagesPagination]
+     */
+    @CheckResult
+    public fun getPinnedMessages(
+        channelType: String,
+        channelId: String,
+        limit: Int,
+        sort: QuerySort<Message>,
+        pagination: PinnedMessagesPagination,
+    ): Call<List<Message>> {
+        return api.getPinnedMessages(
+            channelType = channelType,
+            channelId = channelId,
+            limit = limit,
+            sort = sort,
+            pagination = pagination,
         )
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.client.api
 
 import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
@@ -149,6 +150,15 @@ internal interface ChatApi {
         channelType: String,
         channelId: String,
     ): Call<Unit>
+
+    @CheckResult
+    fun getPinnedMessages(
+        channelType: String,
+        channelId: String,
+        limit: Int,
+        sort: QuerySort<Message>,
+        pagination: PinnedMessagesPagination,
+    ): Call<List<Message>>
 
     @CheckResult
     fun queryChannels(query: QueryChannelsRequest): Call<List<Channel>>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/PinnedMessagesPagination.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/PinnedMessagesPagination.kt
@@ -1,0 +1,55 @@
+package io.getstream.chat.android.client.api.models
+
+import java.util.Date
+
+/**
+ * Pagination options for getting pinned messages.
+ */
+public sealed class PinnedMessagesPagination {
+
+    /**
+     * Pagination option for getting pinned messages around the message with given id.
+     *
+     * @param messageId The id of the message used for generating result.
+     */
+    public data class AroundMessage(val messageId: String) : PinnedMessagesPagination()
+
+    /**
+     * Pagination option for getting pinned messages before the message with given id.
+     *
+     * @param messageId The id of the message used for generating result.
+     * @param inclusive Whether the results should include the message with the given id.
+     */
+    public data class BeforeMessage(val messageId: String, val inclusive: Boolean) : PinnedMessagesPagination()
+
+    /**
+     * Pagination option for getting pinned messages after the message with given id.
+     *
+     * @param messageId The id of the message used for generating result.
+     * @param inclusive Whether the results should include the message with the given id.
+     */
+    public data class AfterMessage(val messageId: String, val inclusive: Boolean) : PinnedMessagesPagination()
+
+    /**
+     * Pagination option for getting messages pinned around the date.
+     *
+     * @param date The date used for generating result.
+     */
+    public data class AroundDate(val date: Date) : PinnedMessagesPagination()
+
+    /**
+     * Pagination option for getting messages pinned before the date.
+     *
+     * @param date The date used for generating result.
+     * @param inclusive Whether the results should include the message with the given id.
+     */
+    public data class BeforeDate(val date: Date, val inclusive: Boolean) : PinnedMessagesPagination()
+
+    /**
+     * Pagination option for getting messages pinned after the date.
+     *
+     * @param date The date used for generating result.
+     * @param inclusive Whether the results should include the message with the given id.
+     */
+    public data class AfterDate(val date: Date, val inclusive: Boolean) : PinnedMessagesPagination()
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ChannelApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/ChannelApi.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
+import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryChannelsRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
@@ -17,10 +18,12 @@ import io.getstream.chat.android.client.api2.model.requests.UpdateCooldownReques
 import io.getstream.chat.android.client.api2.model.response.ChannelResponse
 import io.getstream.chat.android.client.api2.model.response.CompletableResponse
 import io.getstream.chat.android.client.api2.model.response.EventResponse
+import io.getstream.chat.android.client.api2.model.response.MessagesResponse
 import io.getstream.chat.android.client.api2.model.response.QueryChannelsResponse
 import io.getstream.chat.android.client.call.RetrofitCall
 import retrofit2.http.Body
 import retrofit2.http.DELETE
+import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -168,4 +171,11 @@ internal interface ChannelApi {
         @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body body: Map<Any, Any>,
     ): RetrofitCall<CompletableResponse>
+
+    @GET("/channels/{type}/{id}/pinned_messages")
+    fun getPinnedMessages(
+        @Path("type") channelType: String,
+        @Path("id") channelId: String,
+        @UrlQueryPayload @Query("payload") payload: PinnedMessagesRequest,
+    ): RetrofitCall<MessagesResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -3,6 +3,7 @@ package io.getstream.chat.android.client.api2
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ErrorCall
 import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
@@ -31,6 +32,7 @@ import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateMessageRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateUsersRequest
+import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
 import io.getstream.chat.android.client.api2.model.requests.ReactionRequest
 import io.getstream.chat.android.client.api2.model.requests.RejectInviteRequest
@@ -477,6 +479,24 @@ internal class MoshiChatApi(
             connectionId = connectionId,
             body = emptyMap(),
         ).toUnitCall()
+    }
+
+    override fun getPinnedMessages(
+        channelType: String,
+        channelId: String,
+        limit: Int,
+        sort: QuerySort<Message>,
+        pagination: PinnedMessagesPagination,
+    ): Call<List<Message>> {
+        return channelApi.getPinnedMessages(
+            channelType = channelType,
+            channelId = channelId,
+            payload = PinnedMessagesRequest.create(
+                limit = limit,
+                sort = sort,
+                pagination = pagination,
+            ),
+        ).map { response -> response.messages.map(DownstreamMessageDto::toDomain) }
     }
 
     override fun updateChannel(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PinnedMessagesRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/PinnedMessagesRequest.kt
@@ -1,0 +1,77 @@
+package io.getstream.chat.android.client.api2.model.requests
+
+import com.squareup.moshi.JsonClass
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
+import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.models.Message
+import java.util.Date
+
+@JsonClass(generateAdapter = true)
+internal data class PinnedMessagesRequest(
+    val limit: Int,
+    val sort: List<Map<String, Any>>,
+    val id_around: String? = null,
+    val id_gt: String? = null,
+    val id_gte: String? = null,
+    val id_lt: String? = null,
+    val id_lte: String? = null,
+    val pinned_at_around: Date? = null,
+    val pinned_at_after: Date? = null,
+    val pinned_at_after_or_equal: Date? = null,
+    val pinned_at_before: Date? = null,
+    val pinned_at_before_or_equal: Date? = null,
+) {
+
+    companion object {
+        fun create(limit: Int, sort: QuerySort<Message>, pagination: PinnedMessagesPagination): PinnedMessagesRequest {
+            return when (pagination) {
+                is PinnedMessagesPagination.AroundDate -> PinnedMessagesRequest(
+                    limit = limit,
+                    pinned_at_around = pagination.date,
+                    sort = sort.toDto(),
+                )
+                is PinnedMessagesPagination.BeforeDate -> if (pagination.inclusive) PinnedMessagesRequest(
+                    limit = limit,
+                    pinned_at_before_or_equal = pagination.date,
+                    sort = sort.toDto(),
+                ) else PinnedMessagesRequest(
+                    limit = limit,
+                    pinned_at_before = pagination.date,
+                    sort = sort.toDto(),
+                )
+                is PinnedMessagesPagination.AfterDate -> if (pagination.inclusive) PinnedMessagesRequest(
+                    limit = limit,
+                    pinned_at_after_or_equal = pagination.date,
+                    sort = sort.toDto(),
+                ) else PinnedMessagesRequest(
+                    limit = limit,
+                    pinned_at_after = pagination.date,
+                    sort = sort.toDto(),
+                )
+                is PinnedMessagesPagination.AroundMessage -> PinnedMessagesRequest(
+                    limit = limit,
+                    id_around = pagination.messageId,
+                    sort = sort.toDto(),
+                )
+                is PinnedMessagesPagination.BeforeMessage -> if (pagination.inclusive) PinnedMessagesRequest(
+                    limit = limit,
+                    id_lte = pagination.messageId,
+                    sort = sort.toDto(),
+                ) else PinnedMessagesRequest(
+                    limit = limit,
+                    id_lt = pagination.messageId,
+                    sort = sort.toDto(),
+                )
+                is PinnedMessagesPagination.AfterMessage -> if (pagination.inclusive) PinnedMessagesRequest(
+                    limit = limit,
+                    id_gte = pagination.messageId,
+                    sort = sort.toDto(),
+                ) else PinnedMessagesRequest(
+                    limit = limit,
+                    id_gt = pagination.messageId,
+                    sort = sort.toDto(),
+                )
+            }
+        }
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.LifecycleOwner
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.ChatEventListener
 import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.api.models.SendActionRequest
@@ -692,6 +693,35 @@ public class ChannelClient internal constructor(
             offset = offset,
             limit = limit,
             types = types,
+        )
+    }
+
+    /**
+     * Returns a list of message pinned in the channel.
+     * You can sort the list by specifying [sort] parameter.
+     * Keep in mind that for now we only support sorting by [Message.pinnedAt]
+     * The list can be paginated in a few different ways using [limit] and [pagination]
+     *
+     * @param limit Max limit messages to be fetched.
+     * @param sort Desired attachment's types list.
+     * @param pagination Provides different options for pagination.
+     *
+     * @return Executable async [Call] responsible for getting pinned messages.
+     *
+     * @see [PinnedMessagesPagination]
+     */
+    @CheckResult
+    public fun getPinnedMessages(
+        limit: Int,
+        sort: QuerySort<Message>,
+        pagination: PinnedMessagesPagination,
+    ): Call<List<Message>> {
+        return client.getPinnedMessages(
+            channelType = channelType,
+            channelId = channelId,
+            limit = limit,
+            sort = sort,
+            pagination = pagination,
         )
     }
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2331,14 +2331,16 @@ public final class io/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMess
 }
 
 public final class io/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State {
-	public fun <init> (ZLjava/util/List;Z)V
+	public fun <init> (ZLjava/util/List;ZLjava/util/Date;)V
 	public final fun component1 ()Z
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Z
-	public final fun copy (ZLjava/util/List;Z)Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;ZLjava/util/List;ZILjava/lang/Object;)Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;
+	public final fun component4 ()Ljava/util/Date;
+	public final fun copy (ZLjava/util/List;ZLjava/util/Date;)Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;ZLjava/util/List;ZLjava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/ui/pinned/list/viewmodel/PinnedMessageListViewModel$State;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCanLoadMore ()Z
+	public final fun getNextDate ()Ljava/util/Date;
 	public final fun getResults ()Ljava/util/List;
 	public fun hashCode ()I
 	public final fun isLoading ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/pinned/list/PinnedMessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/pinned/list/PinnedMessageListView.kt
@@ -81,6 +81,7 @@ public class PinnedMessageListView : ViewFlipper {
         displayedChild = if (isEmpty) Flipper.EMPTY else Flipper.RESULTS
 
         adapter.submitList(messages)
+        scrollListener.enablePagination()
     }
 
     public fun showLoading() {


### PR DESCRIPTION
### 🎯 Goal

Add support for pinned messages endpoint

### 🛠 Implementation details

- Added new endpoint to `ChatApi`
- Added `getPinnedMessages` to `ChatClient` and `ChannelClient`
- Added `PinnedMessagesPagination` to simplify pagination options
- Refactor `PinnedMessagesViewModel` to use newly created endpoint

### 🧪 Testing

1. Change credentials
2. Run UI Components sample app
3. Go to pinned message list (ChannelInfoView -> PinnedMessages cell)
4. Play with pinning/unpinning and pagination

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
