### PR TITLE
Fix sample app crash after clicking on message option

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsDialogFragment.kt
@@ -128,7 +128,7 @@ class GroupChatInfoMemberOptionsDialogFragment : BottomSheetDialogFragment() {
             if (!state.loading) {
                 binding.apply {
                     optionMessage.isVisible = true
-                    optionViewInfo.isVisible = true
+                    optionViewInfo.isVisible = state.directChannelCid != null
                 }
             }
         }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/member/GroupChatInfoMemberOptionsViewModel.kt
@@ -30,23 +30,12 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.livedata.utils.Event
-import io.getstream.chat.android.offline.extensions.globalState
-import io.getstream.chat.android.offline.extensions.watchChannelAsState
-import io.getstream.chat.android.offline.plugin.state.channel.MessagesState
-import io.getstream.chat.android.offline.plugin.state.global.GlobalState
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.filterNotNull
-import kotlinx.coroutines.flow.flatMapConcat
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
 class GroupChatInfoMemberOptionsViewModel(
     private val cid: String,
     private val memberId: String,
     private val chatClient: ChatClient = ChatClient.instance(),
-    private val globalState: GlobalState = chatClient.globalState,
 ) : ViewModel() {
 
     private val _events = MutableLiveData<Event<UiEvent>>()
@@ -58,56 +47,25 @@ class GroupChatInfoMemberOptionsViewModel(
 
     init {
         viewModelScope.launch {
-            globalState.user
-                .filterNotNull()
-                .map { user ->
-                    chatClient.queryChannels(
-                        request = QueryChannelsRequest(
-                            filter = Filters.and(
-                                Filters.eq("type", "messaging"),
-                                Filters.distinct(listOf(memberId, user.id)),
-                            ),
-                            querySort = QuerySort.desc(Channel::lastUpdated),
-                            messageLimit = 0,
-                            limit = 1,
-                        )
-                    ).await()
-                }.flatMapConcat { result ->
-                    if (result.isSuccess) {
-                        val cid = result.data().firstOrNull()?.cid ?: ""
+            val currentUser = chatClient.getCurrentUser()!!
 
-                        chatClient.watchChannelAsState(cid, 30, viewModelScope)
-                            .filterNotNull()
-                            .flatMapLatest {
-                                it.messagesState
-                            }
-                            .map { mapChannelState(it, cid) }
-                    } else {
-                        MutableStateFlow(null)
-                    }
-                }
-                .filterNotNull()
-                .collect { state ->
-                    _state.value = state
-                }
-        }
-    }
-
-    private fun mapChannelState(messagesState: MessagesState, cid: String): State {
-        return when (messagesState) {
-            is MessagesState.Result -> {
-                State(
-                    directChannelCid = cid,
-                    loading = false,
+            val result = chatClient.queryChannels(
+                request = QueryChannelsRequest(
+                    filter = Filters.and(
+                        Filters.eq("type", "messaging"),
+                        Filters.distinct(listOf(memberId, currentUser.id)),
+                    ),
+                    querySort = QuerySort.desc(Channel::lastUpdated),
+                    messageLimit = 0,
+                    limit = 1,
                 )
+            ).await()
+
+            _state.value = if (result.isSuccess && result.data().isNotEmpty()) {
+                State(directChannelCid = result.data().first().cid, loading = false)
+            } else {
+                State(directChannelCid = null, loading = false)
             }
-            MessagesState.NoQueryActive,
-            MessagesState.Loading,
-            -> State(directChannelCid = null, loading = true)
-            MessagesState.OfflineNoResults -> State(
-                directChannelCid = null,
-                loading = false,
-            )
         }
     }
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/preview/ChatPreviewFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/preview/ChatPreviewFragment.kt
@@ -96,13 +96,13 @@ class ChatPreviewFragment : Fragment() {
             messageListHeaderViewModel.bindView(this, viewLifecycleOwner)
 
             setAvatarClickListener {
-                navigateToChatInfo()
+                navigateToChatInfo(cid)
             }
             setTitleClickListener {
-                navigateToChatInfo()
+                navigateToChatInfo(cid)
             }
             setSubtitleClickListener {
-                navigateToChatInfo()
+                navigateToChatInfo(cid)
             }
         }
 
@@ -120,9 +120,9 @@ class ChatPreviewFragment : Fragment() {
         }
     }
 
-    private fun navigateToChatInfo() {
+    private fun navigateToChatInfo(cid: String) {
         findNavController().navigateSafely(
-            ChatPreviewFragmentDirections.actionOpenChatInfo(userData = args.userData, cid = null)
+            ChatPreviewFragmentDirections.actionOpenChatInfo(userData = args.userData, cid = cid)
         )
     }
 }


### PR DESCRIPTION
closes #3316 

### 🎯 Goal

Fix sample app crash after clicking on message option.

### 🛠 Implementation details

1. Simplify `GroupChatInfoMemberOptionsViewModel` initialization so there is no need to call `watchChannel`
2. Hide channel info option from dialog fragment if the channel doesn't exist
3. Fix crash after clicking on user's avatar in preview fragment

**NOTE:** There is one more issue (infinite loading on `MessageListView`) that will be fixed in a separate PR

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
|https://user-images.githubusercontent.com/17440581/164706673-3be0bec6-a253-42b9-ad68-5f25d136437c.mp4|https://user-images.githubusercontent.com/17440581/164706660-34b13327-c440-4684-9f64-1353af7057c0.mp4|

### 🧪 Testing

1. Go to the group channel, press the channel's avatar and press one of the members
2. Make sure that 1-1 channel doesn't exist. You can do that by deleting the conversation if exists
3. Click on `message` option and you should see a new chat
4. Clicking on user's avatar in the header view shouldn't crash the app

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~Changelog is updated with client-facing changes~
- [ ] ~New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Bugs validated (bugfixes)
