### PR TITLE
[CAS-1485] Fix displaying mentions after newline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Fixed displaying mentions and commands popup when text contains multiple lines. [#2851](https://github.com/GetStream/stream-chat-android/pull/2851)
+- Fixed displaying mentions popup when text contains multiple lines. [#2851](https://github.com/GetStream/stream-chat-android/pull/2851)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed displaying mentions and commands popup when text contains multiple lines. [#2851](https://github.com/GetStream/stream-chat-android/pull/2851)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListController.kt
@@ -83,7 +83,13 @@ public class SuggestionListController(
     }
 
     private companion object {
-        private val COMMAND_PATTERN = Pattern.compile("^/[a-z]*$")
-        private val MENTION_PATTERN = Pattern.compile("^(.* )?@([a-zA-Z]+[0-9]*)*$")
+        /**
+         * Pattern used for matching commands. Includes [Pattern.MULTILINE] flag for proper newline support.
+         */
+        private val COMMAND_PATTERN = Pattern.compile("^/[a-z]*$", Pattern.MULTILINE)
+        /**
+         * Pattern used for matching mentions. Includes [Pattern.MULTILINE] flag for proper newline support.
+         */
+        private val MENTION_PATTERN = Pattern.compile("^(.* )?@([a-zA-Z]+[0-9]*)*$", Pattern.MULTILINE)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListController.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/suggestion/list/SuggestionListController.kt
@@ -84,9 +84,9 @@ public class SuggestionListController(
 
     private companion object {
         /**
-         * Pattern used for matching commands. Includes [Pattern.MULTILINE] flag for proper newline support.
+         * Pattern used for matching commands.
          */
-        private val COMMAND_PATTERN = Pattern.compile("^/[a-z]*$", Pattern.MULTILINE)
+        private val COMMAND_PATTERN = Pattern.compile("^/[a-z]*$")
         /**
          * Pattern used for matching mentions. Includes [Pattern.MULTILINE] flag for proper newline support.
          */


### PR DESCRIPTION
https://stream-io.atlassian.net/browse/CAS-1485

### 🎯 Goal

Fix displaying mentions after a newline

### 🛠 Implementation details

Added `Pattern.MULTILINE` to mention  patterns

### 🧪 Testing

Check if mentions work fine when writing a multiline message in `MessageInputView`

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
