### PR TITLE
Fix updating own capabilities after receiving events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed a crash when attachment upload is in progress or about to start and user is disconnected at the same moment. [#3377](https://github.com/GetStream/stream-chat-android/pull/3377)
+- Fixed updating `Channel::ownCapabilities` after receiving events. [#3420](https://github.com/GetStream/stream-chat-android/pull/3420)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/model/channel/ChannelData.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/model/channel/ChannelData.kt
@@ -62,10 +62,12 @@ public data class ChannelData(
 
     /**
      * Creates a [ChannelData] entity from a [Channel] object.
+     * Keeps existing [ChannelData.ownCapabilities] if the [Channel] object comes with an empty set of capabilities.
      *
-     * @param channel The [Channel] object to convert
+     * @param channel The [Channel] object to convert.
+     * @param currentOwnCapabilities Set of existing own capabilities stored for the Channel.
      */
-    internal constructor(channel: Channel) : this(
+    internal constructor(channel: Channel, currentOwnCapabilities: Set<String>) : this(
         type = channel.type,
         channelId = channel.id,
         name = channel.name,
@@ -79,7 +81,8 @@ public data class ChannelData(
         extraData = channel.extraData,
         createdBy = channel.createdBy,
         team = channel.team,
-        ownCapabilities = channel.ownCapabilities
+        ownCapabilities = channel.ownCapabilities.takeIf { ownCapabilities -> ownCapabilities.isNotEmpty() }
+            ?: currentOwnCapabilities,
     )
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
@@ -385,8 +385,9 @@ internal class ChannelLogic(
         mutableState._members.value = (mutableState._members.value + members.associateBy(Member::getUserId))
     }
 
-    internal fun updateChannelData(channel: Channel) {
-        mutableState._channelData.value = ChannelData(channel)
+    private fun updateChannelData(channel: Channel) {
+        val currentOwnCapabilities = mutableState._channelData.value?.ownCapabilities ?: emptySet()
+        mutableState._channelData.value = ChannelData(channel, currentOwnCapabilities)
     }
 
     private fun setWatchers(watchers: List<User>) {


### PR DESCRIPTION
closes #3413 

### 🎯 Goal
Fix updating own capabilities after receiving events.

### 🛠 Implementation details

`Channel` object from events doesn't contain `ownCapabilities` field.
That's why we should only update `ChannelData::ownCapabilities` if the set is not empty.

### 🧪 Testing
1. Go to the channel and send some messages
2. Add a new user (to this channel) from another device
3. Try to send more messages

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
