### PR TITLE
[3109] Rename inner attachment ViewHolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,8 @@
 ### ✅ Added
 - Added a separate `LinkAttachmentsViewHolder` for handling messages containing link attachments and no other types of attachments. [#3070](https://github.com/GetStream/stream-chat-android/pull/3070)
 - Added a separate `FileAttachmentsViewHolder` for handling messages containing file attachments of different types or file attachments not handled by one of the other `ViewHolder`s. [#3091](https://github.com/GetStream/stream-chat-android/pull/3091)
-- Introduced `AttachmentFactory` as a factory for custom attachment views. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
+- Introduced `InnerAttachmentViewHolder` as an inner ViewHolder for custom attachments. [#3183](https://github.com/GetStream/stream-chat-android/pull/3183)
+- Introduced `AttachmentFactory` as a factory for custom attachment ViewHolders. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 
 ### ⚠️ Changed

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Messages.java
@@ -33,7 +33,7 @@ import io.getstream.chat.android.ui.message.list.MessageListView;
 import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainer;
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactoryManager;
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactory;
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentViewHolder;
+import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.InnerAttachmentViewHolder;
 import io.getstream.chat.docs.java.helpers.MyFileUploader;
 
 public class Messages {
@@ -450,20 +450,20 @@ public class Messages {
 
             @NonNull
             @Override
-            public AttachmentViewHolder createViewHolder(@NonNull Message message,
-                                                         @Nullable MessageListListenerContainer listeners,
-                                                         @NonNull ViewGroup parent) {
+            public InnerAttachmentViewHolder createViewHolder(@NonNull Message message,
+                                                              @Nullable MessageListListenerContainer listeners,
+                                                              @NonNull ViewGroup parent) {
                 // put your custom attachment view creation here
-                return new CustomAttachmentsViewHolder(new TextView(parent.getContext()), listeners);
+                return new CustomInnerAttachmentsViewHolder(new TextView(parent.getContext()), listeners);
             }
         }
 
-        private class CustomAttachmentsViewHolder extends AttachmentViewHolder {
+        private class CustomInnerAttachmentsViewHolder extends InnerAttachmentViewHolder {
 
             private Message message;
             private TextView textView;
 
-            public CustomAttachmentsViewHolder(@NonNull TextView textView,
+            public CustomInnerAttachmentsViewHolder(@NonNull TextView textView,
                                                MessageListListenerContainer listeners) {
                 super(textView);
                 this.textView = textView;

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Messages.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Messages.kt
@@ -20,7 +20,7 @@ import io.getstream.chat.android.ui.message.list.MessageListView
 import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactory
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactoryManager
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentViewHolder
+import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.InnerAttachmentViewHolder
 import io.getstream.chat.docs.kotlin.helpers.MyFileUploader
 import java.io.File
 import java.util.Calendar
@@ -476,16 +476,16 @@ class Messages(
                 message: Message,
                 listeners: MessageListListenerContainer?,
                 parent: ViewGroup,
-            ): AttachmentViewHolder {
+            ): InnerAttachmentViewHolder {
                 // put your custom attachment view creation here
-                return CustomAttachmentViewHolder(TextView(parent.context), listeners)
+                return CustomInnerAttachmentViewHolder(TextView(parent.context), listeners)
             }
         }
 
-        private inner class CustomAttachmentViewHolder(
+        private inner class CustomInnerAttachmentViewHolder(
             private val textView: TextView,
             listeners: MessageListListenerContainer?,
-        ) : AttachmentViewHolder(textView) {
+        ) : InnerAttachmentViewHolder(textView) {
 
             private lateinit var message: Message
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2121,7 +2121,7 @@ public final class io/getstream/chat/android/ui/message/list/adapter/view/intern
 
 public abstract interface class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactory {
 	public abstract fun canHandle (Lio/getstream/chat/android/client/models/Message;)Z
-	public abstract fun createViewHolder (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Landroid/view/ViewGroup;)Lio/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewHolder;
+	public abstract fun createViewHolder (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Landroid/view/ViewGroup;)Lio/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/InnerAttachmentViewHolder;
 }
 
 public final class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactoryManager {
@@ -2129,10 +2129,10 @@ public final class io/getstream/chat/android/ui/message/list/adapter/viewholder/
 	public fun <init> (Ljava/util/List;)V
 	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun canHandle (Lio/getstream/chat/android/client/models/Message;)Z
-	public final fun createViewHolder (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Landroid/view/ViewGroup;)Lio/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewHolder;
+	public final fun createViewHolder (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/ui/message/list/adapter/MessageListListenerContainer;Landroid/view/ViewGroup;)Lio/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/InnerAttachmentViewHolder;
 }
 
-public abstract class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentViewHolder {
+public abstract class io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/InnerAttachmentViewHolder {
 	public fun <init> (Landroid/view/View;)V
 	public final fun getContext ()Landroid/content/Context;
 	public final fun getItemView ()Landroid/view/View;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactory.kt
@@ -31,5 +31,5 @@ public interface AttachmentFactory {
         message: Message,
         listeners: MessageListListenerContainer?,
         parent: ViewGroup,
-    ): AttachmentViewHolder
+    ): InnerAttachmentViewHolder
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactoryManager.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/AttachmentFactoryManager.kt
@@ -33,7 +33,7 @@ public class AttachmentFactoryManager(
         message: Message,
         listeners: MessageListListenerContainer?,
         parent: ViewGroup,
-    ): AttachmentViewHolder {
+    ): InnerAttachmentViewHolder {
         val factory = attachmentFactories.first { it.canHandle(message) }
         return factory.createViewHolder(message, listeners, parent)
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/InnerAttachmentViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/attachment/InnerAttachmentViewHolder.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.client.models.Message
  *
  * @param itemView The view that this ViewHolder controls.
  */
-public abstract class AttachmentViewHolder(public val itemView: View) {
+public abstract class InnerAttachmentViewHolder(public val itemView: View) {
     public val context: Context = itemView.context
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/CustomAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/CustomAttachmentsViewHolder.kt
@@ -12,7 +12,7 @@ import io.getstream.chat.android.ui.message.list.adapter.MessageListItemPayloadD
 import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.message.list.adapter.internal.DecoratedBaseMessageItemViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactoryManager
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentViewHolder
+import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.InnerAttachmentViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.decorator.internal.Decorator
 import io.getstream.chat.android.ui.transformer.ChatMessageTextTransformer
 
@@ -42,7 +42,7 @@ internal class CustomAttachmentsViewHolder(
     /**
      * The inner ViewHolder with custom attachments.
      */
-    private var attachmentViewHolder: AttachmentViewHolder? = null
+    private var innerAttachmentViewHolder: InnerAttachmentViewHolder? = null
 
     /**
      * Initializes the ViewHolder class.
@@ -81,7 +81,7 @@ internal class CustomAttachmentsViewHolder(
      * Updates the custom attachments section of the message.
      */
     private fun bindCustomAttachments(data: MessageListItem.MessageItem) {
-        this.attachmentViewHolder = attachmentFactoryManager.createViewHolder(data.message, listeners, binding.root)
+        this.innerAttachmentViewHolder = attachmentFactoryManager.createViewHolder(data.message, listeners, binding.root)
             .also { attachmentViewHolder ->
                 attachmentViewHolder.onBindViewHolder(data.message)
                 binding.attachmentsContainer.removeAllViews()
@@ -138,7 +138,7 @@ internal class CustomAttachmentsViewHolder(
      * Called when a view in this ViewHolder has been recycled.
      */
     override fun unbind() {
-        attachmentViewHolder?.onUnbindViewHolder()
+        innerAttachmentViewHolder?.onUnbindViewHolder()
         super.unbind()
     }
 
@@ -146,13 +146,13 @@ internal class CustomAttachmentsViewHolder(
      * Called when a view in this ViewHolder has been attached to a window.
      */
     override fun onDetachedFromWindow() {
-        attachmentViewHolder?.onViewDetachedFromWindow()
+        innerAttachmentViewHolder?.onViewDetachedFromWindow()
     }
 
     /**
      * Called when a view in this ViewHolder has been detached from its window.
      */
     override fun onAttachedToWindow() {
-        attachmentViewHolder?.onViewAttachedToWindow()
+        innerAttachmentViewHolder?.onViewAttachedToWindow()
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Choose a more descriptive name for the `AttachmentViewHolder`.

### 🛠 Implementation details

Renamed the class to `InnerAttachmentViewHolder` to indicate that it doesn't represent an individual ViewHolder. It represents just an inner ViewHolder delegate with the lifecycle of the outer ViewHolder.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
