### PR TITLE
Fix setting custom empty and loading views for MessageListView

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed setting custom empty and loading views for `MessageListView`. [#3082](https://github.com/GetStream/stream-chat-android/pull/3082)
 
 ### ⬆️ Improved
 - Disabled command popups when attachments are present. [#3051](https://github.com/GetStream/stream-chat-android/pull/3051)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -527,7 +527,7 @@ public class MessageListView : ConstraintLayout {
 
         loadingViewContainer.removeView(binding.defaultLoadingView)
         messageListViewStyle?.loadingView?.let { loadingView ->
-            this.loadingView = streamThemeInflater.inflate(loadingView, null).apply {
+            this.loadingView = streamThemeInflater.inflate(loadingView, loadingViewContainer, false).apply {
                 isVisible = true
                 loadingViewContainer.addView(this)
             }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_list_view.xml
@@ -25,8 +25,8 @@
 
     <FrameLayout
         android:id="@+id/loadingViewContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -38,14 +38,15 @@
             android:id="@+id/defaultLoadingView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             />
 
     </FrameLayout>
 
     <FrameLayout
         android:id="@+id/emptyStateViewContainer"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
@@ -57,6 +58,7 @@
             android:id="@+id/defaultEmptyStateView"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:layout_gravity="center"
             android:text="@string/stream_ui_message_list_empty"
             android:textColor="@color/stream_ui_text_color_primary"
             android:textDirection="locale"


### PR DESCRIPTION
### 🎯 Goal

Fix setting custom empty and loading views for MessageListView

### 🛠 Implementation details

Fixed empty state and loading containers width and height

### 🎨 UI Changes

_Add relevant screenshots_

| Original | Customized |
| --- | --- |
| <img width="435" alt="Screenshot 2022-02-15 at 15 46 40" src="https://user-images.githubusercontent.com/17440581/154087506-dc47b6a0-1119-43e8-a846-34e70e211eef.png">|<img width="435" alt="Screenshot 2022-02-15 at 15 46 10" src="https://user-images.githubusercontent.com/17440581/154087490-6a5158d7-67ad-43b7-ab82-c56aea395454.png">|



### 🧪 Testing

1. Apply the patch and check if both original and customized versions work fine.
2. Apply the same patch on `develop` and test the customized version.

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt	(revision 8207928457439693a230d01d67bfc0607807fc52)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt	(date 1644935351934)
@@ -60,13 +60,8 @@
                 view.showLoadingView()
             }
             is MessageListViewModel.State.Result -> {
-                if (state.messageListItem.items.isEmpty()) {
-                    view.showEmptyStateView()
-                } else {
-                    view.hideEmptyStateView()
-                }
-                view.displayNewMessages(state.messageListItem)
-                view.hideLoadingView()
+                view.showEmptyStateView()
+                view.showLoadingView()
             }
             MessageListViewModel.State.NavigateUp -> Unit // Not handled here
         }
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision 8207928457439693a230d01d67bfc0607807fc52)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1644936581842)
@@ -1,9 +1,13 @@
 package io.getstream.chat.ui.sample.feature.chat
 
+import android.graphics.Color
 import android.os.Bundle
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
+import android.widget.TextView
 import androidx.activity.OnBackPressedCallback
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
@@ -64,6 +68,30 @@
         initMessagesViewModel()
         initMessageInputViewModel()
         configureBackButtonHandling()
+
+        val emptyViewTest = TextView(requireContext()).apply {
+            text = "EMPTY VIEW"
+            setBackgroundColor(Color.RED)
+        }
+
+        val loadingViewTest = TextView(requireContext()).apply {
+            text = "LOADING VIEW"
+            setBackgroundColor(Color.GREEN)
+        }
+        val lp = FrameLayout.LayoutParams(
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            FrameLayout.LayoutParams.WRAP_CONTENT,
+            Gravity.BOTTOM
+        )
+        binding.messageListView.setEmptyStateView(emptyViewTest, lp)
+        binding.messageListView.setLoadingView(
+            loadingViewTest,
+            FrameLayout.LayoutParams(
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.WRAP_CONTENT,
+                Gravity.CENTER
+            )
+        )
     }
 
     override fun onResume() {

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] ~PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
