### PR TITLE
Fix Detekt Issues on Test module

### DIFF
--- a/config/detekt/detekt-test.yml
+++ b/config/detekt/detekt-test.yml
@@ -1,0 +1,8 @@
+complexity:
+  LongParameterList:
+    active: true
+    functionThreshold: 6
+    constructorThreshold: 7
+    ignoreDefaultParameters: true
+    ignoreDataClasses: true
+    ignoreAnnotatedParameter: []

--- a/scripts/detekt-test.gradle
+++ b/scripts/detekt-test.gradle
@@ -1,0 +1,5 @@
+detekt {
+    // Define the detekt configuration(s) you want to use.
+    // Defaults to the default detekt configuration.
+    config = files("$rootDir/config/detekt/detekt.yml", "$rootDir/config/detekt/detekt-test.yml")
+}

--- a/stream-chat-android-test/build.gradle
+++ b/stream-chat-android-test/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 apply from: "${rootDir}/scripts/android.gradle"
+apply from: "${rootDir}/scripts/detekt-test.gradle"
 
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
     kotlinOptions {

--- a/stream-chat-android-test/detekt-baseline.xml
+++ b/stream-chat-android-test/detekt-baseline.xml
@@ -1,7 +1,0 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<SmellBaseline>
-  <ManuallySuppressedIssues/>
-  <CurrentIssues>
-    <ID>LongParameterList:Mother.kt$( year: Int = positiveRandomInt(), month: Int = positiveRandomInt(), date: Int = positiveRandomInt(), hourOfDay: Int = 0, minute: Int = 0, seconds: Int = 0 )</ID>
-  </CurrentIssues>
-</SmellBaseline>


### PR DESCRIPTION
### 🎯 Goal
Fix the issues we had on Test Module.
On our test module, we have the `Mother` methods that receive a lot of default arguments, In our main "Detekt Rules Set" we only allow 6 arguments per method and dafault argument count on this rule. I have create a new "Detekt Rules Set" that is only applied to this module to avoid this rule that doesn't make sense on this module.
Fixes https://github.com/GetStream/android-internal-board/issues/25

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui)~
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media1.giphy.com/media/ghAbYUswkmXHq/giphy.webp)
