### PR TITLE
Changing deleteConfirmationEnabled to flagMessageConfirmationEnabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - Fixed a bug on Nougat where the reaction colors were not displayed properly. [#3347](https://github.com/GetStream/stream-chat-android/pull/3347)
 - Fixed a bug where custom `MessageListItemViewHolderFactory` was ignore on the message options overlay. [#3343](https://github.com/GetStream/stream-chat-android/pull/3343)
 - Fixed `MessageListViewModel` initialization when channel's data is not available immediately, for example when the view model is created after connecting the user. [#3379](https://github.com/GetStream/stream-chat-android/pull/3379)
+- Fixed configuration for flag message confirmation dialog. [3411](https://github.com/GetStream/stream-chat-android/pull/3411)
 
 ### ⬆️ Improved
 - Added a way to customize reactions behavior to allow multiple reactions. [#3341](https://github.com/GetStream/stream-chat-android/pull/3341)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -283,7 +283,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                 dismiss()
             }
             setFlagMessageListener {
-                if (style.deleteConfirmationEnabled) {
+                if (style.flagMessageConfirmationEnabled) {
                     confirmFlagMessageClickHandler?.onConfirmFlagMessage(message) {
                         messageOptionsHandlers.flagClickHandler.onMessageFlag(message)
                     }


### PR DESCRIPTION
### 🎯 Goal

Fix bug related to configure flag message confirmation.

### 🛠 Implementation details

Changing of style field to another

### 🧪 Testing

diff:

```
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
index 17f5e61dc2..ef86f2c581 100644
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
@@ -24,7 +24,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messagesHeaderView"
-        app:streamUiFlagMessageConfirmationEnabled="true"
+        app:streamUiFlagMessageConfirmationEnabled="false"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="true"
         />
diff --git a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_message_list.xml b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_message_list.xml
index a2057fcdb5..559243829a 100644
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_message_list.xml
@@ -23,7 +23,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messageListHeaderView"
-        app:streamUiFlagMessageConfirmationEnabled="true"
+        app:streamUiFlagMessageConfirmationEnabled="false"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="false"
         />
(END)
```

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (3)](https://user-images.githubusercontent.com/10619102/165535651-252f600a-e8de-4dde-8b74-c2ee2aeec9cd.gif)

