### PR TITLE
[2816] Improve MessageComposer UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ⬆️ Improved
 - `ReactionOptions` now displays the option to show more reactions if there are more than 5 available [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)
 - Improve Korean 🇰🇷 translations. [#2953](https://github.com/GetStream/stream-chat-android/pull/2953)
-- Improved `MessageComposer` UX by disabling commands when attachments or text are present. [#2816](https://github.com/GetStream/stream-chat-android/issues/2816)
-- Improved `MessageComposer` UX by disabling attachment integration button when popups with suggestions are present. [#2816](https://github.com/GetStream/stream-chat-android/issues/2816)
+- Improved `MessageComposer` UX by disabling commands when attachments or text are present. [#2961](https://github.com/GetStream/stream-chat-android/pull/2961)
+- Improved `MessageComposer` UX by disabling attachment integration button when popups with suggestions are present. [#2961](https://github.com/GetStream/stream-chat-android/pull/2961)
 
 ### ✅ Added
 - Added `ExtendedReactionsOptions` and `ReactionsPicker` in order to improve reaction picking UX [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ⬆️ Improved
 - `ReactionOptions` now displays the option to show more reactions if there are more than 5 available [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)
 - Improve Korean 🇰🇷 translations. [#2953](https://github.com/GetStream/stream-chat-android/pull/2953)
+- Improved `MessageComposer` UX by disabling commands when attachments or text are present. [#2816](https://github.com/GetStream/stream-chat-android/issues/2816)
+- Improved `MessageComposer` UX by disabling attachment integration button when popups with suggestions are present. [#2816](https://github.com/GetStream/stream-chat-android/issues/2816)
 
 ### ✅ Added
 - Added `ExtendedReactionsOptions` and `ReactionsPicker` in order to improve reaction picking UX [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -255,7 +255,7 @@ public fun MessageComposer(
         )
     },
 ) {
-    val (_, _, activeAction, validationErrors, mentionSuggestions, commandSuggestions) = messageComposerState
+    val (_, attachments, activeAction, validationErrors, mentionSuggestions, commandSuggestions) = messageComposerState
 
     MessageInputValidationError(validationErrors)
 
@@ -292,7 +292,7 @@ public fun MessageComposer(
             mentionPopupContent(mentionSuggestions)
         }
 
-        if (commandSuggestions.isNotEmpty() && messageComposerState.attachments.isEmpty()) {
+        if (commandSuggestions.isNotEmpty() && attachments.isEmpty()) {
             commandPopupContent(commandSuggestions)
         }
     }
@@ -414,6 +414,7 @@ internal fun DefaultComposerIntegrations(
     val hasMentionSuggestions = messageInputState.mentionSuggestions.isNotEmpty()
 
     val isAttachmentsButtonEnabled = !hasCommandInput && !hasCommandSuggestions && !hasMentionSuggestions
+    val isCommandsButtonEnabled = !hasTextInput && !hasAttachments
 
     Row(
         modifier = Modifier
@@ -436,9 +437,9 @@ internal fun DefaultComposerIntegrations(
             onClick = onAttachmentsClick
         )
 
-        val commandsButtonTint = if (hasCommandSuggestions && !hasTextInput && !hasAttachments) {
+        val commandsButtonTint = if (hasCommandSuggestions && isCommandsButtonEnabled) {
             ChatTheme.colors.primaryAccent
-        } else if (!hasTextInput && !hasAttachments) {
+        } else if (isCommandsButtonEnabled) {
             ChatTheme.colors.textLowEmphasis
         } else {
             ChatTheme.colors.disabled
@@ -448,7 +449,7 @@ internal fun DefaultComposerIntegrations(
             modifier = Modifier
                 .size(32.dp)
                 .padding(4.dp),
-            enabled = !hasTextInput && !hasAttachments,
+            enabled = isCommandsButtonEnabled,
             content = {
                 Icon(
                     painter = painterResource(id = R.drawable.stream_compose_ic_command),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -292,7 +292,7 @@ public fun MessageComposer(
             mentionPopupContent(mentionSuggestions)
         }
 
-        if (commandSuggestions.isNotEmpty()) {
+        if (commandSuggestions.isNotEmpty() && messageComposerState.attachments.isEmpty()) {
             commandPopupContent(commandSuggestions)
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -408,8 +408,12 @@ internal fun DefaultComposerIntegrations(
     onCommandsClick: () -> Unit,
 ) {
     val hasTextInput = messageInputState.inputValue.isNotEmpty()
+    val hasAttachments = messageInputState.attachments.isNotEmpty()
     val hasCommandInput = messageInputState.inputValue.startsWith("/")
     val hasCommandSuggestions = messageInputState.commandSuggestions.isNotEmpty()
+    val hasMentionSuggestions = messageInputState.mentionSuggestions.isNotEmpty()
+
+    val isAttachmentsButtonEnabled = !hasCommandInput && !hasCommandSuggestions && !hasMentionSuggestions
 
     Row(
         modifier = Modifier
@@ -418,7 +422,7 @@ internal fun DefaultComposerIntegrations(
         verticalAlignment = Alignment.CenterVertically
     ) {
         IconButton(
-            enabled = !hasCommandInput,
+            enabled = isAttachmentsButtonEnabled,
             modifier = Modifier
                 .size(32.dp)
                 .padding(4.dp),
@@ -426,15 +430,15 @@ internal fun DefaultComposerIntegrations(
                 Icon(
                     painter = painterResource(id = R.drawable.stream_compose_ic_attachments),
                     contentDescription = stringResource(id = R.string.stream_compose_attachments),
-                    tint = if (hasCommandInput) ChatTheme.colors.disabled else ChatTheme.colors.textLowEmphasis,
+                    tint = if (isAttachmentsButtonEnabled) ChatTheme.colors.textLowEmphasis else ChatTheme.colors.disabled,
                 )
             },
             onClick = onAttachmentsClick
         )
 
-        val commandsButtonTint = if (hasCommandSuggestions && !hasTextInput) {
+        val commandsButtonTint = if (hasCommandSuggestions && !hasTextInput && !hasAttachments) {
             ChatTheme.colors.primaryAccent
-        } else if (!hasTextInput) {
+        } else if (!hasTextInput && !hasAttachments) {
             ChatTheme.colors.textLowEmphasis
         } else {
             ChatTheme.colors.disabled
@@ -444,7 +448,7 @@ internal fun DefaultComposerIntegrations(
             modifier = Modifier
                 .size(32.dp)
                 .padding(4.dp),
-            enabled = !hasTextInput,
+            enabled = !hasTextInput && !hasAttachments,
             content = {
                 Icon(
                     painter = painterResource(id = R.drawable.stream_compose_ic_command),


### PR DESCRIPTION
### 🎯 Goal

Improve the` MessageComposer` UX by making sure that

1. Commands are disabled when text or attachments are present in the composer
2. Disable attachments button when mentions or commands popups are present

Reason for no. 2 Is that otherwise a user can create a situation where `AttachmentsPicker` and popups overlap.

### 🛠 Implementation details

Added additional logic statements to `DefaultComposerIntegrations` that make sure all conditions are satisfied.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![just_attachment_before](https://user-images.githubusercontent.com/37080097/150555605-4bbbffee-9f46-4e55-8799-762705fc3b15.png) | ![just_attachment_after](https://user-images.githubusercontent.com/37080097/150555603-abf72311-fb85-448c-942c-85bca6bed58b.png) |
| ![just_attachment_with_slash_before](https://user-images.githubusercontent.com/37080097/150555652-6d800d25-551c-410f-89d7-be32be3082a5.png) | ![just_attachment_with_slash_after](https://user-images.githubusercontent.com/37080097/150555650-112130c7-7b8e-4ea0-9412-8c9afbbe7645.png) |
| ![mentions_before](https://user-images.githubusercontent.com/37080097/150556945-b3b4b566-d09f-40cb-81d0-c0070a838923.png) | ![mentions_after](https://user-images.githubusercontent.com/37080097/150556940-6929be4e-6318-4cba-9571-5401938e7653.png) |

### 🧪 Testing

To make sure that the `MessageComposer` UX works as intended please

- Check that commands button and popup are disabled when either attachments or text are present
- Integrations are disabled when the message is in edit mode
- Attachment button is disabled when either commands or suggestions popups are present

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![clippy](https://user-images.githubusercontent.com/37080097/150519967-9f1bc105-4a75-4d83-8a0f-df224e7e0b7b.gif)
