### PR TITLE
Exposed clearing of message composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Exposed a way to clear the message composer externally, e.g. when using custom sendMessage handlers. [#3100](https://github.com/GetStream/stream-chat-android/pull/3100)
 
 ### ⚠️ Changed
 - Replaced the `reactionTypes` field in `ChatTheme` with the new `reactionIconFactory` field that allows customizing reaction icons. [#3046](https://github.com/GetStream/stream-chat-android/pull/3046)

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1668,6 +1668,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageC
 	public final fun addSelectedAttachments (Ljava/util/List;)V
 	public final fun buildNewMessage (Ljava/lang/String;Ljava/util/List;)Lio/getstream/chat/android/client/models/Message;
 	public static synthetic fun buildNewMessage$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/models/Message;
+	public final fun clearData ()V
 	public final fun dismissMessageActions ()V
 	public final fun getAlsoSendToChannel ()Lkotlinx/coroutines/flow/MutableStateFlow;
 	public final fun getCommandSuggestions ()Lkotlinx/coroutines/flow/MutableStateFlow;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -193,6 +193,11 @@ public class MessageComposerViewModel(
         messageComposerController.toggleCommandsVisibility()
 
     /**
+     * Clears the input and the current state of the composer.
+     */
+    public fun clearData(): Unit = messageComposerController.clearData()
+
+    /**
      * Disposes the inner [MessageComposerController].
      */
     override fun onCleared() {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -360,7 +360,7 @@ public class MessageComposerController(
      * Clears all the data from the input - both the current [input] value and the
      * [selectedAttachments].
      */
-    private fun clearData() {
+    public fun clearData() {
         input.value = ""
         selectedAttachments.value = emptyList()
         validationErrors.value = emptyList()


### PR DESCRIPTION
### 🎯 Goal

Closes #3099 

Exposed MessageComposer's `clearData()`.

### 🧪 Testing

Can be called from the ViewModel/Controller now, wasn't available before.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
