### PR TITLE
[3262] Set start and end padding on the root layout in stream_ui_item…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Users now able to open `MessageOptionsDialogFragment` by clicking on a reaction left on a Giphy message. [#3620](https://github.com/GetStream/stream-chat-android/pull/3260)
 - inside `MessageOptionsDialogFragment` now properly displays all of the reactions to a message. Previously it erroneously displayed a blank state. [#3620](https://github.com/GetStream/stream-chat-android/pull/3260)
 - Fixed the links in UI Components code snippets. [#3261](https://github.com/GetStream/stream-chat-android/pull/3261)
+- Messages containing links are now properly aligned with other types of messages. They use `@dimen/stream_ui_spacing_small` for their root layout start and end padding. [#3264](https://github.com/GetStream/stream-chat-android/pull/3264)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_link_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_link_attachment.xml
@@ -4,6 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
+    android:paddingStart="@dimen/stream_ui_spacing_small"
+    android:paddingEnd="@dimen/stream_ui_spacing_small"
     >
 
     <io.getstream.chat.android.ui.message.list.adapter.view.internal.GapView
@@ -78,7 +80,6 @@
             android:layout_height="wrap_content"
             android:gravity="start"
             android:hyphenationFrequency="normal"
-            app:lineHeight="16sp"
             android:paddingStart="@dimen/stream_ui_spacing_medium"
             android:paddingTop="@dimen/stream_ui_spacing_small"
             android:paddingEnd="@dimen/stream_ui_spacing_medium"
@@ -87,6 +88,7 @@
             android:textColor="@color/stream_ui_text_color_primary"
             android:textColorLink="@color/stream_ui_accent_blue"
             android:textDirection="locale"
+            app:lineHeight="16sp"
             />
 
     </LinearLayout>


### PR DESCRIPTION
### 🎯 Goal

Align messages containing link attachments properly.

### 🛠 Implementation details

Set the start and end padding of the root layout in `stream_ui_item_link_attachment.xml` to `@dimen/stream_ui_spacing_small`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/37080097/160609620-bc0071bb-6716-4dea-99dc-63055fc67da1.png) | ![after](https://user-images.githubusercontent.com/37080097/160609609-0193ffd2-4dcd-4caa-969e-fee2ce68ee5b.png) |

### 🧪 Testing

Enter any channel in which there is a message containing a link attachment that was sent by a different user than the one currently logged in and check that the padding of said message is the same as the padding of the other messages.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![idk](https://user-images.githubusercontent.com/37080097/160610469-acba8262-af7f-4b97-834b-8bba7e3a884b.gif)

