### PR TITLE
Fix overriding User image and name properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fixed ANR happening on a token request. [#3342](https://github.com/GetStream/stream-chat-android/pull/3342)
+- Fixed overriding User's `image` and `name` properties with empty values when connecting the user. [#3430](https://github.com/GetStream/stream-chat-android/pull/3430)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -97,17 +97,25 @@ internal class SocketFactory(
         private const val ANONYMOUS_USER_ID = "anon"
     }
 
+    /**
+     * Converts the [User] object to a map of properties updated while connecting the user.
+     * [User.name] and [User.image] will only be included if they are not blank.
+     *
+     * @return A map of User's properties to update.
+     */
     private fun User.reduceUserDetails(): Map<String, Any> {
         val details = mutableMapOf(
             "id" to id,
-            "name" to name,
-            "image" to image,
             "role" to role,
             "banned" to banned,
             "invisible" to invisible,
             "teams" to teams,
-        )
-        details.putAll(extraData)
+        ).apply {
+            if (image.isNotBlank()) put("image", image)
+            if (name.isNotBlank()) put("name", name)
+            putAll(extraData)
+        }
+
         return details
     }
 }


### PR DESCRIPTION
closes #3429 

### 🎯 Goal

Fix overriding User's image and name properties

### 🛠 Implementation details

Exclude `image` and `name` properties from user details JSON if they are empty.


### 🧪 Testing

Apply the patch:

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt	(revision ecd2ad4d558a239b9a8baeec99c2a758561df0e8)
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt	(date 1651224614858)
@@ -91,8 +91,8 @@
         SampleUser(
             apiKey = apiKey,
             id = "rafal",
-            name = "Rafal Adasiewicz",
-            image = "https://ca.slack-edge.com/T02RM6X6B-U0177N46AFN-a4e664d1960d-128",
+            name = "",
+            image = "",
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmFmYWwifQ.7Y4QCvc42Km8ETLdCQT5ynjiKVbZZbuN0XTiGxJNU6k"
         ),
         SampleUser(

```

</details>

1. Sign in as `Rafal`
2. Observe that user's image and name stays the same even though they were changed to empty strings

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
