### PR TITLE
Add possibility to customize notification channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,13 @@
 
 ### ✅ Added
 - Added possibility to configure `RetryPolicy` using `ChaClient.Builder()`. [#3069](https://github.com/GetStream/stream-chat-android/pull/3069)
+- Added `notificationChannel` lambda parameter to `NotificationHandlerFactory::createNotificationHandler` which is being used to create a `NotificationChannel`.
+  You can use it to customize notifications priority, channel name, etc. [#3167](https://github.com/GetStream/stream-chat-android/pull/3167)
 
 ### ⚠️ Changed
 - Add `Channel::image`, `Channel:name`, `User::image`, `User::name` properties. [#3139](https://github.com/GetStream/stream-chat-android/pull/3139)
+- `LoadNotificationDataWorker` is now using a separate `NotificationChannel` with `NotificationCompat.PRIORITY_LOW`.
+  You can customize its name by overriding `stream_chat_other_notifications_channel_name` string. [#3167](https://github.com/GetStream/stream-chat-android/pull/3167)
 
 ### ❌ Removed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3153,8 +3153,8 @@ public final class io/getstream/chat/android/client/notifications/handler/Notifi
 
 public final class io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory {
 	public static final field INSTANCE Lio/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory;
-	public final fun createNotificationHandler (Landroid/content/Context;Lkotlin/jvm/functions/Function3;)Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;
-	public static synthetic fun createNotificationHandler$default (Lio/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory;Landroid/content/Context;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;
+	public final fun createNotificationHandler (Landroid/content/Context;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;)Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;
+	public static synthetic fun createNotificationHandler$default (Lio/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory;Landroid/content/Context;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;
 }
 
 public abstract interface class io/getstream/chat/android/client/notifications/handler/PushDeviceGenerator {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
@@ -58,8 +58,8 @@ internal class LoadNotificationDataWorker(
         return ForegroundInfo(
             NOTIFICATION_ID,
             createForegroundNotification(
-                notificationChannelId = context.getString(R.string.stream_chat_notification_channel_id),
-                notificationChannelName = context.getString(R.string.stream_chat_notification_channel_name),
+                notificationChannelId = context.getString(R.string.stream_chat_load_notification_channel_id),
+                notificationChannelName = context.getString(R.string.stream_chat_load_notification_channel_name),
             ),
         )
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
@@ -58,8 +58,8 @@ internal class LoadNotificationDataWorker(
         return ForegroundInfo(
             NOTIFICATION_ID,
             createForegroundNotification(
-                notificationChannelId = context.getString(R.string.stream_chat_load_notification_channel_id),
-                notificationChannelName = context.getString(R.string.stream_chat_load_notification_channel_name),
+                notificationChannelId = context.getString(R.string.stream_chat_other_notifications_channel_id),
+                notificationChannelName = context.getString(R.string.stream_chat_other_notifications_channel_name),
             ),
         )
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
@@ -7,9 +7,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.SharedPreferences
-import android.graphics.Color
 import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.edit
 import io.getstream.chat.android.client.R
@@ -23,9 +21,18 @@ import io.getstream.chat.android.client.receivers.NotificationMessageReceiver
  */
 internal class ChatNotificationHandler(
     private val context: Context,
-    private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent =
-        { _, _, _ -> context.packageManager!!.getLaunchIntentForPackage(context.packageName)!! },
+    private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent,
+    private val notificationChannelFun: (() -> NotificationChannel)?,
 ) : NotificationHandler {
+
+    /**
+     * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
+     * Should never be null in such case.
+     * @see [NotificationHandlerFactory.getDefaultNotificationChannel]
+     */
+    private val notificationChannel: NotificationChannel by lazy {
+        notificationChannelFun!!.invoke()
+    }
 
     private val sharedPreferences: SharedPreferences by lazy {
         context.getSharedPreferences(
@@ -36,40 +43,18 @@ internal class ChatNotificationHandler(
     private val notificationManager: NotificationManager by lazy {
         (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).also {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                it.createNotificationChannel(createNotificationChannel())
+                it.createNotificationChannel(notificationChannel)
             }
         }
     }
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    fun createNotificationChannel(): NotificationChannel {
-        return NotificationChannel(
-            getNotificationChannelId(),
-            getNotificationChannelName(),
-            NotificationManager.IMPORTANCE_DEFAULT,
-        ).apply {
-            setShowBadge(true)
-            importance = NotificationManager.IMPORTANCE_HIGH
-            enableLights(true)
-            lightColor = Color.RED
-            enableVibration(true)
-            vibrationPattern = longArrayOf(
-                100,
-                200,
-                300,
-                400,
-                500,
-                400,
-                300,
-                200,
-                400,
-            )
+    private fun getNotificationChannelId(): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationChannel.id
+        } else {
+            ""
         }
     }
-
-    private fun getNotificationChannelId(): String = context.getString(R.string.stream_chat_notification_channel_id)
-    private fun getNotificationChannelName(): String =
-        context.getString(R.string.stream_chat_notification_channel_name)
 
     override fun showNotification(channel: Channel, message: Message) {
         val notificationId: Int = System.nanoTime().toInt()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
@@ -18,21 +18,13 @@ import io.getstream.chat.android.client.receivers.NotificationMessageReceiver
 
 /**
  * Class responsible for handling chat notifications.
+ * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
  */
 internal class ChatNotificationHandler(
     private val context: Context,
     private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent,
-    private val notificationChannelFun: (() -> NotificationChannel)?,
+    private val notificationChannel: (() -> NotificationChannel),
 ) : NotificationHandler {
-
-    /**
-     * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
-     * Should never be null in such case.
-     * @see [NotificationHandlerFactory.getDefaultNotificationChannel]
-     */
-    private val notificationChannel: NotificationChannel by lazy {
-        notificationChannelFun!!.invoke()
-    }
 
     private val sharedPreferences: SharedPreferences by lazy {
         context.getSharedPreferences(
@@ -43,14 +35,14 @@ internal class ChatNotificationHandler(
     private val notificationManager: NotificationManager by lazy {
         (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).also {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                it.createNotificationChannel(notificationChannel)
+                it.createNotificationChannel(notificationChannel())
             }
         }
     }
 
     private fun getNotificationChannelId(): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationChannel.id
+            notificationChannel().id
         } else {
             ""
         }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
@@ -19,27 +19,22 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.receivers.NotificationMessageReceiver
 import java.util.Date
 
+/**
+ * Class responsible for displaying chat notifications using [NotificationCompat.MessagingStyle].
+ * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
+ */
 @RequiresApi(Build.VERSION_CODES.M)
 internal class MessagingStyleNotificationHandler(
     private val context: Context,
     private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent,
-    notificationChannelFun: (() -> NotificationChannel)?,
+    private val notificationChannel: (() -> NotificationChannel),
 ) : NotificationHandler {
-
-    /**
-     * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
-     * Should never be null in such case.
-     * @see [NotificationHandlerFactory.getDefaultNotificationChannel]
-     */
-    private val notificationChannel: NotificationChannel by lazy {
-        notificationChannelFun!!.invoke()
-    }
 
     private val sharedPreferences: SharedPreferences by lazy { context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE) }
     private val notificationManager: NotificationManager by lazy {
         (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).also { notificationManager ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                notificationManager.createNotificationChannel(notificationChannel)
+                notificationManager.createNotificationChannel(notificationChannel())
             }
         }
     }
@@ -108,7 +103,7 @@ internal class MessagingStyleNotificationHandler(
 
     private fun getNotificationChannelId(): String {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            notificationChannel.id
+            notificationChannel().id
         } else {
             ""
         }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
@@ -22,14 +22,24 @@ import java.util.Date
 @RequiresApi(Build.VERSION_CODES.M)
 internal class MessagingStyleNotificationHandler(
     private val context: Context,
-    private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent =
-        { _, _, _ -> context.packageManager!!.getLaunchIntentForPackage(context.packageName)!! }
+    private val newMessageIntent: (messageId: String, channelType: String, channelId: String) -> Intent,
+    notificationChannelFun: (() -> NotificationChannel)?,
 ) : NotificationHandler {
+
+    /**
+     * Notification channel should only be accessed if Build.VERSION.SDK_INT >= Build.VERSION_CODES.O.
+     * Should never be null in such case.
+     * @see [NotificationHandlerFactory.getDefaultNotificationChannel]
+     */
+    private val notificationChannel: NotificationChannel by lazy {
+        notificationChannelFun!!.invoke()
+    }
+
     private val sharedPreferences: SharedPreferences by lazy { context.getSharedPreferences(SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE) }
     private val notificationManager: NotificationManager by lazy {
-        (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).also {
+        (context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager).also { notificationManager ->
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                it.createNotificationChannel(createNotificationChannel())
+                notificationManager.createNotificationChannel(notificationChannel)
             }
         }
     }
@@ -96,16 +106,14 @@ internal class MessagingStyleNotificationHandler(
             .setConversationTitle(channel.name)
             .setGroupConversation(channel.name.isNotBlank())
 
-    @RequiresApi(api = Build.VERSION_CODES.O)
-    private fun createNotificationChannel(): NotificationChannel {
-        return NotificationChannel(
-            getNotificationChannelId(),
-            context.getString(R.string.stream_chat_notification_channel_name),
-            NotificationManager.IMPORTANCE_DEFAULT,
-        )
+    private fun getNotificationChannelId(): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            notificationChannel.id
+        } else {
+            ""
+        }
     }
 
-    private fun getNotificationChannelId() = context.getString(R.string.stream_chat_notification_channel_id)
     private companion object {
         private const val SHARED_PREFERENCES_NAME = "stream_notifications.sp"
         private const val KEY_NOTIFICATIONS_SHOWN = "KEY_NOTIFICATIONS_SHOWN"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory.kt
@@ -1,10 +1,12 @@
 package io.getstream.chat.android.client.notifications.handler
 
+import android.annotation.SuppressLint
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import androidx.annotation.RequiresApi
 import io.getstream.chat.android.client.R
 
 /**
@@ -20,6 +22,7 @@ public object NotificationHandlerFactory {
      * @param newMessageIntent Lambda expression used to generate an [Intent] to open your app
      * @param notificationChannel Lambda expression used to generate a [NotificationChannel]. Used in SDK_INT >= VERSION_CODES.O.
      */
+    @SuppressLint("NewApi")
     public fun createNotificationHandler(
         context: Context,
         newMessageIntent: ((messageId: String, channelType: String, channelId: String) -> Intent)? = null,
@@ -42,17 +45,14 @@ public object NotificationHandlerFactory {
     private fun createDefaultNewMessageIntent(context: Context): Intent =
         context.packageManager!!.getLaunchIntentForPackage(context.packageName)!!
 
-    private fun getDefaultNotificationChannel(context: Context): (() -> NotificationChannel)? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            {
-                NotificationChannel(
-                    context.getString(R.string.stream_chat_notification_channel_id),
-                    context.getString(R.string.stream_chat_notification_channel_name),
-                    NotificationManager.IMPORTANCE_DEFAULT,
-                )
-            }
-        } else {
-            null
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun getDefaultNotificationChannel(context: Context): (() -> NotificationChannel) {
+        return {
+            NotificationChannel(
+                context.getString(R.string.stream_chat_notification_channel_id),
+                context.getString(R.string.stream_chat_notification_channel_name),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
         }
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory.kt
@@ -1,8 +1,11 @@
 package io.getstream.chat.android.client.notifications.handler
 
+import android.app.NotificationChannel
+import android.app.NotificationManager
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import io.getstream.chat.android.client.R
 
 /**
  * Factory for default [NotificationHandler].
@@ -10,22 +13,24 @@ import android.os.Build
  */
 public object NotificationHandlerFactory {
 
-    @Suppress("DEPRECATION_ERROR")
     /**
-     * Method that create a [NotificationHandler].
+     * Method that creates a [NotificationHandler].
      *
      * @param context The [Context] to build the [NotificationHandler] with.
      * @param newMessageIntent Lambda expression used to generate an [Intent] to open your app
+     * @param notificationChannel Lambda expression used to generate a [NotificationChannel]. Used in SDK_INT >= VERSION_CODES.O.
      */
     public fun createNotificationHandler(
         context: Context,
-        newMessageIntent: ((messageId: String, channelType: String, channelId: String) -> Intent)? = null
+        newMessageIntent: ((messageId: String, channelType: String, channelId: String) -> Intent)? = null,
+        notificationChannel: (() -> NotificationChannel)? = null,
     ): NotificationHandler {
-        (newMessageIntent ?: getDefaultNewMessageIntentFun(context)).let {
+        val notificationChannelFun = notificationChannel ?: getDefaultNotificationChannel(context)
+        (newMessageIntent ?: getDefaultNewMessageIntentFun(context)).let { newMessageIntentFun ->
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                MessagingStyleNotificationHandler(context, it)
+                MessagingStyleNotificationHandler(context, newMessageIntentFun, notificationChannelFun)
             } else {
-                ChatNotificationHandler(context, it)
+                ChatNotificationHandler(context, newMessageIntentFun, notificationChannelFun)
             }
         }
     }
@@ -36,4 +41,18 @@ public object NotificationHandlerFactory {
 
     private fun createDefaultNewMessageIntent(context: Context): Intent =
         context.packageManager!!.getLaunchIntentForPackage(context.packageName)!!
+
+    private fun getDefaultNotificationChannel(context: Context): (() -> NotificationChannel)? {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            {
+                NotificationChannel(
+                    context.getString(R.string.stream_chat_notification_channel_id),
+                    context.getString(R.string.stream_chat_notification_channel_name),
+                    NotificationManager.IMPORTANCE_DEFAULT,
+                )
+            }
+        } else {
+            null
+        }
+    }
 }

--- a/stream-chat-android-client/src/main/res/values-en/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-en/strings.xml
@@ -7,6 +7,7 @@
     <string name="stream_chat_notification_type_hint">Type message</string>
     <string name="stream_chat_notification_read">Mark as read</string>
     <string name="stream_chat_notification_channel_name">New chat messages</string>
+    <string name="stream_chat_other_notifications_channel_name">Other notifications</string>
     <string name="stream_chat_load_notification_data_title">Loading notification data</string>
     <string name="stream_chat_notification_group_summary_content_text">You\'ve received new messages</string>
     <string name="stream_chat_error_notification_group_summary_title">Chat messages</string>

--- a/stream-chat-android-client/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-es/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"Mensajes de Chat"</string>
   <string name="stream_chat_load_notification_data_title">"Obteniendo datos de la notificación"</string>
   <string name="stream_chat_notification_channel_name">"Nuevo Mensaje"</string>
+  <string name="stream_chat_other_notifications_channel_name">"Otras notificaciones"</string>
   <string name="stream_chat_notification_content">"Has recibido un nuevo mensaje"</string>
   <string name="stream_chat_notification_empty_username">"Usuario sin nombre"</string>
   <string name="stream_chat_notification_group_summary_content_text">"Has recibido un nuevo mensaje"</string>

--- a/stream-chat-android-client/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-fr/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"Messages de discussion"</string>
   <string name="stream_chat_load_notification_data_title">"Chargement des données de notification"</string>
   <string name="stream_chat_notification_channel_name">"Nouveaux messages de discussion"</string>
+  <string name="stream_chat_other_notifications_channel_name">"Autres notifications"</string>
   <string name="stream_chat_notification_content">"Vous avez reçu un nouveau message"</string>
   <string name="stream_chat_notification_empty_username">"Utilisateur sans nom"</string>
   <string name="stream_chat_notification_group_summary_content_text">"Vous avez reçu de nouveaux messages"</string>

--- a/stream-chat-android-client/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-hi/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"चैट मैसेज"</string>
   <string name="stream_chat_load_notification_data_title">"नोटिफ़िकेशन डेटा लोड हो रहा है"</string>
   <string name="stream_chat_notification_channel_name">"नए चैट मैसेज"</string>
+  <string name="stream_chat_other_notifications_channel_name">"अन्य नोटिफ़िकेशन्स"</string>
   <string name="stream_chat_notification_content">"आपको नया मैसेज प्राप्त हुआ है"</string>
   <string name="stream_chat_notification_empty_username">"अनाम यूजर"</string>
   <string name="stream_chat_notification_group_summary_content_text">"आपको नए मैसेज प्राप्त हुए हैं"</string>
@@ -12,3 +13,5 @@
   <string name="stream_chat_notification_title">"चैट मैसेज"</string>
   <string name="stream_chat_notification_type_hint">"मैसेज लिखें"</string>
 </resources>
+
+

--- a/stream-chat-android-client/src/main/res/values-id/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-id/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"Pesan obrolan"</string>
   <string name="stream_chat_load_notification_data_title">"Memuat data notifikasi"</string>
   <string name="stream_chat_notification_channel_name">"Pesan baru"</string>
+  <string name="stream_chat_other_notifications_channel_name">"Notifikasi lainnya"</string>
   <string name="stream_chat_notification_content">"Anda mendapat pesan baru"</string>
   <string name="stream_chat_notification_empty_username">"Pengguna anonim"</string>
   <string name="stream_chat_notification_group_summary_content_text">"Anda mendapat pesan baru"</string>

--- a/stream-chat-android-client/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-in/strings.xml
@@ -8,6 +8,7 @@
     <string name="stream_chat_notification_type_hint">Ketik pesan</string>
     <string name="stream_chat_notification_read">Tandai telah dibaca</string>
     <string name="stream_chat_notification_channel_name">Pesan baru</string>
+    <string name="stream_chat_other_notifications_channel_name">Notifikasi lainnya</string>
     <string name="stream_chat_load_notification_data_title">Memuat data notifikasi</string>
     <string name="stream_chat_notification_group_summary_content_text">Anda mendapat pesan baru</string>
     <string name="stream_chat_error_notification_group_summary_title">Pesan obrolan</string>

--- a/stream-chat-android-client/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-it/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"Messaggi"</string>
   <string name="stream_chat_load_notification_data_title">"Caricamento dati di notifica"</string>
   <string name="stream_chat_notification_channel_name">"Nuovi messaggi"</string>
+  <string name="stream_chat_other_notifications_channel_name">"Altre notifiche"</string>
   <string name="stream_chat_notification_content">"Hai ricevuto un nuovo messaggio"</string>
   <string name="stream_chat_notification_empty_username">"Utente senza nome"</string>
   <string name="stream_chat_notification_group_summary_content_text">"Hai ricevuto nuovi messaggi"</string>

--- a/stream-chat-android-client/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-ja/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"チャットメッセージ"</string>
   <string name="stream_chat_load_notification_data_title">"ロード通知データ"</string>
   <string name="stream_chat_notification_channel_name">"新しいチャットメッセージ"</string>
+  <string name="stream_chat_other_notifications_channel_name">"その他の通知"</string>
   <string name="stream_chat_notification_content">"新しいメッセージを受け取りました"</string>
   <string name="stream_chat_notification_empty_username">"名前のないユーザー"</string>
   <string name="stream_chat_notification_group_summary_content_text">"新しいメッセージを受け取りました"</string>

--- a/stream-chat-android-client/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-client/src/main/res/values-ko/strings.xml
@@ -4,6 +4,7 @@
   <string name="stream_chat_error_notification_group_summary_title">"채팅 메시지"</string>
   <string name="stream_chat_load_notification_data_title">"알림 데이터 로드 중"</string>
   <string name="stream_chat_notification_channel_name">"새 채팅 메시지"</string>
+  <string name="stream_chat_other_notifications_channel_name">"기타 알림"</string>
   <string name="stream_chat_notification_content">"새 메시지를 받았습니다"</string>
   <string name="stream_chat_notification_empty_username">"익명의 사용자"</string>
   <string name="stream_chat_notification_group_summary_content_text">"새 메시지를 받았습니다"</string>

--- a/stream-chat-android-client/src/main/res/values/strings.xml
+++ b/stream-chat-android-client/src/main/res/values/strings.xml
@@ -8,9 +8,8 @@
     <string name="stream_chat_notification_read">Mark as read</string>
     <string name="stream_chat_notification_channel_id" translatable="false">stream_GetStreamClient</string>
     <string name="stream_chat_notification_channel_name">New chat messages</string>
-    <string name="stream_chat_load_notification_channel_id" translatable="false">stream_GetStreamClientLoadNotification</string>
-    <!--TODO Translate-->
-    <string name="stream_chat_load_notification_channel_name" translatable="false">New chat messages</string>
+    <string name="stream_chat_other_notifications_channel_id" translatable="false">stream_GetStreamClientOther</string>
+    <string name="stream_chat_other_notifications_channel_name">Other notifications</string>
     <string name="stream_chat_load_notification_data_title">Loading notification data</string>
     <string name="stream_chat_notification_group_summary_content_text">You\'ve received new messages</string>
     <string name="stream_chat_error_notification_group_summary_title">Chat messages</string>

--- a/stream-chat-android-client/src/main/res/values/strings.xml
+++ b/stream-chat-android-client/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
     <string name="stream_chat_notification_read">Mark as read</string>
     <string name="stream_chat_notification_channel_id" translatable="false">stream_GetStreamClient</string>
     <string name="stream_chat_notification_channel_name">New chat messages</string>
+    <string name="stream_chat_load_notification_channel_id" translatable="false">stream_GetStreamClientLoadNotification</string>
+    <!--TODO Translate-->
+    <string name="stream_chat_load_notification_channel_name" translatable="false">New chat messages</string>
     <string name="stream_chat_load_notification_data_title">Loading notification data</string>
     <string name="stream_chat_notification_group_summary_content_text">You\'ve received new messages</string>
     <string name="stream_chat_error_notification_group_summary_title">Chat messages</string>


### PR DESCRIPTION
### 🎯 Goal

Add possibility to customize notification channel.

### 🛠 Implementation details

- Added `notificationChannel` lambda parameter to `NotificationHandlerFactory::createNotificationHandler` which is used to create a `NotificationChannel` used for displaying notifications
- Changed the `NotificationChannel` used for displaying `Loading notification data` notification

### 🧪 Testing
Test push notifications on Android <= O and > O.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] ~PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

