### PR TITLE
3020 - Disallow editing giphy messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED CHANGELOG
+<!-- UNRELEASED START -->
 ## Common changes for all artifacts
 ### 🐞 Fixed
 
@@ -110,12 +111,12 @@
 
 ### ❌ Removed
 
-<!-- UNRELEASED START -->
+<!-- UNRELEASED END -->
+
 # February 9th, 2022 - 4.28.2
 ## Common changes for all artifacts
 - Fix crash with offline support. [#3063](https://github.com/GetStream/stream-chat-android/pull/3063)
 
-<!-- UNRELEASED END -->
 # February 9th, 2022 - 4.28.1
 ## Common changes for all artifacts
 - Fix crash when events were received. [#3058](https://github.com/GetStream/stream-chat-android/pull/3058)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.common.state.ThreadReply
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.isGiphy
 
 /**
  * Displays all available [MessageOptionItem]s.
@@ -123,7 +124,7 @@ public fun defaultMessageOptionsState(
                 iconColor = ChatTheme.colors.textLowEmphasis,
             )
         } else null,
-        if (isOwnMessage) {
+        if (isOwnMessage && !selectedMessage.isGiphy()) {
             MessageOptionItemState(
                 title = R.string.stream_compose_edit_message,
                 iconPainter = painterResource(R.drawable.stream_compose_ic_edit),

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.isMedia
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
 import io.getstream.chat.android.ui.common.extensions.internal.use
 import io.getstream.chat.android.ui.common.extensions.isDeleted
+import io.getstream.chat.android.ui.common.extensions.isGiphyNotEphemeral
 import io.getstream.chat.android.ui.common.extensions.isInThread
 import io.getstream.chat.android.ui.common.navigation.destinations.AttachmentDestination
 import io.getstream.chat.android.ui.common.navigation.destinations.WebLinkDestination
@@ -296,16 +297,20 @@ public class MessageListView : ConstraintLayout {
     private val DEFAULT_MESSAGE_LONG_CLICK_LISTENER =
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { fragmentManager ->
+                val style = requireStyle()
+                val isEditEnabled = style.editMessageEnabled && !message.isGiphyNotEphemeral()
+                val viewStyle = style.copy(editMessageEnabled = isEditEnabled)
+
                 MessageOptionsDialogFragment
                     .newMessageOptionsInstance(
                         message,
                         MessageOptionsView.Configuration(
-                            viewStyle = requireStyle(),
+                            viewStyle = viewStyle,
                             channelConfig = channel.config,
                             hasTextToCopy = message.text.isNotBlank(),
                             suppressThreads = adapter.isThread || message.isInThread(),
                         ),
-                        requireStyle(),
+                        viewStyle,
                         messageListItemViewHolderFactory,
                         messageBackgroundFactory
                     )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -294,6 +294,13 @@ public class MessageListView : ConstraintLayout {
                 }
             }
         }
+
+    /**
+     * Provides a default long click handler for all messages. Based on the configuration options we have and the message
+     * type, we show different kind of options.
+     *
+     * We also disable editing of certain messages, like Giphy messages.
+     */
     private val DEFAULT_MESSAGE_LONG_CLICK_LISTENER =
         MessageLongClickListener { message ->
             context.getFragmentManager()?.let { fragmentManager ->


### PR DESCRIPTION
### 🎯 Goal

It doesn't make sense to edit Giphy messages, as the BE doesn't re-process the giphy command and/or we can end up overriding the message and removing the Giphy.

It's also fairly uncommon to have this type of functionality.

### 🛠 Implementation details

Added checks if the message is a giphy, that we can't edit them.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1644580499](https://user-images.githubusercontent.com/17215808/153587290-2606d05e-3455-415b-8925-558a344b46fe.png)  | ![Screenshot_1644580378](https://user-images.githubusercontent.com/17215808/153587320-1b2fc964-f9f9-4c64-a751-f2fff1146a92.png)  |

| Before | After |
| --- | --- |
| ![Screenshot_1644580466](https://user-images.githubusercontent.com/17215808/153587560-cc6199d1-1870-475e-8cb1-8911dc2e1c56.png) | ![Screenshot_1644580389](https://user-images.githubusercontent.com/17215808/153587408-6f740e71-6f06-4a6c-b132-14fd242f6412.png) |

### 🧪 Testing

Try editing messages on develop and this branch. You shouldn't be able to edit Giphy messages in this branch.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
