### PR TITLE
[3299] Fix custom message item factory on message options overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed a bug where command suggestion popup was displayed even though all the commands were disabled. [#3334](https://github.com/GetStream/stream-chat-android/pull/3334)
+- Fixed a bug where custom `MessageListItemViewHolderFactory` was ignore on the message options overlay. [#3343](https://github.com/GetStream/stream-chat-android/pull/3343)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/FullScreenDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/FullScreenDialogFragment.kt
@@ -24,6 +24,9 @@ import android.view.ViewGroup
 import android.view.Window
 import androidx.fragment.app.DialogFragment
 
+/**
+ * A fragment that displays a full screen overlay dialog.
+ */
 internal open class FullScreenDialogFragment : DialogFragment() {
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/TouchInterceptingFrameLayout.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/TouchInterceptingFrameLayout.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.internal
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.MotionEvent
+import android.widget.FrameLayout
+import io.getstream.chat.android.ui.common.extensions.internal.createStreamThemeWrapper
+
+/**
+ * A [FrameLayout] which intercepts all touch screen motion events.
+ */
+internal class TouchInterceptingFrameLayout : FrameLayout {
+
+    constructor(context: Context) : this(context, null, 0)
+
+    constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+        context.createStreamThemeWrapper(),
+        attrs,
+        defStyleAttr
+    )
+
+    override fun onInterceptTouchEvent(ev: MotionEvent?): Boolean {
+        return true
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/TouchInterceptingFrameLayout.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/internal/TouchInterceptingFrameLayout.kt
@@ -23,7 +23,7 @@ import android.widget.FrameLayout
 import io.getstream.chat.android.ui.common.extensions.internal.createStreamThemeWrapper
 
 /**
- * A [FrameLayout] which intercepts all touch screen motion events.
+ * A [FrameLayout] that consumes all touch screen motion events.
  */
 internal class TouchInterceptingFrameLayout : FrameLayout {
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/MessageListItemViewHolderFactory.kt
@@ -135,34 +135,6 @@ public open class MessageListItemViewHolderFactory {
     private val textTransformer: ChatMessageTextTransformer by lazy { ChatUI.messageTextTransformer }
 
     /**
-     * This is necessary to maintain the configuration of this factory, but without sharing the instance. Please use
-     * clone when sharing the factory between MessageListView and MessageOptionsDialogFragment
-     */
-    internal fun clone(): MessageListItemViewHolderFactory {
-        val newFactory = MessageListItemViewHolderFactory()
-
-        if (::decoratorProvider.isInitialized) {
-            newFactory.decoratorProvider = decoratorProvider
-        }
-        if (::attachmentFactoryManager.isInitialized) {
-            newFactory.attachmentFactoryManager = attachmentFactoryManager
-        }
-        if (::style.isInitialized) {
-            newFactory.style = style
-        }
-        if (::messageReplyStyle.isInitialized) {
-            newFactory.messageReplyStyle = messageReplyStyle
-        }
-        if (::giphyViewHolderStyle.isInitialized) {
-            newFactory.giphyViewHolderStyle = giphyViewHolderStyle
-        }
-
-        newFactory.listenerContainer = listenerContainer
-
-        return newFactory
-    }
-
-    /**
      * Returns a view type value based on the type and contents of the given [item].
      * The view type returned here will be used as a parameter in [createViewHolder].
      *

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -486,20 +486,20 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
      * Executes the given [block] function on [MessageListItemViewHolderFactory] with
      * the provided decorators and then resets them to the previous value.
      *
-     * @param decoratorProvider The temporary provider of item decorators.
+     * @param messageOptionsDecoratorProvider The temporary provider of item decorators.
      * @param block The block of code that will be invoked with the modified item factory.
      */
     private inline fun MessageListItemViewHolderFactory.withDecoratorProvider(
-        decoratorProvider: MessageOptionsDecoratorProvider,
+        messageOptionsDecoratorProvider: MessageOptionsDecoratorProvider,
         block: (MessageListItemViewHolderFactory) -> Unit,
     ) {
         val tempDecoratorProvider = decoratorProvider
 
-        this.decoratorProvider = decoratorProvider
+        decoratorProvider = messageOptionsDecoratorProvider
         try {
             block(this)
         } finally {
-            this.decoratorProvider = tempDecoratorProvider
+            decoratorProvider = tempDecoratorProvider
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_message_options.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_message_options.xml
@@ -22,7 +22,7 @@
             android:layout_marginHorizontal="@dimen/stream_ui_spacing_small"
             />
 
-        <FrameLayout
+        <io.getstream.chat.android.ui.common.internal.TouchInterceptingFrameLayout
             android:id="@+id/messageContainer"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"


### PR DESCRIPTION
### 🎯 Goal

Custom `MessageListItemViewHolderFactory` is ignored by the message options overlay. The default factory is used instead. 

We need to ensure that in case a client provides a custom `MessageListItemViewHolderFactory`, then this factory is also used on the message options overlay.

### 🛠 Implementation details

Removed the `clone()` method, as it is impossible to clone the provided custom implementation of `MessageListItemViewHolderFactory` without reflection. And even with reflection, it is highly unlikely that we will be able to create a new instance of the class that could have constructor parameters.

So, it was decided to use the original message item factory provided by the message list.

### 🧪 Testing

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision fcd407c0ceee79e2805588d298ced3100e7e62ab)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1649856821369)
@@ -25,6 +25,7 @@
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
 import com.getstream.sdk.chat.viewmodel.messages.getCreatedAtOrThrow
@@ -33,8 +34,14 @@
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.livedata.utils.EventObserver
+import io.getstream.chat.android.ui.databinding.StreamUiItemSystemMessageBinding
 import io.getstream.chat.android.ui.message.input.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.DeletedMessageListItemPredicate
+import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemPayloadDiff
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewType
+import io.getstream.chat.android.ui.message.list.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.bindView
@@ -75,6 +82,9 @@
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         headerViewModel.bindView(binding.messagesHeaderView, viewLifecycleOwner)
+
+        binding.messageListView.setMessageViewHolderFactory(CustomViewHolderFactory())
+
         binding.messageListView.setDeletedMessageListItemPredicate(DeletedMessageListItemPredicate.VisibleToAuthorOnly)
         initChatViewModel()
         initMessagesViewModel()
@@ -227,4 +237,43 @@
         val chatError = error() as ChatNetworkError
         return chatError.streamCode == 4
     }
+
+    private class CustomViewHolderFactory : MessageListItemViewHolderFactory() {
+
+        override fun createViewHolder(
+            parentView: ViewGroup,
+            viewType: Int,
+        ): BaseMessageItemViewHolder<out MessageListItem> {
+            return if (viewType == MessageListItemViewType.PLAIN_TEXT) {
+                CustomMessageViewHolder(parentView, listenerContainer)
+            } else {
+                super.createViewHolder(parentView, viewType)
+            }
+        }
+
+        class CustomMessageViewHolder(
+            parent: ViewGroup,
+            val listeners: MessageListListenerContainer?,
+            val binding: StreamUiItemSystemMessageBinding = StreamUiItemSystemMessageBinding.inflate(
+                LayoutInflater.from(parent.context),
+                parent,
+                false
+            ),
+        ) : BaseMessageItemViewHolder<MessageListItem.MessageItem>(binding.root) {
+
+            init {
+                binding.root.setOnClickListener {
+                    listeners?.messageClickListener?.onMessageClick(data.message)
+                }
+                binding.root.setOnLongClickListener {
+                    listeners?.messageLongClickListener?.onMessageLongClick(data.message)
+                    true
+                }
+            }
+
+            override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
+                binding.messageTextView.text = data.message.text
+            }
+        }
+    }
 }

```

</details>

1. Apply the patch above with a custom message item factory
2. Navigate to a text message and trigger the message options overlay
3. The overlay should also use the message item factory above. Also, the message area should not be clickable.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![photo_2022-04-13 16 39 32](https://user-images.githubusercontent.com/9600921/163193336-3397d74e-9c9d-40ba-8bb8-2b339d9338d2.jpeg)

