### PR TITLE
Merge fork of branch `GiphyResizeAux`

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2051,8 +2051,8 @@ public abstract interface class io/getstream/chat/android/ui/message/list/adapte
 public final class io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle {
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IZILio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;Landroid/widget/ImageView$ScaleType;)V
 	public final fun getGiphyConstantSizeEnabled ()Z
-	public final fun getGiphyHeight ()I
 	public final fun getGiphyIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getGiphyMaxHeight ()I
 	public final fun getGiphyType ()Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
 	public final fun getImageBackgroundColor ()I
 	public final fun getPlaceholderIcon ()Landroid/graphics/drawable/Drawable;
@@ -2061,20 +2061,16 @@ public final class io/getstream/chat/android/ui/message/list/adapter/view/GiphyM
 }
 
 public final class io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle {
-	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;ZI)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Landroid/graphics/drawable/Drawable;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
 	public final fun component4 ()I
 	public final fun component5 ()I
 	public final fun component6 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component7 ()Z
-	public final fun component8 ()I
-	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;ZI)Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;ZIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;)Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getGiphyConstantSizeEnabled ()Z
-	public final fun getGiphyHeight ()I
 	public final fun getGiphyIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getImageBackgroundColor ()I
 	public final fun getMoreCountOverlayColor ()I

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2048,6 +2048,18 @@ public abstract interface class io/getstream/chat/android/ui/message/list/adapte
 	public abstract fun getUserClickListener ()Lio/getstream/chat/android/ui/message/list/MessageListView$UserClickListener;
 }
 
+public final class io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle {
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IZILio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;Landroid/widget/ImageView$ScaleType;)V
+	public final fun getGiphyConstantSizeEnabled ()Z
+	public final fun getGiphyHeight ()I
+	public final fun getGiphyIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getGiphyType ()Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
+	public final fun getImageBackgroundColor ()I
+	public final fun getPlaceholderIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getProgressIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getScaleType ()Landroid/widget/ImageView$ScaleType;
+}
+
 public final class io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle {
 	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IILio/getstream/chat/android/ui/common/style/TextStyle;ZI)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
@@ -2071,6 +2083,27 @@ public final class io/getstream/chat/android/ui/message/list/adapter/view/MediaA
 	public final fun getProgressIcon ()Landroid/graphics/drawable/Drawable;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView : androidx/constraintlayout/widget/ConstraintLayout {
+	public static final field Companion Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion;
+	public fun <init> (Landroid/content/Context;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
+	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
+	public final fun setImageShapeByCorners (FFFF)V
+	public final fun showGiphy (Lio/getstream/chat/android/client/models/Attachment;)V
+}
+
+public final class io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion {
+}
+
+public final class io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType : java/lang/Enum {
+	public static final field FIXED_HEIGHT Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
+	public static final field FIXED_HEIGHT_DOWNSAMPLED Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
+	public static final field ORIGINAL Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
+	public final fun getValue ()Ljava/lang/String;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
+	public static fun values ()[Lio/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView$Companion$GiphyInfoType;
 }
 
 public class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewFactory {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle.kt
@@ -1,0 +1,83 @@
+package io.getstream.chat.android.ui.message.list.adapter.view
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.widget.ImageView
+import androidx.annotation.ColorInt
+import androidx.annotation.DimenRes
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
+import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getEnum
+import io.getstream.chat.android.ui.common.extensions.internal.use
+import io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView
+
+/**
+ * Sets the style for [io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView].
+ */
+public class GiphyMediaAttachmentViewStyle(
+    public val progressIcon: Drawable,
+    public val giphyIcon: Drawable,
+    public val placeholderIcon: Drawable,
+    @ColorInt public val imageBackgroundColor: Int,
+    public val giphyConstantSizeEnabled: Boolean,
+    @DimenRes public val giphyHeight: Int,
+    public val giphyType: GiphyMediaAttachmentView.Companion.GiphyInfoType,
+    public val scaleType: ImageView.ScaleType
+) {
+    internal companion object {
+        private const val DEFAULT_HEIGHT_DP = 200
+
+        operator fun invoke(context: Context, attrs: AttributeSet?): GiphyMediaAttachmentViewStyle {
+            context.obtainStyledAttributes(
+                attrs,
+                R.styleable.GiphyMediaAttachmentView,
+                R.attr.streamUiMessageListMediaAttachmentStyle,
+                R.style.StreamUi_MessageList_GiphyMediaAttachment
+            ).use { attributes ->
+                val progressIcon =
+                    attributes.getDrawable(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentProgressIcon)
+                        ?: context.getDrawableCompat(R.drawable.stream_ui_rotating_indeterminate_progress_gradient)!!
+
+                val giphyIcon =
+                    attributes.getDrawable(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentGiphyIcon)
+                        ?: context.getDrawableCompat(R.drawable.stream_ui_giphy_label)!!
+
+                val imageBackgroundColor = attributes.getColor(
+                    R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentImageBackgroundColor,
+                    context.getColorCompat(R.color.stream_ui_grey)
+                )
+
+                val placeholderIcon =
+                    attributes.getDrawable(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentPlaceHolderIcon)
+                        ?: context.getDrawableCompat(R.drawable.stream_ui_picture_placeholder)!!
+
+                val giphyHeight =
+                    attributes.getDimensionPixelSize(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentGiphyMaxHeight,
+                        DEFAULT_HEIGHT_DP.dpToPx())
+
+                val constantSizeEnabled =
+                    attributes.getBoolean(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentConstantSize,
+                        false)
+
+                val giphyType = attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentGiphyType,
+                    GiphyMediaAttachmentView.Companion.GiphyInfoType.FIXED_HEIGHT)
+
+                val scaleType = attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentScaleType, ImageView.ScaleType.CENTER_CROP)
+
+                return GiphyMediaAttachmentViewStyle(
+                    progressIcon = progressIcon,
+                    giphyIcon = giphyIcon,
+                    placeholderIcon = placeholderIcon,
+                    imageBackgroundColor = imageBackgroundColor,
+                    giphyConstantSizeEnabled = constantSizeEnabled,
+                    giphyHeight = giphyHeight,
+                    giphyType = giphyType,
+                    scaleType = scaleType
+                )
+            }
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/GiphyMediaAttachmentViewStyle.kt
@@ -15,7 +15,18 @@ import io.getstream.chat.android.ui.common.extensions.internal.use
 import io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView
 
 /**
- * Sets the style for [io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView].
+ * Sets the style for [io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView] by obtaining
+ * styled attributes.
+ *
+ * @param progressIcon Displayed while the Giphy is Loading.
+ * @param giphyIcon Displays the Giphy logo over the Giphy image.
+ * @param placeholderIcon Displayed while the Giphy is Loading.
+ * @param imageBackgroundColor Sets the background colour for the Giphy container.
+ * @param giphyConstantSizeEnabled If enabled sets a constant size on all Giphy containers.
+ * @param giphyMaxHeight Sets the maximum height a Giphy container is allowed to have.
+ * @param giphyType Sets the Giphy type which directly affects image quality.
+ * @param scaleType Sets the scaling type for loading the image.
+ * E.g. 'centerCrop', 'fitCenter', etc...
  */
 public class GiphyMediaAttachmentViewStyle(
     public val progressIcon: Drawable,
@@ -23,13 +34,16 @@ public class GiphyMediaAttachmentViewStyle(
     public val placeholderIcon: Drawable,
     @ColorInt public val imageBackgroundColor: Int,
     public val giphyConstantSizeEnabled: Boolean,
-    @DimenRes public val giphyHeight: Int,
+    @DimenRes public val giphyMaxHeight: Int,
     public val giphyType: GiphyMediaAttachmentView.Companion.GiphyInfoType,
-    public val scaleType: ImageView.ScaleType
+    public val scaleType: ImageView.ScaleType,
 ) {
     internal companion object {
         private const val DEFAULT_HEIGHT_DP = 200
 
+        /**
+         * Fetches styled attributes and returns them wrapped inside of [GiphyMediaAttachmentViewStyle].
+         */
         operator fun invoke(context: Context, attrs: AttributeSet?): GiphyMediaAttachmentViewStyle {
             context.obtainStyledAttributes(
                 attrs,
@@ -62,10 +76,13 @@ public class GiphyMediaAttachmentViewStyle(
                     attributes.getBoolean(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentConstantSize,
                         false)
 
-                val giphyType = attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentGiphyType,
-                    GiphyMediaAttachmentView.Companion.GiphyInfoType.FIXED_HEIGHT)
+                val giphyType =
+                    attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentGiphyType,
+                        GiphyMediaAttachmentView.Companion.GiphyInfoType.FIXED_HEIGHT)
 
-                val scaleType = attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentScaleType, ImageView.ScaleType.CENTER_CROP)
+                val scaleType =
+                    attributes.getEnum(R.styleable.GiphyMediaAttachmentView_streamUiGiphyMediaAttachmentScaleType,
+                        ImageView.ScaleType.CENTER_CROP)
 
                 return GiphyMediaAttachmentViewStyle(
                     progressIcon = progressIcon,
@@ -73,7 +90,7 @@ public class GiphyMediaAttachmentViewStyle(
                     placeholderIcon = placeholderIcon,
                     imageBackgroundColor = imageBackgroundColor,
                     giphyConstantSizeEnabled = constantSizeEnabled,
-                    giphyHeight = giphyHeight,
+                    giphyMaxHeight = giphyHeight,
                     giphyType = giphyType,
                     scaleType = scaleType
                 )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
@@ -5,10 +5,8 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import androidx.annotation.ColorInt
-import androidx.annotation.DimenRes
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
-import io.getstream.chat.android.ui.common.extensions.internal.dpToPx
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
@@ -21,11 +19,10 @@ import io.getstream.chat.android.ui.common.style.TextStyle
  *
  * @param progressIcon Animated progress drawable. Default value is [R.drawable.stream_ui_rotating_indeterminate_progress_gradient].
  * @param giphyIcon Giphy icon. Default value is [R.drawable.stream_ui_giphy_label].
+ * @param placeholderIcon Displayed while the Giphy is Loading.
  * @param imageBackgroundColor Image background. Default value is [R.color.stream_ui_grey].
  * @param moreCountOverlayColor More count semi-transparent overlay color. Default value is [R.color.stream_ui_overlay].
  * @param moreCountTextStyle Appearance for "more count" text.
- * @param giphyConstantSizeEnabled Boolean to choose if giphy has constant size or auto sizes accordingly with the images size.
- * @param giphyHeight If giphyConstantSize is true, it is possible to choose its height with this field. Width is the max width of messages.
  */
 public data class MediaAttachmentViewStyle(
     public val progressIcon: Drawable,
@@ -34,13 +31,11 @@ public data class MediaAttachmentViewStyle(
     @ColorInt val imageBackgroundColor: Int,
     @ColorInt val moreCountOverlayColor: Int,
     public val moreCountTextStyle: TextStyle,
-    public val giphyConstantSizeEnabled: Boolean,
-    @DimenRes public val giphyHeight: Int,
 ) {
     internal companion object {
-        private const val DEFAULT_HEIGHT_DP = 200
-
-        // TODO - Split into GiphyMediaAttachmentView and MediaAttachmentView styles
+        /**
+         * Fetches styled attributes and returns them wrapped inside of [MediaAttachmentViewStyle].
+         */
         operator fun invoke(context: Context, attrs: AttributeSet?): MediaAttachmentViewStyle {
             context.obtainStyledAttributes(
                 attrs,
@@ -87,14 +82,6 @@ public data class MediaAttachmentViewStyle(
                     a.getDrawable(R.styleable.MediaAttachmentView_streamUiMediaAttachmentPlaceHolderIcon)
                         ?: context.getDrawableCompat(R.drawable.stream_ui_picture_placeholder)!!
 
-                val giphyHeight =
-                    a.getDimensionPixelSize(R.styleable.MediaAttachmentView_streamUiMediaAttachmentGiphyHeight,
-                        DEFAULT_HEIGHT_DP.dpToPx())
-
-                val constantSizeEnabled =
-                    a.getBoolean(R.styleable.MediaAttachmentView_streamUiMediaAttachmentConstantSize,
-                        false)
-
                 return MediaAttachmentViewStyle(
                     progressIcon = progressIcon,
                     giphyIcon = giphyIcon,
@@ -102,8 +89,6 @@ public data class MediaAttachmentViewStyle(
                     moreCountOverlayColor = moreCountOverlayColor,
                     moreCountTextStyle = moreCountTextStyle,
                     placeholderIcon = placeholderIcon,
-                    giphyHeight = giphyHeight,
-                    giphyConstantSizeEnabled = constantSizeEnabled,
                 ).let(TransformStyle.mediaAttachmentStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/MediaAttachmentViewStyle.kt
@@ -16,7 +16,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.use
 import io.getstream.chat.android.ui.common.style.TextStyle
 
 /**
- * Style for [MediaAttachmentView].
+ * Style for [io.getstream.chat.android.ui.message.list.adapter.view.internal.MediaAttachmentView].
  * Use this class together with [TransformStyle.mediaAttachmentStyleTransformer] to change styles programmatically.
  *
  * @param progressIcon Animated progress drawable. Default value is [R.drawable.stream_ui_rotating_indeterminate_progress_gradient].

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView.kt
@@ -10,7 +10,6 @@ import com.getstream.sdk.chat.images.load
 import com.getstream.sdk.chat.images.loadAndResize
 import com.getstream.sdk.chat.model.ModelType
 import com.getstream.sdk.chat.utils.extensions.imagePreviewUrl
-import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -22,11 +21,20 @@ import io.getstream.chat.android.ui.message.list.adapter.view.GiphyMediaAttachme
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-// TODO - document everything
+/**
+ * View used to display Giphy images inside a shapeable container.
+ */
 public class GiphyMediaAttachmentView : ConstraintLayout {
 
+    /**
+     * Binding generated for [io.getstream.chat.android.ui.R.layout.stream_ui_giphy_media_attachment_view].
+     */
     internal val binding: StreamUiGiphyMediaAttachmentViewBinding =
         StreamUiGiphyMediaAttachmentViewBinding.inflate(streamThemeInflater, this, true)
+
+    /**
+     * Style applied to [GiphyMediaAttachmentView].
+     */
     private lateinit var style: GiphyMediaAttachmentViewStyle
 
     public constructor(context: Context) : this(context, null, 0)
@@ -46,8 +54,13 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
         binding.loadingProgressBar.indeterminateDrawable = style.progressIcon
         binding.giphyLabel.setImageDrawable(style.giphyIcon)
         binding.imageView.scaleType = style.scaleType
+        binding.imageView.setBackgroundColor(style.imageBackgroundColor)
     }
 
+    /**
+     * Displays a Giphy inside its container. Depending on [GiphyMediaAttachmentViewStyle.giphyConstantSizeEnabled]
+     * it displays the Giphy either inside of a constant size or a resizeable container.
+     */
     public fun showGiphy(attachment: Attachment) {
         val url = attachment.giphyUrl(style.giphyType) ?: attachment.let {
             it.imagePreviewUrl ?: it.titleLink ?: it.ogUrl
@@ -60,15 +73,18 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
         }
     }
 
+    /**
+     * Displays the Giphy image inside of a constant size container.
+     */
     private fun showConstantSizeGiphy(url: String) {
         binding.mediaAttachmentContent.updateLayoutParams {
-            this.height = style.giphyHeight
-            this.width = style.giphyHeight
+            this.height = style.giphyMaxHeight
+            this.width = style.giphyMaxHeight
         }
 
         binding.loadImage.updateLayoutParams {
-            this.height = style.giphyHeight
-            this.width = style.giphyHeight
+            this.height = style.giphyMaxHeight
+            this.width = style.giphyMaxHeight
         }
 
         CoroutineScope(DispatcherProvider.Main).launch {
@@ -83,13 +99,16 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
         }
     }
 
+    /**
+     * Displays the Giphy image inside of a resizeable container.
+     */
     private fun showResizeableGiphy(url: String) {
         binding.mediaAttachmentContent.updateLayoutParams {
-            this.height = style.giphyHeight
+            this.height = style.giphyMaxHeight
         }
 
         binding.loadImage.updateLayoutParams {
-            this.height = style.giphyHeight
+            this.height = style.giphyMaxHeight
         }
 
         binding.giphyLabel.isVisible = true
@@ -100,7 +119,7 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
             binding.imageView.loadAndResize(
                 data = url,
                 placeholderDrawable = style.placeholderIcon,
-                maxHeight = style.giphyHeight,
+                maxHeight = style.giphyMaxHeight,
                 container = this@GiphyMediaAttachmentView,
                 onStart = { binding.loadImage.isVisible = true },
                 onComplete = { binding.loadImage.isVisible = false }
@@ -108,6 +127,9 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
         }
     }
 
+    /**
+     * Creates and sets the shape of the Giphy image container.
+     */
     public fun setImageShapeByCorners(
         topLeft: Float,
         topRight: Float,
@@ -123,17 +145,31 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
             .let(this::setImageShape)
     }
 
+    /**
+     * Applies the shape to the container that holds the Giphy image.
+     */
     private fun setImageShape(shapeAppearanceModel: ShapeAppearanceModel) {
         binding.imageView.shapeAppearanceModel = shapeAppearanceModel
-        binding.imageView.background = MaterialShapeDrawable(shapeAppearanceModel).apply {
-            setTint(style.imageBackgroundColor)
-        }
     }
 
     public companion object {
+        /**
+         * Default width used for Giphy Images if no width metadata is available.
+         */
         private const val GIPHY_INFO_DEFAULT_WIDTH_DP = 200
+
+        /**
+         * Default height used for Giphy Images if no width metadata is available.
+         */
         private const val GIPHY_INFO_DEFAULT_HEIGHT_DP = 200
 
+        /**
+         * Returns an object containing extra information about the Giphy image based
+         * on its type.
+         *
+         * @see GiphyInfoType
+         * @see GiphyInfo
+         */
         private fun Attachment.giphyInfo(field: GiphyInfoType): GiphyInfo? {
             val giphyInfoMap =
                 (extraData[ModelType.attach_giphy] as? Map<String, Any>?)?.get(field.value) as? Map<String, String>?
@@ -147,18 +183,45 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
             }
         }
 
+        /**
+         * Enum class that holds a value used to obtain Giphy images of different quality level.
+         */
         public enum class GiphyInfoType(public val value: String) {
+            /**
+             * Original quality
+             */
             ORIGINAL("original"),
+
+            /**
+             * Lower quality with a fixed height, adjusts width according to the Giphy aspect ratio
+             */
             FIXED_HEIGHT("fixed_height"),
+
+            /**
+             * Lower quality with a fixed height with width adjusted according to the aspect ratio
+             * and played at a lower framerate.
+             */
             FIXED_HEIGHT_DOWNSAMPLED("fixed_height_downsampled")
         }
 
+        /**
+         * Contains extra information about Giphy attachments.
+         *
+         * @param url Url for the Giphy image.
+         * @param width The with of the Giphy image.
+         * @param height The Height of the Giphy Image.
+         */
         private data class GiphyInfo(
             val url: String,
             @Px val width: Int,
             @Px val height: Int,
         )
 
+        /**
+         * Returns a url for a Giphy image based on its type.
+         *
+         * @see GiphyInfoType
+         */
         private fun Attachment.giphyUrl(type: GiphyInfoType): String? = giphyInfo(type)?.url
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/GiphyMediaAttachmentView.kt
@@ -51,8 +51,17 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
 
     private fun init(attrs: AttributeSet?) {
         style = GiphyMediaAttachmentViewStyle(context, attrs)
+
+        if (style.giphyConstantSizeEnabled) {
+            binding.loadImage.updateLayoutParams {
+                this.height = style.giphyMaxHeight
+                this.width = style.giphyMaxHeight
+            }
+        }
+
         binding.loadingProgressBar.indeterminateDrawable = style.progressIcon
         binding.giphyLabel.setImageDrawable(style.giphyIcon)
+
         binding.imageView.scaleType = style.scaleType
         binding.imageView.setBackgroundColor(style.imageBackgroundColor)
     }
@@ -74,25 +83,16 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
     }
 
     /**
-     * Displays the Giphy image inside of a constant size container.
+     * Displays the Giphy image inside of a constant size container. We call [loadAndResize] here because we need to
+     * resize the container's width based on the constant height.
      */
     private fun showConstantSizeGiphy(url: String) {
-        binding.mediaAttachmentContent.updateLayoutParams {
-            this.height = style.giphyMaxHeight
-            this.width = style.giphyMaxHeight
-        }
-
-        binding.loadImage.updateLayoutParams {
-            this.height = style.giphyMaxHeight
-            this.width = style.giphyMaxHeight
-        }
-
         CoroutineScope(DispatcherProvider.Main).launch {
-            binding.imageView.setImageDrawable(style.placeholderIcon)
-
-            binding.imageView.load(
+            binding.imageView.loadAndResize(
                 data = url,
                 placeholderDrawable = style.placeholderIcon,
+                container = this@GiphyMediaAttachmentView,
+                maxHeight = style.giphyMaxHeight,
                 onStart = { binding.loadImage.isVisible = true },
                 onComplete = { binding.loadImage.isVisible = false }
             )
@@ -100,29 +100,18 @@ public class GiphyMediaAttachmentView : ConstraintLayout {
     }
 
     /**
-     * Displays the Giphy image inside of a resizeable container.
+     * Displays the Giphy image inside of a resizeable container. We call [load] here as the container can be freely
+     * resized based on the image size.
      */
     private fun showResizeableGiphy(url: String) {
-        binding.mediaAttachmentContent.updateLayoutParams {
-            this.height = style.giphyMaxHeight
-        }
-
-        binding.loadImage.updateLayoutParams {
-            this.height = style.giphyMaxHeight
-        }
-
         binding.giphyLabel.isVisible = true
 
         CoroutineScope(DispatcherProvider.Main).launch {
-            binding.imageView.setImageDrawable(style.placeholderIcon)
-
-            binding.imageView.loadAndResize(
+            binding.imageView.load(
                 data = url,
                 placeholderDrawable = style.placeholderIcon,
-                maxHeight = style.giphyMaxHeight,
-                container = this@GiphyMediaAttachmentView,
                 onStart = { binding.loadImage.isVisible = true },
-                onComplete = { binding.loadImage.isVisible = false }
+                onComplete = { binding.loadImage.isVisible = false },
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/MediaAttachmentView.kt
@@ -19,12 +19,28 @@ import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflat
 import io.getstream.chat.android.ui.common.style.setTextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiMediaAttachmentViewBinding
 import io.getstream.chat.android.ui.message.list.adapter.view.MediaAttachmentViewStyle
-// TODO - document everything
+
+/**
+ * View used to display Media attachments such as images.
+ *
+ * Giphy images are handled by a separate View.
+ * @see GiphyMediaAttachmentView
+ */
 internal class MediaAttachmentView : ConstraintLayout {
+    /**
+     * Handles media attachment clicks.
+     */
     var attachmentClickListener: AttachmentClickListener? = null
+
+    /**
+     * Handles media attachment long clicks.
+     */
     var attachmentLongClickListener: AttachmentLongClickListener? = null
     var giphyBadgeEnabled: Boolean = true
 
+    /**
+     * Binding for [io.getstream.chat.android.ui.R.layout.stream_ui_media_attachment_view].
+     */
     internal val binding: StreamUiMediaAttachmentViewBinding =
         StreamUiMediaAttachmentViewBinding.inflate(streamThemeInflater).also {
             it.root.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
@@ -36,6 +52,10 @@ internal class MediaAttachmentView : ConstraintLayout {
                 constrainViewToParentBySide(it.root, ConstraintSet.TOP)
             }
         }
+
+    /**
+     * Style applied to [MediaAttachmentView].
+     */
     private lateinit var style: MediaAttachmentViewStyle
 
     constructor(context: Context) : this(context, null, 0)
@@ -56,6 +76,10 @@ internal class MediaAttachmentView : ConstraintLayout {
         binding.moreCountLabel.setTextStyle(style.moreCountTextStyle)
     }
 
+    /**
+     * Displays the images in a message. Displays a count saying how many more
+     * images the message contains in case they don't all fit in the preview.
+     */
     fun showAttachment(attachment: Attachment, andMoreCount: Int = NO_MORE_COUNT) {
         val url = attachment.imagePreviewUrl ?: attachment.titleLink ?: attachment.ogUrl ?: return
         val showMore = {
@@ -75,10 +99,16 @@ internal class MediaAttachmentView : ConstraintLayout {
         }
     }
 
+    /**
+     * Sets the visibility for the progress bar.
+     */
     private fun showLoading(isLoading: Boolean) {
         binding.loadImage.isVisible = isLoading
     }
 
+    /**
+     * Loads the images.
+     */
     private fun showImageByUrl(imageUrl: String, onCompleteCallback: () -> Unit) {
         binding.imageView.load(
             data = imageUrl,
@@ -91,12 +121,19 @@ internal class MediaAttachmentView : ConstraintLayout {
         )
     }
 
+    /**
+     * Displays how many more images the message contains that are not
+     * able to fit inside the preview.
+     */
     private fun showMoreCount(andMoreCount: Int) {
         binding.moreCount.isVisible = true
         binding.moreCountLabel.text =
             context.getString(R.string.stream_ui_message_list_attachment_more_count, andMoreCount)
     }
 
+    /**
+     * Creates and sets the shape of the image/s container.
+     */
     fun setImageShapeByCorners(
         topLeft: Float,
         topRight: Float,
@@ -112,6 +149,11 @@ internal class MediaAttachmentView : ConstraintLayout {
             .let(this::setImageShape)
     }
 
+    /**
+     * Applies the shape to the image/s container. Also sets the container
+     * background color and the overlay color for the label that displays
+     * how many more images there are in a message.
+     */
     private fun setImageShape(shapeAppearanceModel: ShapeAppearanceModel) {
         binding.imageView.shapeAppearanceModel = shapeAppearanceModel
         binding.loadImage.background = MaterialShapeDrawable(shapeAppearanceModel).apply {
@@ -123,6 +165,9 @@ internal class MediaAttachmentView : ConstraintLayout {
     }
 
     companion object {
+        /**
+         * When all images in a message are able to fit in the preview.
+         */
         private const val NO_MORE_COUNT = 0
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_giphy_media_attachment_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_giphy_media_attachment_view.xml
@@ -13,8 +13,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:adjustViewBounds="true"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
         />
 
@@ -23,10 +24,10 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:visibility="gone"
-        app:layout_constraintBottom_toBottomOf="@id/imageView"
-        app:layout_constraintLeft_toLeftOf="@id/imageView"
-        app:layout_constraintRight_toRightOf="@id/imageView"
-        app:layout_constraintTop_toTopOf="@id/imageView"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
         tools:visibility="visible"
         >
 
@@ -49,5 +50,5 @@
         app:layout_constraintBottom_toBottomOf="@id/imageView"
         app:layout_constraintStart_toStartOf="parent"
         tools:ignore="ContentDescription"
-        tools:visibility="visible"/>
+        />
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_giphy_media_attachment_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_giphy_media_attachment_view.xml
@@ -10,8 +10,8 @@
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/imageView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
         android:adjustViewBounds="true"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"
@@ -46,7 +46,6 @@
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
         android:src="@drawable/stream_ui_giphy_label"
-        android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@id/imageView"
         app:layout_constraintStart_toStartOf="parent"
         tools:ignore="ContentDescription"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_giphy_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_giphy_attachment.xml
@@ -68,7 +68,7 @@
         <io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView
             android:id="@+id/mediaAttachmentView"
             android:layout_width="match_parent"
-            android:layout_height="200dp"
+            android:layout_height="wrap_content"
             />
 
         <TextView

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_giphy_media_attachment_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_giphy_media_attachment_view.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- Giphy Media Attachment View -->
+    <declare-styleable name="GiphyMediaAttachmentView">
+        <!-- Drawable of the media attachment progressbar -->
+        <attr name="streamUiGiphyMediaAttachmentProgressIcon" format="reference" />
+        <!-- Giphy icon drawable -->
+        <attr name="streamUiGiphyMediaAttachmentGiphyIcon" format="reference" />
+        <!-- Media attachment placeholder icon -->
+        <attr name="streamUiGiphyMediaAttachmentPlaceHolderIcon" format="reference" />
+        <!-- Media attachment background color -->
+        <attr name="streamUiGiphyMediaAttachmentImageBackgroundColor" format="color|reference" />
+        <!-- Sets whether the Giphy attachment's size is constant -->
+        <attr name="streamUiGiphyMediaAttachmentConstantSize" format="boolean" />
+        <!-- Sets the Giphy Attachment's height -->
+        <attr name="streamUiGiphyMediaAttachmentGiphyMaxHeight" format="dimension|reference" />
+        <!-- Sets the Giphy type -->
+        <attr name="streamUiGiphyMediaAttachmentGiphyType" format="enum">
+            <enum name="original" value="0" />
+            <enum name="fixedHeight" value="1" />
+            <enum name="fixedHeightDownsampled" value="2" />
+        </attr>
+        <!-- Sets the scaleType -->
+        <attr name="streamUiGiphyMediaAttachmentScaleType" format="enum">
+            <!-- Scale using the image matrix when drawing. See
+                 {@link android.widget.ImageView#setImageMatrix(Matrix)}. -->
+            <enum name="matrix" value="0" />
+            <!-- Scale the image using {@link android.graphics.Matrix.ScaleToFit#FILL}. -->
+            <enum name="fitXY" value="1" />
+            <!-- Scale the image using {@link android.graphics.Matrix.ScaleToFit#START}. -->
+            <enum name="fitStart" value="2" />
+            <!-- Scale the image using {@link android.graphics.Matrix.ScaleToFit#CENTER}. -->
+            <enum name="fitCenter" value="3" />
+            <!-- Scale the image using {@link android.graphics.Matrix.ScaleToFit#END}. -->
+            <enum name="fitEnd" value="4" />
+            <!-- Center the image in the view, but perform no scaling. -->
+            <enum name="center" value="5" />
+            <!-- Scale the image uniformly (maintain the image's aspect ratio) so both dimensions
+                 (width and height) of the image will be equal to or larger than the corresponding
+                 dimension of the view (minus padding). The image is then centered in the view. -->
+            <enum name="centerCrop" value="6" />
+            <!-- Scale the image uniformly (maintain the image's aspect ratio) so that both
+                 dimensions (width and height) of the image will be equal to or less than the
+                 corresponding dimension of the view (minus padding). The image is then centered in
+                 the view. -->
+            <enum name="centerInside" value="7" />
+        </attr>
+    </declare-styleable>
+
+</resources>

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_media_attachment_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_media_attachment_view.xml
@@ -27,8 +27,5 @@
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
-
-        <attr name="streamUiMediaAttachmentConstantSize" format="boolean" />
-        <attr name="streamUiMediaAttachmentGiphyHeight" format="dimension|reference" />
     </declare-styleable>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -505,8 +505,8 @@
         <item name="streamUiGiphyMediaAttachmentImageBackgroundColor">@color/stream_ui_literal_transparent</item>
         <item name="streamUiGiphyMediaAttachmentConstantSize">false</item>
         <item name="streamUiGiphyMediaAttachmentGiphyMaxHeight">200dp</item>
-        <item name="streamUiGiphyMediaAttachmentGiphyType">fixedHeight</item>
-        <item name="streamUiGiphyMediaAttachmentScaleType">fitCenter</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyType">original</item>
+        <item name="streamUiGiphyMediaAttachmentScaleType">centerCrop</item>
     </style>
 
     <style name="StreamUi.MessageList.FileAttachment" parent="StreamUi">

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -498,6 +498,17 @@
         <item name="streamUiMediaAttachmentMoreCountTextStyle">normal</item>
     </style>
 
+    <style name="StreamUi.MessageList.GiphyMediaAttachment" parent="StreamUi">
+        <item name="streamUiGiphyMediaAttachmentProgressIcon">@drawable/stream_ui_rotating_indeterminate_progress_gradient</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyIcon">@drawable/stream_ui_giphy_label</item>
+        <item name="streamUiGiphyMediaAttachmentPlaceHolderIcon">@drawable/stream_ui_picture_placeholder</item>
+        <item name="streamUiGiphyMediaAttachmentImageBackgroundColor">@color/stream_ui_literal_transparent</item>
+        <item name="streamUiGiphyMediaAttachmentConstantSize">true</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyMaxHeight">250dp</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyType">original</item>
+        <item name="streamUiGiphyMediaAttachmentScaleType">centerCrop</item>
+    </style>
+
     <style name="StreamUi.MessageList.FileAttachment" parent="StreamUi">
         <item name="streamUiFileAttachmentProgressBarDrawable">@drawable/stream_ui_rotating_indeterminate_progress_gradient</item>
         <item name="streamUiFileAttachmentBackgroundColor">@color/stream_ui_white</item>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -503,10 +503,10 @@
         <item name="streamUiGiphyMediaAttachmentGiphyIcon">@drawable/stream_ui_giphy_label</item>
         <item name="streamUiGiphyMediaAttachmentPlaceHolderIcon">@drawable/stream_ui_picture_placeholder</item>
         <item name="streamUiGiphyMediaAttachmentImageBackgroundColor">@color/stream_ui_literal_transparent</item>
-        <item name="streamUiGiphyMediaAttachmentConstantSize">true</item>
-        <item name="streamUiGiphyMediaAttachmentGiphyMaxHeight">250dp</item>
-        <item name="streamUiGiphyMediaAttachmentGiphyType">original</item>
-        <item name="streamUiGiphyMediaAttachmentScaleType">centerCrop</item>
+        <item name="streamUiGiphyMediaAttachmentConstantSize">false</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyMaxHeight">200dp</item>
+        <item name="streamUiGiphyMediaAttachmentGiphyType">fixedHeight</item>
+        <item name="streamUiGiphyMediaAttachmentScaleType">fitCenter</item>
     </style>
 
     <style name="StreamUi.MessageList.FileAttachment" parent="StreamUi">


### PR DESCRIPTION
Continued working on resizeable Giphys.

Added:

- Styled attributes for `GiphyMediaAttachmentView`
- Additional capabilities such as constant size and giphy scaling logic
- Kdocs

Note:

Setting the following items in `StreamUi.MessageList.GiphyMediaAttachment` will result in the users seeing the UI as it was previously and visually avodiing introducing a breaking change. 

```xml
<item name="streamUiGiphyMediaAttachmentConstantSize">true</item>
<item name="streamUiGiphyMediaAttachmentGiphyMaxHeight">250dp</item>
<item name="streamUiGiphyMediaAttachmentScaleType">centerCrop</item>
```

The new system with autosizeable Giphy containers is much better however I believe this should be communicated to the users in case they want to keep the old system for some reason .

You can also keep the old square dimensions but have non cropped Giphys by changing to `fitCenter` scaling method such as this.

```xml
<item name="streamUiGiphyMediaAttachmentScaleType">fitCenter</item>
```