### PR TITLE
[3498] ChatClient.Builder.build method is not accessible from Java

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -158,6 +158,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 public final class io/getstream/chat/android/client/ChatClient$Builder : io/getstream/chat/android/client/ChatClient$ChatClientBuilder {
 	public fun <init> (Ljava/lang/String;Landroid/content/Context;)V
 	public final fun baseUrl (Ljava/lang/String;)Lio/getstream/chat/android/client/ChatClient$Builder;
+	public fun build ()Lio/getstream/chat/android/client/ChatClient;
 	public final fun credentialStorage (Lio/getstream/chat/android/client/user/storage/UserCredentialStorage;)Lio/getstream/chat/android/client/ChatClient$Builder;
 	public final fun disableWarmUp ()Lio/getstream/chat/android/client/ChatClient$Builder;
 	public final fun fileUploader (Lio/getstream/chat/android/client/uploader/FileUploader;)Lio/getstream/chat/android/client/ChatClient$Builder;
@@ -172,7 +173,7 @@ public final class io/getstream/chat/android/client/ChatClient$Builder : io/gets
 }
 
 public abstract class io/getstream/chat/android/client/ChatClient$ChatClientBuilder {
-	public final fun build ()Lio/getstream/chat/android/client/ChatClient;
+	public fun build ()Lio/getstream/chat/android/client/ChatClient;
 	protected final fun getPluginFactories ()Ljava/util/List;
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2357,6 +2357,10 @@ internal constructor(
             }
         }
 
+        public override fun build(): ChatClient {
+            return super.build()
+        }
+
         @InternalStreamChatApi
         @Deprecated(
             message = "It shouldn't be used outside of SDK code. Created for testing purposes",
@@ -2435,7 +2439,7 @@ internal constructor(
          * Create a [ChatClient] instance based on the current configuration
          * of the [Builder].
          */
-        public fun build(): ChatClient = internalBuild()
+        public open fun build(): ChatClient = internalBuild()
             .also {
                 instance = it
             }


### PR DESCRIPTION
Closes https://github.com/GetStream/stream-chat-android/issues/3498

### 🎯 Goal

Make `ChatClient.Builder.build` method accessible from Java.

### 🧪 Testing

- cut release build using
```
./gradlew :stream-chat-android-client:assembleRelease
```
- create a separate dummy project
- inject generated `chat-client aar` as a library in the dummy project
- add the code below
```Java
ChatClient client = new ChatClient.Builder("asfdgsfgasfds", context)
        .logLevel(ChatLogLevel.ALL)
        .withPlugin(factory)
        .build(); // <-- here
```

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~
- [ ] ~~New code is covered by unit tests~~
- [ ] ~~Comparison screenshots added for visual changes~~
- [ ] ~~Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] Bugs validated (bugfixes)

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
