### PR TITLE
Bump Compose version to 1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
-- We upgraded our Kotlin version to 1.6, Moshi to 1.13 and Compose to 1.1.0. [#3104](https://github.com/GetStream/stream-chat-android/pull/3104)
+- We upgraded our Kotlin version to 1.6, Moshi to 1.13 and Compose to 1.1.1. [#3104](https://github.com/GetStream/stream-chat-android/pull/3104), [#3123](https://github.com/GetStream/stream-chat-android/pull/3123) 
 - Updated Google's Accompanist version. [#3104](https://github.com/GetStream/stream-chat-android/pull/3104)
 - Replaced KAPT with KSP. [#3113](https://github.com/GetStream/stream-chat-android/pull/3113)
 
@@ -97,7 +97,7 @@
 ### ⚠️ Changed
 - Replaced the `reactionTypes` field in `ChatTheme` with the new `reactionIconFactory` field that allows customizing reaction icons. [#3046](https://github.com/GetStream/stream-chat-android/pull/3046)
 - Disabled editing on Giphy messages given that it's breaking the UX and can override the GIF that was previously put in. [#3071](https://github.com/GetStream/stream-chat-android/pull/3071)
-- Since we're using Compose 1.1.0 for our SDK, we recommend upgrading to avoid conflicts. [#3104](https://github.com/GetStream/stream-chat-android/pull/3104)
+- Since we're using Compose 1.1.1 for our SDK, we recommend upgrading to avoid conflicts. [#3104](https://github.com/GetStream/stream-chat-android/pull/3104), [#3123](https://github.com/GetStream/stream-chat-android/pull/3123)
 
 ### ❌ Removed
 - Removed ExoMedia dependency in favor of standard Android `VideoView`. [#3092](https://github.com/GetStream/stream-chat-android/pull/3092)

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -25,7 +25,7 @@ object Versions {
     internal const val COMPOSE_ACCOMPANIST = "0.23.0"
     internal const val COMPOSE_ACTIVITY = "1.4.0"
     internal const val COMPOSE_VIEW_MODEL = "2.4.1"
-    public const val COMPOSE = "1.1.0"
+    public const val COMPOSE = "1.1.1"
     internal const val CONSTRAINT_LAYOUT = "2.1.2"
     internal const val COROUTINES = "1.5.2"
     internal const val DEXTER = "6.2.3"


### PR DESCRIPTION
### 🎯 Goal

Bump Compose version to [1.1.1](https://developer.android.com/jetpack/androidx/releases/compose-ui#version_11_2). It includes some critical issues fixes below:

Bug Fixes

- Fix NullPointerException at androidx.compose.ui.platform.RenderNodeLayer.updateDisplayList ([aosp/1947059](https://android-review.googlesource.com/c/platform/frameworks/support/+/1947059), [b/206677462](https://issuetracker.google.com/issues/206677462))
- Fix crash caused by clipboard content while reading from clipboard on Android. ([I06020](https://android-review.googlesource.com/#/q/I0602066750e3fce55deceb709f8c04ee9a71dabf), [b/197769306](https://issuetracker.google.com/issues/197769306))
- Fixed RTL in LazyVerticalGrid ([aosp/1931080](https://android-review.googlesource.com/c/platform/frameworks/support/+/1931080), [b/207510535](https://issuetracker.google.com/issues/207510535))


#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [x] Changelog is updated with client-facing changes

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
