### PR TITLE
2884 - Remove read status indicators when the last sent message is not from the current user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### 🐞 Fixed
 - Fixed displaying long usernames in message's footnote within `MessageListView`. [#3149](https://github.com/GetStream/stream-chat-android/pull/3149)
 - A bug that made `ScrollButtonView` in `MessageListView` permanently visible. [#3170](https://github.com/GetStream/stream-chat-android/pull/3170)
+- Fixed display of read status indicators [#3181](https://github.com/GetStream/stream-chat-android/pull/3181)
 
 ### ⬆️ Improved
 
@@ -85,6 +86,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Mitigated the effects of `ClickableText` consuming all pointer events when messages contain links by passing long press handlers to `MessageText`. [#3137](https://github.com/GetStream/stream-chat-android/pull/3137)
+- Fixed display of read status indicators [#3181](https://github.com/GetStream/stream-chat-android/pull/3181)
 
 ### ⬆️ Improved
 - Allowed passing long press handlers to `MessageText`. [#3137](https://github.com/GetStream/stream-chat-android/pull/3137)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -234,15 +234,19 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
                 )
             }
 
+            val isLastMessageFromCurrentUser = lastMessage.user.id == currentUser?.id
+
             Row(verticalAlignment = Alignment.CenterVertically) {
-                MessageReadStatusIcon(
-                    channel = channel,
-                    lastMessage = lastMessage,
-                    currentUser = currentUser,
-                    modifier = Modifier
-                        .padding(end = 8.dp)
-                        .size(16.dp)
-                )
+                if (isLastMessageFromCurrentUser) {
+                    MessageReadStatusIcon(
+                        channel = channel,
+                        lastMessage = lastMessage,
+                        currentUser = currentUser,
+                        modifier = Modifier
+                            .padding(end = 8.dp)
+                            .size(16.dp)
+                    )
+                }
 
                 Timestamp(date = channel.lastUpdated)
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -202,7 +202,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureLastMessageLabelAndTimestamp(lastMessage)
                 }
 
-                if (readStateChanged) {
+                if (readStateChanged || lastMessageChanged) {
                     configureCurrentUserLastMessageStatus(lastMessage)
                 }
 
@@ -267,13 +267,18 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         // pending - if the sync status says it's pending
 
         val currentUserSentLastMessage = lastMessage.user.id == ChatDomain.instance().user.value?.id
+        if (!currentUserSentLastMessage) {
+            messageStatusImageView.setImageDrawable(null)
+            return
+        }
+
         val lastMessageByCurrentUserWasRead = channel.isMessageRead(lastMessage)
         when {
-            !currentUserSentLastMessage || lastMessageByCurrentUserWasRead -> {
+            lastMessageByCurrentUserWasRead -> {
                 messageStatusImageView.setImageDrawable(style.indicatorReadIcon)
             }
 
-            currentUserSentLastMessage && !lastMessageByCurrentUserWasRead -> {
+            !lastMessageByCurrentUserWasRead -> {
                 messageStatusImageView.setImageDrawable(style.indicatorSentIcon)
             }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -272,34 +272,21 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             return
         }
 
-        val lastMessageByCurrentUserWasRead = channel.isMessageRead(lastMessage)
-        when {
-            lastMessageByCurrentUserWasRead -> {
-                messageStatusImageView.setImageDrawable(style.indicatorReadIcon)
-            }
+        val messageRequiresSync = lastMessage.syncStatus in setOf(
+            SyncStatus.IN_PROGRESS,
+            SyncStatus.SYNC_NEEDED,
+            SyncStatus.AWAITING_ATTACHMENTS
+        )
 
-            !lastMessageByCurrentUserWasRead -> {
-                messageStatusImageView.setImageDrawable(style.indicatorSentIcon)
-            }
+        val messageStatusIndicatorIcon = if (messageRequiresSync) {
+            style.indicatorPendingSyncIcon
+        } else {
+            val lastMessageWasRead = channel.isMessageRead(lastMessage)
 
-            else -> determineLastMessageSyncStatus(lastMessage)
+            if (lastMessageWasRead) style.indicatorReadIcon else style.indicatorSentIcon
         }
-    }
 
-    private fun StreamUiChannelListItemForegroundViewBinding.determineLastMessageSyncStatus(message: Message) {
-        when (message.syncStatus) {
-            SyncStatus.IN_PROGRESS, SyncStatus.SYNC_NEEDED, SyncStatus.AWAITING_ATTACHMENTS -> {
-                messageStatusImageView.setImageDrawable(style.indicatorPendingSyncIcon)
-            }
-
-            SyncStatus.COMPLETED -> {
-                messageStatusImageView.setImageDrawable(style.indicatorSentIcon)
-            }
-
-            SyncStatus.FAILED_PERMANENTLY -> {
-                // no direction on this yet
-            }
-        }
+        messageStatusImageView.setImageDrawable(messageStatusIndicatorIcon)
     }
 
     private fun StreamUiChannelListItemBackgroundViewBinding.applyStyle(style: ChannelListViewStyle) {

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -66,8 +66,8 @@
 
     <ImageView
         android:id="@+id/messageStatusImageView"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        android:layout_width="16dp"
+        android:layout_height="16dp"
         android:layout_marginEnd="3dp"
         app:layout_constraintBottom_toBottomOf="@+id/lastMessageLabel"
         app:layout_constraintEnd_toStartOf="@+id/lastMessageTimeLabel"


### PR DESCRIPTION
### 🎯 Goal

Fixing wrong behavior. Closes #2884 

### 🛠 Implementation details

We just added checks to show/remove the read status in case the last message is not from the current user.

### 🎨 UI Changes

| Before Filip | Before Amit |
| --- | --- |
| ![Screenshot_1646748750](https://user-images.githubusercontent.com/17215808/157255117-3c388c3a-a017-4748-a73e-ba2080799c35.png) | ![Screenshot_1646748749](https://user-images.githubusercontent.com/17215808/157255085-2254e96a-cac0-4658-a0d8-3d574e833753.png) |

| After Filip | After Amit |
| --- | --- |
| ![Screenshot_1646748702](https://user-images.githubusercontent.com/17215808/157254971-b840ab77-2fa2-4704-9f41-d867145b6619.png) | ![Screenshot_1646748920](https://user-images.githubusercontent.com/17215808/157255385-111b08ce-a3fd-421e-842b-7ca14f2cf9d1.png) |

### 🧪 Testing

1. Run the sample app on develop - all messages with read statuses should show up even if not ours
2. Run the sample app on this branch - only _our_ messages should have read indicators

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
