### PR TITLE
Fix typing state event in `ChannelMutableState`

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -1,6 +1,5 @@
 package io.getstream.chat.android.offline.experimental.channel.state
 
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.TypingStartEvent
 import io.getstream.chat.android.client.models.Channel
@@ -119,9 +118,7 @@ internal class ChannelMutableState(
                 .sortedBy(ChatEvent::createdAt)
                 .mapNotNull { event ->
                     when (event) {
-                        is TypingStartEvent -> event.user.takeIf { user ->
-                            user.id != ChatClient.instance().getCurrentUser()?.id
-                        }
+                        is TypingStartEvent -> event.user
                         else -> null
                     }
                 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/experimental/channel/state/ChannelMutableState.kt
@@ -1,5 +1,6 @@
 package io.getstream.chat.android.offline.experimental.channel.state
 
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.TypingStartEvent
 import io.getstream.chat.android.client.models.Channel
@@ -19,7 +20,6 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import java.util.Date
@@ -112,19 +112,16 @@ internal class ChannelMutableState(
         _watchers.combine(latestUsers) { watcherMap, userMap -> watcherMap.values.updateUsers(userMap) }
             .map { it.sortedBy(User::createdAt) }
             .stateIn(scope, SharingStarted.Eagerly, emptyList())
-    override val typing: StateFlow<TypingEvent> = userFlow
-        .filterNotNull()
-        .flatMapConcat { currentUser ->
-            _typing.map { typingMap ->
-                currentUser to typingMap
-            }
-        }
-        .map { (currentUser, typingMap) ->
+
+    override val typing: StateFlow<TypingEvent> = _typing
+        .map { typingMap ->
             val userList = typingMap.values
                 .sortedBy(ChatEvent::createdAt)
                 .mapNotNull { event ->
                     when (event) {
-                        is TypingStartEvent -> event.user.takeIf { user -> user != currentUser }
+                        is TypingStartEvent -> event.user.takeIf { user ->
+                            user.id != ChatClient.instance().getCurrentUser()?.id
+                        }
                         else -> null
                     }
                 }


### PR DESCRIPTION
### 🎯 Goal
The typing events state is not reflected correctly in `MessageListViewHeader`. 

### 🛠 Implementation details
- Simplified the logic of populating typing events state.

### 🧪 Testing

- Run the samples app on two devices with different accounts. 
- Type a message in one device and you should be able to see new typing indicators in the header of the other device.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
