### PR TITLE
[2881] Fix wrong tint on reaction drawables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed a bug where command suggestion popup was displayed even though all the commands were disabled. [#3334](https://github.com/GetStream/stream-chat-android/pull/3334)
+- Fixed a bug on Nougat where the reaction colors were not displayed properly. [#3347](https://github.com/GetStream/stream-chat-android/pull/3347)
 
 ### ⬆️ Improved
 - Added a way to customize reactions behavior to allow multiple reactions. [#3341](https://github.com/GetStream/stream-chat-android/pull/3341)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
@@ -83,22 +83,24 @@ public class SupportedReactions(
      */
     private object DefaultReactionDrawables {
         fun loveDrawable(context: Context): ReactionDrawable {
-            val drawableInactive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_love)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_grey))
-            }
-            val drawableActive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_love)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
-            }
+            val drawableInactive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_love)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_grey))
+                }
+            val drawableActive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_love)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
+                }
             return ReactionDrawable(drawableInactive, drawableActive)
         }
 
         fun thumbsUpDrawable(context: Context): ReactionDrawable {
             val drawableInactive =
-                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_up)!!.apply {
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_up)!!.mutate().apply {
                     setTint(context.getColorCompat(R.color.stream_ui_grey))
                 }
             val drawableActive =
-                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_up)!!.apply {
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_up)!!.mutate().apply {
                     setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
                 }
             return ReactionDrawable(drawableInactive, drawableActive)
@@ -106,33 +108,37 @@ public class SupportedReactions(
 
         fun thumbsDownDrawable(context: Context): ReactionDrawable {
             val drawableInactive =
-                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_down)!!.apply {
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_down)!!.mutate().apply {
                     setTint(context.getColorCompat(R.color.stream_ui_grey))
                 }
             val drawableActive =
-                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_down)!!.apply {
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_thumbs_down)!!.mutate().apply {
                     setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
                 }
             return ReactionDrawable(drawableInactive, drawableActive)
         }
 
         fun lolDrawable(context: Context): ReactionDrawable {
-            val drawableInactive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_lol)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_grey))
-            }
-            val drawableActive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_lol)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
-            }
+            val drawableInactive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_lol)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_grey))
+                }
+            val drawableActive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_lol)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
+                }
             return ReactionDrawable(drawableInactive, drawableActive)
         }
 
         fun wutDrawable(context: Context): ReactionDrawable {
-            val drawableInactive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_wut)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_grey))
-            }
-            val drawableActive = ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_wut)!!.apply {
-                setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
-            }
+            val drawableInactive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_wut)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_grey))
+                }
+            val drawableActive =
+                ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_reaction_wut)!!.mutate().apply {
+                    setTint(context.getColorCompat(R.color.stream_ui_accent_blue))
+                }
             return ReactionDrawable(drawableInactive, drawableActive)
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Fix reaction drawables wrong tint.

### 🛠 Implementation details

The drawables used from resources get cached and when a change is applied it is propagated to all of the drawables. Calling `.mutate()` will make drawable mutable ensuring that it won't share its state to other instances. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/38032787/163400032-0b79702e-387e-48ac-bd62-9571bc8607d3.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/38032787/163400538-0f1c98f7-fac3-4dab-8668-797114a8968a.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Run develop branch on Android Nougat (7, API 28). Add reactions to a single message using at least two users. Log in with a user that didn't leave a reaction and leave an exiting reaction. Exit the messages screen and come back in, the reaction colours will be wrong. 

Run this branch. Drawable colours should be properly applied this time.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/38032787/163401726-33c6fb2b-352b-4a8c-9fe1-d638b7875c17.gif)

