### PR TITLE
[ISSUE-2892] Remove sync from chat domain

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.channel.ChannelController
+import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.message.attachment.UploadAttachmentsNetworkType
 import io.getstream.chat.android.offline.model.ConnectionState
 import io.getstream.chat.android.offline.querychannels.QueryChannelsController
@@ -557,6 +558,7 @@ public sealed interface ChatDomain {
         private var backgroundSyncEnabled: Boolean = true
         private var uploadAttachmentsNetworkType: UploadAttachmentsNetworkType =
             UploadAttachmentsNetworkType.NOT_ROAMING
+        private var globalMutableState = GlobalMutableState.getOrCreate()
 
         @VisibleForTesting
         internal fun handler(handler: Handler) = apply {
@@ -603,6 +605,10 @@ public sealed interface ChatDomain {
             return this
         }
 
+        internal fun globalMutableState(globalMutableState: GlobalMutableState): Builder = apply {
+            this.globalMutableState = globalMutableState
+        }
+
         public fun build(): ChatDomain {
             instance?.run {
                 Log.e(
@@ -625,6 +631,7 @@ public sealed interface ChatDomain {
                 backgroundSyncEnabled,
                 appContext,
                 uploadAttachmentsNetworkType = uploadAttachmentsNetworkType,
+                globalState = globalMutableState
             )
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -48,6 +48,7 @@ import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.experimental.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.experimental.querychannels.state.toMutableState
+import io.getstream.chat.android.offline.experimental.sync.SyncManager
 import io.getstream.chat.android.offline.extensions.applyPagination
 import io.getstream.chat.android.offline.extensions.cancelMessage
 import io.getstream.chat.android.offline.extensions.createChannel
@@ -186,7 +187,8 @@ internal class ChatDomainImpl internal constructor(
     private val activeQueryMapImpl: ConcurrentHashMap<String, QueryChannelsController> = ConcurrentHashMap()
 
     @VisibleForTesting
-    internal var eventHandler: EventHandlerImpl = EventHandlerImpl(this, client)
+    //Todo: Move this dependency to constructor
+    internal val eventHandler: EventHandlerImpl by lazy { EventHandlerImpl(this, client, globalState, scope, repos) }
     private var logger = ChatLogger.get("Domain")
 
     private val cleanTask = object : Runnable {
@@ -248,7 +250,7 @@ internal class ChatDomainImpl internal constructor(
         }
 
         if (client.isSocketConnected()) {
-            setOnline()
+            globalState._connectionState.value = ConnectionState.CONNECTED
         }
         startListening()
         initClean()
@@ -420,20 +422,8 @@ internal class ChatDomainImpl internal constructor(
         scope.launch { globalState._typingChannels.emitAll(channelController.typing) }
     }
 
-    internal fun setOffline() {
-        globalState._connectionState.value = ConnectionState.OFFLINE
-    }
-
-    internal fun setOnline() {
-        globalState._connectionState.value = ConnectionState.CONNECTED
-    }
-
     internal fun setConnecting() {
         globalState._connectionState.value = ConnectionState.CONNECTING
-    }
-
-    internal fun setInitialized() {
-        globalState._initialized.value = true
     }
 
     override fun isOnline(): Boolean = globalState.isOnline()
@@ -523,6 +513,7 @@ internal class ChatDomainImpl internal constructor(
      * - event recovery for those channels
      * - API calls to create local channels, messages and reactions
      */
+    //TODO: Move this to another place. Probably to ChatClient.
     suspend fun connectionRecovered(recoverAll: Boolean = false) {
         // 0. ensure load is complete
         initJob?.join()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -48,7 +48,6 @@ import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.experimental.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.experimental.querychannels.state.toMutableState
-import io.getstream.chat.android.offline.experimental.sync.SyncManager
 import io.getstream.chat.android.offline.extensions.applyPagination
 import io.getstream.chat.android.offline.extensions.cancelMessage
 import io.getstream.chat.android.offline.extensions.createChannel
@@ -187,7 +186,7 @@ internal class ChatDomainImpl internal constructor(
     private val activeQueryMapImpl: ConcurrentHashMap<String, QueryChannelsController> = ConcurrentHashMap()
 
     @VisibleForTesting
-    //Todo: Move this dependency to constructor
+    // Todo: Move this dependency to constructor
     internal val eventHandler: EventHandlerImpl by lazy { EventHandlerImpl(this, client, globalState, scope, repos) }
     private var logger = ChatLogger.get("Domain")
 
@@ -513,7 +512,7 @@ internal class ChatDomainImpl internal constructor(
      * - event recovery for those channels
      * - API calls to create local channels, messages and reactions
      */
-    //TODO: Move this to another place. Probably to ChatClient.
+    // TODO: Move this to another place. Probably to ChatClient.
     suspend fun connectionRecovered(recoverAll: Boolean = false) {
         // 0. ensure load is complete
         initJob?.join()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -62,21 +62,28 @@ import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.experimental.extensions.logic
 import io.getstream.chat.android.offline.experimental.extensions.state
+import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.extensions.mergeReactions
 import io.getstream.chat.android.offline.extensions.setMember
 import io.getstream.chat.android.offline.extensions.updateReads
+import io.getstream.chat.android.offline.model.ConnectionState
+import io.getstream.chat.android.offline.repository.RepositoryFacade
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 internal class EventHandlerImpl(
     private val domainImpl: ChatDomainImpl,
     private val client: ChatClient,
+    private val mutableGlobalState: GlobalMutableState,
+    private val scope: CoroutineScope,
+    private val repos: RepositoryFacade
 ) {
     private var logger = ChatLogger.get("EventHandler")
     private var firstConnect = true
 
     internal fun handleEvents(events: List<ChatEvent>) {
         handleConnectEvents(events)
-        domainImpl.scope.launch {
+        scope.launch {
             handleEventsInternal(events, isFromSync = false)
         }
     }
@@ -88,13 +95,15 @@ internal class EventHandlerImpl(
             // connection events are never send on the recovery endpoint, so handle them 1 by 1
             when (event) {
                 is DisconnectedEvent -> {
-                    domainImpl.setOffline()
+                    mutableGlobalState._connectionState.value = ConnectionState.OFFLINE
                 }
                 is ConnectedEvent -> {
                     logger.logI("Received ConnectedEvent, marking the domain as online and initialized")
-                    domainImpl.setOnline()
-                    domainImpl.setInitialized()
-                    domainImpl.scope.launch {
+                    mutableGlobalState._connectionState.value = ConnectionState.CONNECTED
+                    mutableGlobalState._initialized.value = true
+
+                    scope.launch {
+                        //Todo: Figure out where to put this
                         if (domainImpl.recoveryEnabled) {
                             // the first time we connect we should only run recovery against channels and queries that had a failure
                             if (firstConnect) {
@@ -108,13 +117,13 @@ internal class EventHandlerImpl(
                     }
                 }
                 is HealthEvent -> {
-                    domainImpl.scope.launch {
+                    scope.launch {
                         domainImpl.retryFailedEntities()
                     }
                 }
 
                 is ConnectingEvent -> {
-                    domainImpl.setConnecting()
+                    mutableGlobalState._connectionState.value = ConnectionState.CONNECTING
                 }
 
                 else -> Unit // Ignore other events
@@ -133,7 +142,7 @@ internal class EventHandlerImpl(
         val batchBuilder = EventBatchUpdate.Builder()
         batchBuilder.addToFetchChannels(events.filterIsInstance<CidEvent>().map { it.cid })
 
-        val users: List<User> = events.filterIsInstance<UserEvent>().mapNotNull { it.user } +
+        val users: List<User> = events.filterIsInstance<UserEvent>().map { it.user } +
             events.filterIsInstance<HasOwnUser>().map { it.me }
 
         // For some reason backend is not sending us the user instance into some events that they should
@@ -196,7 +205,7 @@ internal class EventHandlerImpl(
             }
         }
         // actually fetch the data
-        val batch = batchBuilder.build(domainImpl)
+        val batch = batchBuilder.build(repos, mutableGlobalState._user)
 
         // step 2. second pass through the events, make a list of what we need to update
         loop@ for (event in events) {
@@ -214,7 +223,7 @@ internal class EventHandlerImpl(
                         cid = event.cid,
                     )
                     batch.addMessageData(event.cid, event.message, isNewMessage = true)
-                    domainImpl.repos.selectChannelWithoutMessages(event.cid)?.copy(hidden = false)
+                    repos.selectChannelWithoutMessages(event.cid)?.copy(hidden = false)
                         ?.let(batch::addChannel)
                 }
                 is MessageDeletedEvent -> {
@@ -339,15 +348,15 @@ internal class EventHandlerImpl(
                 // we use syncState to store the last markAllRead date for a given
                 // user since it makes more sense to write to the database once instead of N times.
                 is MarkAllReadEvent -> {
-                    domainImpl.setTotalUnreadCount(event.totalUnreadCount)
-                    domainImpl.setChannelUnreadCount(event.unreadChannels)
+                    mutableGlobalState._totalUnreadCount.value = event.totalUnreadCount
+                    mutableGlobalState._channelUnreadCount.value = event.unreadChannels
 
                     // only update sync state if the incoming "mark all read" date is newer
                     // this supports using event handler to restore mark all read state in setUser
                     // without redundant db writes.
-                    domainImpl.repos.selectSyncState(event.user.id)?.let { state ->
+                    repos.selectSyncState(event.user.id)?.let { state ->
                         if (state.markedAllReadAt == null || state.markedAllReadAt.before(event.createdAt)) {
-                            domainImpl.repos.insertSyncState(state.copy(markedAllReadAt = event.createdAt))
+                            repos.insertSyncState(state.copy(markedAllReadAt = event.createdAt))
                         }
                     }
                 }
@@ -381,7 +390,7 @@ internal class EventHandlerImpl(
                 }
                 is UserUpdatedEvent -> {
                     event.user
-                        .takeIf { it.id == domainImpl.user.value?.id }
+                        .takeIf { it.id == mutableGlobalState._user.value?.id }
                         ?.let { domainImpl.updateCurrentUser(it) }
                 }
                 is TypingStartEvent,
@@ -408,19 +417,19 @@ internal class EventHandlerImpl(
         for (event in events) {
             when (event) {
                 is NotificationChannelTruncatedEvent -> {
-                    domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
                 }
                 is ChannelTruncatedEvent -> {
-                    domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
                 }
                 is ChannelDeletedEvent -> {
-                    domainImpl.repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
-                    domainImpl.repos.setChannelDeletedAt(event.cid, event.createdAt)
+                    repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    repos.setChannelDeletedAt(event.cid, event.createdAt)
                 }
                 is MessageDeletedEvent -> {
                     if (event.hardDelete) {
-                        domainImpl.repos.deleteChannelMessage(event.message)
-                        domainImpl.repos.evictChannel(event.cid)
+                        repos.deleteChannelMessage(event.message)
+                        repos.evictChannel(event.cid)
                     }
                 }
                 else -> Unit // Ignore other events
@@ -535,8 +544,8 @@ internal class EventHandlerImpl(
         cid: String,
     ) {
         if (shouldUpdateTotalUnreadCounts(isFromSync, cid)) {
-            domainImpl.setTotalUnreadCount(totalUnreadCount)
-            domainImpl.setChannelUnreadCount(channelUnreadCount)
+            mutableGlobalState._totalUnreadCount.value = totalUnreadCount
+            mutableGlobalState._channelUnreadCount.value = channelUnreadCount
         }
     }
 
@@ -567,11 +576,11 @@ internal class EventHandlerImpl(
     }
 
     private fun Message.enrichWithOwnReactions(batch: EventBatchUpdate, user: User?) {
-        ownReactions = if (user != null && domainImpl.user.value?.id != user.id) {
+        ownReactions = if (user != null && mutableGlobalState._user.value?.id != user.id) {
             batch.getCurrentMessage(id)?.ownReactions ?: mutableListOf()
         } else {
             mergeReactions(
-                latestReactions.filter { it.userId == domainImpl.user.value?.id ?: "" },
+                latestReactions.filter { it.userId == mutableGlobalState._user.value?.id ?: "" },
                 batch.getCurrentMessage(id)?.ownReactions ?: mutableListOf()
             ).toMutableList()
         }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/EventHandlerImpl.kt
@@ -103,7 +103,7 @@ internal class EventHandlerImpl(
                     mutableGlobalState._initialized.value = true
 
                     scope.launch {
-                        //Todo: Figure out where to put this
+                        // Todo: Figure out where to put this
                         if (domainImpl.recoveryEnabled) {
                             // the first time we connect we should only run recovery against channels and queries that had a failure
                             if (firstConnect) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/sync/SyncManager.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/sync/SyncManager.kt
@@ -1,4 +1,3 @@
 package io.getstream.chat.android.offline.experimental.sync
 
-class SyncManager {
-}
+public class SyncManager

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/sync/SyncManager.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/sync/SyncManager.kt
@@ -1,0 +1,4 @@
+package io.getstream.chat.android.offline.experimental.sync
+
+class SyncManager {
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseConnectedIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseConnectedIntegrationTest.kt
@@ -58,6 +58,7 @@ internal open class BaseConnectedIntegrationTest : BaseDomainTest() {
             recoveryEnabled,
             backgroundSyncEnabled,
             context,
+            globalState = globalMutableState
         )
 
         chatDomain = chatDomainImpl

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseConnectedMockedTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseConnectedMockedTest.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.integration
 
+import io.getstream.chat.android.offline.model.ConnectionState
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.runBlocking
 import org.junit.After
@@ -14,7 +15,7 @@ internal open class BaseConnectedMockedTest : BaseDomainTest() {
         setupWorkManager()
         client = createConnectedMockClient()
         setupChatDomain(client, currentUser)
-        chatDomainImpl.setOnline()
+        globalMutableState._connectionState.value = ConnectionState.CONNECTED
     }
 
     @After

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.SynchronizedCoroutineTest
 import io.getstream.chat.android.offline.channel.ChannelController
 import io.getstream.chat.android.offline.createRoomDB
+import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.model.ChannelConfig
 import io.getstream.chat.android.offline.querychannels.QueryChannelsController
 import io.getstream.chat.android.offline.querychannels.QueryChannelsSpec
@@ -63,6 +64,7 @@ internal open class BaseDomainTest : SynchronizedCoroutineTest {
     lateinit var queryControllerImpl: QueryChannelsController
     lateinit var query: QueryChannelsSpec
 
+    protected val globalMutableState = GlobalMutableState.create()
     private val recoveryEnabled = false
     private val backgroundSyncEnabled = false
 
@@ -199,6 +201,7 @@ internal open class BaseDomainTest : SynchronizedCoroutineTest {
             .userPresenceEnabled()
             .recoveryDisabled()
             .disableBackgroundSync()
+            .globalMutableState(globalMutableState)
             .build()
 
         chatDomainImpl = chatDomain as ChatDomainImpl

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendReactionTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/SendReactionTest.kt
@@ -2,6 +2,7 @@ package io.getstream.chat.android.offline.usecase
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.offline.integration.BaseConnectedIntegrationTest
+import io.getstream.chat.android.offline.model.ConnectionState
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.amshove.kluent.shouldNotBe
@@ -19,7 +20,7 @@ internal class SendReactionTest : BaseConnectedIntegrationTest() {
         assertSuccess(result)
         data.reaction1.messageId = result.data().id
         // go offline, reaction should still update state
-        chatDomainImpl.setOffline()
+        globalMutableState._connectionState.value = ConnectionState.OFFLINE
         val oldMsg = channelState.getMessage(message1.id)
         val oldReactionCounts = oldMsg!!.reactionCounts
         val result2 = chatDomain.sendReaction(data.channel1.cid, data.reaction1, false).execute()


### PR DESCRIPTION
### 🎯 Goal

Reduce the usage of `ChatDomain` in `EventHandlerImpl`

### 🛠 Implementation details

Deleting methods from `ChatDomain` and using `GlobalState` directly as ChatDomain will be removed and those methods were just a delegation to `GlobalState`.

### 🧪 Testing

Check event handling 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
