### PR TITLE
Fix OfflinePlugin runtime exception

### DIFF
--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/WithPreconditionCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/WithPreconditionCall.kt
@@ -25,9 +25,9 @@ internal class WithPreconditionCall<T : Any>(
 
     override fun enqueue(callback: Call.Callback<T>) {
         job = scope.launch {
-            val result = precondition.invoke()
+            precondition.invoke()
                 .onSuccess { originalCall.enqueue(callback) }
-                .onErrorSuspend { it ->
+                .onErrorSuspend {
                     withContext(DispatcherProvider.Main) {
                         callback.onResult(Result.error(it))
                     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
@@ -17,6 +17,7 @@ import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.client.utils.map
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
@@ -234,7 +235,11 @@ internal class QueryChannelsLogic(
             .intersect(cidList)
             .associateWith { cid ->
                 val (channelType, channelId) = cid.cidToTypeAndId()
-                client.state.channel(channelType, channelId).toChannel()
+                if (ToggleService.isEnabled(ToggleService.TOGGLE_KEY_OFFLINE)) {
+                    client.state.channel(channelType, channelId).toChannel()
+                } else {
+                    chatDomainImpl.channel(cid).toChannel()
+                }
             }
     }
 


### PR DESCRIPTION
### 🎯 Goal

There is a bug when handling events. We use `ChatClient::state` extension function when we refresh channels after certain events but this extension function requires to have configured `OfflinePlugin` in `ChatClient` already.  OfflinePlugin is not configured in release builds.

### 🛠 Implementation details

Added a check to use `ChatDomain::channel()` when OfflinePlugin is disabled.

### 🧪 Testing
- Use SDK 4.28 in your application.
- Wait till you receive any events like `CidEvent` or `MarkAllReadEvent`.
- There must not be any exception and app should behave as expected.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
