### PR TITLE
Remove unused ChatDomain::loadOlderMessages

### DIFF
--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Android.java
@@ -51,6 +51,7 @@ import io.getstream.chat.android.livedata.ChatDomain;
 import io.getstream.chat.android.livedata.controller.ChannelController;
 import io.getstream.chat.android.livedata.controller.QueryChannelsController;
 import io.getstream.chat.android.livedata.controller.ThreadController;
+import io.getstream.chat.android.offline.extensions.ChatClientExtensions;
 import io.getstream.chat.android.ui.ChatUI;
 import io.getstream.chat.android.ui.TransformStyle;
 import io.getstream.chat.android.ui.avatar.AvatarBitmapFactory;
@@ -621,10 +622,10 @@ public class Android {
         }
 
         public void loadMoreMessages() {
-            ChatDomain chatDomain = ChatDomain.instance();
+            ChatClient chatClient = ChatClient.instance();
 
             // TODO: Review docs (https://github.com/GetStream/stream-chat-android/issues/2976)
-            chatDomain.loadOlderMessages("messaging:123", 10)
+            ChatClientExtensions.loadOlderMessages(chatClient, "messaging:123", 10)
                     .enqueue(result -> {
                         if (result.isSuccess()) {
                             Channel channel = result.data();

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Android.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.ChatDomain
+import io.getstream.chat.android.offline.extensions.loadOlderMessages
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.StyleTransformer
@@ -706,11 +707,11 @@ class Android {
         }
 
         fun loadMoreMessages() {
-            val chatDomain = ChatDomain.instance()
+            val chatClient = ChatClient.instance()
 
             // TODO: Review docs (https://github.com/GetStream/stream-chat-android/issues/2976)
             @Suppress("DEPRECATION_ERROR")
-            chatDomain.loadOlderMessages("messaging:123", 10)
+            chatClient.loadOlderMessages("messaging:123", 10)
                 .enqueue { result ->
                     if (result.isSuccess) {
                         val channel = result.data()

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -37,7 +37,6 @@ public abstract interface class io/getstream/chat/android/livedata/ChatDomain {
 	public abstract fun leaveChannel (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun loadMessageById (Ljava/lang/String;Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun loadNewerMessages (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
-	public abstract fun loadOlderMessages (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun markAllRead ()Lio/getstream/chat/android/client/call/Call;
 	public abstract fun markRead (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun queryChannels (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;II)Lio/getstream/chat/android/client/call/Call;
@@ -228,7 +227,6 @@ public abstract interface class io/getstream/chat/android/offline/ChatDomain {
 	public abstract fun leaveChannel (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun loadMessageById (Ljava/lang/String;Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun loadNewerMessages (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
-	public abstract fun loadOlderMessages (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun markAllRead ()Lio/getstream/chat/android/client/call/Call;
 	public abstract fun markRead (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public abstract fun queryChannels (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;III)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomain.kt
@@ -159,26 +159,6 @@ public sealed interface ChatDomain {
     @CheckResult
     public fun getThread(cid: String, parentId: String): Call<ThreadController>
 
-    // loading more
-    /**
-     * Loads older messages for the channel.
-     *
-     * @param cid The full channel id i. e. messaging:123.
-     * @param messageLimit How many new messages to load.
-     *
-     * @return Executable async [Call] responsible for loading older messages in a channel.
-     */
-    @CheckResult
-    @Deprecated(
-        message = "loadOlderMessages is deprecated. Use extension function ChatClient::loadOlderMessages instead",
-        replaceWith = ReplaceWith(
-            expression = "ChatClient.instance().loadOlderMessages(cid, messageLimit)",
-            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
-        ),
-        level = DeprecationLevel.ERROR
-    )
-    public fun loadOlderMessages(cid: String, messageLimit: Int): Call<Channel>
-
     /**
      * Loads newer messages for the channel.
      *

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/livedata/ChatDomainImpl.kt
@@ -136,10 +136,6 @@ internal class ChatDomainImpl internal constructor(internal val chatDomainStateF
     override fun getThread(cid: String, parentId: String): Call<ThreadController> =
         chatDomainStateFlow.getThread(cid, parentId).map(::ThreadControllerImpl)
 
-    @Suppress("DEPRECATION_ERROR")
-    override fun loadOlderMessages(cid: String, messageLimit: Int): Call<Channel> =
-        chatDomainStateFlow.loadOlderMessages(cid, messageLimit)
-
     override fun loadNewerMessages(cid: String, messageLimit: Int): Call<Channel> =
         chatDomainStateFlow.loadNewerMessages(cid, messageLimit)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomain.kt
@@ -165,25 +165,6 @@ public sealed interface ChatDomain {
     public fun getThread(cid: String, parentId: String): Call<ThreadController>
 
     /**
-     * Loads older messages for the channel.
-     *
-     * @param cid The full channel id i. e. messaging:123.
-     * @param messageLimit How many new messages to load.
-     *
-     * @return Executable async [Call] responsible for loading older messages in a channel.
-     */
-    @CheckResult
-    @Deprecated(
-        message = "loadOlderMessages is deprecated. Use extension function ChatClient::loadOlderMessages instead",
-        replaceWith = ReplaceWith(
-            expression = "ChatClient.instance().loadOlderMessages(cid, messageLimit)",
-            imports = arrayOf("io.getstream.chat.android.client.ChatClient")
-        ),
-        level = DeprecationLevel.ERROR
-    )
-    public fun loadOlderMessages(cid: String, messageLimit: Int): Call<Channel>
-
-    /**
      * Loads newer messages for the channel.
      *
      * @param cid The full channel id i. e. messaging:123.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -50,7 +50,6 @@ import io.getstream.chat.android.offline.experimental.querychannels.state.toMuta
 import io.getstream.chat.android.offline.extensions.applyPagination
 import io.getstream.chat.android.offline.extensions.cancelMessage
 import io.getstream.chat.android.offline.extensions.createChannel
-import io.getstream.chat.android.offline.extensions.loadOlderMessages
 import io.getstream.chat.android.offline.extensions.shuffleGiphy
 import io.getstream.chat.android.offline.extensions.users
 import io.getstream.chat.android.offline.message.attachment.UploadAttachmentsNetworkType
@@ -810,9 +809,6 @@ internal class ChatDomainImpl internal constructor(
             )
         }
     }
-
-    override fun loadOlderMessages(cid: String, messageLimit: Int): Call<Channel> =
-        client.loadOlderMessages(cid, messageLimit)
 
     override fun loadNewerMessages(cid: String, messageLimit: Int): Call<Channel> =
         LoadNewerMessages(this).invoke(cid, messageLimit)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/usecase/LoadOldMessagesTest.kt
@@ -5,13 +5,11 @@ import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.whenever
-import io.getstream.chat.android.client.api.models.WatchChannelRequest
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.offline.extensions.loadOlderMessages
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.test.asCall
-import io.getstream.chat.android.test.failedCall
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runBlockingTest
 import org.amshove.kluent.shouldBeEqualTo
@@ -60,24 +58,5 @@ internal class LoadOldMessagesTest : BaseDomainTest2() {
 
         result.isSuccess.shouldBeTrue()
         result.data().cid shouldBeEqualTo desiredCid
-    }
-
-    @Test
-    fun `when online request does NOT work, local cache is used`() = runBlockingTest {
-        val queryChannelCall = Channel(cid = data.channel1.cid).asCall()
-
-        whenever(channelClientMock.watch(any<WatchChannelRequest>())) doReturn queryChannelCall
-
-        // Load older messages using backend.
-        clientMock.loadOlderMessages(data.channel1.cid, 10).execute()
-
-        whenever(channelClientMock.watch(any<WatchChannelRequest>())) doReturn failedCall("the call failed")
-
-        // Now backend fails, so the cache request must work for a successful result.
-        // TODO: Review this test (https://github.com/GetStream/stream-chat-android/issues/2976)
-        @Suppress("DEPRECATION_ERROR")
-        val result = chatDomainImpl.loadOlderMessages(data.channel1.cid, 10).execute()
-
-        result.isSuccess.shouldBeTrue()
     }
 }

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModelTest.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.livedata.controller.ChannelController
 import io.getstream.chat.android.livedata.controller.ThreadController
+import io.getstream.chat.android.offline.extensions.loadOlderMessages
 import io.getstream.chat.android.test.InstantTaskExecutorExtension
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.observeAll
@@ -147,7 +148,7 @@ internal class MessageListViewModelTest {
 
         // TODO: Review this test (https://github.com/GetStream/stream-chat-android/issues/2976)
         @Suppress("DEPRECATION_ERROR")
-        verify(domain).loadOlderMessages(CID, MESSAGES_LIMIT)
+        verify(client).loadOlderMessages(CID, MESSAGES_LIMIT)
     }
 
     @Test


### PR DESCRIPTION
Closes #2976 
### 🎯 Goal

Clean the older unused `ChatDomain::loadOlderMessages` from tests and docs.

### 🛠 Implementation details

- Docs are updated to use `ChatClient::loadOlderMessages` instead of `ChatDomain::loadOlderMessages`.
- Tests are modified/removed which were using `ChatDomain::loadOlderMessages`.

### 🧪 Testing

- Run the sample app and it should work as expected.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
