### PR TITLE
3086 - Improve mention and user search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 ### ⬆️ Improved
 - Disabled command popups when attachments are present. [#3051](https://github.com/GetStream/stream-chat-android/pull/3051)
 - Disabled the attachments button when popups are present. [#3051](https://github.com/GetStream/stream-chat-android/pull/3051)
+- Improved the logic around mentions and users that can be mentioned within the input. [#3087](https://github.com/GetStream/stream-chat-android/pull/3087)
 
 ### ✅ Added
 - Added `ChatUI.channelNameFormatter` to allow customizing the channel's name format. [#3068](https://github.com/GetStream/stream-chat-android/pull/3068)
@@ -72,6 +73,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved the logic around mentions and users that can be mentioned within the input. [#3087](https://github.com/GetStream/stream-chat-android/pull/3087)
 
 ### ✅ Added
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
@@ -30,6 +30,11 @@ internal fun Message.updateUsers(users: Map<String, User>): Message =
 
 /**
  * Fills [Message.mentionedUsersIds] based on [Message.text] and [Channel.members].
+ *
+ * It combines the users found in the input with pre-set [Message.mentionedUsersIds], in case someone
+ * is manually added as a mention.
+ *
+ * @param channel The channel whose members we can check for the mention.
  */
 internal fun Message.populateMentions(channel: Channel) {
     if ('@' !in text) {
@@ -37,11 +42,13 @@ internal fun Message.populateMentions(channel: Channel) {
     }
 
     val text = text.lowercase()
-    mentionedUsersIds = channel.members.mapNotNullTo(mutableListOf()) { member ->
+    val mentions = mentionedUsersIds.toMutableSet() + channel.members.mapNotNullTo(mutableListOf()) { member ->
         if (text.contains("@${member.user.name.lowercase()}")) {
             member.user.id
         } else {
             null
         }
     }
+
+    mentionedUsersIds = mentions.toMutableList()
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/Message.kt
@@ -32,7 +32,7 @@ internal fun Message.updateUsers(users: Map<String, User>): Message =
  * Fills [Message.mentionedUsersIds] based on [Message.text] and [Channel.members].
  *
  * It combines the users found in the input with pre-set [Message.mentionedUsersIds], in case someone
- * is manually added as a mention.
+ * is manually added as a mention. Currently only searches through the channel members for possible mentions.
  *
  * @param channel The channel whose members we can check for the mention.
  */

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -400,6 +400,7 @@ public final class com/getstream/sdk/chat/viewmodel/MessageInputViewModel : andr
 	public final fun keystroke ()V
 	public final fun postMessageToEdit (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun resetThread ()V
+	public final fun selectMention (Lio/getstream/chat/android/client/models/User;)V
 	public final fun sendMessage (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun sendMessage$default (Lcom/getstream/sdk/chat/viewmodel/MessageInputViewModel;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun sendMessageWithAttachments (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -14,6 +14,7 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.livedata.ChatDomain
@@ -50,6 +51,7 @@ public class MessageInputViewModel @JvmOverloads constructor(
     private val _isDirectMessage: MediatorLiveData<Boolean> = MediatorLiveData()
     public val isDirectMessage: LiveData<Boolean> = _isDirectMessage
     private val _channel = MediatorLiveData<Channel>()
+    private val selectedMentions = mutableSetOf<User>()
 
     private val logger = ChatLogger.get("MessageInputViewModel")
 
@@ -101,8 +103,27 @@ public class MessageInputViewModel @JvmOverloads constructor(
         activeThread.postValue(null)
     }
 
+    /**
+     * Stores the selected mention to a [Set], user for populating the mentioned user IDs.
+     *
+     * @param user The selected user to mention.
+     */
+    public fun selectMention(user: User) {
+        this.selectedMentions += user
+    }
+
+    /**
+     * Sends a regular message to the channel.
+     *
+     * @param messageText The current message text.
+     * @param messageTransformer Transformer that applies custom changes to the message, before being sent.
+     */
     public fun sendMessage(messageText: String, messageTransformer: Message.() -> Unit = { }) {
-        val message = Message(cid = cid, text = messageText)
+        val message = Message(
+            cid = cid,
+            text = messageText,
+            mentionedUsersIds = filterMentions(selectedMentions, messageText)
+        )
         activeThread.value?.let { message.parentId = it.id }
         stopTyping()
 
@@ -113,6 +134,13 @@ public class MessageInputViewModel @JvmOverloads constructor(
         )
     }
 
+    /**
+     * Sends a message with non-custom attachments.
+     *
+     * @param messageText The current message text.
+     * @param attachmentsWithMimeTypes Attachments that we support out of the box.
+     * @param messageTransformer Transformer that applies custom changes to the message, before being sent.
+     */
     public fun sendMessageWithAttachments(
         messageText: String,
         attachmentsWithMimeTypes: List<Pair<File, String?>>,
@@ -123,7 +151,12 @@ public class MessageInputViewModel @JvmOverloads constructor(
             Attachment(upload = file, mimeType = mimeType)
         }.toMutableList()
 
-        val message = Message(cid = cid, text = messageText, attachments = attachments).apply(messageTransformer)
+        val message = Message(
+            cid = cid,
+            text = messageText,
+            attachments = attachments,
+            mentionedUsersIds = filterMentions(selectedMentions, messageText)
+        ).apply(messageTransformer)
         chatDomain.sendMessage(message).enqueue(
             onError = { chatError ->
                 logger.logE("Could not send message with cid: ${message.cid}. Error message: ${chatError.message}. Cause message: ${chatError.cause?.message}")
@@ -131,15 +164,45 @@ public class MessageInputViewModel @JvmOverloads constructor(
         )
     }
 
+    /**
+     * Sends a message with custom attachments.
+     *
+     * @param messageText The current message text.
+     * @param customAttachments Attachments that are custom built by the user.
+     * @param messageTransformer Transformer that applies custom changes to the message, before being sent.
+     */
     @ExperimentalStreamChatApi
     public fun sendMessageWithCustomAttachments(
         messageText: String,
         customAttachments: List<Attachment>,
         messageTransformer: Message.() -> Unit = { },
     ) {
-        val message = Message(cid = cid, text = messageText, attachments = customAttachments.toMutableList())
+        val message = Message(
+            cid = cid, text = messageText,
+            attachments = customAttachments.toMutableList(),
+            mentionedUsersIds = filterMentions(selectedMentions, messageText)
+        )
             .apply(messageTransformer)
         chatDomain.sendMessage(message).enqueue()
+    }
+
+    /**
+     * Filters the current input and the mentions the user selected from the suggestion list. Removes any mentions which
+     * are selected but no longer present in the input.
+     *
+     * @param selectedMentions The set of selected users from the suggestion list.
+     * @param message The current message input.
+     *
+     * @return [MutableList] of user IDs of mentioned users.
+     */
+    private fun filterMentions(selectedMentions: Set<User>, message: String): MutableList<String> {
+        val text = message.lowercase()
+
+        val remainingMentions = selectedMentions.filter {
+            text.contains("@${it.name.lowercase()}")
+        }.map { it.id }
+
+        return remainingMentions.toMutableList()
     }
 
     /**

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -202,6 +202,7 @@ public class MessageInputViewModel @JvmOverloads constructor(
             text.contains("@${it.name.lowercase()}")
         }.map { it.id }
 
+        this.selectedMentions.clear()
         return remainingMentions.toMutableList()
     }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -446,6 +446,7 @@ public class MessageComposerController(
             text.contains("@${it.name.lowercase()}")
         }.map { it.id }
 
+        this.selectedMentions.clear()
         return remainingMentions.toMutableList()
     }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -176,6 +176,11 @@ public class MessageComposerController(
         get() = messageMode.value is MessageMode.MessageThread
 
     /**
+     * Represents the selected mentions based on the message suggestion list.
+     */
+    private val selectedMentions: MutableSet<User> = mutableSetOf()
+
+    /**
      * Sets up the data loading operations such as observing the maximum allowed message length.
      */
     init {
@@ -405,11 +410,13 @@ public class MessageComposerController(
 
         val actionMessage = activeAction?.message ?: Message()
         val replyMessageId = (activeAction as? Reply)?.message?.id
+        val mentions = filterMentions(selectedMentions, message)
 
         return if (isInEditMode) {
             actionMessage.copy(
                 text = message,
-                attachments = attachments.toMutableList()
+                attachments = attachments.toMutableList(),
+                mentionedUsersIds = mentions
             )
         } else {
             Message(
@@ -417,9 +424,29 @@ public class MessageComposerController(
                 text = message,
                 parentId = parentMessageId,
                 replyMessageId = replyMessageId,
-                attachments = attachments.toMutableList()
+                attachments = attachments.toMutableList(),
+                mentionedUsersIds = mentions
             )
         }
+    }
+
+    /**
+     * Filters the current input and the mentions the user selected from the suggestion list. Removes any mentions which
+     * are selected but no longer present in the input.
+     *
+     * @param selectedMentions The set of selected users from the suggestion list.
+     * @param message The current message input.
+     *
+     * @return [MutableList] of user IDs of mentioned users.
+     */
+    private fun filterMentions(selectedMentions: Set<User>, message: String): MutableList<String> {
+        val text = message.lowercase()
+
+        val remainingMentions = selectedMentions.filter {
+            text.contains("@${it.name.lowercase()}")
+        }.map { it.id }
+
+        return remainingMentions.toMutableList()
     }
 
     /**
@@ -504,6 +531,7 @@ public class MessageComposerController(
         val augmentedMessageText = "${messageText.substringBeforeLast("@")}@${user.name} "
 
         setMessageInput(augmentedMessageText)
+        selectedMentions += user
     }
 
     /**

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1105,6 +1105,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setMaxMessageLength (I)V
 	public final fun setMaxMessageLengthHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$MaxMessageLengthHandler;)V
 	public final fun setMentionsEnabled (Z)V
+	public final fun setMessageInputMentionListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$MessageInputMentionListener;)V
 	public final fun setMessageInputModeListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$MessageInputViewModeListener;)V
 	public final fun setOnSendButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$OnMessageSendButtonClickListener;)V
 	public final fun setSelectedAttachmentsCountListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$SelectedAttachmentsCountListener;)V
@@ -1183,6 +1184,10 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView$I
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$MaxMessageLengthHandler {
 	public abstract fun onMessageLengthChanged (Ljava/lang/String;IIZ)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$MessageInputMentionListener {
+	public abstract fun onMentionSelected (Lio/getstream/chat/android/client/models/User;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$MessageInputViewModeListener {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflat
 import io.getstream.chat.android.ui.common.style.setTextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiMessageInputBinding
 import io.getstream.chat.android.ui.message.input.MessageInputView.MaxMessageLengthHandler
+import io.getstream.chat.android.ui.message.input.MessageInputView.MessageInputMentionListener
 import io.getstream.chat.android.ui.message.input.MessageInputView.MessageInputViewModeListener
 import io.getstream.chat.android.ui.message.input.MessageInputView.SelectedAttachmentsCountListener
 import io.getstream.chat.android.ui.message.input.attachment.AttachmentSelectionDialogFragment
@@ -155,6 +156,11 @@ public class MessageInputView : ConstraintLayout {
         }
 
     private var messageInputViewModeListener: MessageInputViewModeListener = MessageInputViewModeListener { }
+
+    /**
+     * Listener that handles selected mentions.
+     */
+    private var messageInputMentionListener: MessageInputMentionListener = MessageInputMentionListener { }
 
     public constructor(context: Context) : this(context, null)
 
@@ -279,6 +285,7 @@ public class MessageInputView : ConstraintLayout {
             object : SuggestionListView.OnSuggestionClickListener {
                 override fun onMentionClick(user: User) {
                     binding.messageInputFieldView.autoCompleteUser(user)
+                    messageInputMentionListener.onMentionSelected(user)
                 }
 
                 override fun onCommandClick(command: Command) {
@@ -568,6 +575,15 @@ public class MessageInputView : ConstraintLayout {
      */
     public fun setMessageInputModeListener(listener: MessageInputViewModeListener) {
         messageInputViewModeListener = listener
+    }
+
+    /**
+     * Sets a listener for the mention selection.
+     *
+     * @param listener The listener to be set.
+     */
+    public fun setMessageInputMentionListener(listener: MessageInputMentionListener) {
+        this.messageInputMentionListener = listener
     }
 
     /**
@@ -1097,14 +1113,27 @@ public class MessageInputView : ConstraintLayout {
 
     /**
      * Listener invoked when input mode changes.
-     * Can be used for changing view's appearance based on the current mode - for example, send message buttons' drawables
+     * Can be used for changing view's appearance based on the current mode - for example, send message buttons' drawables.
      */
     public fun interface MessageInputViewModeListener {
         /**
-         * Called when input mode changes
+         * Called when input mode changes.
          *
-         * @param inputMode Current input mode
+         * @param inputMode Current input mode.
          */
         public fun inputModeChanged(inputMode: InputMode)
+    }
+
+    /**
+     * Listener invoked whenever a user selects a mention from the suggestion popup list.
+     *
+     * Used to store the mention before sending the message.
+     */
+    public fun interface MessageInputMentionListener {
+
+        /**
+         * Called when the user is selected in the mention suggestion list.
+         */
+        public fun onMentionSelected(user: User)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/viewmodel/MessageInputViewModelBinding.kt
@@ -18,13 +18,22 @@ import java.io.File
  *
  * This function sets listeners on the view and ViewModel. Call this method
  * before setting any additional listeners on these objects yourself.
+ *
+ * @param view The View to bind to.
+ * @param lifecycleOwner The lifecycle owner to bind the data observing to.
  */
 @JvmName("bind")
-public fun MessageInputViewModel.bindView(view: MessageInputView, lifecycleOwner: LifecycleOwner) {
+public fun MessageInputViewModel.bindView(
+    view: MessageInputView,
+    lifecycleOwner: LifecycleOwner,
+) {
     val handler = MessageInputView.DefaultUserLookupHandler(emptyList())
     view.setUserLookupHandler(handler)
     members.observe(lifecycleOwner) { members ->
         handler.users = members.map(Member::user)
+    }
+    view.setMessageInputMentionListener { selectedUser ->
+        selectMention(selectedUser)
     }
     commands.observe(lifecycleOwner, view::setCommands)
     maxMessageLength.observe(lifecycleOwner, view::setMaxMessageLength)


### PR DESCRIPTION
### 🎯 Goal

Closes #3086 

### 🛠 Implementation details

Added state that keeps the currently selected mentioned users in a set, before sending the message. Added checks to see if they're still in the input before sending it.

Also added checks that match the manual input to see if there's anyone from the channel that we didn't add to the mentions.

### 🧪 Testing

**Testing the new pre-fill logic**:
1. Open any channel and start the mention action.
2. Pick any user from the list.
3. Debug this branch and check if the message before sending has populated `mentionedUserIds`.

**Testing the manual input logic**
1. Open any channel. 
2. Manually write the name of a person you want to mention from the channel. Note: The name has to be 100% match (e.g. "@Filip Babić" for Filip, if he's in the channel).
3. Debug if the message receives new mentions, even without picking a user from the suggestion list.

**Testing that non-matched mention input is removed from mentions**:
1. Open any channel.
2. Start the mention command and **select a user** from the suggestion list.
3. Delete 1 or more characters of the selected user autofill.
4. Debug if the message mention is removed given that it doesn't 100% match the name.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
