### PR TITLE
[2744] Add line separators to image attachment grid

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1118,6 +1118,17 @@ public final class io/getstream/chat/android/compose/ui/filepreview/UrlAttachmen
 	public fun handleAttachmentPreview (Lio/getstream/chat/android/client/models/Attachment;)V
 }
 
+public final class io/getstream/chat/android/compose/ui/imagepreview/ComposableSingletons$ImagePreviewActivityKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/imagepreview/ComposableSingletons$ImagePreviewActivityKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public static field lambda-2 Lkotlin/jvm/functions/Function2;
+	public static field lambda-3 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda-3$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class io/getstream/chat/android/compose/ui/imagepreview/ImagePreviewActivity : androidx/appcompat/app/AppCompatActivity {
 	public static final field $stable I
 	public static final field Companion Lio/getstream/chat/android/compose/ui/imagepreview/ImagePreviewActivity$Companion;
@@ -1340,7 +1351,7 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors$Compa
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamDimens$Companion;
-	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-D9Ej5fM ()F
 	public final fun component10-D9Ej5fM ()F
 	public final fun component11-D9Ej5fM ()F
@@ -1367,19 +1378,21 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamDimens {
 	public final fun component30-D9Ej5fM ()F
 	public final fun component31-D9Ej5fM ()F
 	public final fun component32-D9Ej5fM ()F
+	public final fun component33-D9Ej5fM ()F
 	public final fun component4-D9Ej5fM ()F
 	public final fun component5-D9Ej5fM ()F
 	public final fun component6-D9Ej5fM ()F
 	public final fun component7-D9Ej5fM ()F
 	public final fun component8-D9Ej5fM ()F
 	public final fun component9-D9Ej5fM ()F
-	public final fun copy-AiCbJkQ (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
-	public static synthetic fun copy-AiCbJkQ$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public final fun copy-BArQmKc (FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
+	public static synthetic fun copy-BArQmKc$default (Lio/getstream/chat/android/compose/ui/theme/StreamDimens;FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFIILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamDimens;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachmentsContentFileUploadWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentFileWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentGiphyHeight-D9Ej5fM ()F
 	public final fun getAttachmentsContentGiphyWidth-D9Ej5fM ()F
+	public final fun getAttachmentsContentImageGridSpacing-D9Ej5fM ()F
 	public final fun getAttachmentsContentImageHeight-D9Ej5fM ()F
 	public final fun getAttachmentsContentImageWidth-D9Ej5fM ()F
 	public final fun getAttachmentsContentLinkWidth-D9Ej5fM ()F

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentContent.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -49,6 +50,7 @@ public fun ImageAttachmentContent(
     modifier: Modifier = Modifier,
 ) {
     val (message, onLongItemClick, onImagePreviewResult) = attachmentState
+    val gridSpacing = ChatTheme.dimens.attachmentsContentImageGridSpacing
 
     Row(
         modifier
@@ -58,7 +60,8 @@ public fun ImageAttachmentContent(
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = {},
                 onLongClick = { onLongItemClick(message) }
-            )
+            ),
+        horizontalArrangement = Arrangement.spacedBy(gridSpacing)
     ) {
         val attachments =
             message.attachments.filter { !it.hasLink() && it.isMedia() }
@@ -79,7 +82,8 @@ public fun ImageAttachmentContent(
             Column(
                 modifier = Modifier
                     .weight(1f, fill = false)
-                    .fillMaxHeight()
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(gridSpacing)
             ) {
                 for (imageIndex in 0..3 step 2) {
                     if (imageIndex < imageCount) {
@@ -98,7 +102,8 @@ public fun ImageAttachmentContent(
             Column(
                 modifier = Modifier
                     .weight(1f, fill = false)
-                    .fillMaxHeight()
+                    .fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(gridSpacing)
             ) {
                 for (imageIndex in 1..4 step 2) {
                     if (imageIndex < imageCount) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/imagepreview/ImagePreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/imagepreview/ImagePreviewActivity.kt
@@ -40,6 +40,7 @@ import androidx.compose.foundation.lazy.LazyVerticalGrid
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
@@ -218,25 +219,21 @@ public class ImagePreviewActivity : AppCompatActivity() {
             color = ChatTheme.colors.barsBackground
         ) {
             Row(
-                Modifier.fillMaxWidth(),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                Icon(
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(8.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = null
-                        ) { finish() },
-                    painter = painterResource(id = R.drawable.stream_compose_ic_close),
-                    contentDescription = stringResource(id = R.string.stream_compose_cancel),
-                    tint = ChatTheme.colors.textHighEmphasis
-                )
+                IconButton(onClick = ::finish) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.stream_compose_ic_close),
+                        contentDescription = stringResource(id = R.string.stream_compose_cancel),
+                        tint = ChatTheme.colors.textHighEmphasis,
+                    )
+                }
 
                 ImagePreviewHeaderTitle(
-                    modifier = Modifier
-                        .weight(8f),
+                    modifier = Modifier.weight(8f),
                     message = message
                 )
 
@@ -523,16 +520,21 @@ public class ImagePreviewActivity : AppCompatActivity() {
             elevation = 4.dp,
             color = ChatTheme.colors.barsBackground
         ) {
-            Box(modifier = Modifier.fillMaxWidth()) {
-                Icon(
-                    modifier = Modifier
-                        .align(Alignment.CenterStart)
-                        .padding(8.dp)
-                        .clickable { onShareImageClick(attachments[pagerState.currentPage]) },
-                    painter = painterResource(id = R.drawable.stream_compose_ic_share),
-                    contentDescription = stringResource(id = R.string.stream_compose_image_preview_share),
-                    tint = ChatTheme.colors.textHighEmphasis
-                )
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 8.dp)
+            ) {
+                IconButton(
+                    modifier = Modifier.align(Alignment.CenterStart),
+                    onClick = { onShareImageClick(attachments[pagerState.currentPage]) }
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.stream_compose_ic_share),
+                        contentDescription = stringResource(id = R.string.stream_compose_image_preview_share),
+                        tint = ChatTheme.colors.textHighEmphasis,
+                    )
+                }
 
                 Text(
                     modifier = Modifier.align(Alignment.Center),
@@ -545,19 +547,16 @@ public class ImagePreviewActivity : AppCompatActivity() {
                     color = ChatTheme.colors.textHighEmphasis
                 )
 
-                Icon(
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .padding(8.dp)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = rememberRipple(),
-                            onClick = { imagePreviewViewModel.toggleGallery(isShowingGallery = true) }
-                        ),
-                    painter = painterResource(id = R.drawable.stream_compose_ic_gallery),
-                    contentDescription = stringResource(id = R.string.stream_compose_image_preview_photos),
-                    tint = ChatTheme.colors.textHighEmphasis
-                )
+                IconButton(
+                    modifier = Modifier.align(Alignment.CenterEnd),
+                    onClick = { imagePreviewViewModel.toggleGallery(isShowingGallery = true) }
+                ) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.stream_compose_ic_gallery),
+                        contentDescription = stringResource(id = R.string.stream_compose_image_preview_photos),
+                        tint = ChatTheme.colors.textHighEmphasis,
+                    )
+                }
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamDimens.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
  * @param selectedChannelMenuUserItemHorizontalPadding The padding inside a member tile in the selected channel menu.
  * @param selectedChannelMenuUserItemAvatarSize The size of a member avatar in the selected channel menu.
  * @param attachmentsContentImageWidth The width of image attachments in the message list.
+ * @param attachmentsContentImageGridSpacing The spacing between image tiles in the message list.
  * @param attachmentsContentImageHeight The height of image attachments in the message list.
  * @param attachmentsContentGiphyWidth The with of Giphy attachments in the message list.
  * @param attachmentsContentGiphyHeight The height of Giphy attachments in the message list.
@@ -49,6 +50,7 @@ public data class StreamDimens(
     public val selectedChannelMenuUserItemHorizontalPadding: Dp,
     public val selectedChannelMenuUserItemAvatarSize: Dp,
     public val attachmentsContentImageWidth: Dp,
+    public val attachmentsContentImageGridSpacing: Dp,
     public val attachmentsContentImageHeight: Dp,
     public val attachmentsContentGiphyWidth: Dp,
     public val attachmentsContentGiphyHeight: Dp,
@@ -89,6 +91,7 @@ public data class StreamDimens(
             selectedChannelMenuUserItemHorizontalPadding = 8.dp,
             selectedChannelMenuUserItemAvatarSize = 64.dp,
             attachmentsContentImageWidth = 250.dp,
+            attachmentsContentImageGridSpacing = 2.dp,
             attachmentsContentImageHeight = 200.dp,
             attachmentsContentGiphyWidth = 250.dp,
             attachmentsContentGiphyHeight = 200.dp,


### PR DESCRIPTION
### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
