### PR TITLE
[3259] Fix reactions in UI Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Users now able to open `MessageOptionsDialogFragment` by clicking on a reaction left on a Giphy message. [#3620](https://github.com/GetStream/stream-chat-android/pull/3260)
+- inside `MessageOptionsDialogFragment` now properly displays all of the reactions to a message. Previously it erroneously displayed a blank state. [#3620](https://github.com/GetStream/stream-chat-android/pull/3260)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyAttachmentViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyAttachmentViewHolder.kt
@@ -12,7 +12,6 @@ import io.getstream.chat.android.ui.common.extensions.isReply
 import io.getstream.chat.android.ui.databinding.StreamUiItemGiphyAttachmentBinding
 import io.getstream.chat.android.ui.message.list.adapter.MessageListItemPayloadDiff
 import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainer
-import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainerImpl
 import io.getstream.chat.android.ui.message.list.adapter.internal.DecoratedBaseMessageItemViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.view.internal.GiphyMediaAttachmentView
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.decorator.internal.BackgroundDecorator
@@ -40,34 +39,36 @@ internal class GiphyAttachmentViewHolder(
     ),
 ) : DecoratedBaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root, decorators) {
 
+    init {
+        initializeListeners()
+    }
+
     /**
-     * We override the Message passed to listeners here with the up-to-date Message
-     * object from the [data] property of the base ViewHolder.
-     *
-     * This is required because these listeners will be invoked by the AttachmentViews,
-     * which don't always have an up-to-date Message object in them. This is due to the
-     * optimization that we don't re-create the AttachmentViews when the attachments
-     * of the Message are unchanged. However, other properties (like reactions) might
-     * change, and these listeners should receive a fully up-to-date Message.
+     * Initializes listeners that enable handling clicks on various
+     * elements such as reactions, threads, message containers, etc.
      */
-    private fun modifiedListeners(listeners: MessageListListenerContainer?): MessageListListenerContainer? {
-        return listeners?.let { container ->
-            MessageListListenerContainerImpl(
-                messageClickListener = { container.messageClickListener.onMessageClick(data.message) },
-                messageLongClickListener = { container.messageLongClickListener.onMessageLongClick(data.message) },
-                messageRetryListener = { container.messageRetryListener.onRetryMessage(data.message) },
-                threadClickListener = { container.threadClickListener.onThreadClick(data.message) },
-                attachmentClickListener = { _, attachment ->
-                    container.attachmentClickListener.onAttachmentClick(data.message, attachment)
-                },
-                attachmentDownloadClickListener = container.attachmentDownloadClickListener::onAttachmentDownloadClick,
-                reactionViewClickListener = { container.reactionViewClickListener.onReactionViewClick(data.message) },
-                userClickListener = { container.userClickListener.onUserClick(data.message.user) },
-                giphySendListener = { _, action ->
-                    container.giphySendListener.onGiphySend(data.message, action)
-                },
-                linkClickListener = container.linkClickListener::onLinkClick
-            )
+    private fun initializeListeners() {
+        binding.run {
+            listeners?.let { container ->
+                root.setOnClickListener {
+                    data.message.attachments.firstOrNull()?.let { attachment ->
+                        container.attachmentClickListener.onAttachmentClick(data.message, attachment)
+                    }
+                }
+                reactionsView.setReactionClickListener {
+                    container.reactionViewClickListener.onReactionViewClick(data.message)
+                }
+                footnote.setOnThreadClickListener {
+                    container.threadClickListener.onThreadClick(data.message)
+                }
+                root.setOnLongClickListener {
+                    container.messageLongClickListener.onMessageLongClick(data.message)
+                    true
+                }
+                avatarView.setOnClickListener {
+                    container.userClickListener.onUserClick(data.message.user)
+                }
+            }
         }
     }
 
@@ -92,34 +93,8 @@ internal class GiphyAttachmentViewHolder(
 
         imageCorners(binding.mediaAttachmentView, data)
 
-        modifiedListeners(listeners)?.let { listeners ->
-            setListeners(binding.mediaAttachmentView, listeners, data)
-        }
-
         val attachment = data.message.attachments.first()
         binding.mediaAttachmentView.showGiphy(attachment = attachment)
-    }
-
-    /**
-     * Sets the listeners that are valid for the Giphy container.
-     *
-     * @param mediaAttachmentView The Giphy image container.
-     * @param listeners The set of listeners available.
-     * @param data The data used to propagate events through the listeners.
-     */
-    private fun setListeners(
-        mediaAttachmentView: GiphyMediaAttachmentView,
-        listeners: MessageListListenerContainer,
-        data: MessageListItem.MessageItem,
-    ) {
-        mediaAttachmentView.setOnLongClickListener {
-            listeners.messageLongClickListener.onMessageLongClick(data.message)
-            true
-        }
-
-        mediaAttachmentView.setOnClickListener {
-            listeners.attachmentClickListener.onAttachmentClick(data.message, data.message.attachments.first())
-        }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -11,8 +11,6 @@ import android.widget.LinearLayout
 import androidx.core.os.bundleOf
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.asLiveData
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
@@ -43,8 +41,6 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
 
     private var _binding: StreamUiDialogMessageOptionsBinding? = null
     private val binding get() = _binding!!
-
-    private val currentUser: LiveData<User?> = ChatClient.instance().globalState.user.asLiveData()
 
     private val optionsMode: OptionsMode by lazy {
         requireArguments().getSerializable(ARG_OPTIONS_MODE) as OptionsMode
@@ -196,7 +192,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         with(binding.userReactionsView) {
             isVisible = true
             configure(style)
-            currentUser.value?.let { user -> setMessage(message, user) }
+            ChatClient.instance().globalState.user.value?.let { user -> setMessage(message, user) }
 
             setOnUserReactionClickListener { user, reaction ->
                 userReactionClickHandler?.let {
@@ -208,7 +204,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     }
 
     private fun isMessageAuthorMuted(): Boolean {
-        return currentUser.value?.mutes?.any { mute -> mute.target.id == message.user.id } == true
+        return ChatClient.instance().globalState.user.value?.mutes?.any { mute -> mute.target.id == message.user.id } == true
     }
 
     private fun setupMessageOptions() {


### PR DESCRIPTION
### 🎯 Goal

Fix bugs listed in https://github.com/GetStream/stream-chat-android/issues/3259

### 🛠 Implementation details

- `GiphyAttachmentViewHolder`

Remove `modifiedListeners()` and set the listeners upon initialization.

- `UserReactionsView` not displaying reactions properly

Do not rely on `private val currentUser: LiveData<User?> = ChatClient.instance().globalState.user.asLiveData()`. The `LiveData` is never observed, only having it's value read directly. This in turn leads to a race condition in which the `LiveData` will never emit the value before the value is read as `currentUser?.value`. Instead realy on `ChatClient.instance().globalState.user.?.value`.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| ![Screenshot_1648481759](https://user-images.githubusercontent.com/37080097/160436426-26965c0a-f83b-485c-a26a-e09e821b8f44.png) | ![Screenshot_1648481794](https://user-images.githubusercontent.com/37080097/160436434-1f56812a-a12f-46c3-8951-12080fe2e557.png) |

### 🧪 Testing

1. Make sure that you are able to perform the following options on a Giphy message: 

- Open the options dialog by long clicking
- Open the options dialog and view reactions by clicking on `ViewReactionsView` (the reactions previously left)
- Open external applications such as the browser by clicking on the Giphy attachment
- Make sure that all information is properly synced. e.g. reactions left from another device are readily visible

2. Open a dialog by clicking on a reaction to a message and making sure that the reactions are properly displayed in the dialog.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![doge](https://user-images.githubusercontent.com/37080097/160437822-0858f2b7-f335-471f-906a-540dc9db6020.gif)
