### PR TITLE
[3330 ] Fix crash on compose when opening links without a scheme

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -16,8 +16,10 @@
 
 package io.getstream.chat.android.compose.ui.attachments.content
 
+import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
+import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -39,12 +41,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import coil.compose.rememberImagePainter
 import com.getstream.sdk.chat.model.ModelType
 import com.getstream.sdk.chat.utils.extensions.imagePreviewUrl
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.hasLink
@@ -84,6 +88,10 @@ public fun LinkAttachmentContent(
 
     val hasImage = attachment.imagePreviewUrl != null
     val painter = rememberImagePainter(data = attachment.imagePreviewUrl)
+    val errorMessage = stringResource(
+        id = R.string.stream_compose_message_list_error_cannot_open_link,
+        previewUrl
+    )
 
     Column(
         modifier = modifier
@@ -93,12 +101,19 @@ public fun LinkAttachmentContent(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = {
-                    context.startActivity(
-                        Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse(previewUrl)
+                    try {
+                        context.startActivity(
+                            Intent(
+                                Intent.ACTION_VIEW,
+                                Uri.parse(previewUrl)
+                            )
                         )
-                    )
+                    } catch (e: ActivityNotFoundException) {
+                        Toast
+                            .makeText(context, errorMessage, Toast.LENGTH_LONG)
+                            .show()
+                    }
+
                 },
                 onLongClick = { onLongItemClick(message) }
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -113,7 +113,6 @@ public fun LinkAttachmentContent(
                             .makeText(context, errorMessage, Toast.LENGTH_LONG)
                             .show()
                     }
-
                 },
                 onLongClick = { onLongItemClick(message) }
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -109,6 +109,7 @@ public fun LinkAttachmentContent(
                             )
                         )
                     } catch (e: ActivityNotFoundException) {
+                        e.printStackTrace()
                         Toast
                             .makeText(context, errorMessage, Toast.LENGTH_LONG)
                             .show()

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -58,6 +58,7 @@
         <item quantity="other">%d Replies</item>
     </plurals>
     <string name="stream_compose_message_list_empty_messages">No messages</string>
+    <string name="stream_compose_message_list_error_cannot_open_link">There is no app to view this url:\n%s</string>
 
     <!-- Selected Message Menu -->
     <string name="stream_compose_resend_message">Resend</string>

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -19,4 +19,6 @@
     <string name="stream_ui_message_list_attachment_invalid_url">The load failed due to the invalid url.</string>
     <string name="stream_ui_message_list_attachment_invalid_mime_type">Something went wrong. Unable to open attachment: %s</string>
     <string name="stream_ui_message_list_attachment_display_error">Error. File can\'t be displayed</string>
+    <string name="stream_ui_message_list_error_cannot_open_link">There is no app to view this url:\n%s</string>
+
 </resources>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/WebLinkDestination.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/WebLinkDestination.kt
@@ -32,9 +32,11 @@ public class WebLinkDestination(context: Context, private val url: String) : Cha
         try {
             start(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
         } catch (e: ActivityNotFoundException) {
-            Toast.makeText(context,
+            Toast.makeText(
+                context,
                 context.getString(R.string.stream_ui_message_list_error_cannot_open_link, url),
-                Toast.LENGTH_LONG).show()
+                Toast.LENGTH_LONG
+            ).show()
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/WebLinkDestination.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/navigation/destinations/WebLinkDestination.kt
@@ -23,6 +23,7 @@ import android.net.Uri
 import android.widget.Toast
 import com.getstream.sdk.chat.navigation.destinations.ChatDestination
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.ui.R
 
 @InternalStreamChatApi
 public class WebLinkDestination(context: Context, private val url: String) : ChatDestination(context) {
@@ -31,7 +32,9 @@ public class WebLinkDestination(context: Context, private val url: String) : Cha
         try {
             start(Intent(Intent.ACTION_VIEW, Uri.parse(url)))
         } catch (e: ActivityNotFoundException) {
-            Toast.makeText(context, "There is no app to view this url\n$url", Toast.LENGTH_LONG).show()
+            Toast.makeText(context,
+                context.getString(R.string.stream_ui_message_list_error_cannot_open_link, url),
+                Toast.LENGTH_LONG).show()
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

- Fix a crash which occurs in the Compose SDK when trying to click on an image preview of a link attachment when the link has no scheme (http:// or https://)
- Create strings in values for the use case in both UI Components and Compose so that we do not use hardcoded strings

Closes #3330

### 🛠 Implementation details

- Wrapped the on click action in `LinkAttachmentContent` in a try/ catch block
- Introduce string in values for the error toast

### 🎨 UI Changes

| After (Compose) |
| ![Screenshot_1649769533](https://user-images.githubusercontent.com/37080097/162971573-7524bef6-aa9f-481b-803a-f2d0670ef98d.png) |
| img |

**No UI Changes in UI Components**

### 🧪 Testing

** Do these steps for both UI Components and Compose **

1.  Open a channel and either find or send a link with a full scheme (e.g. 'https://kotlinlang.org/)
2. Click on the attachment preview and make sure that it opens correctly
3. Either find or send a link without a scheme (e.g. kotlinlang.org)
4. Click on the attachment preview and make sure that you get a toast saying "There is no app to view this url: somecoolurl.com"

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![crashplane](https://user-images.githubusercontent.com/37080097/162972671-1ed59798-87b2-411f-8895-40baed4007e2.gif)
