### PR TITLE
Set default message limit in query channel request to 30

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -324,6 +324,6 @@ public class MessageInputViewModel @JvmOverloads constructor(
         /**
          * The default limit for messages that will be requested.
          */
-        private const val DEFAULT_MESSAGES_LIMIT: Int = 0
+        private const val DEFAULT_MESSAGES_LIMIT: Int = 30
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -292,7 +292,9 @@ public class MessageListViewModel(
             stateMerger.removeSource(it)
         }
         messageListData?.let {
-            stateMerger.addSource(it) { stateMerger.value = State.Result(it) }
+            stateMerger.addSource(it) { messageListItemWrapper ->
+                stateMerger.value = State.Result(messageListItemWrapper)
+            }
         }
     }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -625,6 +625,6 @@ public class MessageComposerController(
         /**
          * The default limit for messages count in requests.
          */
-        private const val DEFAULT_MESSAGE_LIMIT: Int = 0
+        private const val DEFAULT_MESSAGE_LIMIT: Int = 30
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModel.kt
@@ -106,6 +106,6 @@ public class MessageListHeaderViewModel(
         /**
          * The default limit for messages that will be requested.
          */
-        private const val DEFAULT_MESSAGES_LIMIT: Int = 0
+        private const val DEFAULT_MESSAGES_LIMIT: Int = 30
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/typing/viewmodel/TypingIndicatorViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/typing/viewmodel/TypingIndicatorViewModel.kt
@@ -48,6 +48,6 @@ public class TypingIndicatorViewModel(
         /**
          * The default limit for messages that will be requested.
          */
-        private const val DEFAULT_MESSAGES_LIMIT: Int = 0
+        private const val DEFAULT_MESSAGES_LIMIT: Int = 30
     }
 }


### PR DESCRIPTION
### 🎯 Goal

There was a bug when loading messages due to a different message limit.

### 🛠 Implementation details

Changed the message limit to 30 in all query requests.

### 🧪 Testing

Run the sample app and open multiple channels. Make sure in each channel, messages are loaded and not stuck showing only one last message.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)

