### PR TITLE
Expose a check if the adapter has been initialized or not in Channel and Message lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - Added a separate `FileAttachmentsViewHolder` for handling messages containing file attachments of different types or file attachments not handled by one of the other `ViewHolder`s. [#3091](https://github.com/GetStream/stream-chat-android/pull/3091)
 - Introduced `AttachmentFactory` as a factory for custom attachment views. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
+- Added a way to check if the adapters and message/channel lists have been initialized or not. [#3182](https://github.com/GetStream/stream-chat-android/pull/3182)
 
 ### ⚠️ Changed
 - Separated the Giphy attachments and content to a GiphyAttachmentViewHolder. [#2932](https://github.com/GetStream/stream-chat-android/pull/2932)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -301,6 +301,7 @@ public final class io/getstream/chat/android/ui/channel/list/ChannelListView : a
 	public final fun hasChannels ()Z
 	public final fun hideLoadingMore ()V
 	public final fun hideLoadingView ()V
+	public final fun isAdapterInitialized ()Z
 	public final fun setChannelDeleteClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
 	public final fun setChannelInfoClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
 	public final fun setChannelItemClickListener (Lio/getstream/chat/android/ui/channel/list/ChannelListView$ChannelClickListener;)V
@@ -1614,6 +1615,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListView : a
 	public final fun hideEmptyStateView ()V
 	public final fun hideLoadingView ()V
 	public final fun init (Lio/getstream/chat/android/client/models/Channel;)V
+	public final fun isAdapterInitialized ()Z
 	public final fun requireStyle ()Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
 	public final fun scrollToMessage (Lio/getstream/chat/android/client/models/Message;)V
 	public final fun setAttachmentClickListener (Lio/getstream/chat/android/ui/message/list/MessageListView$AttachmentClickListener;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListView.kt
@@ -17,6 +17,7 @@ import io.getstream.chat.android.ui.channel.actions.internal.ChannelActionsDialo
 import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelClickListener
 import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelListItemPredicate
 import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelLongClickListener
+import io.getstream.chat.android.ui.channel.list.ChannelListView.ErrorEventHandler
 import io.getstream.chat.android.ui.channel.list.ChannelListView.UserClickListener
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
@@ -95,6 +96,13 @@ public class ChannelListView : FrameLayout {
         }
 
         configureDefaultMoreOptionsListener(context)
+    }
+
+    /**
+     * @return if the list and its adapter are initialized.
+     */
+    public fun isAdapterInitialized(): Boolean {
+        return ::simpleChannelListView.isInitialized && simpleChannelListView.isAdapterInitialized()
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/internal/SimpleChannelListView.kt
@@ -179,6 +179,13 @@ internal class SimpleChannelListView @JvmOverloads constructor(
         return requireAdapter().itemCount > 0
     }
 
+    /**
+     * @return if the adapter is initialized.
+     */
+    fun isAdapterInitialized(): Boolean {
+        return ::adapter.isInitialized
+    }
+
     internal fun getChannel(cid: String): Channel = adapter.getChannel(cid)
 
     override fun onVisibilityChanged(view: View, visibility: Int) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -599,7 +599,7 @@ public class MessageListView : ConstraintLayout {
     }
 
     override fun onDetachedFromWindow() {
-        if (this::adapter.isInitialized) {
+        if (isAdapterInitialized()) {
             adapter.onDetachedFromRecyclerView(binding.chatMessagesRV)
         }
         attachmentGalleryDestination.unregister()
@@ -899,7 +899,7 @@ public class MessageListView : ConstraintLayout {
      * @param messageListItemViewHolderFactory The custom factory to be used when generating item ViewHolders.
      */
     public fun setMessageViewHolderFactory(messageListItemViewHolderFactory: MessageListItemViewHolderFactory) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized, please set MessageViewHolderFactory first"
         }
         this.messageListItemViewHolderFactory = messageListItemViewHolderFactory
@@ -912,7 +912,7 @@ public class MessageListView : ConstraintLayout {
      * @param messageBackgroundFactory The custom factory that provides drawables to be used in the messages background
      */
     public fun setMessageBackgroundFactory(messageBackgroundFactory: MessageBackgroundFactory) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized, please set MessageBackgroundFactory first"
         }
         this.messageBackgroundFactory = messageBackgroundFactory
@@ -924,7 +924,7 @@ public class MessageListView : ConstraintLayout {
      * @param messageDateFormatter The formatter that is used to format the message date.
      */
     public fun setMessageDateFormatter(messageDateFormatter: DateFormatter) {
-        check(::adapter.isInitialized.not()) { "Adapter was already initialized; please set DateFormatter first" }
+        check(isAdapterInitialized().not()) { "Adapter was already initialized; please set DateFormatter first" }
         this.messageDateFormatter = messageDateFormatter
     }
 
@@ -934,7 +934,7 @@ public class MessageListView : ConstraintLayout {
      * @param showAvatarPredicate The predicate that checks if the avatar should be shown.
      */
     public fun setShowAvatarPredicate(showAvatarPredicate: ShowAvatarPredicate) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized; please set ShowAvatarPredicate first"
         }
         this.showAvatarPredicate = showAvatarPredicate
@@ -956,7 +956,7 @@ public class MessageListView : ConstraintLayout {
      * @param messageListItemPredicate The predicate used to filter the list of [MessageListItem].
      */
     public fun setMessageListItemPredicate(messageListItemPredicate: MessageListItemPredicate) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized, please set MessageListItemPredicate first"
         }
         this.messageListItemPredicate = messageListItemPredicate
@@ -980,7 +980,7 @@ public class MessageListView : ConstraintLayout {
      * Alternatively you can pass your custom implementation by implementing the [MessageListItemPredicate] interface.
      */
     public fun setDeletedMessageListItemPredicate(deletedMessageListItemPredicate: MessageListItemPredicate) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized, please set MessageListItemPredicate first"
         }
         this.deletedMessageListItemPredicate = deletedMessageListItemPredicate
@@ -994,7 +994,7 @@ public class MessageListView : ConstraintLayout {
      * @param attachmentFactoryManager Hold the list of factories for custom attachments.
      */
     public fun setAttachmentFactoryManager(attachmentFactoryManager: AttachmentFactoryManager) {
-        check(::adapter.isInitialized.not()) {
+        check(isAdapterInitialized().not()) {
             "Adapter was already initialized, please set attachment factories first"
         }
         this.attachmentFactoryManager = attachmentFactoryManager
@@ -1083,6 +1083,13 @@ public class MessageListView : ConstraintLayout {
                 messagesRV.overScrollMode = View.OVER_SCROLL_ALWAYS
             }
         }
+    }
+
+    /**
+     * @return if the adapter has been initialized or not.
+     */
+    public fun isAdapterInitialized(): Boolean {
+        return ::adapter.isInitialized
     }
 
     //region Listener setters


### PR DESCRIPTION
Fixes #3175 

### 🎯 Goal

Some users require a way to check if the message or channel lists have been initialized (we generally check if the adapter exists for this).

This is required to let them build custom auth logic and show some info only when the data is ready.

### 🛠 Implementation details

Exposed a simple function that tells us if the adapter is initialized or not in these lists.

### 🧪 Testing

No real test, can just call it from the outside before and after binding the data/showing items.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
