### PR TITLE
[3295] Show video thumbnail in attachment picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-- Fixed crash related with logging out while running a request to update channels.
+- Fixed crash related with logging out while running a request to update channels. [3286](https://github.com/GetStream/stream-chat-android/pull/3286)
 
 ### ⬆️ Improved
 
@@ -52,7 +52,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-Added support for file upload configuration that lets you specify what types of files and images you want to allow or block from being uploaded. [3280](https://github.com/GetStream/stream-chat-android/pull/3280)
+- Added support for file upload configuration that lets you specify what types of files and images you want to allow or block from being uploaded. [3280](https://github.com/GetStream/stream-chat-android/pull/3280)
 
 ### ⚠️ Changed
 
@@ -60,6 +60,7 @@ Added support for file upload configuration that lets you specify what types of 
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Added thumbnails for video attachments in the attachment picker. [#3300](https://github.com/GetStream/stream-chat-android/pull/3300)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/build.gradle
+++ b/stream-chat-android-compose/build.gradle
@@ -73,4 +73,5 @@ dependencies {
     // Coil
     implementation Dependencies.composeCoil
     implementation Dependencies.coilGif
+    implementation Dependencies.coilVideo
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -143,28 +144,55 @@ internal fun DefaultImagesPickerItem(
         }
 
         if (isVideo) {
-            Icon(
-                modifier = Modifier
-                    .padding(4.dp)
-                    .size(24.dp)
-                    .mirrorRtl(LocalLayoutDirection.current)
-                    .align(Alignment.BottomStart),
-                painter = painterResource(id = R.drawable.stream_compose_ic_video),
-                contentDescription = null,
-                tint = Color.White
-            )
+            VideoThumbnailOverlay(attachmentMetaData.videoLength)
+        }
+    }
+}
 
-            val videoLength = attachmentMetaData.videoLength
-            if (videoLength != 0L) {
-                Text(
-                    modifier = Modifier
-                        .padding(horizontal = 4.dp, vertical = 8.dp)
-                        .align(Alignment.BottomEnd),
-                    text = MediaStringUtil.convertVideoLength(videoLength),
-                    style = ChatTheme.typography.bodyBold,
-                    color = Color.White
+/**
+ * Represents an overlay that is shown over videos in the picker.
+ *
+ * @param videoLength The duration of video in seconds.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+private fun VideoThumbnailOverlay(
+    videoLength: Long,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        Color.Transparent,
+                        Color.Transparent,
+                        Color.Black
+                    )
                 )
-            }
+            )
+    ) {
+        Icon(
+            modifier = Modifier
+                .padding(4.dp)
+                .size(24.dp)
+                .mirrorRtl(LocalLayoutDirection.current)
+                .align(Alignment.BottomStart),
+            painter = painterResource(id = R.drawable.stream_compose_ic_video),
+            contentDescription = null,
+            tint = Color.White
+        )
+
+        if (videoLength != 0L) {
+            Text(
+                modifier = Modifier
+                    .padding(horizontal = 4.dp, vertical = 8.dp)
+                    .align(Alignment.BottomEnd),
+                text = MediaStringUtil.convertVideoLength(videoLength),
+                style = ChatTheme.typography.bodyBold,
+                color = Color.White
+            )
         }
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+ 
 package io.getstream.chat.android.compose.ui.components.attachments.images
 
 import androidx.compose.foundation.ExperimentalFoundationApi

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
- 
+
 package io.getstream.chat.android.compose.ui.components.attachments.images
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -32,18 +32,27 @@ import androidx.compose.foundation.lazy.LazyVerticalGrid
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.Icon
+import androidx.compose.material.Text
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import coil.compose.rememberImagePainter
+import coil.fetch.VideoFrameUriFetcher
+import coil.request.videoFrameMillis
+import com.getstream.sdk.chat.model.ModelType
+import com.getstream.sdk.chat.utils.MediaStringUtil
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentPickerItemState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.mirrorRtl
 
 /**
  * Shows the UI for images the user can pick for message attachments. Exposes the logic of selecting
@@ -86,7 +95,18 @@ internal fun DefaultImagesPickerItem(
     imageItem: AttachmentPickerItemState,
     onImageSelected: (AttachmentPickerItemState) -> Unit,
 ) {
-    val painter = rememberImagePainter(data = imageItem.attachmentMetaData.uri.toString())
+    val attachmentMetaData = imageItem.attachmentMetaData
+    val isVideo = attachmentMetaData.type == ModelType.attach_video
+
+    val painter = rememberImagePainter(
+        data = attachmentMetaData.uri.toString(),
+        builder = {
+            if (isVideo) {
+                videoFrameMillis(VideoFrameMillis)
+                fetcher(VideoFrameUriFetcher(LocalContext.current))
+            }
+        }
+    )
 
     Box(
         modifier = Modifier
@@ -121,5 +141,35 @@ internal fun DefaultImagesPickerItem(
                 )
             }
         }
+
+        if (isVideo) {
+            Icon(
+                modifier = Modifier
+                    .padding(4.dp)
+                    .size(24.dp)
+                    .mirrorRtl(LocalLayoutDirection.current)
+                    .align(Alignment.BottomStart),
+                painter = painterResource(id = R.drawable.stream_compose_ic_video),
+                contentDescription = null,
+                tint = Color.White
+            )
+
+            val videoLength = attachmentMetaData.videoLength
+            if (videoLength != 0L) {
+                Text(
+                    modifier = Modifier
+                        .padding(horizontal = 4.dp, vertical = 8.dp)
+                        .align(Alignment.BottomEnd),
+                    text = MediaStringUtil.convertVideoLength(videoLength),
+                    style = ChatTheme.typography.bodyBold,
+                    color = Color.White
+                )
+            }
+        }
     }
 }
+
+/**
+ * The time code of the frame to extract from a video.
+ */
+private const val VideoFrameMillis: Long = 1000

--- a/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_video.xml
+++ b/stream-chat-android-compose/src/main/res/drawable/stream_compose_ic_video.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="#000000"
+        android:pathData="M15,8V16H5V8H15ZM16,6H4C3.45,6 3,6.45 3,7V17C3,17.55 3.45,18 4,18H16C16.55,18 17,17.55 17,17V13.5L21,17.5V6.5L17,10.5V7C17,6.45 16.55,6 16,6Z"
+        />
+</vector>


### PR DESCRIPTION
### 🎯 Goal

Apart from images, we should also display videos in the first tab of our attachments picker. Currently, the Compose version of the SDK shows no thumbnails for videos.

### 🛠 Implementation details

In order to support video thumbnails, we need to use `VideoFrameUriFetcher` from the `io.coil-kt:coil-video` library.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2022-04-07 02 44 35](https://user-images.githubusercontent.com/9600921/162092141-ffc0b955-c214-48e7-a506-3163a847c3e5.jpeg) | ![photo_2022-04-07 02 43 19](https://user-images.githubusercontent.com/9600921/162092014-31203d0b-712f-46ee-bb8e-4af93bf607d4.jpeg) |

### 🧪 Testing

1. Open attachment picker and scroll to a video
2. Check that the video thumbnail is displayed

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
