### PR TITLE
Adding UnknownHostException for not permanent network errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ✅ Added
 
 ### ⚠️ Changed
+- UnknownHostException is no longer considered a permanent network error
 
 ### ❌ Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ Consider migrating to `stream-chat-android-ui-components` or `stream-chat-androi
 ### ✅ Added
 
 ### ⚠️ Changed
-- UnknownHostException is no longer considered a permanent network error
+- UnknownHostException is no longer considered a permanent network error. [#3054](https://github.com/GetStream/stream-chat-android/pull/3054)
 
 ### ❌ Removed
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatError.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatError.kt
@@ -6,7 +6,7 @@ import java.net.UnknownHostException
 
 private const val HTTP_TOO_MANY_REQUESTS = 429
 private const val HTTP_TIMEOUT = 408
-private const val API_ERROR = 500
+private const val HTTP_API_ERROR = 500
 
 /**
  * Returns true if an error is a permanent failure instead of a temporary one (broken network, 500, rate limit etc.)
@@ -23,7 +23,7 @@ public fun ChatError.isPermanent(): Boolean {
     return if (this is ChatNetworkError) {
         val networkError: ChatNetworkError = this
         // stream errors are mostly permanent. the exception to this are the rate limit and timeout error
-        val temporaryStreamErrors = listOf(HTTP_TOO_MANY_REQUESTS, HTTP_TIMEOUT, API_ERROR)
+        val temporaryStreamErrors = listOf(HTTP_TOO_MANY_REQUESTS, HTTP_TIMEOUT, HTTP_API_ERROR)
 
         when {
             networkError.statusCode in temporaryStreamErrors -> false

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatError.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatError.kt
@@ -6,6 +6,7 @@ import java.net.UnknownHostException
 
 private const val HTTP_TOO_MANY_REQUESTS = 429
 private const val HTTP_TIMEOUT = 408
+private const val API_ERROR = 500
 
 /**
  * Returns true if an error is a permanent failure instead of a temporary one (broken network, 500, rate limit etc.)
@@ -22,10 +23,10 @@ public fun ChatError.isPermanent(): Boolean {
     return if (this is ChatNetworkError) {
         val networkError: ChatNetworkError = this
         // stream errors are mostly permanent. the exception to this are the rate limit and timeout error
-        val temporaryStreamErrors = listOf(HTTP_TOO_MANY_REQUESTS, HTTP_TIMEOUT)
+        val temporaryStreamErrors = listOf(HTTP_TOO_MANY_REQUESTS, HTTP_TIMEOUT, API_ERROR)
 
         when {
-            networkError.streamCode > 0 && networkError.statusCode in temporaryStreamErrors -> false
+            networkError.statusCode in temporaryStreamErrors -> false
 
             networkError.cause is UnknownHostException -> false
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/ChatErrorTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/ChatErrorTest.kt
@@ -5,6 +5,7 @@ import io.getstream.chat.android.offline.extensions.isPermanent
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Test
+import java.net.UnknownHostException
 
 internal class ChatErrorTest {
 
@@ -36,5 +37,11 @@ internal class ChatErrorTest {
     fun `cool down period error should be permanent`() {
         val error = ChatNetworkError.create(60, "", 403, null)
         error.isPermanent().shouldBeTrue()
+    }
+
+    @Test
+    fun `UnknownHost as cause should be a temporary error`() {
+        val error = ChatNetworkError.create(0, "", 500, UnknownHostException())
+        error.isPermanent().shouldBeFalse()
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Add `UnknownHostException` as a non-permanent network error. If the internet is not available, the user can still regain connection and sync messages editions later. 

### 🛠 Implementation details

Refactor in the class, but the logic is the same, the only change is that `UnknownHostException` is not considered to be a permanent error and it can be the cause of a `ChatNetworkError`

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/153005698-b652de10-5b1d-45f1-bdf9-52cd0bc2686d.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/153005673-cab14867-98a9-4ebc-a0dd-7f2982526561.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Edit a message with and without connection in `develop` and this branch.
### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
