### PR TITLE
[3311] Fix process death issue in Compose sample app

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/BaseConnectedActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/BaseConnectedActivity.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+/**
+ * Base Activity for a logged in user in authorized zone.
+ */
+open class BaseConnectedActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // The application was killed in the background. Starting from the launcher activity.
+        if (savedInstanceState != null && lastNonConfigurationInstance == null) {
+            startActivity(packageManager.getLaunchIntentForPackage(packageName))
+            finishAffinity()
+        }
+    }
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
@@ -21,7 +21,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -66,7 +65,7 @@ import io.getstream.chat.android.compose.viewmodel.channels.ChannelListViewModel
 import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFactory
 import io.getstream.chat.android.offline.extensions.globalState
 
-class ChannelsActivity : AppCompatActivity() {
+class ChannelsActivity : BaseConnectedActivity() {
 
     private val factory by lazy {
         ChannelViewModelFactory(

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -21,7 +21,6 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -74,7 +73,7 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
-class MessagesActivity : AppCompatActivity() {
+class MessagesActivity : BaseConnectedActivity() {
 
     private val factory by lazy {
         MessagesViewModelFactory(


### PR DESCRIPTION
### 🎯 Goal

Fix reconnection issue in Compose sample app.

### 🛠 Implementation details

Our Compose sample app doesn't handle process death gracefully. Even though, we try to keep our Compose app as clean as possible it is still necessary to add some boilerplate to handle the case when the OS kills the app in the background.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2022-04-12 14 23 39](https://user-images.githubusercontent.com/9600921/162949629-dd9dd598-16f2-4688-baad-9eabbb9d7ac3.jpeg) | ![photo_2022-04-12 14 23 36](https://user-images.githubusercontent.com/9600921/162949637-d4d01265-0037-4336-938d-2d0e165ff654.jpeg) |

### 🧪 Testing

1. Open Compose sample app and login with any user
2. On the channels screen, press home button to collapse the application
3. From Android Studio, press the "Terminate Application" button
4. Open recent applications and select the terminated app

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
