### PR TITLE
Add small fix to intercept scrolling when popups are shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### 🐞 Fixed
 - Fixed displaying mentions popup when text contains multiple lines. [#2851](https://github.com/GetStream/stream-chat-android/pull/2851)
 - Fixed the loading/playback speed of GIFs. [#2914](https://github.com/GetStream/stream-chat-android/pull/2914)
+- Fixed scroll persisting after long tapping on an item in the message list. [#2916](https://github.com/GetStream/stream-chat-android/pull/2916)
 
 ### ⬆️ Improved
 - Improved the way thread pagination works. [#2845](https://github.com/GetStream/stream-chat-android/pull/2845)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
@@ -1,11 +1,13 @@
 package io.getstream.chat.android.ui.message.list.internal
 
 import androidx.core.view.isVisible
+import androidx.fragment.app.DialogFragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
+import io.getstream.chat.android.ui.common.extensions.internal.getFragmentManager
 import io.getstream.chat.android.ui.common.extensions.internal.safeCast
 import io.getstream.chat.android.ui.common.extensions.isDeleted
 import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
@@ -42,6 +44,19 @@ internal class MessageListScrollHelper(
         }
         recyclerView.addOnScrollListener(
             object : RecyclerView.OnScrollListener() {
+
+                /**
+                 * Checks if we currently have a popup shown over the list.
+                 *
+                 * @param recyclerView The list that we're observing.
+                 * @param newState The scroll state of the list.
+                 */
+                override fun onScrollStateChanged(recyclerView: RecyclerView, newState: Int) {
+                    super.onScrollStateChanged(recyclerView, newState)
+
+                    stopScrollIfPopupShown(recyclerView)
+                }
+
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
                     if (!scrollToBottomButtonEnabled || currentList.isEmpty()) return
 
@@ -74,6 +89,20 @@ internal class MessageListScrollHelper(
                 }
             }
         )
+    }
+
+    /**
+     * Checks if we have any popups shown over the list and stops scrolling in case we do.
+     *
+     * @param recyclerView The list that's being observed for long taps and scrolling.
+     */
+    private fun stopScrollIfPopupShown(recyclerView: RecyclerView) {
+        val fragmentManager = recyclerView.context.getFragmentManager() ?: return
+        val hasDialogsShown = fragmentManager.fragments.any { it is DialogFragment }
+
+        if (hasDialogsShown) {
+            recyclerView.stopScroll()
+        }
     }
 
     internal fun scrollToMessage(message: Message) {


### PR DESCRIPTION
Proposed fix for #2912 

### 🎯 Goal

Our users have reported that long tapping on an item in the list both opens a dialog and allows them to scroll while holding the press. This shouldn't happen.

### 🛠 Implementation details

Added a check in our ScrollHelper that checks if we have any `DialogFragment`s active. If we do, it manually calls stop scrolling on the list to prevent further scroll, which releases the long tap/press.

### 🧪 Testing

- Open any messages screen (any channel). 
- Long tap on a message and keep holding the click.
- Attempt to scroll the list behind by holding and pulling the click up or down (while the dialog is active).

Before this change: The list kept scrolling.
After this change: The list should be static.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![scrolling](https://user-images.githubusercontent.com/17215808/148545150-fe273b3a-e03c-4a52-8cd2-982a5ec747c4.gif)