### PR TITLE
[3089] Fix default events handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed how member removal is handled in `DefaultChatEventHandler`. [#3090](https://github.com/GetStream/stream-chat-android/pull/3090)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added possibility to configure `RetryPolicy` using `ChaClient.Builder()`. [#3069](https://github.com/GetStream/stream-chat-android/pull/3069)
+- Added the `member` field to the `MemberRemovedEvent`. [#3090](https://github.com/GetStream/stream-chat-android/pull/3090)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1227,21 +1227,23 @@ public final class io/getstream/chat/android/client/events/MemberAddedEvent : io
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/client/events/MemberRemovedEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/UserEvent {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+public final class io/getstream/chat/android/client/events/MemberRemovedEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasMember, io/getstream/chat/android/client/events/UserEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/events/MemberRemovedEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/MemberRemovedEvent;Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/MemberRemovedEvent;
+	public final fun component7 ()Lio/getstream/chat/android/client/models/Member;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;)Lio/getstream/chat/android/client/events/MemberRemovedEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/MemberRemovedEvent;Ljava/lang/String;Ljava/util/Date;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Member;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/MemberRemovedEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;
 	public fun getCreatedAt ()Ljava/util/Date;
+	public fun getMember ()Lio/getstream/chat/android/client/models/Member;
 	public fun getType ()Ljava/lang/String;
 	public fun getUser ()Lio/getstream/chat/android/client/models/User;
 	public fun hashCode ()I

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -254,6 +254,7 @@ private fun MemberRemovedEventDto.toDomain(): MemberRemovedEvent {
         cid = cid,
         channelType = channel_type,
         channelId = channel_id,
+        member = member.toDomain(),
     )
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -99,6 +99,7 @@ internal data class MemberRemovedEventDto(
     val cid: String,
     val channel_type: String,
     val channel_id: String,
+    val member: DownstreamMemberDto,
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -185,7 +185,8 @@ public data class MemberRemovedEvent(
     override val cid: String,
     override val channelType: String,
     override val channelId: String,
-) : CidEvent(), UserEvent
+    override val member: Member,
+) : CidEvent(), UserEvent, HasMember
 
 /**
  * Triggered when a channel member is updated (promoted to moderator/accepted/.rejected the invite)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -102,7 +102,8 @@ internal fun createMemberRemovedEventStringJson() =
             "channel_type": "channelType",
             "channel_id": "channelId",
             "cid": "channelType:channelId",
-            "user": ${createUserJsonString()}
+            "user": ${createUserJsonString()},
+            "member": ${createMemberJsonString()}
         """.trimIndent()
     )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -187,7 +187,7 @@ internal object EventArguments {
     private val channelUpdatedByUserEvent = ChannelUpdatedByUserEvent(EventType.CHANNEL_UPDATED, date, cid, channelType, channelId, user, message, channel)
     private val channelVisibleEvent = ChannelVisibleEvent(EventType.CHANNEL_VISIBLE, date, cid, channelType, channelId, user)
     private val memberAddedEvent = MemberAddedEvent(EventType.MEMBER_ADDED, date, user, cid, channelType, channelId, member)
-    private val memberRemovedEvent = MemberRemovedEvent(EventType.MEMBER_REMOVED, date, user, cid, channelType, channelId)
+    private val memberRemovedEvent = MemberRemovedEvent(EventType.MEMBER_REMOVED, date, user, cid, channelType, channelId, member)
     private val memberUpdatedEvent = MemberUpdatedEvent(EventType.MEMBER_UPDATED, date, user, cid, channelType, channelId, member)
     private val messageDeletedEvent = MessageDeletedEvent(EventType.MESSAGE_DELETED, date, user, cid, channelType, channelId, message, hardDelete = false)
     private val messageDeletedServerSideEvent = MessageDeletedEvent(EventType.MESSAGE_DELETED, date, null, cid, channelType, channelId, message, hardDelete = true)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/ChatEventHandler.kt
@@ -170,7 +170,11 @@ internal fun removeIfCurrentUserLeftChannel(
     channel: Channel?,
     member: Member,
 ): EventHandlingResult {
-    val currentUserId = ChatClient.instance().getCurrentUser()?.id
+    val currentUserId: String? = if (ChatClient.isInitialized) {
+        ChatClient.instance().getCurrentUser()?.id
+    } else {
+        null
+    }
     val removedMemberId = member.getUserId()
 
     return if (currentUserId == removedMemberId) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
@@ -17,8 +17,9 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * @param channels The list of visible channels.
  */
-public class DefaultChatEventHandler(private val channels: StateFlow<List<Channel>>) :
-    BaseChatEventHandler() {
+public class DefaultChatEventHandler(
+    private val channels: StateFlow<List<Channel>>,
+) : BaseChatEventHandler() {
 
     /**
      *  Handles [NotificationAddedToChannelEvent] event. It adds the channel if it is absent.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandler.kt
@@ -79,7 +79,7 @@ public class DefaultChatEventHandler(
         event: MemberRemovedEvent,
         filter: FilterObject,
         cachedChannel: Channel?,
-    ): EventHandlingResult = removeIfChannelIsPresent(channels, cachedChannel)
+    ): EventHandlingResult = removeIfCurrentUserLeftChannel(channels, cachedChannel, event.member)
 
     /**
      * Handles [NotificationRemovedFromChannelEvent]. It removes the channel if it's present in the list.
@@ -90,5 +90,5 @@ public class DefaultChatEventHandler(
     override fun handleNotificationRemovedFromChannelEvent(
         event: NotificationRemovedFromChannelEvent,
         filter: FilterObject,
-    ): EventHandlingResult = removeIfChannelIsPresent(channels, event.channel)
+    ): EventHandlingResult = removeIfCurrentUserLeftChannel(channels, event.channel, event.member)
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
@@ -837,5 +837,6 @@ internal fun randomMemberRemovedEvent(cid: String = randomString()): MemberRemov
         cid = cid,
         channelType = randomString(),
         channelId = randomString(),
+        member = randomMember()
     )
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test
 internal class DefaultChatEventHandlerTest {
 
     @Test
-    fun `Given the channel is not present, When received NotificationAddedToChannelEvent, Should channel be added`() {
+    fun `Given the channel is not present When received NotificationAddedToChannelEvent Should channel be added`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyList()))
@@ -29,7 +29,7 @@ internal class DefaultChatEventHandlerTest {
     }
 
     @Test
-    fun `Given the channel is present, When received NotificationAddedToChannelEvent, Should Event be skiped`() {
+    fun `Given the channel is present When received NotificationAddedToChannelEvent Should skip the event`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(listOf(channel)))
@@ -45,7 +45,7 @@ internal class DefaultChatEventHandlerTest {
     }
 
     @Test
-    fun `Given the channel is not present, When received NotificationRemovedFromChannelEvent, Should channel be removed`() {
+    fun `Given the channel is not present When received NotificationRemovedFromChannelEvent Should skip the event`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyList()))
@@ -61,7 +61,7 @@ internal class DefaultChatEventHandlerTest {
     }
 
     @Test
-    fun `Given the channel is present, When received NotificationRemovedFromChannelEvent, Should channel be removed`() {
+    fun `Given the channel is present When received NotificationRemovedFromChannelEvent for some other member Should skip the event`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(listOf(channel)))
@@ -73,11 +73,11 @@ internal class DefaultChatEventHandlerTest {
             Filters.neutral()
         )
 
-        result `should be equal to` EventHandlingResult.Remove(cid)
+        result `should be equal to` EventHandlingResult.Skip
     }
 
     @Test
-    fun `Given the channel is not present, When received NotificationMessageNewEvent, Should channel be added`() {
+    fun `Given the channel is not present When received NotificationMessageNewEvent Should add the channel`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyList()))
@@ -93,7 +93,7 @@ internal class DefaultChatEventHandlerTest {
     }
 
     @Test
-    fun `Given the channel is not present, When received NotificationMessageNewEvent, Should event be skiped`() {
+    fun `Given the channel is not present When received NotificationMessageNewEvent Should skip the event`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(listOf(channel)))

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/utils/TestDataHelper.kt
@@ -427,7 +427,7 @@ internal class TestDataHelper {
 
     // member removed doesn't have a cid
     val memberRemovedFromChannel =
-        MemberRemovedEvent(EventType.MEMBER_REMOVED, Date(), member2.user, channel1.cid, channel1.type, channel1.id)
+        MemberRemovedEvent(EventType.MEMBER_REMOVED, Date(), member2.user, channel1.cid, channel1.type, channel1.id, member1)
 
     val notificationRemovedFromChannel =
         NotificationRemovedFromChannelEvent(


### PR DESCRIPTION
### 🎯 Goal

Closes #3089

Don't remove the channel from the UI if a member removal event arrives and the removed member is no the current user.

### 🧪 Testing

1. User1: Launch UI components sample app and create a named channel with users User2 and User3
2. User2: Observe that the channel has appeared
3. User1: Remove irrelevant User3 from the channel

Actual result:
User2: the channel disappears from the channel list even though user2 is still a member of the channel

Expected result:
User2 observes that the number of sections in the channel's avatar is reduced and the channel remains in the list

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
