### PR TITLE
[2944] Handle absent member count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed deserialization issue when parsing the `Message` object while searching for a message from a channel with 0 members. [#2947](https://github.com/GetStream/stream-chat-android/pull/2947)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ChannelInfoDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ChannelInfoDto.kt
@@ -6,7 +6,7 @@ import com.squareup.moshi.JsonClass
 internal data class ChannelInfoDto(
     val cid: String?,
     val id: String?,
-    val member_count: Int,
+    val member_count: Int = 0,
     val name: String?,
     val type: String?,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamMessageDtoAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamMessageDtoAdapterTest.kt
@@ -2,8 +2,10 @@ package io.getstream.chat.android.client.parser2
 
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamJson
+import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamJsonWithChannelInfo
 import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamJsonWithoutExtraData
 import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamMessage
+import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamMessageWithChannelInfo
 import io.getstream.chat.android.client.parser2.testdata.MessageDtoTestData.downstreamMessageWithoutExtraData
 import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
@@ -17,6 +19,12 @@ internal class DownstreamMessageDtoAdapterTest {
     fun `Deserialize JSON message with custom fields`() {
         val message = parser.fromJson(downstreamJson, DownstreamMessageDto::class.java)
         message shouldBeEqualTo downstreamMessage
+    }
+
+    @Test
+    fun `Deserialize JSON message with channel info`() {
+        val message = parser.fromJson(downstreamJsonWithChannelInfo, DownstreamMessageDto::class.java)
+        message shouldBeEqualTo downstreamMessageWithChannelInfo
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/ChannelInfoDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/ChannelInfoDtoTestData.kt
@@ -1,0 +1,24 @@
+package io.getstream.chat.android.client.parser2.testdata
+
+import io.getstream.chat.android.client.api2.model.dto.ChannelInfoDto
+import org.intellij.lang.annotations.Language
+
+internal object ChannelInfoDtoTestData {
+
+    @Language("JSON")
+    val channelInfoJsonWithoutMemberCount =
+        """{
+          "cid": "channelType:channelId",
+          "id": "channelId",
+          "type": "channelType",
+          "name": "name"
+        }
+        """.withoutWhitespace()
+    val channelInfoDtoWithoutMemberCount = ChannelInfoDto(
+        cid = "channelType:channelId",
+        id = "channelId",
+        type = "channelType",
+        member_count = 0,
+        name = "name"
+    )
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
@@ -160,6 +160,66 @@ internal object MessageDtoTestData {
     )
 
     @Language("JSON")
+    val downstreamJsonWithChannelInfo =
+        """{
+          "attachments" : [],
+          "cid": "cid",
+          "created_at": "2020-06-10T11:04:31.0Z",
+          "html": "",
+          "i18n": {},
+          "id": "8584452-6d711169-0224-41c2-b9aa-1adbe624521b",
+          "latest_reactions": [],
+          "mentioned_users": [],
+          "own_reactions": [],
+          "reaction_counts": {},
+          "reaction_scores": {},
+          "reply_count": 0,
+          "pinned": false,
+          "shadowed": false,
+          "show_in_channel": false,
+          "silent": false,
+          "text": "",
+          "thread_participants" : [],
+          "type": "",
+          "updated_at": "2020-06-10T11:04:31.588Z",
+          "user": ${UserDtoTestData.downstreamJson},
+          "channel": ${ChannelInfoDtoTestData.channelInfoJsonWithoutMemberCount}
+        }""".withoutWhitespace()
+    val downstreamMessageWithChannelInfo = DownstreamMessageDto(
+        id = "8584452-6d711169-0224-41c2-b9aa-1adbe624521b",
+        cid = "cid",
+        text = "",
+        html = "",
+        parent_id = null,
+        command = null,
+        user = UserDtoTestData.downstreamUser,
+        silent = false,
+        shadowed = false,
+        created_at = Date(1591787071000),
+        updated_at = Date(1591787071588),
+        deleted_at = null,
+        extraData = emptyMap(),
+        type = "",
+        reply_count = 0,
+        reaction_counts = emptyMap(),
+        reaction_scores = emptyMap(),
+        latest_reactions = emptyList(),
+        own_reactions = emptyList(),
+        show_in_channel = false,
+        mentioned_users = emptyList(),
+        i18n = emptyMap(),
+        thread_participants = emptyList(),
+        attachments = emptyList(),
+        quoted_message_id = null,
+        quoted_message = null,
+        pinned = false,
+        pinned_by = null,
+        pinned_at = null,
+        pin_expires = null,
+        channel = ChannelInfoDtoTestData.channelInfoDtoWithoutMemberCount
+    )
+
+    @Language("JSON")
     val upstreamJson =
         """{
           "attachments": [${AttachmentDtoTestData.json}],


### PR DESCRIPTION
https://github.com/GetStream/stream-chat-android/issues/2944

### 🎯 Goal

Fix the deserialization issue when searching for a message in a channel with 0 members:

```
com.squareup.moshi.JsonDataException: Required value 'member_count' missing at $.channel at $.results[0].message 
```

### 🛠 Implementation details

The `member_count` field is an optional field. It can be absent for a channel containing 0 members. This is not an issue for `ChannelDto` as the `member_count` field already defaults to 0 there. 

Added the default value to `ChannelInfoDto.member_count` so that searching for a message in a channel with 0 members completes without errors.

### 🧪 Testing

1. Apply the patch below to the `develop` branch
2. Ensure that searching for "abcde" returns an error

1. Apply the patch below to the `bugfix/2944-handle-absent-member-count` branch
2. Ensure that searching for "abcde" returns a message
3. Check that the channel that contains the message actually contains 0 members

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel.kt	(revision eb1402b8a7c8512a999029cc9a261c1bf4584ca9)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/search/list/viewmodel/SearchViewModel.kt	(date 1642457793660)
@@ -156,7 +156,7 @@
         // TODO: use the pagination based on "limit" nad "next" params here
         return ChatClient.instance()
             .searchMessages(
-                channelFilter = Filters.`in`("members", listOf(currentUser.id)),
+                channelFilter = Filters.eq("type", "messaging"),
                 messageFilter = Filters.autocomplete("text", query),
                 offset = offset,
                 limit = QUERY_LIMIT,
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(revision eb1402b8a7c8512a999029cc9a261c1bf4584ca9)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(date 1642457793655)
@@ -35,7 +35,6 @@
         ChannelListViewModelFactory(
             filter = Filters.and(
                 Filters.eq("type", "messaging"),
-                Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
                 Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
             ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
~~- [ ] Comparison screenshots added for visual changes~~
~- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
