### PR TITLE
[Proof of Concept] Synchronize chat events

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/ChatDomainImpl.kt
@@ -356,7 +356,9 @@ internal class ChatDomainImpl internal constructor(
     private fun startListening() {
         if (eventSubscription.isDisposed) {
             eventSubscription = client.subscribe {
-                eventHandler.handleEvents(listOf(it))
+                scope.launch {
+                    eventHandler.handleEvents(listOf(it))
+                }
             }
         }
     }


### PR DESCRIPTION
This is a simple proof of concept PR used to validate the idea and should not be treated as a merge-ready PR.

### 🎯 Goal

Currently due to launching multiple coroutines our chat events can come in asynchronously which can cause race conditions.

The aim of this PR is to use `MutableSharedFlow` as a simple and effective synchronization mechanism while providing buffer capabilities for events that replace the previous events (connect events).

### 🛠 Implementation details

- Introduce relevant `MutableSharedFlows`
- Introduce collect and job hygiene (cancellation) functions