### PR TITLE
Sync cached channels after setting the user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,11 +119,16 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ❌ Removed
 
 <!-- UNRELEASED START -->
+# February 2nd, 2022 - 4.27.2
+## stream-chat-android-offline
+### 🐞 Fixed
+- Fixed refreshing cached channels after setting the user. [#3010](https://github.com/GetStream/stream-chat-android/pull/3010)
+<!-- UNRELEASED END -->
+
 # January 31th, 2022 - 4.27.1
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed clearing cache after receiving channel truncated event. [#3001](https://github.com/GetStream/stream-chat-android/pull/3001)
-<!-- UNRELEASED END -->
 
 # January 25th, 2022 - 4.27.0
 ## stream-chat-android-client

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -6,7 +6,7 @@ object Configuration {
     const val minSdk = 21
     const val majorVersion = 4
     const val minorVersion = 27
-    const val patchVersion = 1
+    const val patchVersion = 2
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -657,6 +657,7 @@ public final class io/getstream/chat/android/offline/repository/domain/channel/C
 	public fun insertMany (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun select (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun select (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun selectAllCids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectSyncNeeded (Lio/getstream/chat/android/client/utils/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setDeletedAt (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun setHidden (Ljava/lang/String;ZLjava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -259,7 +259,7 @@ internal class ChatDomainImpl internal constructor(
         }
     }
     private val syncStateFlow: MutableStateFlow<SyncState?> = MutableStateFlow(null)
-    internal var initJob: Deferred<SyncState?>? = null
+    internal var initJob: Deferred<*>? = null
 
     private val offlineSyncFirebaseMessagingHandler = OfflineSyncFirebaseMessagingHandler()
 
@@ -312,6 +312,10 @@ internal class ChatDomainImpl internal constructor(
                 ?.let { eventHandler.handleEvent(it) }
 
             syncState.also { syncStateFlow.value = it }
+
+            // Sync cached channels
+            val cachedChannelsCids = repos.selectAllCids()
+            replayEventsForChannels(cachedChannelsCids)
         }
 
         if (client.isSocketConnected()) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelDao.kt
@@ -4,6 +4,7 @@ import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
+import androidx.room.Transaction
 import io.getstream.chat.android.client.utils.SyncStatus
 import java.util.Date
 
@@ -14,6 +15,10 @@ internal interface ChannelDao {
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMany(channelEntities: List<ChannelEntity>)
+
+    @Transaction
+    @Query("SELECT cid FROM stream_chat_channel_state")
+    suspend fun selectAllCids(): List<String>
 
     @Query(
         "SELECT * FROM stream_chat_channel_state " +

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelRepository.kt
@@ -17,6 +17,13 @@ internal interface ChannelRepository {
     suspend fun selectChannelWithoutMessages(cid: String): Channel?
 
     /**
+     * Selects all channels' cids.
+     *
+     * @return A list of channels' cids stored in the repository.
+     */
+    suspend fun selectAllCids(): List<String>
+
+    /**
      * Select channels by full channel IDs [Channel.cid]
      *
      * @param channelCIDs A list of [Channel.cid] as query specification.
@@ -66,6 +73,8 @@ internal class ChannelRepositoryImpl(
     override suspend fun selectChannelWithoutMessages(cid: String): Channel? {
         return selectChannels(listOf(cid)).getOrNull(0)
     }
+
+    override suspend fun selectAllCids(): List<String> = channelDao.selectAllCids()
 
     override suspend fun selectChannels(channelCIDs: List<String>, forceCache: Boolean): List<Channel> {
         if (channelCIDs.isEmpty()) {


### PR DESCRIPTION
### 🎯 Goal

Sync cached channels after setting the user.

### 🛠 Implementation details
Add calling sync endpoint for all cached channels after setting the user.

### 🎨 UI Changes
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/17440581/152116997-2c3f62ba-3136-48ac-9e92-cca27607ec69.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/17440581/152118053-ea520f2d-f8ff-4f23-a1ab-d2d557ca1441.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing

You will need two devices and apply a patch on one of them (it adds truncating channel after clicking on user avatar in `ChatFragment`).

1. Turn off `OfflinePlugin` - use `ChatDomain` instead
2. Send a message from device A and log out
2. Click on user avatar on device B (truncate channel)
3. Log in as the same user on device A and go to the same channel
4. Observe channel is truncated

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(revision 851d0f068967850baf7f5e32a5902563011d122f)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(date 1642542167472)
@@ -4,11 +4,12 @@
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
 import io.getstream.chat.android.livedata.utils.Event
-import io.getstream.chat.ui.sample.util.extensions.isAnonymousChannel
 
 class ChatViewModel(private val cid: String, private val chatDomain: ChatDomain = ChatDomain.instance()) : ViewModel() {
 
@@ -31,16 +32,10 @@
     fun onAction(action: Action) {
         when (action) {
             is Action.HeaderClicked -> {
-                val controller = requireNotNull(channelController)
-                _navigationEvent.value = Event(
-                    if (action.members.size > 2 ||
-                        controller.offlineChannelData.value?.isAnonymousChannel() == false
-                    ) {
-                        NavigationEvent.NavigateToGroupChatInfo(cid)
-                    } else {
-                        NavigationEvent.NavigateToChatInfo(cid)
-                    }
-                )
+                ChatClient.instance()
+                    .channel(cid)
+                    .truncate(Message(text = "System message"))
+                    .enqueue()
             }
         }
     }

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] ~PR targets the `develop` branch~
- [ ] ~PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

