### PR TITLE
[2680] Improve message input attachments UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Switched from vertical to horizontal scrolling for files in the preview section of the message composer. [#3289](https://github.com/GetStream/stream-chat-android/pull/3289)
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentPreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentPreviewContent.kt
@@ -4,11 +4,10 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Surface
@@ -38,12 +37,11 @@ public fun FileAttachmentPreviewContent(
     onAttachmentRemoved: (Attachment) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    LazyColumn(
+    LazyRow(
         modifier = modifier
-            .clip(RoundedCornerShape(16.dp))
-            .heightIn(max = 300.dp),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.Top)
+            .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start)
     ) {
         items(attachments) { attachment ->
             Surface(
@@ -54,7 +52,7 @@ public fun FileAttachmentPreviewContent(
             ) {
                 Row(
                     modifier = Modifier
-                        .fillMaxWidth()
+                        .width(200.dp)
                         .height(50.dp)
                         .padding(vertical = 8.dp, horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically
@@ -63,8 +61,8 @@ public fun FileAttachmentPreviewContent(
 
                     Column(
                         modifier = Modifier
-                            .fillMaxWidth(0.85f)
-                            .padding(start = 16.dp),
+                            .weight(1f)
+                            .padding(horizontal = 8.dp),
                         horizontalAlignment = Alignment.Start,
                         verticalArrangement = Arrangement.Center
                     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentPreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentPreviewContent.kt
@@ -35,7 +35,7 @@ public fun ImageAttachmentPreviewContent(
     modifier: Modifier = Modifier,
 ) {
     LazyRow(
-        modifier = modifier.clip(RoundedCornerShape(16.dp)),
+        modifier = modifier.clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp, Alignment.Start)
     ) {


### PR DESCRIPTION
### 🎯 Goal

Implement horizontal scrolling for file previews in the message composer.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2022-04-04 23 52 51](https://user-images.githubusercontent.com/9600921/161630266-f1347dfb-7728-4377-9fdc-348fcb2a1481.jpeg) | ![photo_2022-04-04 23 46 51](https://user-images.githubusercontent.com/9600921/161629401-c41c947b-6596-4231-9f2e-b2d723fcdf9d.jpeg) |
| ![photo_2022-04-04 23 52 48](https://user-images.githubusercontent.com/9600921/161630272-5867da24-d8ce-4beb-af86-14421a78a937.jpeg) | ![photo_2022-04-04 23 46 53](https://user-images.githubusercontent.com/9600921/161629396-a2a2a679-b36e-4e52-abaf-bc011b9f2e1f.jpeg) |

### 🧪 Testing

1. Run Compose sample app and select several file attachments
2. Verify that they can be scrolled horizontally

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
