### PR TITLE
[2808, 2676, 2843, 2842] Fix scrolling behavior in Messages and Chann…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,6 +178,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### 🐞 Fixed
 - Fixed the message grouping logic to now include date separators when splitting message groups [#2770](https://github.com/GetStream/stream-chat-android/pull/2770)
 - Fixed a small issue with user avatars flickering [#2822](https://github.com/GetStream/stream-chat-android/pull/2822)
+- Fixed faulty scrolling behavior in `Channels` and `Messages` by temporarily removing keys inside `LazyColum`s. [#2844](https://github.com/GetStream/stream-chat-android/pull/2844) 
 
 ### ⬆️ Improved
 - Improved the UI for message footers to be more respective of thread replies [#2765](https://github.com/GetStream/stream-chat-android/pull/2765)
@@ -185,6 +186,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Improved the API structure more, made the components package more clear [#2795](https://github.com/GetStream/stream-chat-android/pull/2795)
 - Improved the way to customize the message item types and containers [#2791](https://github.com/GetStream/stream-chat-android/pull/2791)
 - Added more parameters to the stateless version of the MessageComposer for consistency [#2809](https://github.com/GetStream/stream-chat-android/pull/2809)
+- Updated primary accent colors in order to achieve a better contrast ratio for accessibility [#2844](https://github.com/GetStream/stream-chat-android/pull/2844)
+- Removed default background color from `MessageItem` [#2844](https://github.com/GetStream/stream-chat-android/pull/2844)
 
 ### ✅ Added
 - Added site name labels to link attachments for websites using the Open Graph protocol [#2785](https://github.com/GetStream/stream-chat-android/pull/2785)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
@@ -21,6 +21,8 @@ import io.getstream.chat.android.compose.ui.components.LoadingFooter
  * @param modifier Modifier for styling.
  * @param itemContent Customizable UI component, that represents each item in the list.
  * @param divider Customizable UI component, that represents item dividers.
+ *
+ * TODO: Reinstate keys in items once https://issuetracker.google.com/issues/212279111 gets fixed.
  */
 @Composable
 public fun Channels(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
@@ -39,8 +39,7 @@ public fun Channels(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         items(
-            items = channelItems,
-            key = { it.channel.cid }
+            items = channelItems
         ) { item ->
             itemContent(item)
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -28,6 +28,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.End
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -141,7 +142,7 @@ public fun MessageItem(
     }
 
     val backgroundColor =
-        if (focusState is MessageFocused || message.pinned) ChatTheme.colors.highlight else ChatTheme.colors.appBackground
+        if (focusState is MessageFocused || message.pinned) ChatTheme.colors.highlight else Color.Transparent
     val shouldAnimateBackground = !message.pinned && focusState != null
 
     val color = if (shouldAnimateBackground) animateColorAsState(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -66,10 +66,7 @@ public fun Messages(
             contentPadding = PaddingValues(vertical = 16.dp)
         ) {
             itemsIndexed(
-                messages,
-                key = { _, item ->
-                    if (item is MessageItemState) item.message.id else item.toString()
-                }
+                messages
             ) { index, item ->
                 itemContent(item)
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -40,6 +40,8 @@ import kotlin.math.abs
  * @param onScrolledToBottom Handler when the user reaches the bottom of the list.
  * @param itemContent Composable that represents the item that displays each message.
  * @param modifier Modifier for styling.
+ *
+ * TODO: Reinstate keys in items once https://issuetracker.google.com/issues/212279111 gets fixed.
  */
 @Composable
 public fun Messages(

--- a/stream-chat-android-compose/src/main/res/values/colors.xml
+++ b/stream-chat-android-compose/src/main/res/values/colors.xml
@@ -11,7 +11,7 @@
     <color name="stream_compose_link_background">#E9F1FF</color>
     <color name="stream_compose_overlay_regular">#80000000</color>
     <color name="stream_compose_overlay_dark">#99000000</color>
-    <color name="stream_compose_primary_accent">#006CFF</color>
+    <color name="stream_compose_primary_accent">#005FFF</color>
     <color name="stream_compose_error_accent">#FF3742</color>
     <color name="stream_compose_info_accent">#20E070</color>
     <color name="stream_compose_highlight">#FBF4DD</color>
@@ -27,7 +27,7 @@
     <color name="stream_compose_link_background_dark">#00193D</color>
     <color name="stream_compose_overlay_regular_dark">#33000000</color>
     <color name="stream_compose_overlay_dark_dark">#99FFFFFF</color>
-    <color name="stream_compose_primary_accent_dark">#006CFF</color>
+    <color name="stream_compose_primary_accent_dark">#337EFF</color>
     <color name="stream_compose_error_accent_dark">#FF3742</color>
     <color name="stream_compose_info_accent_dark">#20E070</color>
     <color name="stream_compose_highlight_dark">#302D22</color>


### PR DESCRIPTION
### 🎯 Goal

This PR addressed a few smaller and two larger in nature issues.

1. Fix bad behavior in `LazyColumns` where the new items inserted into lists are not automatically displayed but require the user to manually scroll in order to see them. Problem appears in `Channels` and `Messages` and is debilitating in `Messages` when a large influx of messages pops up.
2. Remove unnecessary background from `Messageitem` which was limiting customizability of any component hosting `MessageItem` such as `MessageList`.
3. Update primary accent colors with the new ones in order to provide a better contrast ratio and a better accessibility along with it.

Issue regarding 1. linked [here](https://issuetracker.google.com/issues/212279111).

### 🛠 Implementation details

1. In order to solve our issues with `LazyColumns` and bad scrolling behavior we unfortunately had to remove keys from `items`. There were a couple permutations tried such as using a `key` utility function which would result in visible flickering and triggering conditions which would use scroll to top which resulted in visible UI jerks.
2. Default background color was replaced with a transparent color
3. Color updated

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![old](https://user-images.githubusercontent.com/37080097/147678605-8bb47dec-e1f7-4b7f-8ab1-45ae7a25772f.png) | ![new](https://user-images.githubusercontent.com/37080097/147678602-2c5c3456-d121-463c-a702-2ce7067d4c0b.png) |

### 🧪 Testing

Test `Channels` by entering a channel inside `MessageActivity` that is not on the top of the list, sending a new message and going back to the `ChannelActivity`. The new channel should appear on top and you should not have to manually scroll in order to see it.
 
Test `Messages` by opening any channel inside of the Compose sample app and sending a message to that channel from another chat app using a different account to the one used inside the Compose sample app. The message should be visible without the user having to manually scroll in order to see it.
 
You can test this by manually assigning a background color to `MessageList`  inside of `MessageScreen` through the modifier. There should be no default background on the `MessageItem`.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![hammering](https://user-images.githubusercontent.com/37080097/147680056-46bf1294-4c7b-4595-8925-d426dedbc834.gif)

