### PR TITLE
Add immediate dispatcher provider and apply it to MessageComposerController.kt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `DispatcherProvider.Immediate` to our providers for operations that require no-scheduling [#3355](https://github.com/GetStream/stream-chat-android/pull/3355)
 
 ### ⚠️ Changed
 - Changed visibility of the `retry` extension to internal. [#3353](https://github.com/GetStream/stream-chat-android/pull/3353)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fixed the message input handling when typing quickly or holding down the delete (backspace) button. [#3355](https://github.com/GetStream/stream-chat-android/pull/3355)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-- Added `DispatcherProvider.Immediate` to our providers for operations that require no-scheduling [#3355](https://github.com/GetStream/stream-chat-android/pull/3355)
 
 ### ⚠️ Changed
 - Changed visibility of the `retry` extension to internal. [#3353](https://github.com/GetStream/stream-chat-android/pull/3353)

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/internal/coroutines/DispatcherProvider.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/internal/coroutines/DispatcherProvider.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider.res
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider.set
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.MainCoroutineDispatcher
 
 /**
  * Coroutine dispatchers used internally by Stream libraries. Should always be used
@@ -31,9 +32,31 @@ import kotlinx.coroutines.Dispatchers
 @InternalStreamChatApi
 public object DispatcherProvider {
 
+    /**
+     * Represents the Main coroutine dispatcher, tied to the UI thread.
+     */
     public var Main: CoroutineDispatcher = Dispatchers.Main
         internal set
 
+    /**
+     * Represents the Immediate coroutine dispatcher, which is usually tied to the UI thread.
+     *
+     * Useful for some cases where the UI updates require immediate execution, without dispatching the update events.
+     */
+    public val Immediate: CoroutineDispatcher
+        get() {
+            val mainDispatcher = Main
+
+            return if (mainDispatcher is MainCoroutineDispatcher) {
+                mainDispatcher.immediate
+            } else {
+                mainDispatcher
+            }
+        }
+
+    /**
+     * Represents the IO coroutine dispatcher, which is usually tied to background work.
+     */
     public var IO: CoroutineDispatcher = Dispatchers.IO
         internal set
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -73,6 +73,10 @@ public class MessageComposerController(
     /**
      * Creates a [CoroutineScope] that allows us to cancel the ongoing work when the parent
      * ViewModel is disposed.
+     *
+     * We use the [DispatcherProvider.Immediate] variant here to make sure the UI updates don't go through the
+     * process of dispatching events. This fixes several bugs where the input state breaks when deleting or typing really
+     * fast.
      */
     private val scope = CoroutineScope(DispatcherProvider.Main)
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -78,7 +78,7 @@ public class MessageComposerController(
      * process of dispatching events. This fixes several bugs where the input state breaks when deleting or typing really
      * fast.
      */
-    private val scope = CoroutineScope(DispatcherProvider.Main)
+    private val scope = CoroutineScope(DispatcherProvider.Immediate)
 
     /**
      * Buffers typing updates.


### PR DESCRIPTION
### 🎯 Goal

Fixes #3349 

### 🛠 Implementation details

Relying on the `Dispatchers.Main.Immediate` helps us force the state/UI updates that aren't asynchronous, to be fully synchronous - i.e. to avoid dispatching events cycle.

By avoiding dispatching event cycles, the UI updates are no longer race-conditioned in Compose and things work nicely.

Lovely framework bug ^^

### 🎨 UI Changes

| Before | After |
| --- | --- |
| https://user-images.githubusercontent.com/17215808/163799261-93ef7df9-987c-4791-9a44-c68b5221b7a2.mp4 | https://user-images.githubusercontent.com/17215808/163799308-1e6d3a52-31e2-4feb-b587-1efc473afbd7.mp4 |

### 🧪 Testing

1. Run the app on develop on a live device (not emulator)
2. Try typing really fast in the message input (random bashing also works)
3. Sporadically, the message input seems to clear and reset. Also, holding the delete button (backspace) tends to stop sometimes.
4. Run the sample on this branch. Try the same thing. Typing fast should work and holding the delete button should also work.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs