### PR TITLE
Fix marking read when using ChatDomain

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1274,6 +1274,18 @@ public class ChatClient internal constructor(
             .precondition { onChannelMarkReadPrecondition(channelType, channelId) }
     }
 
+    /**
+     * Marks the specified channel as read without running a precondition.
+     *
+     * @param channelType Type of the channel.
+     * @param channelId Id of the channel.
+     */
+    @InternalStreamChatApi
+    @CheckResult
+    public fun markReadInternal(channelType: String, channelId: String): Call<Unit> {
+        return api.markRead(channelType, channelId)
+    }
+
     @CheckResult
     public fun updateUsers(users: List<User>): Call<List<User>> {
         return api.updateUsers(users)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/usecase/MarkRead.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/usecase/MarkRead.kt
@@ -25,7 +25,7 @@ internal class MarkRead(private val domainImpl: ChatDomainImpl) {
             channelController.markRead().let { markedRead ->
                 if (markedRead) {
                     domainImpl.client
-                        .markRead(channelController.channelType, channelController.channelId)
+                        .markReadInternal(channelController.channelType, channelController.channelId)
                         .await()
                 }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/MarkReadTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/MarkReadTest.kt
@@ -62,7 +62,7 @@ internal class MarkReadTest {
         whenever(channelController.channelType) doReturn channelType
         whenever(channelController.channelId) doReturn channelId
         val markReadCall = TestCall(Result(Unit))
-        whenever(client.markRead(any(), any())) doReturn markReadCall
+        whenever(client.markReadInternal(any(), any())) doReturn markReadCall
     }
 
     @Test
@@ -98,7 +98,7 @@ internal class MarkReadTest {
             sut.invoke(cid).execute()
 
             verify(channelController).markRead()
-            verify(client).markRead(channelType, channelId)
+            verify(client).markReadInternal(channelType, channelId)
         }
 
     @Test


### PR DESCRIPTION
### 🎯 Goal

Fix marking read when using ChatDomain

### 🛠 Implementation details
Mark read wasn't working fine when `OfflinePlugin` is configured but we are using `ChatDomain.markRead` because we were running a precondition twice:
1. In `ChatClient.markRead` method
2. In `MarkRead` class, using `channelController.markRead()`

Introduced new internal `ChatClient.markRead` method that skips the precondition.
It'll be removed once `ChatDomain `is merged.


### 🧪 Testing

Test if mark read works fine when `ChatDomain` approach

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-team or #compose-chat-sdk-team) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/17440581/150986922-d91a2a46-c74b-4102-96da-15e545588e40.gif)

