### PR TITLE
Added minimum frame delay for giphies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed displaying mentions popup when text contains multiple lines. [#2851](https://github.com/GetStream/stream-chat-android/pull/2851)
+- Fixed the loading/playback speed of GIFs. [#2914](https://github.com/GetStream/stream-chat-android/pull/2914)
 
 ### ⬆️ Improved
 - Improved the way thread pagination works. [#2845](https://github.com/GetStream/stream-chat-android/pull/2845)
@@ -91,6 +92,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Fixed faulty scrolling behavior in `Messages` by adding an autoscroll. [#2857](https://github.com/GetStream/stream-chat-android/pull/2857)
 - Fixed the font size of avatar initials in the message list. [2862](https://github.com/GetStream/stream-chat-android/pull/2862)
 - Fixed faulty scrolling behavior in `Channels` by adding an autoscroll. [#2887](  https://github.com/GetStream/stream-chat-android/pull/2887)
+- Fixed the loading/playback speed of GIFs. [#2914](https://github.com/GetStream/stream-chat-android/pull/2914)
 
 ### ⬆️ Improved
 - Added an animation to the `SelectedChannelMenu` component.

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/coil/StreamImageLoaderFactory.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/coil/StreamImageLoaderFactory.kt
@@ -38,9 +38,9 @@ public class StreamImageLoaderFactory(
             }
             .componentRegistry {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder(context))
+                    add(ImageDecoderDecoder(context, enforceMinimumFrameDelay = true))
                 } else {
-                    add(GifDecoder())
+                    add(GifDecoder(enforceMinimumFrameDelay = true))
                 }
             }
             .apply(builder)


### PR DESCRIPTION
Fixes #2913 

### 🎯 Goal

We had to apply minimum frame delay to our GIF loading factory so that all gifs load with the speed they should have.

### 🧪 Testing

Send the following Giphy link in a message, to any channel (https://giphy.com/gifs/bbc-3o6ZtbprtmmjsZzn2M), it should load as a Link attachment. Observe the GIF in the link preview.

The GIF will be much faster without these changes and it will load normally once the changes are applied.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

This is ironic, so I won't do it. :]
