### PR TITLE
[2957] Fix code snippets links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed the links in UI Components code snippets. [#3261](https://github.com/GetStream/stream-chat-android/pull/3261)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelListHeader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelListHeader.kt
@@ -9,14 +9,14 @@ import io.getstream.chat.android.ui.channel.list.header.viewmodel.ChannelListHea
 import io.getstream.chat.android.ui.channel.list.header.viewmodel.bindView
 
 /**
- * [Channel List Header](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list-header/)
+ * [Channel List Header](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list-header/)
  */
 private class ChannelListHeaderViewSnippets : Fragment() {
 
     private lateinit var channelListHeaderView: ChannelListHeaderView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list-header/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list-header/#usage)
      */
     fun usage() {
         // Get ViewModel
@@ -26,7 +26,7 @@ private class ChannelListHeaderViewSnippets : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list-header/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list-header/#handling-actions)
      */
     fun handlingActions() {
         channelListHeaderView.setOnActionButtonClickListener {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelListView.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelListView.kt
@@ -26,14 +26,14 @@ import io.getstream.chat.android.ui.channel.list.viewmodel.factory.ChannelListVi
 import io.getstream.chat.android.ui.common.style.TextStyle
 
 /**
- * [Channel List](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list/)
+ * [Channel List](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list/)
  */
 private class ChannelListViewSnippets() : Fragment() {
 
     private lateinit var channelListView: ChannelListView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list/#usage)
      */
     fun usage() {
         // Instantiate the ViewModel
@@ -52,7 +52,7 @@ private class ChannelListViewSnippets() : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list/#handling-actions)
      */
     fun handlingActions() {
         channelListView.setChannelItemClickListener { channel ->
@@ -67,7 +67,7 @@ private class ChannelListViewSnippets() : Fragment() {
     }
 
     /**
-     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list/#customization)
+     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list/#customization)
      */
     fun customization() {
         TransformStyle.channelListStyleTransformer = StyleTransformer { defaultStyle ->
@@ -88,7 +88,7 @@ private class ChannelListViewSnippets() : Fragment() {
     }
 
     /**
-     * [Creating a Custom ViewHolder Factory](https://getstream.io/chat/docs/sdk/android/ui/components/channel-list/#creating-a-custom-viewholder-factory)
+     * [Creating a Custom ViewHolder Factory](https://getstream.io/chat/docs/sdk/android/ui/channel-components/channel-list/#creating-a-custom-viewholder-factory)
      */
     fun customViewHolderFactory() {
         class CustomChannelListItemViewHolderFactory : ChannelListItemViewHolderFactory() {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/ChatUi.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/ChatUi.kt
@@ -35,14 +35,14 @@ import org.threeten.bp.LocalTime
 import org.threeten.bp.format.DateTimeFormatter
 
 /**
- * [General Configuration](https://getstream.io/chat/docs/sdk/android/ui/chatui)
+ * [General Configuration](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/)
  */
 private class ChatUiSnippets {
 
     private lateinit var context: Context
 
     /**
-     * [Custom Reactions](https://getstream.io/chat/docs/sdk/android/ui/chatui/#custom-reactions)
+     * [Custom Reactions](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#custom-reactions)
      */
     fun customReactions() {
         val loveDrawable = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_love)!!
@@ -55,7 +55,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Custom MIME Type Icons](https://getstream.io/chat/docs/sdk/android/ui/chatui/#custom-mime-type-icons)
+     * [Custom MIME Type Icons](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#custom-mime-type-icons)
      */
     fun customMimeTypeIcons() {
         ChatUI.mimeTypeIconProvider = MimeTypeIconProvider { mimeType ->
@@ -75,7 +75,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Customizing Avatar](https://getstream.io/chat/docs/sdk/android/ui/chatui/#customizing-avatar)
+     * [Customizing Avatar](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#customizing-avatar)
      */
     fun customizingAvatar() {
         ChatUI.avatarBitmapFactory = object : AvatarBitmapFactory(context) {
@@ -97,7 +97,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Customizing Image Headers](https://getstream.io/chat/docs/sdk/android/ui/chatui/#adding-extra-headers-to-image-requests)
+     * [Customizing Image Headers](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#adding-extra-headers-to-image-requests)
      */
     fun customizingImageHeaders() {
         ChatUI.imageHeadersProvider = object : ImageHeadersProvider {
@@ -108,7 +108,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Changing the Default Font](https://getstream.io/chat/docs/sdk/android/ui/chatui/#changing-the-default-font)
+     * [Changing the Default Font](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#changing-the-default-font)
      */
     fun changingTheDefaultFont() {
         ChatUI.fonts = object : ChatFonts {
@@ -125,7 +125,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Transforming Message Text](https://getstream.io/chat/docs/sdk/android/ui/chatui/#transforming-message-text)
+     * [Transforming Message Text](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#transforming-message-text)
      */
     fun transformingMessageText() {
         ChatUI.messageTextTransformer =
@@ -136,14 +136,14 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Applying Markdown](https://getstream.io/chat/docs/sdk/android/ui/chatui/#markdown)
+     * [Applying Markdown](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#markdown)
      */
     fun applyingMarkDown() {
         ChatUI.messageTextTransformer = MarkdownTextTransformer(context)
     }
 
     /**
-     * [Customizing Navigator](https://getstream.io/chat/docs/sdk/android/ui/chatui/#navigator)
+     * [Customizing Navigator](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#navigator)
      */
     fun customizingNavigator() {
         val navigationHandler = ChatNavigationHandler { destination: ChatDestination ->
@@ -155,7 +155,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Customizing Channel Name Formatter](https://getstream.io/chat/docs/sdk/android/ui/chatui/#customizing-channelnameformatter)
+     * [Customizing Channel Name Formatter](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#customizing-channelnameformatter)
      */
     fun customizingChannelNameFormatter() {
         ChatUI.channelNameFormatter = ChannelNameFormatter { channel, currentUser ->
@@ -164,7 +164,7 @@ private class ChatUiSnippets {
     }
 
     /**
-     * [Customizing Date Formatter](https://getstream.io/chat/docs/sdk/android/ui/chatui/#customizing-dateformatter)
+     * [Customizing Date Formatter](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#customizing-dateformatter)
      */
     fun customizingDateFormatter() {
         ChatUI.dateFormatter = object : DateFormatter {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageInput.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageInput.kt
@@ -27,14 +27,14 @@ import io.getstream.chat.docs.databinding.CustomAttachmentItemBinding
 import java.io.File
 
 /**
- * [Message Input](https://getstream.io/chat/docs/sdk/android/ui/components/message-input/)
+ * [Message Input](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-input/)
  */
 private class MessageInputViewSnippets() : Fragment() {
 
     private lateinit var messageInputView: MessageInputView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/message-input/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-input/#usage)
      */
     fun usage() {
         // Get ViewModel
@@ -45,7 +45,7 @@ private class MessageInputViewSnippets() : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/message-input/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-input/#handling-actions)
      */
     fun handlingActions() {
         messageInputView.setOnSendButtonClickListener {
@@ -125,7 +125,7 @@ private class MessageInputViewSnippets() : Fragment() {
     }
 
     /**
-     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/components/message-input/#customization)
+     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-input/#customization)
      */
     fun customization() {
         TransformStyle.messageInputStyleTransformer = StyleTransformer { viewStyle ->

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
@@ -35,14 +35,14 @@ import org.threeten.bp.LocalTime
 import org.threeten.bp.format.DateTimeFormatter
 
 /**
- * [Message List](https://getstream.io/chat/docs/sdk/android/ui/components/message-list/)
+ * [Message List](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list/)
  */
 class MessageListViewSnippets : Fragment() {
 
     private lateinit var messageListView: MessageListView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/message-list/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list/#usage)
      */
     fun usage() {
         // Init view model
@@ -55,7 +55,7 @@ class MessageListViewSnippets : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/message-list/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list/#handling-actions)
      */
     fun handlingActions() {
         messageListView.setLastMessageReadHandler {
@@ -109,7 +109,7 @@ class MessageListViewSnippets : Fragment() {
     }
 
     /**
-     * [Listeners](https://getstream.io/chat/docs/sdk/android/ui/components/message-list/#listeners)
+     * [Listeners](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list/#listeners)
      */
     fun listeners() {
         messageListView.setMessageClickListener { message: Message ->
@@ -136,7 +136,7 @@ class MessageListViewSnippets : Fragment() {
     }
 
     /**
-     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/components/message-list/#customization)
+     * [Customization](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list/#customization)
      */
     fun customization() {
         TransformStyle.messageListItemStyleTransformer = StyleTransformer { defaultViewStyle ->

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageListHeader.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageListHeader.kt
@@ -10,14 +10,14 @@ import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.factory.MessageListViewModelFactory
 
 /**
- * [Message List Header](https://getstream.io/chat/docs/sdk/android/ui/components/message-list-header/)
+ * [Message List Header](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list-header/)
  */
 private class MessageListHeaderViewSnippets() : Fragment() {
 
     private lateinit var messageListHeaderView: MessageListHeaderView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/message-list-header/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list-header/#usage)
      */
     fun usage() {
         // Get ViewModel
@@ -28,7 +28,7 @@ private class MessageListHeaderViewSnippets() : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/message-list-header/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/message-components/message-list-header/#handling-actions)
      */
     fun handlingActions() {
         messageListHeaderView.setAvatarClickListener {

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/utility/AttachmentGallery.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/utility/AttachmentGallery.kt
@@ -8,14 +8,14 @@ import io.getstream.chat.android.ui.gallery.AttachmentGalleryDestination
 import io.getstream.chat.android.ui.message.list.MessageListView
 
 /**
- * [Attachment Gallery](https://getstream.io/chat/docs/sdk/android/ui/components/attachment-gallery/)
+ * [Attachment Gallery](https://getstream.io/chat/docs/sdk/android/ui/utility-components/attachment-gallery/)
  */
 private class AttachmentGallery {
 
     private lateinit var messageListView: MessageListView
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/attachment-gallery/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/utility-components/attachment-gallery/#handling-actions)
      */
     fun handlingActions() {
         messageListView.setAttachmentReplyOptionClickHandler { resultItem ->
@@ -41,7 +41,7 @@ private class AttachmentGallery {
     }
 
     /**
-     * [Navigating to Attachment Gallery](https://getstream.io/chat/docs/sdk/android/ui/components/attachment-gallery/#navigating-to-attachment-gallery)
+     * [Navigating to Attachment Gallery](https://getstream.io/chat/docs/sdk/android/ui/utility-components/attachment-gallery/#navigating-to-attachment-gallery)
      */
     fun navigatingToAttachmentGallery(activity: AppCompatActivity) {
         // Create Attachment Gallery Destination

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/utility/SearchView.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/utility/SearchView.kt
@@ -10,7 +10,7 @@ import io.getstream.chat.android.ui.search.list.viewmodel.SearchViewModel
 import io.getstream.chat.android.ui.search.list.viewmodel.bindView
 
 /**
- * [Search View](https://getstream.io/chat/docs/sdk/android/ui/components/search-view/)
+ * [Search View](https://getstream.io/chat/docs/sdk/android/ui/utility-components/search-view/)
  */
 private class SearchView : Fragment() {
 
@@ -18,7 +18,7 @@ private class SearchView : Fragment() {
     lateinit var searchResultListView: SearchResultListView
 
     /**
-     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/components/search-view/#usage)
+     * [Usage](https://getstream.io/chat/docs/sdk/android/ui/utility-components/search-view/#usage)
      */
     fun usage() {
         // Get ViewModel
@@ -32,7 +32,7 @@ private class SearchView : Fragment() {
     }
 
     /**
-     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/components/search-view/#handling-actions)
+     * [Handling Actions](https://getstream.io/chat/docs/sdk/android/ui/utility-components/search-view/#handling-actions)
      */
     fun handlingActions() {
         searchInputView.setContinuousInputChangedListener {
@@ -47,7 +47,7 @@ private class SearchView : Fragment() {
     }
 
     /**
-     * [Updating Search Query Programmatically](https://getstream.io/chat/docs/sdk/android/ui/components/search-view/#updating-the-search-query-programmatically)
+     * [Updating Search Query Programmatically](https://getstream.io/chat/docs/sdk/android/ui/utility-components/search-view/#updating-the-search-query-programmatically)
      */
     fun updatingSearchQueryProgrammatically() {
         // Update the current search query programmatically


### PR DESCRIPTION
### 🎯 Goal

Due to concurrent changes to the docs (code snippets, documentation structure), some of the links in the snippets are broken.

### 🧪 Testing

Check that the links are no longer broken.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
