### PR TITLE
Fix clearing cache after receiving channel truncated event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,12 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ❌ Removed
 
 <!-- UNRELEASED START -->
+# January 31th, 2022 - 4.27.1
+## stream-chat-android-offline
+### 🐞 Fixed
+- Fixed clearing cache after receiving channel truncated event. [#3001](https://github.com/GetStream/stream-chat-android/pull/3001)
+<!-- UNRELEASED END -->
+
 # January 25th, 2022 - 4.27.0
 ## stream-chat-android-client
 ### 🐞 Fixed
@@ -171,7 +177,6 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 - Added `ExtendedReactionsOptions` and `ReactionsPicker` in order to improve reaction picking UX [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)
 - Added documentation for [`ReactionsPicker`](https://getstream.io/chat/docs/sdk/android/compose/message-components/reactions-picker/) [#2918](https://github.com/GetStream/stream-chat-android/pull/2918)
 - Added ways to customize the channel, message and member query limit when building a ChannelListViewModel [#2948](https://github.com/GetStream/stream-chat-android/pull/2948)
-<!-- UNRELEASED END -->
 
 
 # January 12th, 2022 - 4.26.0

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -582,6 +582,11 @@ internal class ChatDomainImpl internal constructor(
         }
     }
 
+    /**
+     * Updates [SyncState.lastSyncedAt] exposed via [syncStateFlow] with a given date.
+     *
+     * @param date The new last sync date.
+     */
     private fun updateLastSyncDate(date: Date) {
         syncStateFlow.value?.let { syncStateFlow.value = it.copy(lastSyncedAt = date) }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -574,12 +574,16 @@ internal class ChatDomainImpl internal constructor(
             queryEvents(cids).also { resultChatEvent ->
                 if (resultChatEvent.isSuccess) {
                     eventHandler.handleEventsInternal(resultChatEvent.data())
-                    syncStateFlow.value?.let { syncStateFlow.value = it.copy(lastSyncedAt = now) }
+                    updateLastSyncDate(now)
                 }
             }
         } else {
             Result(emptyList())
         }
+    }
+
+    private fun updateLastSyncDate(date: Date) {
+        syncStateFlow.value?.let { syncStateFlow.value = it.copy(lastSyncedAt = date) }
     }
 
     /**
@@ -666,6 +670,10 @@ internal class ChatDomainImpl internal constructor(
         val activeChannelCids = getActiveChannelCids()
         if (activeChannelCids.isNotEmpty()) {
             replayEventsForChannels(activeChannelCids)
+        } else {
+            // Last sync date is being updated after replaying events for active channels.
+            // We should also update it if we don't have active channels but sync was completed.
+            updateLastSyncDate(Date())
         }
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -389,11 +389,9 @@ internal class EventHandlerImpl(
             when (event) {
                 is NotificationChannelTruncatedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
-                    domainImpl.repos.evictChannel(event.cid)
                 }
                 is ChannelTruncatedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
-                    domainImpl.repos.evictChannel(event.cid)
                 }
                 is ChannelDeletedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -389,9 +389,11 @@ internal class EventHandlerImpl(
             when (event) {
                 is NotificationChannelTruncatedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    domainImpl.repos.evictChannel(event.cid)
                 }
                 is ChannelTruncatedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    domainImpl.repos.evictChannel(event.cid)
                 }
                 is ChannelDeletedEvent -> {
                     domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -255,6 +255,12 @@ internal class ChannelLogic(
         }
     }
 
+    /**
+     * Updates [ChannelMutableState._messages] with new messages.
+     * The message will by only updated if it's creation/update date is newer than the one stored in the StateFlow.
+     *
+     * @param messages The list of messages to update.
+     */
     private fun parseMessages(messages: List<Message>): Map<String, Message> {
         val currentMessages = mutableState._messages.value
         return currentMessages + attachmentUrlValidator.updateValidAttachmentsUrl(messages, currentMessages)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -257,7 +257,7 @@ internal class ChannelLogic(
 
     /**
      * Updates [ChannelMutableState._messages] with new messages.
-     * The message will by only updated if it's creation/update date is newer than the one stored in the StateFlow.
+     * The message will by only updated if its creation/update date is newer than the one stored in the StateFlow.
      *
      * @param messages The list of messages to update.
      */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -256,7 +256,7 @@ internal class ChannelLogic(
     }
 
     private fun parseMessages(messages: List<Message>): Map<String, Message> {
-        val currentMessages = mutableState.messageList.value.associateBy(Message::id)
+        val currentMessages = mutableState._messages.value
         return currentMessages + attachmentUrlValidator.updateValidAttachmentsUrl(messages, currentMessages)
             .filter { newMessage -> isMessageNewerThanCurrent(currentMessages[newMessage.id], newMessage) }
             .associateBy(Message::id)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/RepositoryFacade.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.offline.request.isRequestingMoreThanLastMessage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import java.util.Date
 
 internal class RepositoryFacade constructor(
     userRepository: UserRepository,
@@ -97,6 +98,14 @@ internal class RepositoryFacade constructor(
     override suspend fun insertMessages(messages: List<Message>, cache: Boolean) {
         insertUsers(messages.flatMap(Message::users))
         messageRepository.insertMessages(messages, cache)
+    }
+
+    /**
+     * Deletes channel messages before [hideMessagesBefore] and removes channel from the cache.
+     */
+    override suspend fun deleteChannelMessagesBefore(cid: String, hideMessagesBefore: Date) {
+        evictChannel(cid)
+        messageRepository.deleteChannelMessagesBefore(cid, hideMessagesBefore)
     }
 
     override suspend fun insertReaction(reaction: Reaction) {


### PR DESCRIPTION
### 🎯 Goal

Fix clearing cache after receiving channel truncated event.

### 🛠 Implementation details

1. Replace `mutableState.messageList` with `mutableState._messages` when parsing messages to prevent propagating wrong state when updating `mutable._messages`
2. Remove `channel` from LRU cache when it was truncated
3. Fix updating `lastSyncAt` when recovery was run but there were no active channels

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/17440581/151767617-20505ab2-efda-4521-b2ff-b39b4b2eea79.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/17440581/151767600-3564f2a9-1ef0-4d20-8877-71f936dd8702.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing

You will need two devices and apply a patch on one of them (it adds truncating channel after clicking on user avatar in `ChatFragment`).

1. Turn off `OfflinePlugin` - use `ChatDomain` instead
2. Send a message from device A and turn on airplane mode
2. Click on user avatar on device B (truncate channel)
3. Turn off airplane mode on device A and observe channel is properly truncated after the sync
4. Go back to channel list and click on the same channel one more time -> observe channel is properly truncated

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(revision 851d0f068967850baf7f5e32a5902563011d122f)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(date 1642542167472)
@@ -4,11 +4,12 @@
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
 import io.getstream.chat.android.livedata.utils.Event
-import io.getstream.chat.ui.sample.util.extensions.isAnonymousChannel
 
 class ChatViewModel(private val cid: String, private val chatDomain: ChatDomain = ChatDomain.instance()) : ViewModel() {
 
@@ -31,16 +32,10 @@
     fun onAction(action: Action) {
         when (action) {
             is Action.HeaderClicked -> {
-                val controller = requireNotNull(channelController)
-                _navigationEvent.value = Event(
-                    if (action.members.size > 2 ||
-                        controller.offlineChannelData.value?.isAnonymousChannel() == false
-                    ) {
-                        NavigationEvent.NavigateToGroupChatInfo(cid)
-                    } else {
-                        NavigationEvent.NavigateToChatInfo(cid)
-                    }
-                )
+                ChatClient.instance()
+                    .channel(cid)
+                    .truncate(Message(text = "System message"))
+                    .enqueue()
             }
         }
     }

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] ~PR targets the `develop` branch~
- [ ] ~PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

