### PR TITLE
Fixed User deserialization error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed `User` model deserialization error when `User.image` is null. [#3283](https://github.com/GetStream/stream-chat-android/pull/3283)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
@@ -24,8 +24,8 @@ internal fun User.toDto(): UpstreamUserDto =
 internal fun DownstreamUserDto.toDomain(): User =
     User(
         id = id,
-        name = name,
-        image = image,
+        name = name ?: "",
+        image = image ?: "",
         role = role,
         invisible = invisible,
         banned = banned,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -28,8 +28,8 @@ internal data class UpstreamUserDto(
 @JsonClass(generateAdapter = true)
 internal data class DownstreamUserDto(
     val id: String,
-    val name: String = "",
-    val image: String = "",
+    val name: String?,
+    val image: String?,
     val role: String,
     val invisible: Boolean = false,
     val banned: Boolean,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamUserDtoAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/DownstreamUserDtoAdapterTest.kt
@@ -3,8 +3,10 @@ package io.getstream.chat.android.client.parser2
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserDto
 import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamJson
 import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamJsonWithoutExtraData
+import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamJsonWithoutImageAndName
 import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamUser
 import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamUserWithoutExtraData
+import io.getstream.chat.android.client.parser2.testdata.UserDtoTestData.downstreamUserWithoutImageAndName
 import org.amshove.kluent.invoking
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldThrow
@@ -17,6 +19,12 @@ internal class DownstreamUserDtoAdapterTest {
     fun `Deserialize JSON user without custom fields`() {
         val user = parser.fromJson(downstreamJsonWithoutExtraData, DownstreamUserDto::class.java)
         user shouldBeEqualTo downstreamUserWithoutExtraData
+    }
+
+    @Test
+    fun `Deserialize JSON user without image and name fields`() {
+        val user = parser.fromJson(downstreamJsonWithoutImageAndName, DownstreamUserDto::class.java)
+        user shouldBeEqualTo downstreamUserWithoutImageAndName
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
@@ -54,6 +54,50 @@ internal object UserDtoTestData {
         )
 
     @Language("JSON")
+    val downstreamJsonWithoutImageAndName =
+        """{
+            "id": "",
+            "role": "",
+            "name": null,
+            "image": null,
+            "invisible": false,
+            "banned": false,
+            "devices": [],
+            "online": false,
+            "created_at": null,
+            "updated_at": null,
+            "last_active": null,
+            "total_unread_count": 0,
+            "unread_channels": 0,
+            "unread_count": 0,
+            "mutes": [],
+            "teams": [],
+            "channel_mutes": []
+         }"""
+
+    val downstreamUserWithoutImageAndName =
+        DownstreamUserDto(
+            banned = false,
+            id = "",
+            name = null,
+            image = null,
+            invisible = false,
+            role = "",
+            devices = emptyList(),
+            online = false,
+            updated_at = null,
+            created_at = null,
+            last_active = null,
+            total_unread_count = 0,
+            unread_channels = 0,
+            unread_count = 0,
+            mutes = emptyList(),
+            teams = emptyList(),
+            channel_mutes = emptyList(),
+            extraData = emptyMap(),
+        )
+
+    @Language("JSON")
     val downstreamJson =
         """{
             "id": "userId",


### PR DESCRIPTION
#3278 

### 🎯 Goal

Fixed `User` model deserialization error when `User.image` is null.

### 🛠 Implementation details

Made `DownstreamUserDto.name` and `DownstreamUserDto.image` nullable. 

### 🧪 Testing

Run tests and check if users' images and names work as expected.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
