### PR TITLE
Allow customizing retry message action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Introduced `InnerAttachmentViewHolder` as an inner ViewHolder for custom attachments. [#3183](https://github.com/GetStream/stream-chat-android/pull/3183)
 - Introduced `AttachmentFactory` as a factory for custom attachment ViewHolders. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
+- Added `streamUiRetryMessageActionEnabled` attribute to `MessageListView` that allows to show/hide retry action in message's overlay. []()
 
 ### ⚠️ Changed
 - Separated the Giphy attachments and content to a GiphyAttachmentViewHolder. [#2932](https://github.com/GetStream/stream-chat-android/pull/2932)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - Introduced `AttachmentFactory` as a factory for custom attachment ViewHolders. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Added a way to check if the adapters and message/channel lists have been initialized or not. [#3182](https://github.com/GetStream/stream-chat-android/pull/3182)
-- Added `streamUiRetryMessageActionEnabled` attribute to `MessageListView` that allows to show/hide retry action in message's overlay. [#3185](https://github.com/GetStream/stream-chat-android/pull/3185)
+- Added `streamUiRetryMessageEnabled` attribute to `MessageListView` that allows to show/hide retry action in message's overlay. [#3185](https://github.com/GetStream/stream-chat-android/pull/3185)
 
 ### ⚠️ Changed
 - Separated the Giphy attachments and content to a GiphyAttachmentViewHolder. [#2932](https://github.com/GetStream/stream-chat-android/pull/2932)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,7 +70,7 @@
 - Introduced `AttachmentFactory` as a factory for custom attachment ViewHolders. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Added a way to check if the adapters and message/channel lists have been initialized or not. [#3182](https://github.com/GetStream/stream-chat-android/pull/3182)
-- Added `streamUiRetryMessageActionEnabled` attribute to `MessageListView` that allows to show/hide retry action in message's overlay. []()
+- Added `streamUiRetryMessageActionEnabled` attribute to `MessageListView` that allows to show/hide retry action in message's overlay. [#3185](https://github.com/GetStream/stream-chat-android/pull/3185)
 
 ### ⚠️ Changed
 - Separated the Giphy attachments and content to a GiphyAttachmentViewHolder. [#2932](https://github.com/GetStream/stream-chat-android/pull/2932)

--- a/docusaurus/docs/Android/03-ui/05-components/05-message-list.mdx
+++ b/docusaurus/docs/Android/03-ui/05-components/05-message-list.mdx
@@ -236,7 +236,7 @@ Some xml attributes let you to enable/disable features in `MessageListView`.
 - `streamUiReactionsEnabled` - whether users can react to messages
 - `streamUiReplyEnabled` - whether users can reply to messages
 - `streamUiCopyMessageActionEnabled` - whether users can copy messages
-- `streamUiRetryMessageActionEnabled` - whether users can retry failed messages
+- `streamUiRetryMessageEnabled` - whether users can retry failed messages
 - `streamUiEditMessageEnabled` - whether users can edit their messages
 - `streamUiFlagMessageEnabled` - whether users can flag messages
 - `streamUiFlagMessageConfirmationEnabled` - whether users will see the confirmation dialog when flag messages

--- a/docusaurus/docs/Android/03-ui/05-components/05-message-list.mdx
+++ b/docusaurus/docs/Android/03-ui/05-components/05-message-list.mdx
@@ -236,6 +236,7 @@ Some xml attributes let you to enable/disable features in `MessageListView`.
 - `streamUiReactionsEnabled` - whether users can react to messages
 - `streamUiReplyEnabled` - whether users can reply to messages
 - `streamUiCopyMessageActionEnabled` - whether users can copy messages
+- `streamUiRetryMessageActionEnabled` - whether users can retry failed messages
 - `streamUiEditMessageEnabled` - whether users can edit their messages
 - `streamUiFlagMessageEnabled` - whether users can flag messages
 - `streamUiFlagMessageConfirmationEnabled` - whether users will see the confirmation dialog when flag messages

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1844,7 +1844,7 @@ public abstract interface class io/getstream/chat/android/ui/message/list/Messag
 }
 
 public final class io/getstream/chat/android/ui/message/list/MessageListViewStyle {
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;III)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;III)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public final fun component10 ()I
 	public final fun component11 ()Z
@@ -1869,24 +1869,25 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun component29 ()Z
 	public final fun component3 ()Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;
 	public final fun component30 ()Z
-	public final fun component31 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component31 ()Z
 	public final fun component32 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component33 ()I
+	public final fun component33 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component34 ()I
-	public final fun component35 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component36 ()I
-	public final fun component37 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component38 ()I
+	public final fun component35 ()I
+	public final fun component36 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component37 ()I
+	public final fun component38 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component39 ()I
 	public final fun component4 ()Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;
 	public final fun component40 ()I
+	public final fun component41 ()I
 	public final fun component5 ()Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;
 	public final fun component6 ()Z
 	public final fun component7 ()I
 	public final fun component8 ()I
 	public final fun component9 ()Z
-	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;III)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;III)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getBlockEnabled ()Z
@@ -1918,6 +1919,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun getReplyIcon ()I
 	public final fun getReplyMessageStyle ()Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;
 	public final fun getRetryIcon ()I
+	public final fun getRetryMessageEnabled ()Z
 	public final fun getScrollButtonBehaviour ()Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;
 	public final fun getScrollButtonViewStyle ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public final fun getThreadMessagesStart ()I

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -273,7 +273,7 @@ public data class MessageListViewStyle(
                     attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
 
                 val retryMessageEnabled =
-                    attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageActionEnabled, true)
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageEnabled, true)
 
                 val deleteConfirmationEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -49,6 +49,7 @@ import io.getstream.chat.android.ui.message.list.internal.ScrollButtonView
  * @property deleteIcon Icon for delete message option. Default value is [R.drawable.stream_ui_ic_delete].
  * @property deleteMessageEnabled Enables/disables delete message feature. Enabled by default.
  * @property copyTextEnabled Enables/disables copy text feature. Enabled by default.
+ * @property retryMessageEnabled Enables/disables retry failed message feature. Enabled by default.
  * @property deleteConfirmationEnabled Enables/disables showing confirmation dialog before deleting message. Enabled by default.
  * @property flagMessageConfirmationEnabled Enables/disables showing confirmation dialog before flagging message. Disabled by default.
  * @property messageOptionsText Text appearance of message option items.
@@ -91,6 +92,7 @@ public data class MessageListViewStyle(
     val deleteIcon: Int,
     val deleteMessageEnabled: Boolean,
     val copyTextEnabled: Boolean,
+    val retryMessageEnabled: Boolean,
     val deleteConfirmationEnabled: Boolean,
     val flagMessageConfirmationEnabled: Boolean,
     val messageOptionsText: TextStyle,
@@ -270,6 +272,9 @@ public data class MessageListViewStyle(
                 val copyTextEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
 
+                val retryMessageEnabled =
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageActionEnabled, true)
+
                 val deleteConfirmationEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiDeleteConfirmationEnabled, true)
 
@@ -398,6 +403,7 @@ public data class MessageListViewStyle(
                     blockEnabled = blockEnabled,
                     deleteIcon = deleteIcon,
                     copyTextEnabled = copyTextEnabled,
+                    retryMessageEnabled = retryMessageEnabled,
                     deleteConfirmationEnabled = deleteConfirmationEnabled,
                     flagMessageConfirmationEnabled = flagMessageConfirmationEnabled,
                     deleteMessageEnabled = deleteMessageEnabled,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -112,7 +112,7 @@ internal class MessageOptionsView : FrameLayout {
                     style.retryIcon,
                 )
 
-                binding.retryTV.isVisible = true
+                binding.retryTV.isVisible = style.retryMessageEnabled
                 binding.threadReplyTV.isVisible = false
             }
             SyncStatus.COMPLETED -> {
@@ -236,6 +236,7 @@ internal class MessageOptionsView : FrameLayout {
         val pinMessageEnabled: Boolean,
         val muteEnabled: Boolean,
         val blockEnabled: Boolean,
+        val retryMessageEnabled: Boolean,
     ) : Serializable {
         internal companion object {
             operator fun invoke(
@@ -256,6 +257,7 @@ internal class MessageOptionsView : FrameLayout {
                     pinMessageEnabled = viewStyle.pinMessageEnabled,
                     muteEnabled = viewStyle.muteEnabled,
                     blockEnabled = viewStyle.blockEnabled,
+                    retryMessageEnabled = viewStyle.retryMessageEnabled,
                 )
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -252,6 +252,7 @@
         <attr name="streamUiReplyOptionIcon" format="reference" />
         <attr name="streamUiReplyEnabled" format="boolean" />
         <attr name="streamUiCopyMessageActionEnabled" format="boolean" />
+        <attr name="streamUiRetryMessageActionEnabled" format="boolean" />
         <attr name="streamUiCopyOptionIcon" format="reference" />
         <attr name="streamUiEditOptionIcon" format="reference" />
         <attr name="streamUiEditMessageEnabled" format="boolean" />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -252,7 +252,7 @@
         <attr name="streamUiReplyOptionIcon" format="reference" />
         <attr name="streamUiReplyEnabled" format="boolean" />
         <attr name="streamUiCopyMessageActionEnabled" format="boolean" />
-        <attr name="streamUiRetryMessageActionEnabled" format="boolean" />
+        <attr name="streamUiRetryMessageEnabled" format="boolean" />
         <attr name="streamUiCopyOptionIcon" format="reference" />
         <attr name="streamUiEditOptionIcon" format="reference" />
         <attr name="streamUiEditMessageEnabled" format="boolean" />

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -411,7 +411,7 @@
         <item name="streamUiReplyOptionIcon">@drawable/stream_ui_ic_arrow_curve_left_grey</item>
         <item name="streamUiReplyEnabled">true</item>
         <item name="streamUiCopyMessageActionEnabled">true</item>
-        <item name="streamUiRetryMessageActionEnabled">true</item>
+        <item name="streamUiRetryMessageEnabled">true</item>
         <item name="streamUiCopyOptionIcon">@drawable/stream_ui_ic_copy</item>
         <item name="streamUiEditOptionIcon">@drawable/stream_ui_ic_edit</item>
         <item name="streamUiEditMessageEnabled">true</item>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -411,6 +411,7 @@
         <item name="streamUiReplyOptionIcon">@drawable/stream_ui_ic_arrow_curve_left_grey</item>
         <item name="streamUiReplyEnabled">true</item>
         <item name="streamUiCopyMessageActionEnabled">true</item>
+        <item name="streamUiRetryMessageActionEnabled">true</item>
         <item name="streamUiCopyOptionIcon">@drawable/stream_ui_ic_copy</item>
         <item name="streamUiEditOptionIcon">@drawable/stream_ui_ic_edit</item>
         <item name="streamUiEditMessageEnabled">true</item>


### PR DESCRIPTION
### 🎯 Goal
Allow customizing retry message action

### 🛠 Implementation details
Added `streamUiRetryMessageEnabled` attribute to `MessageListView` which is `true` by defauly.

### 🧪 Testing
1. Apply the patch. It will disable `retry message` option and mark every message sent by the current user as failed
2. Check that option is not visible
3. Go to `fragment_chat` and change flag to `true`
4. Check that option is available

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt	(revision 62f9c4c5e9f88d0986610d7f882e01475022d346)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt	(date 1646822913844)
@@ -3,6 +3,7 @@
 package io.getstream.chat.android.ui.message.list.viewmodel
 
 import androidx.lifecycle.LifecycleOwner
+import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.BlockUser
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.DeleteMessage
@@ -16,6 +17,7 @@
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.ReplyMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.RetryMessage
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel.Event.ThreadModeEntered
+import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.livedata.utils.EventObserver
 import io.getstream.chat.android.ui.gallery.toAttachment
 import io.getstream.chat.android.ui.message.list.MessageListView
@@ -65,7 +67,19 @@
                 } else {
                     view.hideEmptyStateView()
                 }
-                view.displayNewMessages(state.messageListItem)
+                view.displayNewMessages(
+                    state.messageListItem.copy(
+                        items = state.messageListItem.items.map {
+                            if (it is MessageListItem.MessageItem && it.isMine) {
+                                it.apply {
+                                    message.syncStatus = SyncStatus.FAILED_PERMANENTLY
+                                }
+                            } else {
+                                it
+                            }
+                        }
+                    )
+                )
                 view.hideLoadingView()
             }
             MessageListViewModel.State.NavigateUp -> Unit // Not handled here
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 62f9c4c5e9f88d0986610d7f882e01475022d346)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1646822913843)
@@ -27,6 +27,7 @@
         app:streamUiFlagMessageConfirmationEnabled="true"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="true"
+        app:streamUiRetryMessageEnabled="false"
         />
 
     <io.getstream.chat.android.ui.message.input.MessageInputView

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
