### PR TITLE
[ISSUE-2897] ChatDomain remove delete message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 
 ### ⚠️ Changed
 - Deprecated `ChatDomain::deleteChannel` in favour of `ChatClient::deleteChannel`. [#3007](https://github.com/GetStream/stream-chat-android/pull/3007)
+- Deprecated `ChatDomain.deleteMessage`, in favour of `ChatClient.deleteMessageAndUpdateLocalData` [3011](https://github.com/GetStream/stream-chat-android/pull/3011). 
 
 ### ❌ Removed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `ChatDomain.deleteMessage` | 2022.02.1<br/>4.27.0 | 2022.03.01 ⌛ | 2022.03.31 ⌛ | Use `ChatClient. deleteMessageAndUpdateLocalData ` instead. |
 | `ChatDomain.editMessage` | 2022.01.31<br/>4.27.0 | 2022.02.28 ⌛ | 2022.03.21 ⌛ | Use `ChatClient.updateMessage` instead. |
 | `ChatDomain#deleteChannel` | 2022.02.08<br/>4.27.0 | 2022.03.08 ⌛ | 2022.04.08 ⌛ | Use `ChatClient.deleteChannel` instead. |
 | `ChatDomain#leaveChannel` | 2022.01.25<br/>4.27.0 | 2022.02.22 ⌛ | 2022.03.15 ⌛ | Use `ChatClient.removeMembers` instead. |

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -33,6 +33,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun deleteMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;Z)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
+	public final fun deleteMessageAndUpdateLocalData (Lio/getstream/chat/android/client/models/Message;Z)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun deleteMessageAndUpdateLocalData$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/Message;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteReaction (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun devToken (Ljava/lang/String;)Ljava/lang/String;
 	public final fun disableSlowMode (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
@@ -1875,6 +1877,11 @@ public abstract interface class io/getstream/chat/android/client/experimental/pl
 
 public final class io/getstream/chat/android/client/experimental/plugin/listeners/ChannelMarkReadListener$DefaultImpls {
 	public static fun onChannelMarkReadPrecondition (Lio/getstream/chat/android/client/experimental/plugin/listeners/ChannelMarkReadListener;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener {
+	public abstract fun onMessageDeleteRequest (Lio/getstream/chat/android/client/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onMessageDeleteResult (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/utils/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/EditMessageListener {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -33,8 +33,6 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun deleteMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;Z)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
-	public final fun deleteMessageAndUpdateLocalData (Lio/getstream/chat/android/client/models/Message;Z)Lio/getstream/chat/android/client/call/Call;
-	public static synthetic fun deleteMessageAndUpdateLocalData$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/Message;ZILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteReaction (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun devToken (Ljava/lang/String;)Ljava/lang/String;
 	public final fun disableSlowMode (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
@@ -1880,8 +1878,8 @@ public final class io/getstream/chat/android/client/experimental/plugin/listener
 }
 
 public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener {
-	public abstract fun onMessageDeleteRequest (Lio/getstream/chat/android/client/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageDeleteResult (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/utils/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onMessageDeleteRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onMessageDeleteResult (Ljava/lang/String;Lio/getstream/chat/android/client/utils/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/EditMessageListener {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -936,6 +936,22 @@ public class ChatClient internal constructor(
         return api.deleteMessage(messageId, hard)
     }
 
+    public fun deleteMessageAndUpdateLocalData(message: Message, hard: Boolean = false): Call<Message> {
+        val relevantPlugins = plugins.filterIsInstance<DeleteMessageListener>()
+
+        return this.deleteMessage(message.id, hard)
+            .doOnStart(scope) {
+                relevantPlugins.forEach { listener ->
+                    listener.onMessageDeleteRequest(message)
+                }
+            }
+            .doOnResult(scope) { result ->
+                relevantPlugins.forEach { listener ->
+                    listener.onMessageDeleteResult(message, result)
+                }
+            }
+    }
+
     @CheckResult
     public fun getMessage(messageId: String): Call<Message> {
         return api.getMessage(messageId)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.events.UserEvent
 import io.getstream.chat.android.client.experimental.plugin.Plugin
 import io.getstream.chat.android.client.experimental.plugin.listeners.ChannelMarkReadListener
+import io.getstream.chat.android.client.experimental.plugin.listeners.DeleteMessageListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.EditMessageListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.QueryChannelsListener

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
@@ -14,7 +14,7 @@ public interface DeleteMessageListener {
      *
      * @param message [Message].
      */
-    public suspend fun onMessageDeleteRequest(message: Message)
+    public suspend fun onMessageDeleteRequest(messageId: String)
 
     /**
      * Method called when a request for message edition return. Use it to update database, update messages or to present
@@ -22,5 +22,5 @@ public interface DeleteMessageListener {
      *
      * @param result the result of the API call.
      */
-    public suspend fun onMessageDeleteResult(originalMessage: Message, result: Result<Message>)
+    public suspend fun onMessageDeleteResult(originalMessageId: String, result: Result<Message>)
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
@@ -1,0 +1,23 @@
+package io.getstream.chat.android.client.experimental.plugin.listeners
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.utils.Result
+
+public interface DeleteMessageListener {
+
+    /**
+     * Method called when a request for message edition happens. Use it to update database, update messages in the SDK,
+     * update the UI when a message occurs...
+     *
+     * @param message [Message].
+     */
+    public suspend fun onMessageDeleteRequest(message: Message)
+
+    /**
+     * Method called when a request for message edition return. Use it to update database, update messages or to present
+     * an error to the user.
+     *
+     * @param result the result of the API call.
+     */
+    public suspend fun onMessageDeleteResult(originalMessage: Message, result: Result<Message>)
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteMessageListener.kt
@@ -3,6 +3,9 @@ package io.getstream.chat.android.client.experimental.plugin.listeners
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 
+/**
+ * Listener for requests of message deletion and for message deletion results.
+ */
 public interface DeleteMessageListener {
 
     /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModel.kt
@@ -93,7 +93,7 @@ public class ImagePreviewViewModel(
 
             chatClient.updateMessage(message).enqueue()
         } else if (message.text.isEmpty() && numberOfAttachments == 1) {
-            chatClient.deleteMessageAndUpdateLocalData(message).enqueue { result ->
+            chatClient.deleteMessage(message.id).enqueue { result ->
                 if (result.isSuccess) {
                     message = result.data()
                 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModel.kt
@@ -93,7 +93,7 @@ public class ImagePreviewViewModel(
 
             chatClient.updateMessage(message).enqueue()
         } else if (message.text.isEmpty() && numberOfAttachments == 1) {
-            chatDomain.deleteMessage(message).enqueue { result ->
+            chatClient.deleteMessageAndUpdateLocalData(message).enqueue { result ->
                 if (result.isSuccess) {
                     message = result.data()
                 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -738,7 +738,7 @@ public class MessageListViewModel(
         messageActions = messageActions - messageActions.filterIsInstance<Delete>()
         removeOverlay()
 
-        chatClient.deleteMessageAndUpdateLocalData(message, hard).enqueue()
+        chatClient.deleteMessage(message.id, hard).enqueue()
     }
 
     /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -738,7 +738,7 @@ public class MessageListViewModel(
         messageActions = messageActions - messageActions.filterIsInstance<Delete>()
         removeOverlay()
 
-        chatDomain.deleteMessage(message, hard).enqueue()
+        chatClient.deleteMessageAndUpdateLocalData(message, hard).enqueue()
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -421,8 +421,24 @@ public sealed interface ChatDomain {
      * @see io.getstream.chat.android.livedata.utils.RetryPolicy
      */
     @CheckResult
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun deleteMessage(message: Message, hard: Boolean = false): Call<Message>
 
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun deleteMessage(message: Message): Call<Message>
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -215,9 +215,25 @@ internal class ChatDomainImpl internal constructor(internal val chatDomainStateF
     )
     override fun editMessage(message: Message): Call<Message> = chatDomainStateFlow.editMessage(message)
 
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     override fun deleteMessage(message: Message, hard: Boolean): Call<Message> =
         chatDomainStateFlow.deleteMessage(message, hard)
 
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     override fun deleteMessage(message: Message): Call<Message> =
         chatDomainStateFlow.deleteMessage(message, false)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -427,8 +427,24 @@ public sealed interface ChatDomain {
      * @see io.getstream.chat.android.offline.utils.RetryPolicy
      */
     @CheckResult
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun deleteMessage(message: Message, hard: Boolean = false): Call<Message>
 
+    @Deprecated(
+        message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+        replaceWith = ReplaceWith(
+            expression = "ChatClient.instance().deleteMessage(message)",
+            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+        ),
+        level = DeprecationLevel.WARNING
+    )
     public fun deleteMessage(message: Message): Call<Message>
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -80,6 +80,12 @@ public class OfflinePlugin(
         logic = LogicRegistry(state)
     }
 
+    /**
+     * Method called when a request for message edition happens. Use it to update database, update messages in the SDK,
+     * update the UI when a message occurs...
+     *
+     * @param message [Message].
+     */
     override suspend fun onMessageDeleteRequest(message: Message) {
         val isOnline = globalState.isOnline()
         val channelLogic = channelLogicForMessage(message)
@@ -92,6 +98,12 @@ public class OfflinePlugin(
         updateAndSaveMessages(messagesToBeDeleted, channelLogic)
     }
 
+    /**
+     * Method called when a request for message edition return. Use it to update database, update messages or to present
+     * an error to the user.
+     *
+     * @param result the result of the API call.
+     */
     override suspend fun onMessageDeleteResult(originalMessage: Message, result: Result<Message>) {
         if (result.isSuccess) {
             val deletedMessage = result.data()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.offline.experimental.plugin
 
 import android.content.Context
-import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
@@ -264,7 +263,7 @@ public class OfflinePlugin(
         )
     }
 
-    private fun requireRepos() : RepositoryFacade{
+    private fun requireRepos(): RepositoryFacade {
         return repos ?: throw IllegalStateException("RepositoryFace was set too late in OfflinePlugin")
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -1,6 +1,7 @@
 package io.getstream.chat.android.offline.experimental.plugin
 
 import android.content.Context
+import android.util.Log
 import androidx.annotation.VisibleForTesting
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
@@ -119,7 +120,10 @@ public class OfflinePlugin(
             updateAndSaveMessages(deletedMessage.let(::listOf), channelLogicForMessage(deletedMessage))
         } else {
             requireRepos().selectMessage(originalMessageId)?.let { originalMessage ->
-                val failureMessage = originalMessage.updateFailedMessage(result.error())
+                val failureMessage = originalMessage.copy(
+                    syncStatus = SyncStatus.SYNC_NEEDED,
+                    updatedLocallyAt = Date(),
+                )
                 updateAndSaveMessages(failureMessage.let(::listOf), channelLogicForMessage(failureMessage))
             }
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -264,7 +264,7 @@ public class OfflinePlugin(
     }
 
     private fun requireRepos(): RepositoryFacade {
-        return repos ?: throw IllegalStateException("RepositoryFace was set too late in OfflinePlugin")
+        return repos ?: throw IllegalStateException("RepositoryFacade was set too late in OfflinePlugin")
     }
 
     internal fun clear() {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/usecase/DeleteMessage.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/usecase/DeleteMessage.kt
@@ -7,6 +7,14 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.utils.validateCid
 
+@Deprecated(
+    message = "DeleteMessage is deprecated. Use function ChatClient::deleteMessage instead",
+    replaceWith = ReplaceWith(
+        expression = "ChatClient.instance().deleteMessage(message)",
+        imports = arrayOf("io.getstream.chat.android.client.ChatClient")
+    ),
+    level = DeprecationLevel.WARNING
+)
 internal class DeleteMessage(private val domainImpl: ChatDomainImpl) {
     /**
      * Deletes the specified message, request is retried according to the retry policy specified on the chatDomain.

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -289,7 +289,7 @@ public class MessageListViewModel @JvmOverloads constructor(
                 onBackButtonPressed()
             }
             is Event.DeleteMessage -> {
-                domain.deleteMessage(event.message, event.hard)
+                client.deleteMessageAndUpdateLocalData(event.message, event.hard)
                     .enqueue(
                         onError = { chatError ->
                             logger.logE("Could not delete message: ${chatError.message}, Hard: ${event.hard}. Cause: ${chatError.cause?.message}")

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -289,7 +289,7 @@ public class MessageListViewModel @JvmOverloads constructor(
                 onBackButtonPressed()
             }
             is Event.DeleteMessage -> {
-                client.deleteMessageAndUpdateLocalData(event.message, event.hard)
+                client.deleteMessage(event.message.id, event.hard)
                     .enqueue(
                         onError = { chatError ->
                             logger.logE("Could not delete message: ${chatError.message}, Hard: ${event.hard}. Cause: ${chatError.cause?.message}")

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
@@ -104,7 +104,7 @@ internal class MessageListViewModelTest {
         whenever(domain.threadLoadMore(any(), any(), any())) doReturn threadLoadMoreCall
         whenever(threadLoadMoreResult.isSuccess) doReturn true
         whenever(threadLoadMoreResult.data()) doReturn emptyList()
-        whenever(domain.deleteMessage(any(), any())) doReturn deleteMessageCall
+        whenever(client.deleteMessageAndUpdateLocalData(any(), any())) doReturn deleteMessageCall
         whenever(domain.getThread(any(), any())) doReturn getThreadCall
         whenever(getThreadResult.isSuccess) doReturn true
         whenever(getThreadResult.data()) doReturn threadController
@@ -157,7 +157,7 @@ internal class MessageListViewModelTest {
 
         viewModel.onEvent(MessageListViewModel.Event.DeleteMessage(MESSAGE, hard = false))
 
-        verify(domain).deleteMessage(MESSAGE, false)
+        verify(client).deleteMessageAndUpdateLocalData(MESSAGE, false)
     }
 
     @Test
@@ -167,7 +167,7 @@ internal class MessageListViewModelTest {
 
         viewModel.onEvent(MessageListViewModel.Event.DeleteMessage(MESSAGE, hard = true))
 
-        verify(domain).deleteMessage(MESSAGE, true)
+        verify(client).deleteMessageAndUpdateLocalData(MESSAGE, true)
     }
 
     @Test

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
@@ -104,7 +104,7 @@ internal class MessageListViewModelTest {
         whenever(domain.threadLoadMore(any(), any(), any())) doReturn threadLoadMoreCall
         whenever(threadLoadMoreResult.isSuccess) doReturn true
         whenever(threadLoadMoreResult.data()) doReturn emptyList()
-        whenever(client.deleteMessageAndUpdateLocalData(any(), any())) doReturn deleteMessageCall
+        whenever(client.deleteMessage(any(), any())) doReturn deleteMessageCall
         whenever(domain.getThread(any(), any())) doReturn getThreadCall
         whenever(getThreadResult.isSuccess) doReturn true
         whenever(getThreadResult.data()) doReturn threadController
@@ -157,7 +157,7 @@ internal class MessageListViewModelTest {
 
         viewModel.onEvent(MessageListViewModel.Event.DeleteMessage(MESSAGE, hard = false))
 
-        verify(client).deleteMessageAndUpdateLocalData(MESSAGE, false)
+        verify(client).deleteMessage(MESSAGE.id, false)
     }
 
     @Test
@@ -167,7 +167,7 @@ internal class MessageListViewModelTest {
 
         viewModel.onEvent(MessageListViewModel.Event.DeleteMessage(MESSAGE, hard = true))
 
-        verify(client).deleteMessageAndUpdateLocalData(MESSAGE, true)
+        verify(client).deleteMessage(MESSAGE.id, true)
     }
 
     @Test


### PR DESCRIPTION
issue: https://github.com/GetStream/stream-chat-android/issues/2897

### 🎯 Goal

Remove/Deprecate `ChatDomain.deleteMessage` and use `ChatClient.deleteMessage
`
### 🛠 Implementation details

Adding a new method `ChatClient.deleteMessageAndUpdateLocalData`. This method had to be create because `ChatClient.deleteMessage` uses message.id instead of the whole message, which won't work for `ChannelLogic`. One option would be to change the original method, I'm open to other solutions as well. 

### 🧪 Testing

Test that deleting a message works the same way in `develop` and this branch.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
