### PR TITLE
[3414] Update sync timestamp after sync api returns success

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerImpl.kt
@@ -159,6 +159,7 @@ internal class EventHandlerImpl(
     private suspend fun replayEventsForChannels(cids: List<String>): Result<List<ChatEvent>> {
         return queryEvents(cids)
             .onSuccessSuspend { eventList ->
+                syncManager.updateSyncStateForEvents()
                 handleEventsInternal(eventList, isFromSync = true)
             }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
@@ -111,6 +111,17 @@ internal class SyncManager(
     }
 
     /**
+     * Store the latest sync state of events. Sync state is updated whenever sync api returns a success response.
+     */
+    internal suspend fun updateSyncStateForEvents() {
+        syncStateFlow.value?.let { syncState ->
+            val newSyncState = syncState.copy(lastSyncedAt = Date())
+            repos.insertSyncState(newSyncState)
+            syncStateFlow.value = newSyncState
+        }
+    }
+
+    /**
      * Updates all the read state for the SDK. If the currentDate of this update is older then the most recent one, the update
      * is ignored.
      *


### PR DESCRIPTION
Closes #3414 
### 🎯 Goal
We don't update the `lastSyncedAt` timestamp in `SyncState`. So when the user is reconnected, the sync history API always returns empty because the latest time is used instead of `lastSyncedAt`.

### 🛠 Implementation details
- Added a method to update `lastSyncedAt` whenever sync API returns success.

### 🧪 Testing
- Run the sample app on two devices.
- Open the same channel on both devices.
- Scroll to messages older than the last 30 messages on both devices.
- User 1 disconnects the internet.
- Send a reaction to a message from user 2.
- Turn on the internet on User 1 device.
- Reaction should be updated as soon as user 1 is connected again.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs