### PR TITLE
Remove ExperimentalStreamChatApi annotation from OP related classes

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2025,7 +2025,6 @@ public class ChatClient internal constructor(
         return "$header.$payload.$devSignature"
     }
 
-    @ExperimentalStreamChatApi
     internal fun <R, T : Any> Call<T>.precondition(
         pluginsList: List<R>,
         preconditionCheck: suspend R.() -> Result<Unit>,
@@ -2191,7 +2190,6 @@ public class ChatClient internal constructor(
         }
 
         @InternalStreamChatApi
-        @ExperimentalStreamChatApi
         public fun withPlugin(pluginFactory: PluginFactory): Builder = apply {
             pluginFactories.add(pluginFactory)
         }
@@ -2202,7 +2200,6 @@ public class ChatClient internal constructor(
          * @see [ErrorHandlerFactory]
          */
         @InternalStreamChatApi
-        @ExperimentalStreamChatApi
         public fun withErrorHandler(errorHandlerFactory: ErrorHandlerFactory): Builder = apply {
             this.errorHandlerFactories.add(errorHandlerFactory)
         }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/ErrorHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/ErrorHandler.kt
@@ -1,13 +1,10 @@
 package io.getstream.chat.android.client.experimental.errorhandler
 
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
-
 /**
  * Extension for [io.getstream.chat.android.client.ChatClient] that allows handling plugins' errors.
  *
  * @see [io.getstream.chat.android.client.experimental.plugin.Plugin]
  */
-@ExperimentalStreamChatApi
 public interface ErrorHandler : Comparable<ErrorHandler> {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/factory/ErrorHandlerFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/factory/ErrorHandlerFactory.kt
@@ -1,14 +1,12 @@
 package io.getstream.chat.android.client.experimental.errorhandler.factory
 
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Factory used to provide an [ErrorHandler] that will be used to handle plugins' errors.
  *
  * @see [io.getstream.chat.android.client.experimental.plugin.Plugin]
  */
-@ExperimentalStreamChatApi
 public interface ErrorHandlerFactory {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/DeleteReactionErrorHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/DeleteReactionErrorHandler.kt
@@ -5,12 +5,10 @@ import io.getstream.chat.android.client.call.ReturnOnErrorCall
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Error handler for [io.getstream.chat.android.client.ChatClient.deleteReaction] calls.
  */
-@ExperimentalStreamChatApi
 public interface DeleteReactionErrorHandler : ErrorHandler {
 
     /**
@@ -29,7 +27,6 @@ public interface DeleteReactionErrorHandler : ErrorHandler {
     ): ReturnOnErrorCall<Message>
 }
 
-@ExperimentalStreamChatApi
 internal fun Call<Message>.onMessageError(
     errorHandlers: List<DeleteReactionErrorHandler>,
     cid: String?,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/QueryMembersErrorHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/QueryMembersErrorHandler.kt
@@ -7,12 +7,10 @@ import io.getstream.chat.android.client.call.ReturnOnErrorCall
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Error handler for [io.getstream.chat.android.client.ChatClient.queryMembers] calls.
  */
-@ExperimentalStreamChatApi
 public interface QueryMembersErrorHandler : ErrorHandler {
 
     /**
@@ -36,7 +34,6 @@ public interface QueryMembersErrorHandler : ErrorHandler {
     ): ReturnOnErrorCall<List<Member>>
 }
 
-@ExperimentalStreamChatApi
 internal fun Call<List<Member>>.onQueryMembersError(
     errorHandlers: List<QueryMembersErrorHandler>,
     channelType: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/SendReactionErrorHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/errorhandler/listeners/SendReactionErrorHandler.kt
@@ -6,12 +6,10 @@ import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Error handler for [io.getstream.chat.android.client.ChatClient.sendReaction] calls.
  */
-@ExperimentalStreamChatApi
 public interface SendReactionErrorHandler : ErrorHandler {
 
     /**
@@ -32,7 +30,6 @@ public interface SendReactionErrorHandler : ErrorHandler {
     ): ReturnOnErrorCall<Reaction>
 }
 
-@ExperimentalStreamChatApi
 internal fun Call<Reaction>.onReactionError(
     errorHandlers: List<SendReactionErrorHandler>,
     reaction: Reaction,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/Plugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/Plugin.kt
@@ -1,12 +1,10 @@
 package io.getstream.chat.android.client.experimental.plugin
 
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Plugin is an extension for [ChatClient].
  */
-@ExperimentalStreamChatApi
 public interface Plugin {
     /**
      * Name of this plugin.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteReactionListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/DeleteReactionListener.kt
@@ -4,12 +4,10 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Listener for [io.getstream.chat.android.client.ChatClient.deleteReaction] calls.
  */
-@ExperimentalStreamChatApi
 public interface DeleteReactionListener {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/GetMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/GetMessageListener.kt
@@ -3,9 +3,7 @@ package io.getstream.chat.android.client.experimental.plugin.listeners
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /**
  * Listener of [ChatClient.getMessage] requests.
  */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/HideChannelListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/HideChannelListener.kt
@@ -2,9 +2,7 @@ package io.getstream.chat.android.client.experimental.plugin.listeners
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /**
  * Listener of [ChatClient.hideChannel] requests.
  */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryChannelListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryChannelListener.kt
@@ -4,9 +4,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /**
  * Listener of [ChatClient.queryChannel] requests.
  */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryChannelsListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryChannelsListener.kt
@@ -5,9 +5,7 @@ import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /**
  * Listener of [ChatClient.queryChannels] requests.
  */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryMembersListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/QueryMembersListener.kt
@@ -5,9 +5,7 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /**
  * Listener of [ChatClient.queryMembers] requests.
  */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/SendMessageListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/SendMessageListener.kt
@@ -3,12 +3,10 @@ package io.getstream.chat.android.client.experimental.plugin.listeners
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Listener for [ChatClient.sendMessage] requests.
  */
-@ExperimentalStreamChatApi
 public interface SendMessageListener {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/SendReactionListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/SendReactionListener.kt
@@ -4,12 +4,10 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
 /**
  * Listener for [io.getstream.chat.android.client.ChatClient.sendReaction] calls.
  */
-@ExperimentalStreamChatApi
 public interface SendReactionListener {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/ThreadQueryListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/plugin/listeners/ThreadQueryListener.kt
@@ -3,9 +3,7 @@ package io.getstream.chat.android.client.experimental.plugin.listeners
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 
-@ExperimentalStreamChatApi
 /** Listener for reply queries. */
 public interface ThreadQueryListener {
     /**

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MockClientBuilder.kt
@@ -18,7 +18,6 @@ import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.utils.TokenUtils
 import io.getstream.chat.android.client.utils.observable.FakeChatSocket
 import io.getstream.chat.android.client.utils.retry.NoRetryPolicy
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import kotlinx.coroutines.test.TestCoroutineScope
 import org.mockito.Mockito
 import java.util.Date
@@ -27,7 +26,6 @@ import java.util.Date
  * Used for integrations tests.
  * Initialises mock internals of [ChatClient]
  */
-@ExperimentalStreamChatApi
 internal class MockClientBuilder(
     private val testCoroutineScope: TestCoroutineScope,
 ) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/QueryChannelReference.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/QueryChannelReference.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelState
 import io.getstream.chat.android.offline.experimental.extensions.state
@@ -14,7 +13,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 /** Reference for the [ChatClient.queryChannel] request. */
 public class QueryChannelReference internal constructor(
     private val channelType: String,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/logic/ChannelLogic.kt
@@ -68,7 +68,6 @@ import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.client.utils.onError
 import io.getstream.chat.android.client.utils.onSuccess
 import io.getstream.chat.android.client.utils.onSuccessSuspend
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.channel.ChannelData
@@ -90,7 +89,6 @@ import kotlinx.coroutines.async
 import java.util.Date
 import kotlin.math.max
 
-@ExperimentalStreamChatApi
 internal class ChannelLogic(
     private val mutableState: ChannelMutableState,
     private val chatDomainImpl: ChatDomainImpl,
@@ -99,7 +97,7 @@ internal class ChannelLogic(
 
     private val logger = ChatLogger.get("Query channel request")
 
-    public val cid: String
+    val cid: String
         get() = mutableState.cid
 
     private var lastMarkReadEvent: Date? by mutableState::lastMarkReadEvent

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.channel.ChannelData
 import io.getstream.chat.android.offline.extensions.updateUsers
 import io.getstream.chat.android.offline.message.wasCreatedAfter
@@ -25,7 +24,6 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import java.util.Date
 
-@ExperimentalStreamChatApi
 internal class ChannelMutableState(
     override val channelType: String,
     override val channelId: String,
@@ -186,5 +184,4 @@ internal class ChannelMutableState(
     }
 }
 
-@ExperimentalStreamChatApi
 internal fun ChannelState.toMutableState(): ChannelMutableState = this as ChannelMutableState

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelState.kt
@@ -7,12 +7,10 @@ import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.channel.ChannelData
 import kotlinx.coroutines.flow.StateFlow
 
-@ExperimentalStreamChatApi
 @InternalStreamChatApi
 /** State container with reactive data of a channel.*/
 public interface ChannelState {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/MessagesState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/MessagesState.kt
@@ -1,14 +1,12 @@
 package io.getstream.chat.android.offline.experimental.channel.state
 
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
 
 /**
  * Represents of possible state of messages for [ChannelState].
  */
-@ExperimentalStreamChatApi
 @InternalStreamChatApi
 public sealed class MessagesState {
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/RepliesQueryReference.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/RepliesQueryReference.kt
@@ -4,7 +4,6 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.thread.state.ThreadState
 import io.getstream.chat.android.offline.experimental.extensions.state
@@ -12,7 +11,6 @@ import io.getstream.chat.android.offline.experimental.plugin.query.QueryReferenc
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-@ExperimentalStreamChatApi
 @InternalStreamChatApi
 /** Reference for the [ChatClient.getReplies] request. */
 public class RepliesQueryReference(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/logic/ThreadLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/logic/ThreadLogic.kt
@@ -5,12 +5,10 @@ import io.getstream.chat.android.client.experimental.plugin.listeners.ThreadQuer
 import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.logic.ChannelLogic
 import io.getstream.chat.android.offline.experimental.channel.thread.state.ThreadMutableState
 
 /** Logic class for thread state management. Implements [ThreadQueryListener] as listener for LLC requests. */
-@ExperimentalStreamChatApi
 internal class ThreadLogic(private val mutableState: ThreadMutableState, private val channelLogic: ChannelLogic) :
     ThreadQueryListener {
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/state/ThreadMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/thread/state/ThreadMutableState.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.offline.experimental.channel.thread.state
 
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutableState
 import io.getstream.chat.android.offline.message.wasCreatedAfterOrAt
 import kotlinx.coroutines.CoroutineScope
@@ -12,7 +11,6 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-@ExperimentalStreamChatApi
 internal class ThreadMutableState(
     override val parentId: String,
     private val channelMutableState: ChannelMutableState,
@@ -40,5 +38,4 @@ internal class ThreadMutableState(
     override val endOfOlderMessages: StateFlow<Boolean> = _endOfOlderMessages
 }
 
-@ExperimentalStreamChatApi
 internal fun ThreadState.toMutableState(): ThreadMutableState = this as ThreadMutableState

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/DeleteReactionErrorHandlerFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/DeleteReactionErrorHandlerFactory.kt
@@ -2,14 +2,12 @@ package io.getstream.chat.android.offline.experimental.errorhandler.factory
 
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.experimental.errorhandler.factory.ErrorHandlerFactory
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.experimental.errorhandler.listener.DeleteReactionErrorHandlerImpl
 import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import kotlinx.coroutines.CoroutineScope
 
-@ExperimentalStreamChatApi
 /**
  * Factory for [DeleteReactionErrorHandlerImpl]
  */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/QueryMembersErrorHandlerFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/QueryMembersErrorHandlerFactory.kt
@@ -2,14 +2,12 @@ package io.getstream.chat.android.offline.experimental.errorhandler.factory
 
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.experimental.errorhandler.factory.ErrorHandlerFactory
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.experimental.errorhandler.listener.QueryMembersErrorHandlerImpl
 import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import kotlinx.coroutines.CoroutineScope
 
-@ExperimentalStreamChatApi
 /**
  * Factory for [QueryMembersErrorHandlerImpl]
  */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/SendReactionErrorHandlerFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/factory/SendReactionErrorHandlerFactory.kt
@@ -2,13 +2,11 @@ package io.getstream.chat.android.offline.experimental.errorhandler.factory
 
 import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.experimental.errorhandler.factory.ErrorHandlerFactory
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.experimental.errorhandler.listener.SendReactionErrorHandlerImpl
 import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import kotlinx.coroutines.CoroutineScope
 
-@ExperimentalStreamChatApi
 /**
  * Factory for [SendReactionErrorHandlerImpl].
  */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/DeleteReactionErrorHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/DeleteReactionErrorHandlerImpl.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.experimental.errorhandler.listeners.Dele
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import kotlinx.coroutines.CoroutineScope
@@ -18,11 +17,9 @@ import kotlinx.coroutines.CoroutineScope
  * [DeleteReactionErrorHandler] implementation for [io.getstream.chat.android.offline.experimental.errorhandler.OfflineErrorHandler].
  * Checks if the change was done offline and can be synced.
  *
- * @param scope [CoroutineScope]
  * @param logic [LogicRegistry]
  * @param globalState [GlobalState] provided by the [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
  */
-@ExperimentalStreamChatApi
 internal class DeleteReactionErrorHandlerImpl(
     private val scope: CoroutineScope,
     private val logic: LogicRegistry,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/QueryMembersErrorHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/QueryMembersErrorHandlerImpl.kt
@@ -9,7 +9,6 @@ import io.getstream.chat.android.client.experimental.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.experimental.errorhandler.listeners.QueryMembersErrorHandler
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import io.getstream.chat.android.offline.repository.domain.channel.ChannelRepository
@@ -24,7 +23,6 @@ import kotlinx.coroutines.CoroutineScope
  * @param globalState [GlobalState] provided by the [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
  * @param repos [RepositoryFacade] to access datasource.
  */
-@ExperimentalStreamChatApi
 internal class QueryMembersErrorHandlerImpl(
     private val scope: CoroutineScope,
     private val globalState: GlobalState,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/SendReactionErrorHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/errorhandler/listener/SendReactionErrorHandlerImpl.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.experimental.errorhandler.listeners.Send
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.extensions.enrichWithDataBeforeSending
 import kotlinx.coroutines.CoroutineScope
@@ -20,7 +19,6 @@ import kotlinx.coroutines.CoroutineScope
  * @param scope [CoroutineScope]
  * @param globalState [GlobalState] provided by the [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
  */
-@ExperimentalStreamChatApi
 internal class SendReactionErrorHandlerImpl(private val scope: CoroutineScope, private val globalState: GlobalState) :
     SendReactionErrorHandler {
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/extensions/ChatClient.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/extensions/ChatClient.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.offline.experimental.extensions
 
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalMutableState
 import io.getstream.chat.android.offline.experimental.global.GlobalState
@@ -12,7 +11,6 @@ import io.getstream.chat.android.offline.experimental.plugin.state.StateRegistry
 /**
  * [StateRegistry] instance that contains all state objects exposed in offline plugin.
  */
-@ExperimentalStreamChatApi
 internal val ChatClient.state: StateRegistry
     get() = requireNotNull(StateRegistry.get()) {
         "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
@@ -22,7 +20,6 @@ internal val ChatClient.state: StateRegistry
 /**
  * [LogicRegistry] instance that contains all objects responsible for handling logic in offline plugin.
  */
-@ExperimentalStreamChatApi
 internal val ChatClient.logic: LogicRegistry
     get() = requireNotNull(LogicRegistry.get()) {
         "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
@@ -36,5 +33,4 @@ public val ChatClient.globalState: GlobalState
     get() = GlobalMutableState.getOrCreate()
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 public fun ChatClient.asReferenced(): ChatClientReferenceAdapter = ChatClientReferenceAdapter(this)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/global/GlobalMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/global/GlobalMutableState.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.models.ChannelMute
 import io.getstream.chat.android.client.models.Mute
 import io.getstream.chat.android.client.models.TypingEvent
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.model.ConnectionState
 import io.getstream.chat.android.offline.utils.Event
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -100,5 +99,4 @@ internal class GlobalMutableState private constructor() : GlobalState {
     }
 }
 
-@ExperimentalStreamChatApi
 internal fun GlobalState.toMutableState(): GlobalMutableState = this as GlobalMutableState

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/interceptor/DefaultInterceptor.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/interceptor/DefaultInterceptor.kt
@@ -2,7 +2,6 @@ package io.getstream.chat.android.offline.experimental.interceptor
 
 import io.getstream.chat.android.client.experimental.interceptor.Interceptor
 import io.getstream.chat.android.client.experimental.interceptor.SendMessageInterceptor
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 /**
@@ -12,7 +11,6 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
  * @param sendMessageInterceptor [SendMessageInterceptor]
  */
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 internal class DefaultInterceptor(sendMessageInterceptor: SendMessageInterceptor) :
     Interceptor,
     SendMessageInterceptor by sendMessageInterceptor

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/interceptor/SendMessageInterceptorImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/interceptor/SendMessageInterceptorImpl.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import io.getstream.chat.android.client.experimental.interceptor.SendMessageInterceptor
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.extensions.populateMentions
@@ -16,7 +15,6 @@ import kotlinx.coroutines.CoroutineScope
  * Implementation of [SendMessageInterceptor] that upload attachments, update original message
  * with new attachments and return updated message.
  */
-@ExperimentalStreamChatApi
 internal class SendMessageInterceptorImpl(
     private val context: Context,
     private val logic: LogicRegistry,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/OfflinePlugin.kt
@@ -16,8 +16,6 @@ import io.getstream.chat.android.client.experimental.plugin.listeners.SendMessag
 import io.getstream.chat.android.client.experimental.plugin.listeners.SendReactionListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.ShuffleGiphyListener
 import io.getstream.chat.android.client.experimental.plugin.listeners.ThreadQueryListener
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 /**
  * Implementation of [Plugin] that brings support for the offline feature. This class work as a delegator of calls for one
@@ -39,8 +37,6 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
  * @param sendMessageListener [SendMessageListener]
  * @param queryMembersListener [QueryMembersListener]
  */
-@InternalStreamChatApi
-@ExperimentalStreamChatApi
 internal class OfflinePlugin(
     private val queryChannelsListener: QueryChannelsListener,
     private val queryChannelListener: QueryChannelListener,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/adapter/ChatClientReferenceAdapter.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/adapter/ChatClientReferenceAdapter.kt
@@ -4,7 +4,6 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.experimental.channel.QueryChannelReference
@@ -13,7 +12,6 @@ import io.getstream.chat.android.offline.experimental.querychannels.QueryChannel
 import io.getstream.chat.android.offline.request.QueryChannelPaginationRequest
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 /**
  * Adapter for [ChatClient] that wraps some of it's request with [io.getstream.chat.android.offline.experimental.plugin.QueryReference].
  */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/factory/StreamOfflinePluginFactory.kt
@@ -6,7 +6,6 @@ import io.getstream.chat.android.client.experimental.plugin.Plugin
 import io.getstream.chat.android.client.experimental.plugin.factory.PluginFactory
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.setup.InitializationCoordinator
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.livedata.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
@@ -37,7 +36,6 @@ import io.getstream.chat.android.offline.repository.creation.builder.RepositoryF
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 
-@ExperimentalStreamChatApi
 /**
  * Implementation of [PluginFactory] that provides [OfflinePlugin].
  *

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ChannelMarkReadListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ChannelMarkReadListenerImpl.kt
@@ -2,10 +2,8 @@ package io.getstream.chat.android.offline.experimental.plugin.listener
 
 import io.getstream.chat.android.client.experimental.plugin.listeners.ChannelMarkReadListener
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
-@ExperimentalStreamChatApi
 internal class ChannelMarkReadListenerImpl(private val logic: LogicRegistry) : ChannelMarkReadListener {
 
     override suspend fun onChannelMarkReadPrecondition(channelType: String, channelId: String): Result<Unit> =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/DeleteMessageListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/DeleteMessageListenerImpl.kt
@@ -5,13 +5,11 @@ import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.repository.domain.message.MessageRepository
 import java.util.Date
 
-@ExperimentalStreamChatApi
 /**
  * Listener for requests of message deletion and for message deletion results.
  */

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/DeleteReactionListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/DeleteReactionListenerImpl.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutableState
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
@@ -25,7 +24,6 @@ import java.util.Date
  * @param globalState [GlobalState] provided by the [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
  * @param repos [RepositoryFacade] to cache intermediate data and final result.
  */
-@ExperimentalStreamChatApi
 internal class DeleteReactionListenerImpl(
     private val logic: LogicRegistry,
     private val globalState: GlobalState,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/EditMessageListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/EditMessageListenerImpl.kt
@@ -7,13 +7,11 @@ import io.getstream.chat.android.client.extensions.isPermanent
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.logic.ChannelLogic
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import java.util.Date
 
-@ExperimentalStreamChatApi
 internal class EditMessageListenerImpl(
     private val logic: LogicRegistry,
     private val globalState: GlobalState,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/GetMessageListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/GetMessageListenerImpl.kt
@@ -4,10 +4,8 @@ import io.getstream.chat.android.client.experimental.plugin.listeners.GetMessage
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
-@ExperimentalStreamChatApi
 internal class GetMessageListenerImpl(private val logic: LogicRegistry) : GetMessageListener {
     override suspend fun onGetMessageResult(
         result: Result<Message>,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/HideChannelListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/HideChannelListenerImpl.kt
@@ -2,10 +2,8 @@ package io.getstream.chat.android.offline.experimental.plugin.listener
 
 import io.getstream.chat.android.client.experimental.plugin.listeners.HideChannelListener
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
-@ExperimentalStreamChatApi
 internal class HideChannelListenerImpl(private val logic: LogicRegistry) : HideChannelListener {
     override suspend fun onHideChannelPrecondition(
         channelType: String,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/MarkAllReadListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/MarkAllReadListenerImpl.kt
@@ -1,11 +1,9 @@
 package io.getstream.chat.android.offline.experimental.plugin.listener
 
 import io.getstream.chat.android.client.experimental.plugin.listeners.MarkAllReadListener
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import kotlinx.coroutines.awaitAll
 
-@ExperimentalStreamChatApi
 internal class MarkAllReadListenerImpl(private val logic: LogicRegistry) : MarkAllReadListener {
     override suspend fun onMarkAllReadRequest() {
         logic.getActiveChannelsLogic().map { channel ->

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryChannelListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryChannelListenerImpl.kt
@@ -4,10 +4,8 @@ import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.experimental.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
-@ExperimentalStreamChatApi
 internal class QueryChannelListenerImpl(private val logic: LogicRegistry) : QueryChannelListener {
 
     override suspend fun onQueryChannelPrecondition(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryChannelsListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryChannelsListenerImpl.kt
@@ -4,13 +4,11 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.experimental.plugin.listeners.QueryChannelsListener
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
 /**
  * Document this!!
  */
-@ExperimentalStreamChatApi
 internal class QueryChannelsListenerImpl(private val logic: LogicRegistry) : QueryChannelsListener {
 
     override suspend fun onQueryChannelsRequest(request: QueryChannelsRequest) {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryMembersListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/QueryMembersListenerImpl.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.experimental.plugin.listeners.QueryMembersListener
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import io.getstream.chat.android.offline.utils.toCid
 
@@ -15,7 +14,6 @@ import io.getstream.chat.android.offline.utils.toCid
  *
  * @param repos [RepositoryFacade] to cache intermediate data and final result.
  */
-@ExperimentalStreamChatApi
 internal class QueryMembersListenerImpl(
     private val repos: RepositoryFacade,
 ) : QueryMembersListener {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendGiphyListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendGiphyListenerImpl.kt
@@ -4,7 +4,6 @@ import io.getstream.chat.android.client.experimental.plugin.listeners.SendGiphyL
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
 /**
@@ -13,7 +12,6 @@ import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
  *
  * @param logic [LogicRegistry]
  */
-@ExperimentalStreamChatApi
 internal class SendGiphyListenerImpl(private val logic: LogicRegistry) : SendGiphyListener {
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendMessageListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendMessageListenerImpl.kt
@@ -7,13 +7,11 @@ import io.getstream.chat.android.client.extensions.isPermanent
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.logic.ChannelLogic
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.repository.RepositoryFacade
 import java.util.Date
 
-@ExperimentalStreamChatApi
 internal class SendMessageListenerImpl(
     private val logic: LogicRegistry,
     private val repos: RepositoryFacade,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendReactionListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/SendReactionListenerImpl.kt
@@ -7,7 +7,6 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutableState
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
@@ -25,7 +24,6 @@ import java.util.Date
  * @param globalState [GlobalState] provided by the [io.getstream.chat.android.offline.experimental.plugin.OfflinePlugin].
  * @param repos [RepositoryFacade] to cache intermediate data and final result.
  */
-@ExperimentalStreamChatApi
 internal class SendReactionListenerImpl(
     private val logic: LogicRegistry,
     private val globalState: GlobalState,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ShuffleGiphyListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ShuffleGiphyListenerImpl.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
 /**
@@ -14,7 +13,6 @@ import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
  *
  * @param logic [LogicRegistry]
  */
-@ExperimentalStreamChatApi
 internal class ShuffleGiphyListenerImpl(private val logic: LogicRegistry) : ShuffleGiphyListener {
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ThreadQueryListenerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/listener/ThreadQueryListenerImpl.kt
@@ -3,10 +3,8 @@ package io.getstream.chat.android.offline.experimental.plugin.listener
 import io.getstream.chat.android.client.experimental.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 
-@ExperimentalStreamChatApi
 internal class ThreadQueryListenerImpl(private val logic: LogicRegistry) : ThreadQueryListener {
 
     override fun onGetRepliesPrecondition(messageId: String, limit: Int): Result<Unit> =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/logic/LogicRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/logic/LogicRegistry.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.experimental.channel.logic.ChannelLogic
@@ -19,7 +18,6 @@ import io.getstream.chat.android.offline.experimental.querychannels.state.toMuta
 import kotlinx.coroutines.runBlocking
 import java.util.concurrent.ConcurrentHashMap
 
-@ExperimentalStreamChatApi
 /**
  * Registry-container for logic objects related to:
  * 1. Query channels

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/query/QueryReference.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/query/QueryReference.kt
@@ -1,12 +1,10 @@
 package io.getstream.chat.android.offline.experimental.plugin.query
 
 import io.getstream.chat.android.client.call.Call
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import kotlinx.coroutines.CoroutineScope
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 /**
  * Generic reference entity that wrap a request to ChatClient and expose offline state (see [asState]).
  * [T] is a type of requested data.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/plugin/state/StateRegistry.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelMutableState
@@ -22,7 +21,6 @@ import kotlinx.coroutines.runBlocking
 import java.util.concurrent.ConcurrentHashMap
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 /**
  * Registry of all state objects exposed in the offline plugin. This class should have only one instance for the SDK.
  *

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/QueryChannelsReference.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/QueryChannelsReference.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.experimental.extensions.state
 import io.getstream.chat.android.offline.experimental.plugin.query.QueryReference
@@ -14,7 +13,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 public class QueryChannelsReference internal constructor(
     public val request: QueryChannelsRequest,
     private val chatClient: ChatClient

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/logic/QueryChannelsLogic.kt
@@ -19,7 +19,6 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.client.utils.map
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.experimental.channel.state.ChannelState
 import io.getstream.chat.android.offline.experimental.extensions.state
@@ -40,7 +39,6 @@ import io.getstream.chat.android.offline.request.toAnyChannelPaginationRequest
 import io.getstream.chat.android.offline.utils.Event
 import kotlinx.coroutines.flow.MutableStateFlow
 
-@ExperimentalStreamChatApi
 internal class QueryChannelsLogic(
     private val mutableState: QueryChannelsMutableState,
     private val chatDomainImpl: ChatDomainImpl,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/ChannelsStateData.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/ChannelsStateData.kt
@@ -1,12 +1,10 @@
 package io.getstream.chat.android.offline.experimental.querychannels.state
 
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomainImpl
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 public sealed class ChannelsStateData {
     /** No query is currently running.
      * If you know that a query will be started you typically want to display a loading icon.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsMutableState.kt
@@ -5,7 +5,6 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.User
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.extensions.updateUsers
 import io.getstream.chat.android.offline.querychannels.ChatEventHandler
 import io.getstream.chat.android.offline.querychannels.DefaultChatEventHandler
@@ -18,7 +17,6 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 
-@ExperimentalStreamChatApi
 internal class QueryChannelsMutableState(
     override val filter: FilterObject,
     override val sort: QuerySort<Channel>,
@@ -71,5 +69,4 @@ internal class QueryChannelsMutableState(
         }.stateIn(scope, SharingStarted.Eagerly, null)
 }
 
-@ExperimentalStreamChatApi
 internal fun QueryChannelsState.toMutableState(): QueryChannelsMutableState = this as QueryChannelsMutableState

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/querychannels/state/QueryChannelsState.kt
@@ -4,13 +4,11 @@ import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.querychannels.ChatEventHandler
 import kotlinx.coroutines.flow.StateFlow
 
 @InternalStreamChatApi
-@ExperimentalStreamChatApi
 public interface QueryChannelsState {
     /** The filter is associated with this query channels state. */
     public val filter: FilterObject

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/MessageSendingService.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/MessageSendingService.kt
@@ -8,7 +8,6 @@ import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.message.attachment.UploadAttachmentsWorker
@@ -25,7 +24,6 @@ import java.util.UUID
 /**
  * A service that does everything required to send message i.e. preparing the message, uploading attachments, setting correct state.
  */
-@ExperimentalStreamChatApi
 internal class MessageSendingService(
     private val logic: LogicRegistry,
     private val globalState: GlobalState,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/MessageSendingServiceFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/message/MessageSendingServiceFactory.kt
@@ -1,7 +1,6 @@
 package io.getstream.chat.android.offline.message
 
 import android.content.Context
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.experimental.global.GlobalState
 import io.getstream.chat.android.offline.experimental.plugin.logic.LogicRegistry
 import io.getstream.chat.android.offline.message.attachment.UploadAttachmentsWorker
@@ -12,7 +11,6 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Factory to generate and provide instances of [MessageSendingService].
  */
-@ExperimentalStreamChatApi
 internal object MessageSendingServiceFactory {
     private val messageSendingServices: ConcurrentHashMap<Pair<String, String>, MessageSendingService> =
         ConcurrentHashMap()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.client.models.EventType
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.observable.Disposable
-import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.offline.ChatDomain
 import io.getstream.chat.android.offline.ChatDomainImpl
 import io.getstream.chat.android.offline.SynchronizedCoroutineTest
@@ -57,7 +56,6 @@ import java.util.concurrent.Executors
 /**
  * Sets up a ChatDomain object with a mocked ChatClient.
  */
-@ExperimentalStreamChatApi
 internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
 
     /** a realistic set of chat data, please only add to this, don't update */


### PR DESCRIPTION
### 🎯 Goal

Remove `ExperimentalStreamChatApi` annotation from OP related classes

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] ~PR is linked to the GitHub issue it resolves~
