### PR TITLE
Expose attributes and customization for tab colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 - Introduced `InnerAttachmentViewHolder` as an inner ViewHolder for custom attachments. [#3183](https://github.com/GetStream/stream-chat-android/pull/3183)
 - Introduced `AttachmentFactory` as a factory for custom attachment ViewHolders. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
 - Introduced `AttachmentFactoryManager` as a manager for the list of registered attachment factories. The class is exposed via `ChatUI`. [#3116](https://github.com/GetStream/stream-chat-android/pull/3116)
+- Added an attribute to customize the color state list of the AttachmentsDialog buttons called `streamUiAttachmentTabButtonColorStateList`. [#3242](https://github.com/GetStream/stream-chat-android/pull/3242)
 
 ### ⚠️ Changed
 - Separated the Giphy attachments and content to a GiphyAttachmentViewHolder. [#2932](https://github.com/GetStream/stream-chat-android/pull/2932)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1345,7 +1345,7 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 
 public final class io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle$Companion;
-	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component10 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component11 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
@@ -1358,6 +1358,7 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun component18 ()I
 	public final fun component19 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Landroid/graphics/drawable/Drawable;
+	public final fun component20 ()Landroid/content/res/ColorStateList;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/String;
@@ -1365,8 +1366,8 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun component7 ()Landroid/graphics/drawable/Drawable;
 	public final fun component8 ()Landroid/graphics/drawable/Drawable;
 	public final fun component9 ()Landroid/graphics/drawable/Drawable;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ZZILandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;ILjava/lang/Object;)Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAllowAccessToCameraIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getAllowAccessToCameraText ()Ljava/lang/String;
@@ -1383,6 +1384,7 @@ public final class io/getstream/chat/android/ui/message/input/attachment/Attachm
 	public final fun getPictureAttachmentIcon ()Landroid/graphics/drawable/Drawable;
 	public final fun getRecentFilesText ()Ljava/lang/String;
 	public final fun getRecentFilesTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun getToggleButtonColorStateList ()Landroid/content/res/ColorStateList;
 	public final fun getVideoDurationTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getVideoIconDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getVideoIconVisible ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -9,6 +9,7 @@ import com.getstream.sdk.chat.utils.AttachmentConstants
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getColorStateListCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.use
@@ -357,6 +358,9 @@ public data class MessageInputViewStyle(
                     a.getDrawable(R.styleable.MessageInputView_streamUiAttachmentSelectionAttachIcon)
                         ?: context.getDrawableCompat(R.drawable.stream_ui_ic_next)!!
 
+                val attachmentDialogTabButtonColorStateList = a.getColorStateList(R.styleable.MessageInputView_streamUiAttachmentTabButtonColorStateList)
+                    ?: context.getColorStateListCompat(R.color.stream_ui_attachment_tab_button)
+
                 val attachmentDialogStyle = AttachmentSelectionDialogStyle(
                     pictureAttachmentIcon = pictureAttachmentIcon,
                     fileAttachmentIcon = fileAttachmentIcon,
@@ -377,6 +381,7 @@ public data class MessageInputViewStyle(
                     videoIconVisible = videoIconVisible,
                     backgroundColor = attachmentSelectionBackgroundColor,
                     attachButtonIcon = attachmentSelectionAttachIcon,
+                    toggleButtonColorStateList = attachmentDialogTabButtonColorStateList
                 )
 
                 val commandInputCancelIcon = a.getDrawable(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogFragment.kt
@@ -59,6 +59,7 @@ public class AttachmentSelectionDialogFragment : BottomSheetDialogFragment(), At
 
             mediaAttachmentButton.run {
                 background = attachmentSelectionDialogStyle.pictureAttachmentIcon
+                backgroundTintList = attachmentSelectionDialogStyle.toggleButtonColorStateList
 
                 isChecked = true
                 setOnClickListener {
@@ -68,6 +69,7 @@ public class AttachmentSelectionDialogFragment : BottomSheetDialogFragment(), At
 
             fileAttachmentButton.run {
                 background = attachmentSelectionDialogStyle.fileAttachmentIcon
+                backgroundTintList = attachmentSelectionDialogStyle.toggleButtonColorStateList
 
                 setOnClickListener {
                     setSelectedButton(fileAttachmentButton, AttachmentDialogPagerAdapter.PAGE_FILE_ATTACHMENT)
@@ -76,6 +78,7 @@ public class AttachmentSelectionDialogFragment : BottomSheetDialogFragment(), At
 
             cameraAttachmentButton.run {
                 background = attachmentSelectionDialogStyle.cameraAttachmentIcon
+                backgroundTintList = attachmentSelectionDialogStyle.toggleButtonColorStateList
 
                 setOnClickListener {
                     setSelectedButton(cameraAttachmentButton, AttachmentDialogPagerAdapter.PAGE_CAMERA_ATTACHMENT)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/attachment/AttachmentSelectionDialogStyle.kt
@@ -1,12 +1,14 @@
 package io.getstream.chat.android.ui.message.input.attachment
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.getColorCompat
+import io.getstream.chat.android.ui.common.extensions.internal.getColorStateListCompat
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.style.TextStyle
 
@@ -30,6 +32,7 @@ public data class AttachmentSelectionDialogStyle(
     val videoLengthLabelVisible: Boolean,
     @ColorInt val backgroundColor: Int,
     val attachButtonIcon: Drawable,
+    val toggleButtonColorStateList: ColorStateList?
 ) {
     public companion object {
         /**
@@ -67,6 +70,7 @@ public data class AttachmentSelectionDialogStyle(
                 videoLengthLabelVisible = true,
                 backgroundColor = context.getColorCompat(R.color.stream_ui_white_smoke),
                 attachButtonIcon = context.getDrawableCompat(R.drawable.stream_ui_ic_next)!!,
+                toggleButtonColorStateList = context.getColorStateListCompat(R.color.stream_ui_attachment_tab_button)
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_input_view.xml
@@ -163,6 +163,7 @@
         <attr name="streamUiAttachmentVideoIconVisible" format="boolean" />
         <attr name="streamUiAttachmentSelectionBackgroundColor" format="color|reference" />
         <attr name="streamUiAttachmentSelectionAttachIcon" format="reference" />
+        <attr name="streamUiAttachmentTabButtonColorStateList" format="color|reference" />
 
         <!-- Attachment permissions -->
         <attr name="streamUiAllowAccessToGalleryText" format="string" />

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -998,6 +998,7 @@
         <item name="streamUiMessageInputCloseButtonIconDrawable">@drawable/stream_ui_ic_clear</item>
         <item name="streamUiAttachmentSelectionBackgroundColor">@color/stream_ui_white_smoke</item>
         <item name="streamUiAttachmentSelectionAttachIcon">@drawable/stream_ui_ic_next</item>
+        <item name="streamUiAttachmentTabButtonColorStateList">@color/stream_ui_attachment_tab_button</item>
         <item name="streamUiCooldownTimerTextSize">@dimen/stream_ui_text_large</item>
         <item name="streamUiCooldownTimerTextColor">@color/stream_ui_literal_white</item>
         <item name="streamUiCooldownTimerTextStyle">bold</item>


### PR DESCRIPTION
### 🎯 Goal

Fixes #3241 

### 🛠 Implementation details

We exposed a way to customize the icons, but not the colors of the icons. This way our users can easily customize both.

Exposed a color state list attribute to the MessageInputView style, that's propagated to the AttachmentDialogStyle.

### 🎨 UI Changes

No UI changes per se, but testing with the given patch will produce the following:

![Screenshot_1648034866](https://user-images.githubusercontent.com/17215808/159689582-05535141-181d-4141-9cb5-0e7b7fe1fc0e.png)

### 🧪 Testing

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components/src/main/res/color/stream_ui_test.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/res/color/stream_ui_test.xml b/stream-chat-android-ui-components/src/main/res/color/stream_ui_test.xml
new file mode 100644
--- /dev/null	(date 1648034363548)
+++ b/stream-chat-android-ui-components/src/main/res/color/stream_ui_test.xml	(date 1648034363548)
@@ -0,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/stream_ui_accent_red" android:state_checked="true" android:state_enabled="true" />
+    <item android:color="@color/stream_ui_accent_blue" android:state_checked="false" android:state_enabled="true" />
+    <item android:color="@color/stream_ui_accent_green" android:state_enabled="false" />
+</selector>
Index: stream-chat-android-ui-components/src/main/res/values/styles.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/res/values/styles.xml b/stream-chat-android-ui-components/src/main/res/values/styles.xml
--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml	(revision 8ebd3a54d252c76c412ab8d8098158674d959f65)
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml	(date 1648033617916)
@@ -998,7 +998,7 @@
         <item name="streamUiMessageInputCloseButtonIconDrawable">@drawable/stream_ui_ic_clear</item>
         <item name="streamUiAttachmentSelectionBackgroundColor">@color/stream_ui_white_smoke</item>
         <item name="streamUiAttachmentSelectionAttachIcon">@drawable/stream_ui_ic_next</item>
-        <item name="streamUiAttachmentTabButtonColorStateList">@color/stream_ui_attachment_tab_button</item>
+        <item name="streamUiAttachmentTabButtonColorStateList">@color/stream_ui_test</item>
         <item name="streamUiCooldownTimerTextSize">@dimen/stream_ui_text_large</item>
         <item name="streamUiCooldownTimerTextColor">@color/stream_ui_literal_white</item>
         <item name="streamUiCooldownTimerTextStyle">bold</item>
```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs