### PR TITLE
Move shuffleGiphy method to LLC

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -127,6 +127,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public static final fun setVERSION_PREFIX_HEADER (Lio/getstream/chat/android/client/header/VersionPrefixHeader;)V
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
 	public final fun showChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun shuffleGiphy (Lio/getstream/chat/android/client/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public final fun stopWatching (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun subscribe (Lio/getstream/chat/android/client/ChatEventListener;)Lio/getstream/chat/android/client/utils/observable/Disposable;
 	public final fun subscribeFor (Landroidx/lifecycle/LifecycleOwner;[Ljava/lang/Class;Lio/getstream/chat/android/client/ChatEventListener;)Lio/getstream/chat/android/client/utils/observable/Disposable;
@@ -2007,6 +2008,10 @@ public abstract interface class io/getstream/chat/android/client/experimental/pl
 	public abstract fun onSendReactionPrecondition (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/models/Reaction;)Lio/getstream/chat/android/client/utils/Result;
 	public abstract fun onSendReactionRequest (Ljava/lang/String;Lio/getstream/chat/android/client/models/Reaction;ZLio/getstream/chat/android/client/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onSendReactionResult (Ljava/lang/String;Lio/getstream/chat/android/client/models/Reaction;ZLio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/utils/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/ShuffleGiphyListener {
+	public abstract fun onShuffleGiphyResult (Ljava/lang/String;Lio/getstream/chat/android/client/utils/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/experimental/plugin/listeners/ThreadQueryListener {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/ShuffleGiphyListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/ShuffleGiphyListener.kt
@@ -1,0 +1,21 @@
+package io.getstream.chat.android.client.experimental.plugin.listeners
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.utils.Result
+
+/**
+ * Listener for [io.getstream.chat.android.client.ChatClient.shuffleGiphy] calls.
+ */
+public interface ShuffleGiphyListener {
+
+    /**
+     * A method called after receiving the response from the shuffle Giphy call.
+     *
+     * @param cid The full channel id, i.e. "messaging:123".
+     * @param result The API call result.
+     */
+    public suspend fun onShuffleGiphyResult(
+        cid: String,
+        result: Result<Message>,
+    )
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -51,7 +51,6 @@ import io.getstream.chat.android.offline.extensions.applyPagination
 import io.getstream.chat.android.offline.extensions.cancelMessage
 import io.getstream.chat.android.offline.extensions.createChannel
 import io.getstream.chat.android.offline.extensions.loadOlderMessages
-import io.getstream.chat.android.offline.extensions.shuffleGiphy
 import io.getstream.chat.android.offline.extensions.users
 import io.getstream.chat.android.offline.message.attachment.UploadAttachmentsNetworkType
 import io.getstream.chat.android.offline.message.users

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -14,6 +14,7 @@ import io.getstream.chat.android.client.experimental.plugin.listeners.QueryMembe
 import io.getstream.chat.android.client.experimental.plugin.listeners.SendGiphyListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.SendMessageListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.SendReactionListener
+import io.getstream.chat.android.client.experimental.plugin.listeners.ShuffleGiphyListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
@@ -34,7 +35,9 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
  * @param sendReactionListener [SendReactionListener]
  * @param deleteMessageListener [DeleteMessageListener]
  * @param sendGiphyListener [SendGiphyListener]
+ * @param shuffleGiphyListener [ShuffleGiphyListener]
  * @param sendMessageListener [SendMessageListener]
+ * @param queryMembersListener [QueryMembersListener]
  */
 @InternalStreamChatApi
 @ExperimentalStreamChatApi
@@ -51,6 +54,7 @@ internal class OfflinePlugin(
     private val sendReactionListener: SendReactionListener,
     private val deleteMessageListener: DeleteMessageListener,
     private val sendGiphyListener: SendGiphyListener,
+    private val shuffleGiphyListener: ShuffleGiphyListener,
     private val sendMessageListener: SendMessageListener,
     private val queryMembersListener: QueryMembersListener,
 ) : Plugin,
@@ -66,6 +70,7 @@ internal class OfflinePlugin(
     SendReactionListener by sendReactionListener,
     DeleteMessageListener by deleteMessageListener,
     SendGiphyListener by sendGiphyListener,
+    ShuffleGiphyListener by shuffleGiphyListener,
     SendMessageListener by sendMessageListener,
     QueryMembersListener by queryMembersListener {
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/factory/StreamOfflinePluginFactory.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.offline.experimental.plugin.listener.QueryMembe
 import io.getstream.chat.android.offline.experimental.plugin.listener.SendGiphyListenerImpl
 import io.getstream.chat.android.offline.experimental.plugin.listener.SendMessageListenerImpl
 import io.getstream.chat.android.offline.experimental.plugin.listener.SendReactionListenerImpl
+import io.getstream.chat.android.offline.experimental.plugin.listener.ShuffleGiphyListenerImpl
 import io.getstream.chat.android.offline.experimental.plugin.listener.ThreadQueryListenerImpl
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.experimental.plugin.state.StateRegistry
@@ -134,6 +135,7 @@ public class StreamOfflinePluginFactory(
             deleteMessageListener = DeleteMessageListenerImpl(logic, globalState, repos),
             sendMessageListener = SendMessageListenerImpl(logic, repos),
             sendGiphyListener = SendGiphyListenerImpl(logic),
+            shuffleGiphyListener = ShuffleGiphyListenerImpl(logic),
             queryMembersListener = QueryMembersListenerImpl(repos),
         )
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ShuffleGiphyListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ShuffleGiphyListenerImpl.kt
@@ -1,0 +1,37 @@
+package io.getstream.chat.android.offline.experimental.plugin.listener
+
+import io.getstream.chat.android.client.experimental.plugin.listeners.ShuffleGiphyListener
+import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
+
+/**
+ * [ShuffleGiphyListener] implementation for [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
+ * Handles updating the DB and state.
+ *
+ * @param logic [LogicRegistry]
+ */
+@ExperimentalStreamChatApi
+internal class ShuffleGiphyListenerImpl(private val logic: LogicRegistry) : ShuffleGiphyListener {
+
+    /**
+     * Added a new message to the DB and the state if request was successful.
+     *
+     * @param cid The full channel id, i.e. "messaging:123".
+     * @param result The API call result.
+     */
+    override suspend fun onShuffleGiphyResult(cid: String, result: Result<Message>) {
+        if (result.isSuccess) {
+            val (channelType, channelId) = cid.cidToTypeAndId()
+            val processedMessage = result.data().apply {
+                syncStatus = SyncStatus.COMPLETED
+            }
+
+            logic.channel(channelType = channelType, channelId = channelId)
+                .updateAndSaveMessages(listOf(processedMessage))
+        }
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -4,30 +4,22 @@ package io.getstream.chat.android.offline.extensions
 
 import androidx.annotation.CheckResult
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.api.models.SendActionRequest
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
-import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.call.doOnResult
 import io.getstream.chat.android.client.call.onErrorReturn
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.experimental.plugin.listeners.GetMessageListener
-import io.getstream.chat.android.client.extensions.retry
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.channel.CreateChannelService
 import io.getstream.chat.android.offline.usecase.DownloadAttachment
 import io.getstream.chat.android.offline.utils.validateCid
-
-private const val KEY_MESSAGE_ACTION = "image_action"
-private const val MESSAGE_ACTION_SHUFFLE = "shuffle"
-private const val MESSAGE_ACTION_SEND = "send"
 
 /**
  * Returns the instance of [ChatDomainImpl] as cast of singleton [ChatDomain.instance] to the [ChatDomainImpl] class.
@@ -194,43 +186,6 @@ internal fun ChatClient.needsMarkRead(cid: String): Boolean {
     val channelController = domainImpl().channel(cid)
 
     return channelController.markRead()
-}
-
-/**
- * Performs giphy shuffle operation. Removes the original "ephemeral" message from local storage.
- * Returns new "ephemeral" message with new giphy url.
- * API call to remove the message is retried according to the retry policy specified on the chatDomain
- *
- * @param message The message to send.
- * @see io.getstream.chat.android.offline.utils.RetryPolicy
- */
-internal fun ChatClient.shuffleGiphy(message: Message): Call<Message> {
-    val domainImpl = domainImpl()
-    return CoroutineCall(domainImpl.scope) {
-        val cid = message.cid
-        val channelController = domainImpl.channel(cid)
-        val channelClient = channel(channelController.channelType, channelController.channelId)
-
-        validateCid(cid)
-
-        val request = message.run {
-            SendActionRequest(cid, id, type, mapOf(KEY_MESSAGE_ACTION to MESSAGE_ACTION_SHUFFLE))
-        }
-
-        val result = channelClient.sendAction(request).retry(domainImpl.scope, retryPolicy).await()
-
-        if (result.isSuccess) {
-            val processedMessage: Message = result.data()
-            processedMessage.apply {
-                syncStatus = SyncStatus.COMPLETED
-                domainImpl.repos.insertMessage(this)
-            }
-            channelController.upsertMessage(processedMessage)
-            Result(processedMessage)
-        } else {
-            Result(result.error())
-        }
-    }
 }
 
 /**


### PR DESCRIPTION
closes #3140 

### 🎯 Goal

Move `shuffleGiphy` method to LLC

### 🛠 Implementation details

Converted `shuffleGiphy` extension function to a method and applied side effects.

### 🧪 Testing

Check if shuffling a Giphy works as expected

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] New feature tested and works
- [ ] All code we touched has new or updated KDocs
