### PR TITLE
Add ChatDomain migration guide to sidebar

### DIFF
--- a/docusaurus/sidebars-android.js
+++ b/docusaurus/sidebars-android.js
@@ -32,6 +32,10 @@ module.exports = {
                   type: 'doc',
                   id: 'client/guides/offline-support',
                 },
+                {
+                  type: 'doc',
+                  id: 'client/guides/chatdomain-migration',
+                },
             ]
 //        items: [
 //            {


### PR DESCRIPTION
### 🎯 Goal

Add `ChatDomain` migration guide to the sidebar.

### 🧪 Testing
1. Run `npx stream-chat-docusaurus -i -s`
2. Make sure `ChatDomain migration` page is visible in sidebard

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] New feature tested and works
