### PR TITLE
[2941] Fix deleting channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,7 +68,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Handlling video attachments that's don't have mime-type, but have type. [2919](https://github.com/GetStream/stream-chat-android/pull/2919)
+- Handling video attachments that's don't have mime-type, but have type. [2919](https://github.com/GetStream/stream-chat-android/pull/2919)
 
 ### ⬆️ Improved
 
@@ -80,6 +80,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fixed crashes caused by deleting channels [#2942](https://github.com/GetStream/stream-chat-android/pull/2942)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelListViewModel.kt
@@ -336,7 +336,7 @@ public class ChannelListViewModel(
     public fun deleteConversation(channel: Channel) {
         dismissChannelAction()
 
-        chatDomain.deleteChannel(channel.id).enqueue()
+        chatDomain.deleteChannel(channel.cid).enqueue()
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Fix crashes caused by exceptions being thrown because of the use of `channel.id` instead `channel.cid` in `ChannelListViewModel.deleteConversation(Channel)` when deleting channels.

### 🛠 Implementation details

Replace the use of `channel.id` with `channel.cid` inside `ChannelListViewModel.deleteConversation(Channel)`.

### 🧪 Testing

Launch the Compose Sample app, long press on a channel item to open the bottom sheet containing channel options and delete a conversation.

Make sure the app does not throw any exceptions or crash.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~~New code is covered by unit tests~~
- [ ] ~~Comparison screenshots added for visual changes~~
- [ ] ~~Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
