### PR TITLE
Using most recent update, instead of simply prioritizing createdAt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-
+- Small fix for edit message without internet [#2998](https://github.com/GetStream/stream-chat-android/pull/2998)
 ### ⬆️ Improved
 
 ### ✅ Added

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -327,10 +327,24 @@ internal class ChannelLogic(
             return
         }
         val newLastMessageAt =
-            newMessages.mapNotNull { it.createdAt ?: it.createdLocallyAt }.maxOfOrNull(Date::getTime) ?: return
+            newMessages.mapNotNull { maxDate(it.createdAt, it.createdLocallyAt) }.maxOfOrNull(Date::getTime) ?: return
         mutableState.lastMessageAt.value = when (val currentLastMessageAt = mutableState.lastMessageAt.value) {
             null -> Date(newLastMessageAt)
             else -> max(currentLastMessageAt.time, newLastMessageAt).let(::Date)
+        }
+    }
+
+    private fun maxDate(firstDate: Date?, secondDate: Date?): Date? {
+        return when {
+            firstDate == null && secondDate == null -> null
+
+            firstDate != null && secondDate == null -> firstDate
+
+            firstDate == null && secondDate != null -> secondDate
+
+            firstDate != null && secondDate != null -> if (firstDate.after(secondDate)) firstDate else secondDate
+
+            else -> error("invalid state")
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fixing `ChannelLogic.updateLastMessageAtByNewMessages`

### 🛠 Implementation details

Using the most recent between `createdAt` and `createdLocallyAt` instead of simply using `createdAt` if it is not null. It is not easy to reproduce =|

### 🧪 Testing

Edit a message without internet and check that is doesn't go back to the previous text once the connection is recovered. Also test edit message in a broad way

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~. No issue I saw this bug while solving another issue. 

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [ ] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
