### PR TITLE
[3169] Fix scroll to bottom button appearing when it should not

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
@@ -58,7 +58,9 @@ internal class MessageListScrollHelper(
                 }
 
                 override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
-                    if (!scrollToBottomButtonEnabled || currentList.isEmpty()) return
+                    if (!scrollToBottomButtonEnabled || currentList.isEmpty()) {
+                        return
+                    }
 
                     val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
                     val lastPotentiallyVisibleItemPosition = currentList.indexOfLast { it.isValid() }
@@ -132,7 +134,7 @@ internal class MessageListScrollHelper(
     }
 
     internal fun onMessageListChanged(isThreadStart: Boolean, hasNewMessages: Boolean, isInitialList: Boolean) {
-        if (!hasNewMessages || adapter.currentList.isEmpty()) {
+        if (!scrollToBottomButtonEnabled || (!hasNewMessages || adapter.currentList.isEmpty())) {
             return
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/ScrollButtonView.kt
@@ -41,7 +41,7 @@ internal class ScrollButtonView : FrameLayout {
     }
 
     fun setUnreadCount(unreadCount: Int) {
-        if (scrollButtonViewStyle.scrollButtonUnreadEnabled) {
+        if (scrollButtonViewStyle.scrollButtonEnabled && scrollButtonViewStyle.scrollButtonUnreadEnabled) {
             setUnreadCountValue(unreadCount)
             setUnreadCountTextViewVisible(unreadCount > 0)
         } else {


### PR DESCRIPTION
### 🎯 Goal

Fix a bug where a combination of attributes mentioned in [#3169](https://github.com/GetStream/stream-chat-android/issues/3169) resulted in the scroll to bottom button being visible all of the time after a new message was sent.

### 🛠 Implementation details

Fix logic conditions to show the scroll to bottom button only when it is appropriate.

### 🎨 ~~UI Changes~~

**No UI Changes, only functional changes.**

### 🧪 Testing

1. Checkout main or develop and apply the patch
2. Open any channel and send a message to it  from a different account

Result: The scroll to bottom button is now permanently visible

1. Checkout the branch from this PR
2. Open any channel and send a message to it  from a different account

Result: The scroll to bottom button is not visible because it is disabled

```
Index: stream-chat-android-ui-components/src/main/res/values/styles.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/res/values/styles.xml b/stream-chat-android-ui-components/src/main/res/values/styles.xml
--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml	(revision 33af89721345e7a9ae1d2fb3bc60d5b4348c38d0)
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml	(date 1646420555651)
@@ -266,7 +266,7 @@
 
     <style name="StreamUi.MessageList" parent="StreamUi">
         <!-- Scroll button-->
-        <item name="streamUiScrollButtonEnabled">true</item>
+        <item name="streamUiScrollButtonEnabled">false</item>
         <item name="streamUiScrollButtonUnreadEnabled">true</item>
         <item name="streamUiScrollButtonColor">@color/stream_ui_white</item>
         <item name="streamUiScrollButtonRippleColor">@color/stream_ui_white_smoke</item>
```

### ☑️Contributor Checklist

#### General
- [ x Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] ~~PR targets the `develop` branch~~ (targets main because it's a fix intended to be released)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] ~~Comparison screenshots added for visual changes~~
- [ ] ~~Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![scroll](https://user-images.githubusercontent.com/37080097/156826316-c54319f3-c1e1-44bc-b81e-8c9ac6168c5e.gif)

