### PR TITLE
Add ChatDomain migration guide

### DIFF
--- a/docusaurus/docs/Android/02-client/06-guides/06-offline-support.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/06-offline-support.mdx
@@ -48,7 +48,7 @@ val channelState = chatClient.state.channel(channelType = "messaging", channelId
 val threadState = chatClient.state.thread(messageId = "parentMessageId")
 
 // Gives you access to GlobalState object
-chatClient.globalState
+val globalState = chatClient.globalState
 ```
 
 :::warning

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -44,7 +44,7 @@ chatDomain.sendMessage(message).enqueue { result ->
 ```
 
 In the new approach, all the operations should be performed using the `ChatClient` so you don't need to bother yourself whether to use `ChatDomain` or `ChatClient`.
-You can use the snippet below to send a message using the new approach:
+You can use the snippet below to send a message:
 
 ```kotlin
 val message = Message(cid = cid, text = messageText)

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -71,7 +71,7 @@ We've renamed the objects used to obtain a state:
 - `QueryChannelsController` was replaced by [`QueryChannelsState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/querychannels/QueryChannelsState.kt) .
 - `ChannelController` was replaced by [`ChannelState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/ChannelState.kt).
 - `ThreadController` was replaced by [`ThreadState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/thread/ThreadState.kt).
-- Global state available through `ChatDomain` object can be now obtained from [`GlobalState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/global/GlobalState.kt) object.
+- Global state available through `ChatDomain` can be now obtained from [`GlobalState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/global/GlobalState.kt).
 
 You can access the objects mentioned above like this:
 

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -133,6 +133,30 @@ ChatClient.instance().updateMessage(messageToUpdate).enqueue { result ->
 }
 ```
 
+and `leaveChannel` was replaced by `removeMembers`:
+
+```kotlin
+// Old approach
+ChatDomain.instance().leaveChannel(cid).enqueue { result ->
+    if (result.isSuccess) {
+        // Handle success
+    } else {
+        // Handle error
+    }
+}
+
+// New approach
+chatClient.getCurrentUser()?.let { currentUser ->
+    ChatClient.instance().channel(cid).removeMembers(listOf(currentUser.id)).enqueue { result ->
+        if (result.isSuccess) {
+            // Handle success
+        } else {
+            // Handle error
+        }
+    }
+}
+```
+
 The same applies to the method's parameters as some of them were changed.
 [Here](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt) you can find the list of available methods.
 

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -1,0 +1,143 @@
+# ChatDomain Migration
+
+**v5.0.0** release brings a big change to the offline support library - it replaces `ChatDomain` with a new, easy-to-use `OfflinePlugin`.
+You can read more about motivation and featured changes in the [announcement blog post](https://getstream.io/blog/).  <!--TODO: Replace with a real link -->
+
+The guide will help you with migrating from version `4.X.X` to `5.X.X`.
+
+### Initialization
+
+Compared to `ChatDomain`, which was a standalone singleton with its own API, the `OfflinePlugin` is a plugin that should be provided to the `ChatClient.Builder`:
+
+```kotlin
+val offlinePluginFactory = StreamOfflinePluginFactory(
+    config = Config(
+        backgroundSyncEnabled = true,
+        userPresence = true,
+        persistenceEnabled = true,
+        uploadAttachmentsNetworkType = UploadAttachmentsNetworkType.NOT_ROAMING,
+    ),
+    appContext = context,
+)
+
+ChatClient.Builder(apiKey, context).withPlugin(offlinePluginFactory).build()
+```
+
+From this point, the caching mechanism will be enabled and you'll have access to state objects.
+
+You can read more about the initialization process in [Getting Started](../../01-basics/03-getting-started.mdx#adding-an-offline-plugin) page.
+
+### Requesting Data
+
+`ChatDomain` was mirroring some of the `ChatClient` API but adding offline support. For example, if you wanted to send a message with offline support, you were supposed to call:
+
+```kotlin
+val message = Message(cid = cid, text = "New message")
+
+chatDomain.sendMessage(message).enqueue { result ->
+    if (result.isSuccess) {
+        // Handle success
+    } else {
+        // Handler error
+    }
+}
+```
+
+In the new approach, all the operations should be performed using the `ChatClient` so you don't need to bother yourself whether to use `ChatDomain` or `ChatClient`.
+You can use the snippet below to send a message using the new approach:
+
+```kotlin
+val message = Message(cid = cid, text = messageText)
+
+chatClient.channel(cid).sendMessage(message).enqueue { result ->
+    if (result.isSuccess) {
+        // Handle success
+    } else {
+        // Handle error
+    }
+}
+```
+
+:::note
+`chatClient.channel(cid)` returns a `ChannelClient` that uses `ChatClient` under the hood and simplifies performing actions in particular channel.
+:::
+
+The approach mentioned above can be applied to all API-call-related `ChatDomain` methods.
+
+### Observing the State
+
+We've renamed the objects used to obtain a state:
+
+- `QueryChannelsController` was replaced by [`QueryChannelsState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/querychannels/QueryChannelsState.kt) .
+- `ChannelController` was replaced by [`ChannelState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/ChannelState.kt).
+- `ThreadController` was replaced by [`ThreadState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/thread/ThreadState.kt).
+- Global state available through `ChatDomain` object can be now obtained from [`GlobalState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/global/GlobalState.kt) object.
+
+You can access the objects mentioned above like this:
+
+```kotlin
+// Returns QueryChannelsState object based on filter and sort used to query channels
+val queryChannelsState = chatClient.state.queryChannels(filter = filter, sort = sort)
+
+// Returns ChannelState object for a given channel
+val channelState = chatClient.state.channel(channelType = "messaging", channelId = "sampleId")
+
+// Returns ThreadState object for a thread associated with a given parentMessageId
+val threadState = chatClient.state.thread(messageId = "parentMessageId")
+
+// Gives you access to GlobalState object
+val globalState = chatClient.globalState
+```
+
+In addition to that, the offline library provides a bunch of extension methods that can be used to obtain the state after performing a particular API call:
+
+```kotlin
+// Old approach - returns ChannelController object and performs watchChannel request
+ChatDomain.instance().watchChannel(cid = "messaging:sampleId", messageLimit = 30).enqueue { result ->
+    if (result.isSuccess) {
+        val channelController = result.data()
+    } else {
+        // Handle error
+    }
+}
+
+// New approach - returns ChannelState object and performs watchChannel request
+val channelState = chatClient.watchChannelAsState(cid = "messaging:sampleId", messageLimit = 30, coroutineScope = scope)
+```
+
+You can read more in the [Offline Support](https://getstream.io/chat/docs/sdk/android/client/guides/offline-support/) documentation.
+
+### Other changes
+
+You might notice that some of the method names have changed. For example, `editMessage` was replaced with `updateMessage`:
+
+```kotlin
+// Old approach
+val messageToUpdate = Message(text = "Updated text")
+ChatDomain.instance().editMessage(messageToUpdate).enqueue { result ->
+    if (result.isSuccess) {
+        // Handle success
+    } else {
+        // Handle error
+    }
+}
+
+// New approach
+val messageToUpdate = Message(text = "Updated text")
+ChatClient.instance().updateMessage(messageToUpdate).enqueue { result ->
+    if (result.isSuccess) {
+        // Handle success
+    } else {
+        // Handle error
+    }
+}
+```
+
+The same applies to the method's parameters as some of them were changed.
+[Here](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt) you can find the list of available methods.
+
+Last, but not least, we've reorganized the offline library package structure to better match the current implementation.
+This shouldn't affect you much because most of the classes are brand new, but you can spot that some of the remaining public classes were moved.
+For example, `io.getstream.chat.android.offline.querychannels.ChatEventHandler` was moved to `io.getstream.chat.android.offline.event.handler.chat.ChatEventHandler`.
+
+We strongly recommend to remove imports that cannot be resolved and reimport such classes again.

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -7,7 +7,7 @@ The guide will help you with migrating from version `4.X.X` to `5.X.X`.
 
 ### Initialization
 
-Compared to `ChatDomain`, which was a standalone singleton with its own API, the `OfflinePlugin` is a plugin that should be provided to the `ChatClient.Builder`:
+Compared to `ChatDomain`, which was a standalone singleton with its own API, `OfflinePlugin` is a plugin that should be provided to the `ChatClient.Builder`:
 
 ```kotlin
 val offlinePluginFactory = StreamOfflinePluginFactory(

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -66,7 +66,7 @@ The approach mentioned above can be applied to all API-call-related `ChatDomain`
 
 ### Observing the State
 
-We've renamed the objects used to obtain a state:
+We've renamed the objects used to obtain state:
 
 - `QueryChannelsController` was replaced by [`QueryChannelsState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/querychannels/QueryChannelsState.kt) .
 - `ChannelController` was replaced by [`ChannelState`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/ChannelState.kt).

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -23,7 +23,7 @@ val offlinePluginFactory = StreamOfflinePluginFactory(
 ChatClient.Builder(apiKey, context).withPlugin(offlinePluginFactory).build()
 ```
 
-From this point, the caching mechanism will be enabled and you'll have access to state objects.
+From this point onward, the caching mechanism will be enabled and you'll have access to state objects.
 
 You can read more about the initialization process in [Getting Started](../../01-basics/03-getting-started.mdx#adding-an-offline-plugin) page.
 

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -29,7 +29,7 @@ You can read more about the initialization process in [Getting Started](../../01
 
 ### Requesting Data
 
-`ChatDomain` was mirroring some of the `ChatClient` API but adding offline support. For example, if you wanted to send a message with offline support, you were supposed to call:
+`ChatDomain` mirrored some of the `ChatClient` API while adding offline support. For example, if you wanted to send a message with offline support, you were supposed to call:
 
 ```kotlin
 val message = Message(cid = cid, text = "New message")

--- a/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/07-chatdomain-migration.mdx
@@ -1,7 +1,7 @@
 # ChatDomain Migration
 
 **v5.0.0** release brings a big change to the offline support library - it replaces `ChatDomain` with a new, easy-to-use `OfflinePlugin`.
-You can read more about motivation and featured changes in the [announcement blog post](https://getstream.io/blog/).  <!--TODO: Replace with a real link -->
+You can read more about the motivation behind the effort and featured changes in the [announcement blog post](https://getstream.io/blog/).  <!--TODO: Replace with a real link -->
 
 The guide will help you with migrating from version `4.X.X` to `5.X.X`.
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -688,7 +688,7 @@ public final class io/getstream/chat/android/client/api/models/WatchChannelReque
 
 public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public final fun acceptInvite (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
-	public final fun addMembers ([Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun addMembers (Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public final fun banUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
 	public final fun create (Ljava/util/List;Ljava/util/Map;)Lio/getstream/chat/android/client/call/Call;
 	public final fun delete ()Lio/getstream/chat/android/client/call/Call;
@@ -740,7 +740,7 @@ public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public final fun queryMembers (IILio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public static synthetic fun queryMembers$default (Lio/getstream/chat/android/client/channel/ChannelClient;IILio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/QuerySort;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun rejectInvite ()Lio/getstream/chat/android/client/call/Call;
-	public final fun removeMembers ([Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun removeMembers (Ljava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public final fun removeShadowBan (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendAction (Lio/getstream/chat/android/client/api/models/SendActionRequest;)Lio/getstream/chat/android/client/call/Call;
 	public final fun sendEvent (Ljava/lang/String;Ljava/util/Map;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1646,35 +1646,46 @@ public class ChatClient internal constructor(
     @CheckResult
     public fun queryUsers(query: QueryUsersRequest): Call<List<User>> = api.queryUsers(query)
 
+    /**
+     * Adds members to a given channel.
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param memberIds The list of the member ids to be added.
+     *
+     * @return Executable async [Call] responsible for adding the members.
+     */
     @CheckResult
     public fun addMembers(
         channelType: String,
         channelId: String,
-        members: List<String>,
+        memberIds: List<String>,
     ): Call<Channel> {
         return api.addMembers(
             channelType,
             channelId,
-            members
+            memberIds,
         )
     }
 
     /**
-     * Method to remove members of a given channel.
+     * Removes members from a given channel.
      *
      * @param channelType The channel type. ie messaging.
      * @param channelId The channel id. ie 123.
-     * @param members The list of the members to be removed.
+     * @param memberIds The list of the member ids to be removed.
+     *
+     * @return Executable async [Call] responsible for removing the members.
      */
     @CheckResult
     public fun removeMembers(
         channelType: String,
         channelId: String,
-        members: List<String>,
+        memberIds: List<String>,
     ): Call<Channel> = api.removeMembers(
         channelType,
         channelId,
-        members
+        memberIds,
     )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -560,14 +560,32 @@ public class ChannelClient internal constructor(
     public fun disableSlowMode(): Call<Channel> =
         client.disableSlowMode(channelType, channelId)
 
+    /**
+     * Adds members to a given channel.
+     *
+     * @see [ChatClient.addMembers]
+     *
+     * @param memberIds The list of the member ids to be added.
+     *
+     * @return Executable async [Call] responsible for adding the members.
+     */
     @CheckResult
-    public fun addMembers(vararg userIds: String): Call<Channel> {
-        return client.addMembers(channelType, channelId, userIds.toList())
+    public fun addMembers(memberIds: List<String>): Call<Channel> {
+        return client.addMembers(channelType = channelType, channelId = channelId, memberIds = memberIds)
     }
 
+    /**
+     * Removes members from a given channel.
+     *
+     * @see [ChatClient.removeMembers]
+     *
+     * @param memberIds The list of the member ids to be removed.
+     *
+     * @return Executable async [Call] responsible for removing the members.
+     */
     @CheckResult
-    public fun removeMembers(vararg userIds: String): Call<Channel> {
-        return client.removeMembers(channelType, channelId, userIds.toList())
+    public fun removeMembers(memberIds: List<String>): Call<Channel> {
+        return client.removeMembers(channelType = channelType, channelId = channelId, memberIds = memberIds)
     }
 
     @CheckResult

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Channels.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/Channels.java
@@ -373,7 +373,7 @@ public class Channels {
             ChannelClient channelClient = client.channel("messaging", "general");
 
             // Add members with ids "thierry" and "josh"
-            channelClient.addMembers("thierry", "josh").enqueue(result -> {
+            channelClient.addMembers(Arrays.asList("thierry", "josh")).enqueue(result -> {
                 if (result.isSuccess()) {
                     Channel channel = result.data();
                 } else {
@@ -382,7 +382,7 @@ public class Channels {
             });
 
             // Remove member with id "tommaso"
-            channelClient.removeMembers("tommaso").enqueue(result -> {
+            channelClient.removeMembers(Arrays.asList("tommaso")).enqueue(result -> {
                 if (result.isSuccess()) {
                     Channel channel = result.data();
                 } else {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Channels.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/Channels.kt
@@ -351,7 +351,7 @@ class Channels(val client: ChatClient, val channelClient: ChannelClient) {
             val channelClient = client.channel("messaging", "general")
 
             // Add members with ids "thierry" and "josh"
-            channelClient.addMembers("thierry", "josh").enqueue { result ->
+            channelClient.addMembers(listOf("thierry", "josh")).enqueue { result ->
                 if (result.isSuccess) {
                     val channel: Channel = result.data()
                 } else {
@@ -360,7 +360,7 @@ class Channels(val client: ChatClient, val channelClient: ChannelClient) {
             }
 
             // Remove member with id "tommaso"
-            channelClient.removeMembers("tommaso").enqueue { result ->
+            channelClient.removeMembers(listOf("tommaso")).enqueue { result ->
                 if (result.isSuccess) {
                     val channel: Channel = result.data()
                 } else {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
@@ -110,7 +110,7 @@ class GroupChatInfoMemberOptionsViewModel(
 
     private fun removeFromChannel() {
         viewModelScope.launch {
-            val result = chatClient.channel(cid).removeMembers(memberId).await()
+            val result = chatClient.channel(cid).removeMembers(listOf(memberId)).await()
             if (result.isSuccess) {
                 _events.value = Event(UiEvent.Dismiss)
             } else {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
@@ -63,7 +63,7 @@ class GroupChatInfoAddUsersViewModel(
 
     private fun addMember(user: User) {
         viewModelScope.launch {
-            val response = channelClient.addMembers(user.id).await()
+            val response = channelClient.addMembers(listOf(user.id)).await()
             if (response.isSuccess) {
                 _userAddedState.value = true
             } else {


### PR DESCRIPTION
closes #3034 

### 🎯 Goal

Add `ChatDomain` migration guide.

### 🛠 Implementation details

1. Add migration guide.
2. Unify `addMembers` and `removeMembers` API

### 🧪 Testing
**NOTE: Some of the link won't work correctly before the release **

1. Checkout the branch
3. Run `npx stream-chat-docusaurus -i -s`
4. Review the migration guide page

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [x] Release notes and docs clearly describe changes
