### PR TITLE
[3217] Add support for message delivery indicator in the message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@
 
 ### ✅ Added
 - Added code snippets from the Compose documentation to the `stream-chat-android-docs` module. [3197](https://github.com/GetStream/stream-chat-android/pull/3197)
+- Added support for delivery indicator in the message list. [#3218](https://github.com/GetStream/stream-chat-android/pull/3218)
 
 ### ⚠️ Changed
 - Replaced the `reactionTypes` field in `ChatTheme` with the new `reactionIconFactory` field that allows customizing reaction icons. [#3046](https://github.com/GetStream/stream-chat-android/pull/3046)

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -347,8 +347,8 @@ public final class io/getstream/chat/android/compose/state/messages/list/Message
 
 public final class io/getstream/chat/android/compose/state/messages/list/MessageItemState : io/getstream/chat/android/compose/state/messages/list/MessageListItemState {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;Z)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/Message;
 	public final fun component2 ()Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;
 	public final fun component3 ()Ljava/lang/String;
@@ -356,8 +356,9 @@ public final class io/getstream/chat/android/compose/state/messages/list/Message
 	public final fun component5 ()Lio/getstream/chat/android/compose/state/messages/list/MessageFocusState;
 	public final fun component6 ()Z
 	public final fun component7 ()Lio/getstream/chat/android/client/models/User;
-	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;)Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;
+	public final fun component8 ()Z
+	public final fun copy (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;Z)Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/compose/state/messages/list/MessageItemGroupPosition;Ljava/lang/String;ZLio/getstream/chat/android/compose/state/messages/list/MessageFocusState;ZLio/getstream/chat/android/client/models/User;ZILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/list/MessageItemState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentUser ()Lio/getstream/chat/android/client/models/User;
 	public final fun getFocusState ()Lio/getstream/chat/android/compose/state/messages/list/MessageFocusState;
@@ -366,6 +367,7 @@ public final class io/getstream/chat/android/compose/state/messages/list/Message
 	public final fun getParentMessageId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun isInThread ()Z
+	public final fun isMessageRead ()Z
 	public final fun isMine ()Z
 	public fun toString ()Ljava/lang/String;
 }
@@ -886,6 +888,7 @@ public final class io/getstream/chat/android/compose/ui/components/channels/Comp
 
 public final class io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIconKt {
 	public static final fun MessageReadStatusIcon (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageReadStatusIcon (Lio/getstream/chat/android/client/models/Message;ZLandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/UnreadCountIndicatorKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/list/MessageListItemState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/list/MessageListItemState.kt
@@ -40,6 +40,7 @@ public data class SystemMessageState(val message: Message) : MessageListItemStat
  * @param focusState The focus state of the message.
  * @param isInThread If the message is being displayed in a thread.
  * @param currentUser The currently logged in user.
+ * @param isMessageRead If the message is read by any member.
  */
 public data class MessageItemState(
     val message: Message,
@@ -49,4 +50,5 @@ public data class MessageItemState(
     val focusState: MessageFocusState? = null,
     val isInThread: Boolean = false,
     val currentUser: User? = null,
+    val isMessageRead: Boolean = false,
 ) : MessageListItemState()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -240,7 +240,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
                 if (isLastMessageFromCurrentUser) {
                     MessageReadStatusIcon(
                         channel = channel,
-                        lastMessage = lastMessage,
+                        message = lastMessage,
                         currentUser = currentUser,
                         modifier = Modifier
                             .padding(end = 8.dp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -12,6 +12,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.list.MessageItemGroupPosition
 import io.getstream.chat.android.compose.state.messages.list.MessageItemState
 import io.getstream.chat.android.compose.ui.components.Timestamp
+import io.getstream.chat.android.compose.ui.components.channels.MessageReadStatusIcon
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
 /**
@@ -50,6 +51,12 @@ public fun MessageFooter(messageItem: MessageItemState) {
                     text = message.user.name,
                     style = ChatTheme.typography.footnote,
                     color = ChatTheme.colors.textLowEmphasis
+                )
+            } else {
+                MessageReadStatusIcon(
+                    modifier = Modifier.padding(end = 4.dp),
+                    message = messageItem.message,
+                    isMessageRead = messageItem.isMessageRead
                 )
             }
 


### PR DESCRIPTION
### 🎯 Goal

Implement message delivery indicator in the message list.

### 🎨 UI Changes

https://user-images.githubusercontent.com/9600921/158708776-7ff004cc-4563-459d-8781-31c3064d2ec0.mp4

### 🧪 Testing

1. Send a message
2. Read the message from another client
3. Observe that the message was read

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
