### PR TITLE
Fixing client.state NPE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed crash related with logging out while running a request to update channels.
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -45,7 +45,9 @@ internal class LogicRegistry internal constructor(
                 stateRegistry.queryChannels(filter, sort).toMutableState(),
                 client,
                 repos,
-                GlobalMutableState.get().toMutableState()
+                GlobalMutableState.get().toMutableState(),
+                this,
+                stateRegistry
             )
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -21,11 +21,11 @@ import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.map
 import io.getstream.chat.android.offline.event.handler.chat.EventHandlingResult
 import io.getstream.chat.android.offline.extensions.internal.applyPagination
-import io.getstream.chat.android.offline.extensions.internal.logic
 import io.getstream.chat.android.offline.extensions.internal.users
-import io.getstream.chat.android.offline.extensions.state
 import io.getstream.chat.android.offline.model.channel.internal.ChannelConfig
 import io.getstream.chat.android.offline.model.querychannels.pagination.internal.AnyChannelPaginationRequest
+import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
+import io.getstream.chat.android.offline.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.plugin.state.channel.ChannelState
 import io.getstream.chat.android.offline.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.offline.plugin.state.querychannels.QueryChannelsState
@@ -43,6 +43,8 @@ internal class QueryChannelsLogic(
     private val client: ChatClient,
     private val repos: RepositoryFacade,
     private val globalState: GlobalMutableState,
+    private val logicRegistry: LogicRegistry,
+    private val stateRegistry: StateRegistry
 ) {
 
     private val logger = ChatLogger.get("QueryChannelsLogic")
@@ -103,7 +105,7 @@ internal class QueryChannelsLogic(
      */
     internal suspend fun addChannel(channel: Channel) {
         addChannels(listOf(channel), repos)
-        client.logic.channel(channel.type, channel.id).updateDataFromChannel(channel)
+        logicRegistry.channel(channel.type, channel.id).updateDataFromChannel(channel)
     }
 
     private suspend fun addChannels(channels: List<Channel>, queryChannelsRepository: QueryChannelsRepository) {
@@ -202,7 +204,7 @@ internal class QueryChannelsLogic(
                 .let { removeChannels(it, repos) }
         }
         mutableState.channelsOffset.value += channels.size
-        channels.forEach { client.logic.channel(it.type, it.id).updateDataFromChannel(it) }
+        channels.forEach { logicRegistry.channel(it.type, it.id).updateDataFromChannel(it) }
         addChannels(channels, repos)
     }
 
@@ -272,7 +274,7 @@ internal class QueryChannelsLogic(
             .intersect(cidList)
             .associateWith { cid ->
                 val (channelType, channelId) = cid.cidToTypeAndId()
-                client.state.channel(channelType, channelId).toChannel()
+                stateRegistry.channel(channelType, channelId).toChannel()
             }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix NPE in client.state.

### 🛠 Implementation details

We run `QueryChannelsLogic.updateOnlineChannels` asynchronously so changes in ChatClient.state can result in unpredictable results. An example is that client.state may be null, is the user disconnects while waiting for the results of the request. 

By passing the reference in the constructor, this reference won't be lost in the middle of the request. 

### 🧪 Testing

Log in and out some times in the app, in different scenarios.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
