### PR TITLE
Cacheable token provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Internal implementation only asks to the provided `TokenProvider` a new token when it is really needed. [#2995](https://github.com/GetStream/stream-chat-android/pull/2995)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -77,6 +77,7 @@ import io.getstream.chat.android.client.notifications.handler.NotificationHandle
 import io.getstream.chat.android.client.socket.ChatSocket
 import io.getstream.chat.android.client.socket.InitConnectionListener
 import io.getstream.chat.android.client.socket.SocketListener
+import io.getstream.chat.android.client.token.CacheableTokenProvider
 import io.getstream.chat.android.client.token.ConstantTokenProvider
 import io.getstream.chat.android.client.token.TokenManager
 import io.getstream.chat.android.client.token.TokenManagerImpl
@@ -261,7 +262,8 @@ public class ChatClient internal constructor(
         tokenProvider: TokenProvider,
         listener: InitConnectionListener? = null,
     ) {
-        if (tokenUtils.getUserId(tokenProvider.loadToken()) != user.id) {
+        val cacheableTokenProvider = CacheableTokenProvider(tokenProvider)
+        if (tokenUtils.getUserId(cacheableTokenProvider.loadToken()) != user.id) {
             logger.logE("The user_id provided on the JWT token doesn't match with the current user you try to connect")
             listener?.onError(ChatError("The user_id provided on the JWT token doesn't match with the current user you try to connect"))
             return
@@ -270,14 +272,14 @@ public class ChatClient internal constructor(
         when {
             userState is UserState.UserSet && userState.user.id == user.id && socketStateService.state == SocketState.Idle -> {
                 userStateService.onUserUpdated(user)
-                tokenManager.setTokenProvider(tokenProvider)
+                tokenManager.setTokenProvider(cacheableTokenProvider)
                 connectionListener = listener
                 socketStateService.onConnectionRequested()
                 socket.connect(user)
                 notifySetUser(user)
             }
             userState is UserState.NotSet -> {
-                initializeClientWithUser(user, tokenProvider)
+                initializeClientWithUser(user, cacheableTokenProvider)
                 connectionListener = listener
                 socketStateService.onConnectionRequested()
                 socket.connect(user)
@@ -295,7 +297,7 @@ public class ChatClient internal constructor(
 
     private fun initializeClientWithUser(
         user: User,
-        tokenProvider: TokenProvider,
+        tokenProvider: CacheableTokenProvider,
     ) {
         userStateService.onSetUser(user)
         // fire a handler here that the chatDomain and chatUI can use
@@ -345,7 +347,7 @@ public class ChatClient internal constructor(
         userCredentialStorage.get()?.let { config ->
             initializeClientWithUser(
                 user = User(id = config.userId).apply { name = config.userName },
-                tokenProvider = ConstantTokenProvider(config.userToken),
+                tokenProvider = CacheableTokenProvider(ConstantTokenProvider(config.userToken)),
             )
         }
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/CacheableTokenProvider.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/CacheableTokenProvider.kt
@@ -1,0 +1,19 @@
+package io.getstream.chat.android.client.token
+
+/**
+ * An implementation of [TokenProvider] that keeps previous values of the loaded token.
+ * This implementation delegate the process to obtain a new token to another tokenProvider.
+ *
+ * @property tokenProvider The [TokenProvider] used to obtain new tokens
+ */
+internal class CacheableTokenProvider(private val tokenProvider: TokenProvider) : TokenProvider {
+    private var cachedToken = ""
+    override fun loadToken(): String = tokenProvider.loadToken().also { cachedToken = it }
+
+    /**
+     * Obtain the cached token.
+     *
+     * @return The cached token.
+     */
+    fun getCachedToken(): String = cachedToken
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/CacheableTokenProvider.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/CacheableTokenProvider.kt
@@ -4,7 +4,7 @@ package io.getstream.chat.android.client.token
  * An implementation of [TokenProvider] that keeps previous values of the loaded token.
  * This implementation delegate the process to obtain a new token to another tokenProvider.
  *
- * @property tokenProvider The [TokenProvider] used to obtain new tokens
+ * @property tokenProvider The [TokenProvider] used to obtain new tokens.
  */
 internal class CacheableTokenProvider(private val tokenProvider: TokenProvider) : TokenProvider {
     private var cachedToken = ""

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManager.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManager.kt
@@ -5,7 +5,7 @@ internal interface TokenManager {
     fun loadSync(): String
     fun expireToken()
     fun hasTokenProvider(): Boolean
-    fun setTokenProvider(provider: TokenProvider)
+    fun setTokenProvider(provider: CacheableTokenProvider)
     fun getToken(): String
     fun hasToken(): Boolean
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManager.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManager.kt
@@ -1,11 +1,46 @@
 package io.getstream.chat.android.client.token
 
 internal interface TokenManager {
+    /**
+     * Ensure a token has been loaded.
+     */
     fun ensureTokenLoaded()
+
+    /**
+     * Load a new token.
+     */
     fun loadSync(): String
+
+    /**
+     * Expire the current token.
+     */
     fun expireToken()
+
+    /**
+     * Check if a [TokenProvider] has been provided.
+     *
+     * @return true if a token provider has been provided, false on another case.
+     */
     fun hasTokenProvider(): Boolean
+
+    /**
+     * Inject a new [CacheableTokenProvider]
+     *
+     * @param provider A [CacheableTokenProvider]
+     */
     fun setTokenProvider(provider: CacheableTokenProvider)
+
+    /**
+     * Obtain last token loaded.
+     *
+     * @return the last token loaded. If the token was expired an empty [String] will be returned.
+     */
     fun getToken(): String
+
+    /**
+     * Check if a token was loaded.
+     *
+     * @return true if a token was loaded and it is not expired, false on another case.
+     */
     fun hasToken(): Boolean
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManagerImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/token/TokenManagerImpl.kt
@@ -21,9 +21,9 @@ internal class TokenManagerImpl : TokenManager {
         }
     }
 
-    override fun setTokenProvider(provider: TokenProvider) {
-        this.token = EMPTY_TOKEN
+    override fun setTokenProvider(provider: CacheableTokenProvider) {
         this.provider = provider
+        this.token = provider.getCachedToken()
     }
 
     override fun hasTokenProvider(): Boolean {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/TokenAuthInterceptorTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/TokenAuthInterceptorTests.kt
@@ -6,6 +6,7 @@ import io.getstream.chat.android.client.api.FakeResponse.Body
 import io.getstream.chat.android.client.errors.ChatErrorCode
 import io.getstream.chat.android.client.errors.ChatRequestError
 import io.getstream.chat.android.client.parser2.MoshiChatParser
+import io.getstream.chat.android.client.token.CacheableTokenProvider
 import io.getstream.chat.android.client.token.FakeTokenManager
 import io.getstream.chat.android.client.token.FakeTokenProvider
 import io.getstream.chat.android.client.token.TokenManagerImpl
@@ -74,7 +75,7 @@ internal class TokenAuthInterceptorTests {
         val tm = TokenManagerImpl()
         val interceptor = TokenAuthInterceptor(tm, parser) { false }
 
-        tm.setTokenProvider(FakeTokenProvider("token-a", "token-b"))
+        tm.setTokenProvider(CacheableTokenProvider(FakeTokenProvider("token-a", "token-b")))
 
         val chain = FakeChain(
             FakeResponse(444, Body("""{ "code": 40 }""")),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -76,7 +76,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         sut.connectUser(Mother.randomUser { id = "userId" }, tokenProviderMock).enqueue()
 
-        verify(tokenManager).setTokenProvider(tokenProviderMock)
+        verify(tokenManager).setTokenProvider(any())
     }
 
     @Test
@@ -118,7 +118,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         sut.connectUser(Mother.randomUser { id = "userId" }, tokenProviderMock).enqueue()
 
-        verify(tokenManager).setTokenProvider(tokenProviderMock)
+        verify(tokenManager).setTokenProvider(any())
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/CacheableTokenProviderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/CacheableTokenProviderTest.kt
@@ -1,0 +1,46 @@
+package io.getstream.chat.android.client.token
+
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doReturnConsecutively
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import io.getstream.chat.android.test.positiveRandomInt
+import io.getstream.chat.android.test.randomString
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class CacheableTokenProviderTest {
+
+    private val delegatedTokenProvider: TokenProvider = mock()
+    private val cacheableTokenProvider = CacheableTokenProvider(delegatedTokenProvider)
+
+    @Test
+    fun `Initial cached token should be empty`() {
+        cacheableTokenProvider.getCachedToken() `should be equal to` ""
+    }
+
+    @Test
+    fun `CacheableTokenProvider should store last value`() {
+        val tokens = List(positiveRandomInt(20)) { randomString() }
+        whenever(delegatedTokenProvider.loadToken()) doReturnConsecutively tokens
+
+        tokens.forEach { cacheableTokenProvider.loadToken() }
+        val result = cacheableTokenProvider.getCachedToken()
+
+        result `should be equal to` tokens.last()
+        verify(delegatedTokenProvider, times(tokens.size)).loadToken()
+    }
+
+    @Test
+    fun `CacheableTokenProvider should delegate the process to obtain a token to his delegated token provider`() {
+        val token = randomString()
+        whenever(delegatedTokenProvider.loadToken()) doReturn token
+
+        val result = cacheableTokenProvider.loadToken()
+
+        result `should be equal to` token
+        verify(delegatedTokenProvider).loadToken()
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
@@ -10,7 +10,7 @@ internal class FakeTokenManager(val tkn: String) : TokenManager {
         // empty
     }
 
-    override fun setTokenProvider(provider: TokenProvider) {
+    override fun setTokenProvider(provider: CacheableTokenProvider) {
         // empty
     }
 


### PR DESCRIPTION
### 🎯 Goal
Our internal implementation was requesting new token multiple times even though it wasn't expired.
close #2966 

### 🛠 Implementation details
Create an implementation that caches a token to be used if it has not been invalidated. 
It is an internal implementation that doesn't change our public API and doesn't force our customers to create an implementation that keeps it.

### 🧪 Testing
Inject a custom `TokenProvider` and verify that `loadToken()` method is not called multiple times

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media4.giphy.com/media/iK5Mdx9bqZIH0jj6Sj/giphy.webp)
