### PR TITLE
Feature/3287 allow multiple reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fixed a bug where command suggestion popup was displayed even though all the commands were disabled. [#3334](https://github.com/GetStream/stream-chat-android/pull/3334)
 
 ### ⬆️ Improved
+- Added a way to customize reactions behavior to allow multiple reactions. [#3341](https://github.com/GetStream/stream-chat-android/pull/3341)
 
 ### ✅ Added
 

--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -31,7 +31,6 @@
     <ID>MagicNumber:GroupAvatar.kt$4</ID>
     <ID>MagicNumber:ImageAttachmentContent.kt$3</ID>
     <ID>MagicNumber:ImageAttachmentContent.kt$4</ID>
-    <ID>MagicNumber:ImagePreviewActivity.kt$ImagePreviewActivity$3f</ID>
     <ID>MagicNumber:ImagePreviewActivity.kt$ImagePreviewActivity$8f</ID>
     <ID>MagicNumber:ImageUtils.kt$255</ID>
     <ID>MagicNumber:ImagesPicker.kt$3</ID>

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2338,7 +2338,8 @@ public final class io/getstream/chat/android/ui/message/list/reactions/view/View
 }
 
 public final class io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding {
-	public static final fun bind (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel;Lio/getstream/chat/android/ui/message/list/MessageListView;Landroidx/lifecycle/LifecycleOwner;)V
+	public static final fun bind (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel;Lio/getstream/chat/android/ui/message/list/MessageListView;Landroidx/lifecycle/LifecycleOwner;Z)V
+	public static synthetic fun bind$default (Lcom/getstream/sdk/chat/viewmodel/messages/MessageListViewModel;Lio/getstream/chat/android/ui/message/list/MessageListView;Landroidx/lifecycle/LifecycleOwner;ZILjava/lang/Object;)V
 }
 
 public final class io/getstream/chat/android/ui/message/list/viewmodel/factory/MessageListViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {

--- a/stream-chat-android-ui-components/detekt-baseline.xml
+++ b/stream-chat-android-ui-components/detekt-baseline.xml
@@ -23,7 +23,7 @@
     <ID>LongMethod:MessageInputViewStyle.kt$MessageInputViewStyle.Companion$internal operator fun invoke(context: Context, attrs: AttributeSet?): MessageInputViewStyle</ID>
     <ID>LongMethod:MessageListHeaderViewStyle.kt$MessageListHeaderViewStyle.Companion$operator fun invoke(context: Context, attrs: AttributeSet?): MessageListHeaderViewStyle</ID>
     <ID>LongMethod:MessageListItemStyle.kt$MessageListItemStyle.Builder$fun build(): MessageListItemStyle</ID>
-    <ID>LongMethod:MessageListViewModelBinding.kt$ @JvmName("bind") public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: LifecycleOwner)</ID>
+    <ID>LongMethod:MessageListViewModelBinding.kt$ @JvmName("bind") public fun MessageListViewModel.bindView( view: MessageListView, lifecycleOwner: LifecycleOwner, enforceUniqueReactions: Boolean = true, )</ID>
     <ID>LongMethod:MessageListViewStyle.kt$MessageListViewStyle.Companion$operator fun invoke(context: Context, attrs: AttributeSet?): MessageListViewStyle</ID>
     <ID>LongMethod:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment$private fun setupOptionsClickListeners( messageOptionsHandlers: MessageOptionsHandlers, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>
     <ID>LongMethod:MessageOptionsView.kt$MessageOptionsView$internal fun configure( configuration: Configuration, style: MessageListViewStyle, isMessageTheirs: Boolean, syncStatus: SyncStatus, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/viewmodel/MessageListViewModelBinding.kt
@@ -44,9 +44,17 @@ import io.getstream.chat.android.ui.message.list.MessageListView
  *
  * This function sets listeners on the view and ViewModel. Call this method
  * before setting any additional listeners on these objects yourself.
+ *
+ * @param view The [MessageListView] to bind the ViewModel to.
+ * @param lifecycleOwner Current owner of the lifecycle in which the events are handled.
+ * @param enforceUniqueReactions If message reactions are unique or a single user can post multiple reactions.
  */
 @JvmName("bind")
-public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: LifecycleOwner) {
+public fun MessageListViewModel.bindView(
+    view: MessageListView,
+    lifecycleOwner: LifecycleOwner,
+    enforceUniqueReactions: Boolean = true,
+) {
 
     view.deletedMessageListItemPredicateLiveData.observe(lifecycleOwner) { messageListItemPredicate ->
         if (messageListItemPredicate != null) {
@@ -77,7 +85,7 @@ public fun MessageListViewModel.bindView(view: MessageListView, lifecycleOwner: 
     }
     view.setMessageRetryHandler { onEvent(RetryMessage(it)) }
     view.setMessageReactionHandler { message, reactionType ->
-        onEvent(MessageReaction(message, reactionType, enforceUnique = true))
+        onEvent(MessageReaction(message, reactionType, enforceUnique = enforceUniqueReactions))
     }
     view.setUserMuteHandler { onEvent(MuteUser(it)) }
     view.setUserUnmuteHandler { onEvent(MessageListViewModel.Event.UnmuteUser(it)) }


### PR DESCRIPTION
### 🎯 Goal

Fixes #3287 for XML

### 🛠 Implementation details

Added param to the bindView function of the `MessageListView` to allow multiple reactions.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1649842572](https://user-images.githubusercontent.com/17215808/163147172-e6f81318-cbf4-4842-afef-9f275704f56e.png) | ![Screenshot_1649842476](https://user-images.githubusercontent.com/17215808/163147207-cc159c83-8e66-425e-abd4-83f34443eed2.png) |

### 🧪 Testing

1. Run the app on `develop`.
2. Try adding more than 1 reaction to an item - you shouldn't be able to do that (only unique reactions allowed).
3. Run the app on this branch and apply the patch below.
4. Add multiple reactions - now it should work.

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision a96cd621ba2ac84b4f956ac601b1c7ad71d6fab5)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1649842505369)
@@ -154,7 +154,7 @@
     private fun initMessagesViewModel() {
         val calendar = Calendar.getInstance()
         messageListViewModel.apply {
-            bindView(binding.messageListView, viewLifecycleOwner)
+            bindView(binding.messageListView, viewLifecycleOwner, false)
             setDateSeparatorHandler { previousMessage, message ->
                 if (previousMessage == null) {
                     true
```

</details>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs