### PR TITLE
Fix updating ChatDomain::totalUnreadCount and ChatDomain::channelUnreadCount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed updating `ChatDomain::totalUnreadCount` and `ChatDomain::channelUnreadCount` after restoring app from the background and
+  when sending a message to a channel without read enabled. [#3121](https://github.com/GetStream/stream-chat-android/pull/3121)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -573,7 +573,7 @@ internal class ChatDomainImpl internal constructor(
         return if (cids.isNotEmpty()) {
             queryEvents(cids).also { resultChatEvent ->
                 if (resultChatEvent.isSuccess) {
-                    eventHandler.handleEventsInternal(resultChatEvent.data())
+                    eventHandler.handleEventsInternal(resultChatEvent.data(), isFromSync = true)
                     updateLastSyncDate(now)
                 }
             }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/ChatDomainImplReplayEventsForActiveChannelsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/ChatDomainImplReplayEventsForActiveChannelsTest.kt
@@ -77,7 +77,7 @@ internal class ChatDomainImplReplayEventsForActiveChannelsTest {
 
             sut.replayEvents(cid)
 
-            verify(eventHandlerImpl).handleEventsInternal(events)
+            verify(eventHandlerImpl).handleEventsInternal(events, isFromSync = true)
         }
 
     private class Fixture(private val coroutineScope: CoroutineScope) {


### PR DESCRIPTION
### 🎯 Goal

Fix updating `ChatDomain::totalUnreadCount` and `ChatDomain::channelUnreadCount`

### 🛠 Implementation details

The unread counts shouldn't be updated if the event comes from the sync endpoint or the channel doesn't have `read-events` capability.

### 🧪 Testing
You should test two scenarios. For both, you'll need to use `ui-components`, apply a patch and use two devices. The patch modifies `ChannelListViewModel::filter` so you should see two channels: `livestream` and `messaging`. Before testing, run the app and filter the logs by `UnreadTest` keyword.

Scenario 1:
1. Open the app on device 1 and stay on `ChannelListView`
2. Send a message to `livestream` channel from device 2
3. Observe that unread counts stay the same (are not being updated)
4. Check the same behavior on `main` - unread counts are being reset to 0

Scenario 2:
1. Open the app on device 1 and stay on `ChannelListView`
2. Move the app on device 1 to the background
3. From device 2 send a few messages to a `messaging` channel
4. Move the app on device 1 to the foreground
5. Observe that unread counts are correct
6. Check the same behavior on `main` - unread counts are being reset to 0 at some point (not always)

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(revision 5648d6dc5af3c455809d9a63614b8072197172de)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(date 1645627263332)
@@ -13,7 +13,6 @@
 import androidx.fragment.app.viewModels
 import androidx.navigation.findNavController
 import com.getstream.sdk.chat.utils.Utils
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.isAnonymousChannel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
@@ -33,9 +32,10 @@
     private val viewModel: ChannelListViewModel by viewModels {
         ChannelListViewModelFactory(
             filter = Filters.and(
-                Filters.eq("type", "messaging"),
-                Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
-                Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
+                Filters.or(
+                    Filters.eq("cid", "messaging:sample-app-channel-54"),
+                    Filters.eq("cid", "livestream:livestream-clone-android"),
+                ),
             ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),
         )
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt	(revision 5648d6dc5af3c455809d9a63614b8072197172de)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt	(date 1645627112837)
@@ -32,6 +32,8 @@
 import io.getstream.chat.android.offline.querychannels.QueryChannelsController
 import io.getstream.chat.android.ui.common.extensions.internal.EXTRA_DATA_MUTED
 import io.getstream.chat.android.ui.common.extensions.internal.isMuted
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -81,6 +83,17 @@
                 initData(filter)
             }
         }
+        val logger = ChatLogger.get("UnreadTest")
+        GlobalScope.launch {
+            chatDomain.totalUnreadCount.collect {
+                logger.logE("New total unread $it")
+            }
+        }
+        GlobalScope.launch {
+            chatDomain.channelUnreadCount.collect {
+                logger.logE("New channel unread $it")
+            }
+        }
     }
 
     private fun initData(filterObject: FilterObject) {

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] ~PR targets the `develop` branch~
- [ ] ~PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
