### PR TITLE
[3418] fix unresponsive message input

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -756,7 +756,7 @@ public class MessageInputView : ConstraintLayout {
                     handleKeyStroke()
 
                     /** Debouncing when clearing the input will cause the suggestion list
-                     popup to appear briefly after clearing the input in certain cases. */
+                    popup to appear briefly after clearing the input in certain cases. */
                     if (messageText.isEmpty()) {
                         messageInputDebouncer?.cancelLastDebounce()
                         suggestionListController?.onNewMessageText(messageText)
@@ -929,6 +929,7 @@ public class MessageInputView : ConstraintLayout {
         }
         binding.messageInputFieldView.binding.messageEditText.isEnabled = canSend
         binding.messageInputFieldView.binding.messageEditText.isFocusable = canSend
+        binding.messageInputFieldView.binding.messageEditText.isFocusableInTouchMode = canSend
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -756,7 +756,7 @@ public class MessageInputView : ConstraintLayout {
                     handleKeyStroke()
 
                     /** Debouncing when clearing the input will cause the suggestion list
-                    popup to appear briefly after clearing the input in certain cases. */
+                     popup to appear briefly after clearing the input in certain cases. */
                     if (messageText.isEmpty()) {
                         messageInputDebouncer?.cancelLastDebounce()
                         suggestionListController?.onNewMessageText(messageText)


### PR DESCRIPTION
### 🎯 Goal

Message input is unresponsive upon first entering a channel offline. 
This PR aims to make the input responsive.

Closes #3418

### 🛠 Implementation details

Set `isFocusableInTouchMode` on `MessageInputView`s inner `EditText` as well.

### 🧪 Testing

1. Kill app if app is open
2. Go offline
3. Open app
4. Enter a channel for the first time in this session (has to be the first)
5. Try to click on the `EditText` inside `MessageInputView`

Expected behavior: The field is clickable, responsive and you can input a message

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~ (No need, this is a fix for a yet unreleased feature)
- [ ] ~~New code is covered by unit tests~~
- [ ] ~~Comparison screenshots added for visual changes~~
- [ ] ~~Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![pleaserespond](https://user-images.githubusercontent.com/37080097/165721839-01fdb462-aa97-452e-8311-b6036e0eba52.gif)