### PR TITLE
[3439] Don't expose Coil ImageLoader in ChatTheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@
 - Added own capabilities. If you are using our components individually this has the possibility of introducing a change in functionality. You can find the guide on implementing own capabilities [here](https://getstream.io/chat/docs/sdk/android/compose/guides/implementing-own-capabilities/). [#3389](https://github.com/GetStream/stream-chat-android/pull/3389)
 - Changed the default filter for Channels in `ChannelsScreen` and `ChannelList` to only filter messaging channels. It will still filter the channels the current user is a member of, as that's the most common case. [#3410](https://github.com/GetStream/stream-chat-android/pull/3410)
 - Changed the `ChannelListViewModel.setFilters(newFilters)` to override the previous ones, rather than combining the two. [#3410](https://github.com/GetStream/stream-chat-android/pull/3410)
+- Replaced the `imageLoader` parameter in `ChatTheme` with the new `imageLoaderFactory` parameter that can used to provide a custom Coil `ImageLoader` factory.  [#3441](https://github.com/GetStream/stream-chat-android/pull/3441)
 
 ### ❌ Removed
 

--- a/docusaurus/docs/Android/04-compose/03-general-customization/01-chat-theme.mdx
+++ b/docusaurus/docs/Android/04-compose/03-general-customization/01-chat-theme.mdx
@@ -13,7 +13,7 @@ The `ChatTheme` component is a wrapper that **you should use as the root** of al
 * **DateFormatter**: Used to define the timestamp formatting in the app. You can use the default formatting, or customize it to your needs.
 * **ChannelNameFormatter**: Used to define the channel name formatting in the app. You can use the default implementation, or customize it according to your needs.
 * **MessagePreviewFormatter**: Used to define the message preview formatting in the app. You can use the default implementation, or customize the display of message previews according to your needs.
-* **ImageLoader**: Coil image loader used to load images. You can use the default image loader, or provide a custom one.
+* **ImageLoaderFactory**: Used to create Coil image loader instances. You can use the default image loader factory, or provide a custom one.
 * **MessageAlignmentProvider** Used to provide an alignment for a particular message. You can use the default implementation which aligns the messages of the current user to end, or customize it according to your needs.
 
 :::note
@@ -178,13 +178,13 @@ You can find out more about it by reading the [class documentation](https://gith
 
 The message preview formatter can be customized by overriding `ChatTheme.messagePreviewFormatter` with your own implementation of `MessagePreviewFormatter`
 
-### ImageLoader
+### StreamCoilImageLoaderFactory
 
-Coil `ImageLoader` used to load images. The default implementation is provided by `StreamCoilImageLoader`.
+`StreamCoilImageLoaderFactory.defaultFactory()` provides the default factory that creates new Coil `ImageLoader` instances.
 
-You can find out more about it by reading the [class documentation](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoader.kt).
+You can find out more about it by reading the [class documentation](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt).
 
-You can easily customize how the images are loaded by passing your own implementation of `ImageLoader` to `ChatTheme`.
+You can easily customize how the images are loaded by passing your own implementation of `StreamCoilImageLoaderFactory` to `ChatTheme`.
 
 ### MessageAlignmentProvider
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1299,7 +1299,7 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatTheme {
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
-	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Landroidx/compose/material/ripple/RippleTheme;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/compose/ui/util/ReactionIconFactory;Lcom/getstream/sdk/chat/utils/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lcoil/ImageLoader;Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
+	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Landroidx/compose/material/ripple/RippleTheme;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/compose/ui/util/ReactionIconFactory;Lcom/getstream/sdk/chat/utils/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lio/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory;Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
@@ -1610,6 +1610,15 @@ public final class io/getstream/chat/android/compose/ui/util/StorageHelperWrappe
 	public final fun getAttachmentsFromUris (Ljava/util/List;)Ljava/util/List;
 	public final fun getFiles ()Ljava/util/List;
 	public final fun getMedia ()Ljava/util/List;
+}
+
+public abstract interface class io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory {
+	public static final field Companion Lio/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory$Companion;
+	public abstract fun imageLoader (Landroid/content/Context;)Lcoil/ImageLoader;
+}
+
+public final class io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory$Companion {
+	public final fun defaultFactory ()Lio/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/util/UserUtilsKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -38,7 +38,7 @@ import io.getstream.chat.android.compose.ui.util.ChannelNameFormatter
 import io.getstream.chat.android.compose.ui.util.MessageAlignmentProvider
 import io.getstream.chat.android.compose.ui.util.MessagePreviewFormatter
 import io.getstream.chat.android.compose.ui.util.ReactionIconFactory
-import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoader
+import io.getstream.chat.android.compose.ui.util.StreamCoilImageLoaderFactory
 
 /**
  * Local providers for various properties we connect to our components, for styling.
@@ -93,7 +93,7 @@ private val LocalMessageAlignmentProvider = compositionLocalOf<MessageAlignmentP
  * @param dateFormatter [DateFormatter] used throughout the app for date and time information.
  * @param channelNameFormatter [ChannelNameFormatter] used throughout the app for channel names.
  * @param messagePreviewFormatter [MessagePreviewFormatter] used to generate a string preview for the given message.
- * @param imageLoader [ImageLoader] used by Coil to load images.
+ * @param imageLoaderFactory A factory that creates new Coil [ImageLoader] instances.
  * @param messageAlignmentProvider [MessageAlignmentProvider] used to provide message alignment for the given message.
  * @param content The content shown within the theme wrapper.
  */
@@ -116,7 +116,7 @@ public fun ChatTheme(
         typography = typography,
         attachmentFactories = attachmentFactories
     ),
-    imageLoader: ImageLoader = StreamCoilImageLoader.imageLoader(LocalContext.current),
+    imageLoaderFactory: StreamCoilImageLoaderFactory = StreamCoilImageLoaderFactory.defaultFactory(),
     messageAlignmentProvider: MessageAlignmentProvider = MessageAlignmentProvider.defaultMessageAlignmentProvider(),
     content: @Composable () -> Unit,
 ) {
@@ -136,7 +136,7 @@ public fun ChatTheme(
         LocalDateFormatter provides dateFormatter,
         LocalChannelNameFormatter provides channelNameFormatter,
         LocalMessagePreviewFormatter provides messagePreviewFormatter,
-        LocalImageLoader provides imageLoader,
+        LocalImageLoader provides imageLoaderFactory.imageLoader(LocalContext.current),
         LocalMessageAlignmentProvider provides messageAlignmentProvider,
     ) {
         content()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/DefaultStreamCoilImageLoader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/DefaultStreamCoilImageLoader.kt
@@ -22,11 +22,33 @@ import coil.ImageLoaderFactory
 import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
 
 /**
+ * A factory that creates new Coil [ImageLoader] instances.
+ */
+public fun interface StreamCoilImageLoaderFactory {
+
+    /**
+     * Returns a new Coil [ImageLoader].
+     */
+    public fun imageLoader(context: Context): ImageLoader
+
+    public companion object {
+        /**
+         * Returns the default singleton instance of [StreamCoilImageLoaderFactory].
+         *
+         * @return The default implementation of [StreamCoilImageLoaderFactory].
+         */
+        public fun defaultFactory(): StreamCoilImageLoaderFactory {
+            return DefaultStreamCoilImageLoaderFactory
+        }
+    }
+}
+
+/**
  * Provides a custom image loader that uses the [StreamImageLoaderFactory] to build the default loading settings.
  *
  * Gives support to load GIFs.
  */
-internal object StreamCoilImageLoader {
+internal object DefaultStreamCoilImageLoaderFactory : StreamCoilImageLoaderFactory {
 
     /**
      * Loads images in the app, with our default settings.
@@ -44,7 +66,7 @@ internal object StreamCoilImageLoader {
      * @param context - The [Context] to build the [ImageLoader] with.
      * @return [ImageLoader] that loads images in the app.
      */
-    internal fun imageLoader(context: Context): ImageLoader = imageLoader ?: newImageLoader(context)
+    override fun imageLoader(context: Context): ImageLoader = imageLoader ?: newImageLoader(context)
 
     /**
      * Builds a new [ImageLoader] using the given Android [Context]. If the loader already exists, we return it.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
@@ -28,7 +28,7 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.theme.StreamTypography
 
 /**
- *  An interface that allows to generate a preview text for the given message.
+ * An interface that allows to generate a preview text for the given message.
  */
 public fun interface MessagePreviewFormatter {
 


### PR DESCRIPTION
### 🎯 Goal

Ensure that clients are able to use `ChatTheme` without the need to add Coil dependency to their projects.

<img width="516" alt="Screenshot 2022-05-01 at 23 37 47" src="https://user-images.githubusercontent.com/9600921/166163689-051ae2a9-51f7-44fe-9782-33c7684acf69.png">

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
