### PR TITLE
Postponing API call, but not plugins apply

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1346,17 +1346,16 @@ public class ChatClient internal constructor(
      */
     @CheckResult
     public fun queryChannels(request: QueryChannelsRequest): Call<List<Channel>> {
-        return queryChannelsPostponeHelper.postponeQueryChannels {
-            val relevantPlugins = plugins.filterIsInstance<QueryChannelsListener>()
+        val relevantPlugins = plugins.filterIsInstance<QueryChannelsListener>()
 
+        return queryChannelsPostponeHelper.postponeQueryChannels {
             api.queryChannels(request)
-                .doOnStart(scope) {
-                    relevantPlugins.forEach { it.onQueryChannelsRequest(request) }
-                }
-                .doOnResult(scope) { result ->
-                    relevantPlugins.forEach { it.onQueryChannelsResult(result, request) }
-                }
-                .precondition(relevantPlugins) { onQueryChannelsPrecondition(request) }
+        }.doOnStart(scope) {
+            relevantPlugins.forEach { it.onQueryChannelsRequest(request) }
+        }.doOnResult(scope) { result ->
+            relevantPlugins.forEach { it.onQueryChannelsResult(result, request) }
+        }.precondition(relevantPlugins) {
+            onQueryChannelsPrecondition(request)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix QueryChannels.

### 🛠 Implementation details

`QueryChannelsPostponeHelper` has to be applied only in the API call, but not in the plugins. Otherwise, the database call (and any other plugin) will be postponed too. In our current case, that stops data from being fetched from database. 

### 🎨 UI Changes


<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/158478457-e5e99857-45dc-4c19-a785-bb01d55ccb21.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/158478632-e41c4839-9005-465b-ab6d-40daa24ba638.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Do the test in the video.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- ~ [] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy (2)](https://user-images.githubusercontent.com/10619102/158478760-7e8bf460-e4fc-4c52-af2d-f13a51218a2a.gif)
