### PR TITLE
[3348] Add ChannelListViewModel and MessageListViewModel loadMore onl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@
 - Added the "Copy Message" option to link messages [#3354](https://github.com/GetStream/stream-chat-android/pull/3354)
 
 ### ⚠️ Changed
+- `loadMore` calls inside `MessageListViewModel` and `ChannelListViewModel` should no longer load data if there is no network connection. [3362](https://github.com/GetStream/stream-chat-android/pull/3362)
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
@@ -272,6 +272,7 @@ public class ChannelListViewModel(
      * Loads more data when the user reaches the end of the channels list.
      */
     public fun loadMore() {
+        if (chatClient.globalState.isOffline()) return
         val currentConfig = queryConfig.value
 
         channelsState = channelsState.copy(isLoadingMore = true)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -455,6 +455,7 @@ public class MessageListViewModel(
      * Triggered when the user loads more data by reaching the end of the current messages.
      */
     public fun loadMore() {
+        if (chatClient.globalState.isOffline()) return
         val messageMode = messageMode
 
         if (messageMode is MessageMode.MessageThread) {


### PR DESCRIPTION
### 🎯 Goal

Disable load more calls if there is no network connection.

### 🛠 Implementation details

Added check to `MessageListViewModel` and `ChannelListViewModel` `loadMore` function if the user is offline to stop loading calls in that case.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

### 🧪 Testing

1. Run the app on develop and turn off the network connections
2. Scroll to the bottom of the list
3. Build this branch and repeat

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![network](https://user-images.githubusercontent.com/38032787/164183225-01e1734b-ded9-4208-8732-903f58fcd200.gif)
