### PR TITLE
[3188] Fix message options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@
 
 ### ❌ Removed
 - All usage of `ChatDomain`. [#3190](https://github.com/GetStream/stream-chat-android/pull/3190)
+- Removed "Pin message", "Reply", "Thread reply" message actions for messages that are not synced. [#3226](https://github.com/GetStream/stream-chat-android/pull/3226)
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
@@ -114,6 +115,7 @@
 
 ### ❌ Removed
 - Removed all use of `ChatDomain` inside the SDK. [#3148](https://github.com/GetStream/stream-chat-android/pull/3148)
+- Removed "Pin message", "Reply", "Thread reply" message actions for messages that are not synced. [#3226](https://github.com/GetStream/stream-chat-android/pull/3226)
 
 ## stream-chat-android-markdown-transformer
 ### 🐞 Fixed

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/SyncStatus.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/SyncStatus.kt
@@ -1,15 +1,32 @@
 package io.getstream.chat.android.client.utils
 
+/**
+ * If the message has been sent to the servers.
+ */
 public enum class SyncStatus(public val status: Int) {
-    /** when the entity is new or changed */
+    /**
+     * When the entity is new or changed.
+     */
     SYNC_NEEDED(-1),
-    /** when the entity has been succesfully synced */
+
+    /**
+     * When the entity has been successfully synced.
+     */
     COMPLETED(1),
-    /** after the retry strategy we still failed to sync this */
+
+    /**
+     * After the retry strategy we still failed to sync this.
+     */
     FAILED_PERMANENTLY(2),
-    /** when sync is in progress */
+
+    /**
+     * When sync is in progress.
+     */
     IN_PROGRESS(3),
-    /** when message waits its' attachments to be sent */
+
+    /**
+     * When message waits its' attachments to be sent.
+     */
     AWAITING_ATTACHMENTS(4);
 
     public companion object {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -51,7 +52,9 @@ public fun MessageOptions(
 ) {
     Column(modifier = modifier) {
         options.forEach { option ->
-            itemContent(option)
+            key(option.action) {
+                itemContent(option)
+            }
         }
     }
 }
@@ -94,6 +97,10 @@ public fun defaultMessageOptionsState(
     currentUser: User?,
     isInThread: Boolean,
 ): List<MessageOptionItemState> {
+    if (selectedMessage.id.isEmpty()) {
+        return emptyList()
+    }
+
     val selectedMessageUserId = selectedMessage.user.id
 
     val isTextOnlyMessage = selectedMessage.text.isNotEmpty() && selectedMessage.attachments.isEmpty()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -24,6 +24,9 @@ import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -38,6 +41,7 @@ import io.getstream.chat.android.common.state.MessageMode
 import io.getstream.chat.android.common.state.Reply
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.imagepreview.ImagePreviewResultType
+import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemState
 import io.getstream.chat.android.compose.state.messages.SelectedMessageOptionsState
 import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsPickerState
 import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsState
@@ -191,6 +195,18 @@ public fun MessagesScreen(
 
         val selectedMessage = selectedMessageState?.message ?: Message()
 
+        val newMessageOptions = defaultMessageOptionsState(
+            selectedMessage = selectedMessage,
+            currentUser = user,
+            isInThread = listViewModel.isInThread
+        )
+
+        var messageOptions by rememberSaveable { mutableStateOf<List<MessageOptionItemState>>(emptyList()) }
+
+        if (newMessageOptions.isNotEmpty()) {
+            messageOptions = newMessageOptions
+        }
+
         AnimatedVisibility(
             visible = selectedMessageState is SelectedMessageOptionsState && selectedMessage.id.isNotEmpty(),
             enter = fadeIn(),
@@ -209,11 +225,7 @@ public fun MessagesScreen(
                             animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
                         )
                     ),
-                messageOptions = defaultMessageOptionsState(
-                    selectedMessage = selectedMessage,
-                    currentUser = user,
-                    isInThread = listViewModel.isInThread
-                ),
+                messageOptions = messageOptions,
                 message = selectedMessage,
                 onMessageAction = { action ->
                     composerViewModel.performMessageAction(action)

--- a/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_thread.xml
+++ b/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_thread.xml
@@ -2,8 +2,10 @@
     android:width="24dp"
     android:height="24dp"
     android:viewportWidth="24"
-    android:viewportHeight="24">
-  <path
-      android:pathData="M4,4H20V16H5.17L4,17.17V4ZM4,2C2.9,2 2.01,2.9 2.01,4L2,22L6,18H20C21.1,18 22,17.1 22,16V4C22,2.9 21.1,2 20,2H4ZM6,12H14V14H6V12ZM6,9H18V11H6V9ZM6,6H18V8H6V6Z"
-      android:fillColor="#72767E"/>
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#000000"
+        android:pathData="M4,4H20V16H5.17L4,17.17V4ZM4,2C2.9,2 2.01,2.9 2.01,4L2,22L6,18H20C21.1,18 22,17.1 22,16V4C22,2.9 21.1,2 20,2H4ZM6,12H14V14H6V12ZM6,9H18V11H6V9ZM6,6H18V8H6V6Z"
+        />
 </vector>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -12,6 +12,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.createStreamTheme
 import io.getstream.chat.android.ui.common.extensions.internal.setStartDrawable
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
 import io.getstream.chat.android.ui.common.style.TextStyle
+import io.getstream.chat.android.ui.common.style.setTextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiMessageOptionsViewBinding
 import io.getstream.chat.android.ui.message.list.MessageListViewStyle
 import java.io.Serializable
@@ -20,8 +21,10 @@ internal class MessageOptionsView : FrameLayout {
 
     private val binding = StreamUiMessageOptionsViewBinding.inflate(streamThemeInflater, this, true)
 
-    constructor(context: Context) : super(context.createStreamThemeWrapper())
-    constructor(context: Context, attrs: AttributeSet?) : super(context.createStreamThemeWrapper(), attrs)
+    constructor(context: Context) : this(context, null, 0)
+
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+
     constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
         context.createStreamThemeWrapper(),
         attrs,
@@ -36,192 +39,92 @@ internal class MessageOptionsView : FrameLayout {
         isMessageAuthorMuted: Boolean,
         isMessagePinned: Boolean,
     ) {
-        if (isMessageTheirs) {
-            configureTheirsMessage(
-                configuration = configuration,
-                style = style,
-                isMessageAuthorMuted = isMessageAuthorMuted,
-                isMessagePinned = isMessagePinned,
-            )
+        val isMessageMine = !isMessageTheirs
+        val isMessageSynced = syncStatus == SyncStatus.COMPLETED
+
+        configureMessageOption(
+            isVisible = isMessageMine && syncStatus == SyncStatus.FAILED_PERMANENTLY,
+            textView = binding.retryTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.retryIcon,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.replyEnabled && isMessageSynced,
+            textView = binding.replyTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.replyIcon,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.threadsEnabled && isMessageSynced,
+            textView = binding.threadReplyTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.threadReplyIcon,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.copyTextEnabled,
+            textView = binding.copyTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.copyIcon,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.editMessageEnabled && isMessageMine,
+            textView = binding.editTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.editIcon,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.flagEnabled && isMessageTheirs,
+            textView = binding.flagTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.flagIcon,
+        )
+
+        val (pinText, pinIcon) = if (isMessagePinned) {
+            R.string.stream_ui_message_list_unpin_message to style.unpinIcon
         } else {
-            configureMineMessage(
-                configuration = configuration,
-                style = style,
-                syncStatus = syncStatus,
-                isMessagePinned = isMessagePinned,
-            )
+            R.string.stream_ui_message_list_pin_message to style.pinIcon
         }
+        configureMessageOption(
+            isVisible = configuration.pinMessageEnabled && isMessageSynced,
+            textView = binding.pinTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = pinIcon,
+            optionText = pinText,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.deleteMessageEnabled && isMessageMine,
+            textView = binding.deleteTV,
+            textStyle = style.warningMessageOptionsText,
+            optionIcon = style.deleteIcon,
+        )
+
+        val (muteText, muteIcon) = if (isMessageAuthorMuted) {
+            R.string.stream_ui_message_list_unmute_user to style.unmuteIcon
+        } else {
+            R.string.stream_ui_message_list_mute_user to style.muteIcon
+        }
+        configureMessageOption(
+            isVisible = configuration.muteEnabled && isMessageTheirs,
+            textView = binding.muteTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = muteIcon,
+            optionText = muteText,
+        )
+
+        configureMessageOption(
+            isVisible = configuration.blockEnabled && isMessageTheirs,
+            textView = binding.blockTV,
+            textStyle = style.messageOptionsText,
+            optionIcon = style.blockIcon,
+        )
+
         binding.messageOptionsContainer.setCardBackgroundColor(style.messageOptionsBackgroundColor)
-    }
-
-    private fun configureTheirsMessage(
-        configuration: Configuration,
-        style: MessageListViewStyle,
-        isMessageAuthorMuted: Boolean,
-        isMessagePinned: Boolean,
-    ) {
-        val textStyle = style.messageOptionsText
-
-        configureReply(configuration, style)
-
-        if (configuration.threadsEnabled) {
-            binding.threadReplyTV.configureListItem(textStyle, style.threadReplyIcon)
-        } else {
-            binding.threadReplyTV.isVisible = false
-        }
-
-        configureCopyMessage(configuration, style)
-
-        binding.flagTV.configureListItem(textStyle, style.flagIcon)
-        binding.muteTV.configureListItem(textStyle, style.muteIcon)
-        binding.editTV.isVisible = false
-        binding.deleteTV.isVisible = false
-        configureMute(
-            configuration = configuration,
-            style = style,
-            isMessageAuthorMuted = isMessageAuthorMuted,
-        )
-        configureFlag(configuration = configuration, style = style)
-        configurePin(
-            configuration = configuration,
-            style = style,
-            isMessagePinned = isMessagePinned
-        )
-        configureBlock(configuration = configuration, style = style)
-    }
-
-    private fun configureMineMessage(
-        configuration: Configuration,
-        style: MessageListViewStyle,
-        syncStatus: SyncStatus,
-        isMessagePinned: Boolean,
-    ) {
-
-        configureReply(configuration, style)
-
-        if (configuration.threadsEnabled) {
-            binding.threadReplyTV.configureListItem(style.messageOptionsText, style.threadReplyIcon)
-        } else {
-            binding.threadReplyTV.isVisible = false
-        }
-
-        when (syncStatus) {
-            SyncStatus.FAILED_PERMANENTLY -> {
-                binding.retryTV.configureListItem(
-                    style.messageOptionsText,
-                    style.retryIcon,
-                )
-
-                binding.retryTV.isVisible = style.retryMessageEnabled
-                binding.threadReplyTV.isVisible = false
-            }
-            SyncStatus.COMPLETED -> {
-                // Empty
-            }
-            SyncStatus.SYNC_NEEDED, SyncStatus.IN_PROGRESS, SyncStatus.AWAITING_ATTACHMENTS -> {
-                binding.threadReplyTV.isVisible = false
-            }
-        }
-
-        configureCopyMessage(configuration, style)
-
-        configureEditMessage(configuration, style)
-        binding.flagTV.isVisible = false
-        binding.muteTV.isVisible = false
-        binding.blockTV.isVisible = false
-        configureDeleteMessage(configuration, style)
-        configurePin(
-            configuration = configuration,
-            style = style,
-            isMessagePinned = isMessagePinned
-        )
-    }
-
-    private fun configureEditMessage(configuration: Configuration, style: MessageListViewStyle) {
-        binding.editTV.apply {
-            if (configuration.editMessageEnabled) {
-                isVisible = true
-                configureListItem(style.messageOptionsText, style.editIcon)
-            } else {
-                isVisible = false
-            }
-        }
-    }
-
-    private fun configureReply(configuration: Configuration, style: MessageListViewStyle) {
-        if (configuration.replyEnabled) {
-            binding.replyTV.configureListItem(style.messageOptionsText, style.replyIcon)
-        } else {
-            binding.replyTV.isVisible = false
-        }
-    }
-
-    private fun configureFlag(configuration: Configuration, style: MessageListViewStyle) {
-        if (configuration.flagEnabled) {
-            binding.flagTV.configureListItem(style.messageOptionsText, style.flagIcon)
-        } else {
-            binding.flagTV.isVisible = false
-        }
-    }
-
-    private fun configurePin(
-        configuration: Configuration,
-        style: MessageListViewStyle,
-        isMessagePinned: Boolean,
-    ) {
-        if (configuration.pinMessageEnabled) {
-            if (isMessagePinned) {
-                binding.pinTV.text = context.getString(R.string.stream_ui_message_list_unpin_message)
-                binding.pinTV.configureListItem(style.messageOptionsText, style.unpinIcon)
-            } else {
-                binding.pinTV.text = context.getString(R.string.stream_ui_message_list_pin_message)
-                binding.pinTV.configureListItem(style.messageOptionsText, style.pinIcon)
-            }
-        } else {
-            binding.pinTV.isVisible = false
-        }
-    }
-
-    private fun configureMute(
-        configuration: Configuration,
-        style: MessageListViewStyle,
-        isMessageAuthorMuted: Boolean,
-    ) {
-        if (configuration.muteEnabled) {
-            val icon = if (isMessageAuthorMuted) style.unmuteIcon else style.muteIcon
-            binding.muteTV.configureListItem(style.messageOptionsText, icon)
-            binding.muteTV.setText(if (isMessageAuthorMuted) R.string.stream_ui_message_list_unmute_user else R.string.stream_ui_message_list_mute_user)
-        } else {
-            binding.muteTV.isVisible = false
-        }
-    }
-
-    private fun configureBlock(configuration: Configuration, style: MessageListViewStyle) {
-        binding.blockTV.isVisible = configuration.blockEnabled
-        if (configuration.blockEnabled) {
-            binding.blockTV.configureListItem(style.messageOptionsText, style.blockIcon)
-        }
-    }
-
-    private fun configureCopyMessage(configuration: Configuration, style: MessageListViewStyle) {
-        if (configuration.copyTextEnabled) {
-            binding.copyTV.isVisible = true
-            binding.copyTV.configureListItem(style.messageOptionsText, style.copyIcon)
-        } else {
-            binding.copyTV.isVisible = false
-        }
-    }
-
-    @Suppress("DEPRECATION_ERROR")
-    private fun configureDeleteMessage(configuration: Configuration, style: MessageListViewStyle) {
-        if (configuration.deleteMessageEnabled) {
-            binding.deleteTV.apply {
-                isVisible = true
-                configureListItem(style.warningMessageOptionsText, style.deleteIcon)
-            }
-        } else {
-            binding.deleteTV.isVisible = false
-        }
     }
 
     internal data class Configuration(
@@ -244,21 +147,20 @@ internal class MessageOptionsView : FrameLayout {
                 channelConfig: Config,
                 hasTextToCopy: Boolean,
                 suppressThreads: Boolean,
-            ) =
-                Configuration(
-                    replyEnabled = viewStyle.replyEnabled,
-                    threadsEnabled = if (suppressThreads) false else viewStyle.threadsEnabled && channelConfig.isThreadEnabled,
-                    editMessageEnabled = viewStyle.editMessageEnabled,
-                    deleteMessageEnabled = viewStyle.deleteMessageEnabled,
-                    copyTextEnabled = viewStyle.copyTextEnabled && hasTextToCopy,
-                    deleteConfirmationEnabled = viewStyle.deleteConfirmationEnabled,
-                    reactionsEnabled = viewStyle.reactionsEnabled && channelConfig.isReactionsEnabled,
-                    flagEnabled = viewStyle.flagEnabled,
-                    pinMessageEnabled = viewStyle.pinMessageEnabled,
-                    muteEnabled = viewStyle.muteEnabled,
-                    blockEnabled = viewStyle.blockEnabled,
-                    retryMessageEnabled = viewStyle.retryMessageEnabled,
-                )
+            ) = Configuration(
+                replyEnabled = viewStyle.replyEnabled,
+                threadsEnabled = if (suppressThreads) false else viewStyle.threadsEnabled && channelConfig.isThreadEnabled,
+                editMessageEnabled = viewStyle.editMessageEnabled,
+                deleteMessageEnabled = viewStyle.deleteMessageEnabled,
+                copyTextEnabled = viewStyle.copyTextEnabled && hasTextToCopy,
+                deleteConfirmationEnabled = viewStyle.deleteConfirmationEnabled,
+                reactionsEnabled = viewStyle.reactionsEnabled && channelConfig.isReactionsEnabled,
+                flagEnabled = viewStyle.flagEnabled,
+                pinMessageEnabled = viewStyle.pinMessageEnabled,
+                muteEnabled = viewStyle.muteEnabled,
+                blockEnabled = viewStyle.blockEnabled,
+                retryMessageEnabled = viewStyle.retryMessageEnabled,
+            )
         }
     }
 
@@ -322,8 +224,20 @@ internal class MessageOptionsView : FrameLayout {
         }
     }
 
-    private fun TextView.configureListItem(textStyle: TextStyle, icon: Int) {
-        setStartDrawable(icon)
-        textStyle.apply(this)
+    private fun configureMessageOption(
+        isVisible: Boolean,
+        textView: TextView,
+        textStyle: TextStyle,
+        optionIcon: Int,
+        optionText: Int? = null,
+    ) {
+        if (isVisible) {
+            textView.isVisible = true
+            textView.setStartDrawable(optionIcon)
+            textView.setTextStyle(textStyle)
+            optionText?.let { textView.text = context.getString(optionText) }
+        } else {
+            textView.isVisible = false
+        }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Reduce the number of message actions for failed / pending messages.

### 🎨 UI Changes

**Compose: theirs message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 36 37](https://user-images.githubusercontent.com/9600921/159023075-447c4ff7-cd7e-4abe-b13f-016707dd5bb1.jpeg) | ![photo_2022-03-18 17 20 11](https://user-images.githubusercontent.com/9600921/159020078-e81752f1-4f89-488d-97e2-e8d10efcae3c.jpeg) |

**Compose: mine message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 36 08](https://user-images.githubusercontent.com/9600921/159023000-066dbbd2-727e-49e6-afea-5231839f59e7.jpeg) | ![photo_2022-03-18 17 19 29](https://user-images.githubusercontent.com/9600921/159019994-c5ceda3b-1a6e-4e5c-a0a8-9c2eaadc5a32.jpeg) |

**Compose: failed message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 32 29](https://user-images.githubusercontent.com/9600921/159022338-5f44cca2-6eff-4da5-81a7-1c99fec09e07.jpeg) | ![photo_2022-03-18 17 18 00](https://user-images.githubusercontent.com/9600921/159019750-b9a85462-00e5-4e64-8415-e3e3b7b1021f.jpeg) |

**UI Components: theirs message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 37 44](https://user-images.githubusercontent.com/9600921/159023309-801b1e7d-2fd2-4860-9b3a-0a70b3864d40.jpeg) | ![photo_2022-03-18 17 16 10](https://user-images.githubusercontent.com/9600921/159019435-8f41daae-35dc-4ac5-80aa-6e2ca496d20c.jpeg) |

**UI Components: mine message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 37 18](https://user-images.githubusercontent.com/9600921/159023218-72f48d6c-757b-4086-b9be-d33b8b7c0b3a.jpeg) | ![photo_2022-03-18 17 15 33](https://user-images.githubusercontent.com/9600921/159019328-e380726c-882b-47ec-90b2-1fa9097fb8d7.jpeg) |

**UI Components: failed message** 

| Before | After |
| --- | --- |
| ![photo_2022-03-18 17 31 39](https://user-images.githubusercontent.com/9600921/159022216-dd652422-8e71-4bb3-b58d-c1f8f8e7b070.jpeg) | ![photo_2022-03-18 17 14 02](https://user-images.githubusercontent.com/9600921/159019152-58c60d6a-6068-40c8-89f5-dc2b9a8bee27.jpeg) |

### 🧪 Testing

1. Open Compose / UI Components sample app
2. Navigate to the message list
3. Show message options for a message awaiting sync / failed message
4. Observe that there are no actions that only make sense for a sent message

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
