### PR TITLE
Exposed a way to customize message content and replace or replicate t…

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -889,6 +889,10 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Mess
 	public static final fun MessageBubble-yWKOrZg (JLandroidx/compose/ui/graphics/Shape;Landroidx/compose/ui/Modifier;Landroidx/compose/foundation/BorderStroke;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/components/messages/MessageContentKt {
+	public static final fun MessageContent (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
+}
+
 public final class io/getstream/chat/android/compose/ui/components/messages/MessageFooterKt {
 	public static final fun MessageFooter (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Landroidx/compose/runtime/Composer;I)V
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
@@ -1,0 +1,128 @@
+package io.getstream.chat.android.compose.ui.components.messages
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResult
+import io.getstream.chat.android.compose.state.messages.list.GiphyAction
+import io.getstream.chat.android.compose.ui.attachments.content.MessageAttachmentsContent
+import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageTextContent
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.isDeleted
+import io.getstream.chat.android.compose.ui.util.isGiphyEphemeral
+
+/**
+ * Represents the default message content within the bubble that can show different UI based on the message state.
+ *
+ * @param message The message to show.
+ * @param modifier Modifier for styling.
+ * @param onLongItemClick Handler when the item is long clicked.
+ * @param onGiphyActionClick Handler for Giphy actions.
+ * @param onImagePreviewResult Handler when selecting images in the default content.
+ * @param giphyEphemeralContent Composable that represents the default Giphy message content.
+ * @param deletedMessageContent Composable that represents the default content of a deleted message.
+ * @param regularMessageContent Composable that represents the default regular message content, such as attachments and
+ * text.
+ */
+@Composable
+public fun MessageContent(
+    message: Message,
+    modifier: Modifier = Modifier,
+    onLongItemClick: (Message) -> Unit = {},
+    onGiphyActionClick: (GiphyAction) -> Unit = {},
+    onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
+    giphyEphemeralContent: @Composable () -> Unit = {
+        DefaultMessageGiphyContent(
+            message = message,
+            onGiphyActionClick = onGiphyActionClick
+        )
+    },
+    deletedMessageContent: @Composable () -> Unit = {
+        DefaultMessageDeletedContent(modifier = modifier)
+    },
+    regularMessageContent: @Composable () -> Unit = {
+        DefaultMessageContent(
+            message = message,
+            onLongItemClick = onLongItemClick,
+            onImagePreviewResult = onImagePreviewResult
+        )
+    },
+) {
+    when {
+        message.isGiphyEphemeral() -> giphyEphemeralContent()
+        message.isDeleted() -> deletedMessageContent()
+        else -> regularMessageContent()
+    }
+}
+
+/**
+ * Represents the default ephemeral Giphy message content.
+ *
+ * @param message The message to show.
+ * @param onGiphyActionClick Handler for Giphy actions.
+ */
+@Composable
+internal fun DefaultMessageGiphyContent(
+    message: Message,
+    onGiphyActionClick: (GiphyAction) -> Unit,
+) {
+    GiphyMessageContent(
+        message = message,
+        onGiphyActionClick = onGiphyActionClick
+    )
+}
+
+/**
+ * Represents the default deleted message content.
+ *
+ * @param modifier Modifier for styling.
+ */
+@Composable
+internal fun DefaultMessageDeletedContent(
+    modifier: Modifier,
+) {
+    Text(
+        modifier = modifier
+            .padding(
+                start = 12.dp,
+                end = 12.dp,
+                top = 8.dp,
+                bottom = 8.dp
+            ),
+        text = stringResource(id = R.string.stream_compose_message_deleted),
+        color = ChatTheme.colors.textLowEmphasis,
+        style = ChatTheme.typography.footnoteItalic
+    )
+}
+
+/**
+ * Represents the default regular message content that can contain attachments and text.
+ *
+ * @param message The message to show.
+ * @param onLongItemClick Handler when the item is long clicked.
+ * @param onImagePreviewResult Handler when selecting images in the default content.
+ */
+@Composable
+internal fun DefaultMessageContent(
+    message: Message,
+    onLongItemClick: (Message) -> Unit,
+    onImagePreviewResult: (ImagePreviewResult?) -> Unit,
+) {
+    Column {
+        MessageAttachmentsContent(
+            message = message,
+            onLongItemClick = onLongItemClick,
+            onImagePreviewResult = onImagePreviewResult,
+        )
+
+        if (message.text.isNotEmpty()) {
+            DefaultMessageTextContent(message = message)
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -21,7 +21,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -43,10 +42,9 @@ import io.getstream.chat.android.compose.state.messages.list.MessageItemGroupPos
 import io.getstream.chat.android.compose.state.messages.list.MessageItemGroupPosition.Top
 import io.getstream.chat.android.compose.state.messages.list.MessageItemState
 import io.getstream.chat.android.compose.state.reactionoptions.ReactionOptionItemState
-import io.getstream.chat.android.compose.ui.attachments.content.MessageAttachmentsContent
 import io.getstream.chat.android.compose.ui.components.avatar.UserAvatar
-import io.getstream.chat.android.compose.ui.components.messages.GiphyMessageContent
 import io.getstream.chat.android.compose.ui.components.messages.MessageBubble
+import io.getstream.chat.android.compose.ui.components.messages.MessageContent
 import io.getstream.chat.android.compose.ui.components.messages.MessageFooter
 import io.getstream.chat.android.compose.ui.components.messages.MessageHeaderLabel
 import io.getstream.chat.android.compose.ui.components.messages.MessageReactions
@@ -387,41 +385,12 @@ internal fun DefaultMessageItemCenterContent(
         shape = messageBubbleShape,
         color = messageBubbleColor,
         content = {
-            when {
-                message.isGiphyEphemeral() -> {
-                    GiphyMessageContent(
-                        message = messageItem.message,
-                        onGiphyActionClick = onGiphyActionClick
-                    )
-                }
-                message.isDeleted() -> {
-                    Text(
-                        modifier = modifier
-                            .padding(
-                                start = 12.dp,
-                                end = 12.dp,
-                                top = 8.dp,
-                                bottom = 8.dp
-                            ),
-                        text = stringResource(id = R.string.stream_compose_message_deleted),
-                        color = ChatTheme.colors.textLowEmphasis,
-                        style = ChatTheme.typography.footnoteItalic
-                    )
-                }
-                else -> {
-                    Column {
-                        MessageAttachmentsContent(
-                            message = messageItem.message,
-                            onLongItemClick = onLongItemClick,
-                            onImagePreviewResult = onImagePreviewResult,
-                        )
-
-                        if (message.text.isNotEmpty()) {
-                            DefaultMessageContent(message = message)
-                        }
-                    }
-                }
-            }
+            MessageContent(
+                message = message,
+                onLongItemClick = onLongItemClick,
+                onGiphyActionClick = onGiphyActionClick,
+                onImagePreviewResult = onImagePreviewResult
+            )
         }
     )
 }
@@ -432,7 +401,7 @@ internal fun DefaultMessageItemCenterContent(
  * @param message The message to show.
  */
 @Composable
-internal fun DefaultMessageContent(message: Message) {
+internal fun DefaultMessageTextContent(message: Message) {
     val quotedMessage = message.replyTo
 
     Column {


### PR DESCRIPTION
### 🎯 Goal

Some of our users require a customizable message bubble (to remove it) and this is a way to provide the inner content that can be reused in custom UI.

### 🎨 UI Changes

No UI changes - just customization.

### 🧪 Testing

Things should work the same. Content should be exposed for use outside of the MessageBubble.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
