### PR TITLE
[ISSUE-3318] Fixing editing message while offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed crash related with logging out while running a request to update channels. [3286](https://github.com/GetStream/stream-chat-android/pull/3286)
+- Fixed bug where user was not able to send and edit a message while offline. [3318](https://github.com/GetStream/stream-chat-android/pull/3324)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -81,7 +81,10 @@ public fun MessageFooter(messageItem: MessageItemState) {
                 )
             }
 
-            Timestamp(date = message.updatedAt ?: message.createdAt)
+            val date = message.updatedAt ?: message.createdAt ?: message.createdLocallyAt
+            if (date != null) {
+                Timestamp(date = date)
+            }
         }
     }
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
@@ -267,8 +267,9 @@ internal class SyncManager(
                     logger.logD("Deleting message: ${message.id}")
                     channelClient.deleteMessage(message.id).await()
                 }
-                message.updatedLocallyAt != null -> {
+                message.updatedLocallyAt != null && message.createdAt != null -> {
                     logger.logD("Updating message: ${message.id}")
+
                     channelClient.updateMessage(message).await()
                 }
                 else -> {


### PR DESCRIPTION
issue: [3318](https://github.com/GetStream/stream-chat-android/issues/3318)

### 🎯 Goal

Fix editing message while offline.

### 🛠 Implementation details

Check if the message was sent to the backend before trying to update it. If the message was not sent, we shouldn't try to update it in the backend, but send it with the new text. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/162757769-b4ce0351-924d-46d8-b3c7-f9aea97a0369.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/162757742-df6a97b3-aa6e-4d6d-9e26-583ae5b7d8f0.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>
### 🧪 Testing

- Use airplane mode. 
- Send a message
- Edit it
- Become online. 

In develop you will see that the message failed and in this branch, it will be sent. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/162758453-da771ea3-1c31-40f2-92bb-3b659cbd5eee.gif)


