### PR TITLE
[3515] Enable Command Shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added the public method `switchToCommandMode(command: Command)` inside `MessageInputView`. This method allows switching the input to command mode using the desired command directly, instead of having to select it from the dialog. An example of its usage is provided inside the patch within the linked PR. [#3515](https://github.com/GetStream/stream-chat-android/pull/3515)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1104,6 +1104,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setAttachmentButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$AttachmentButtonClickListener;)V
 	public final fun setChatMode (Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;)V
 	public final fun setCommands (Ljava/util/List;)V
+	public final fun setCommandsButtonClickListener (Lio/getstream/chat/android/ui/message/input/MessageInputView$CommandsButtonClickListener;)V
 	public final fun setCommandsEnabled (Z)V
 	public final fun setCooldownInterval (I)V
 	public final fun setInputMode (Lio/getstream/chat/android/ui/message/input/MessageInputView$InputMode;)V
@@ -1124,6 +1125,7 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView :
 	public final fun setUserLookupHandler (Lio/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler;)V
 	public final fun submitAttachments (Ljava/util/Collection;Lio/getstream/chat/android/ui/message/input/attachment/AttachmentSource;)V
 	public final fun submitCustomAttachments (Ljava/util/Collection;Lio/getstream/chat/android/ui/message/input/attachment/selected/internal/SelectedCustomAttachmentViewHolderFactory;)V
+	public final fun switchToCommandMode (Lio/getstream/chat/android/client/models/Command;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$AttachmentButtonClickListener {
@@ -1139,6 +1141,10 @@ public final class io/getstream/chat/android/ui/message/input/MessageInputView$C
 	public static final field GROUP_CHAT Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
 	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
 	public static fun values ()[Lio/getstream/chat/android/ui/message/input/MessageInputView$ChatMode;
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/input/MessageInputView$CommandsButtonClickListener {
+	public abstract fun onCommandsButtonClicked ()V
 }
 
 public final class io/getstream/chat/android/ui/message/input/MessageInputView$DefaultUserLookupHandler : io/getstream/chat/android/ui/message/input/MessageInputView$UserLookupHandler {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -217,11 +217,11 @@ public class MessageInputView : ConstraintLayout {
      */
     private var messageInputMentionListener: MessageInputMentionListener = MessageInputMentionListener { }
 
-    public constructor(context: Context) : this(context, null)
+    public constructor (context: Context) : this(context, null)
 
-    public constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
+    public constructor (context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
 
-    public constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
+    public constructor (context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
         context.createStreamThemeWrapper(),
         attrs,
         defStyleAttr
@@ -645,13 +645,22 @@ public class MessageInputView : ConstraintLayout {
         }
 
     /**
-     * Sets a click listener for the attachment button. If you want to implement custom attachment flow do not forget
+     * Sets a click listener for the attachment button. If you want to implement a custom attachment flow do not forget
      * to set selected attachments via the [submitAttachments] method.
      *
-     * @param listener Listener that being invoked when user clicks on the attachment button in [MessageInputView].
+     * @param listener Listener that is invoked when the user clicks on the attachment button in [MessageInputView].
      */
     public fun setAttachmentButtonClickListener(listener: AttachmentButtonClickListener) {
         binding.attachmentsButton.setOnClickListener { listener.onAttachmentButtonClicked() }
+    }
+
+    /**
+     * Sets a click listener for the commands button.
+     *
+     * @param listener Listener that is invoked when the user clicks on the commands button in [MessageInputView].
+     */
+    public fun setCommandsButtonClickListener(listener: CommandsButtonClickListener) {
+        binding.commandsButton.setOnClickListener { listener.onCommandsButtonClicked() }
     }
 
     /**
@@ -735,6 +744,19 @@ public class MessageInputView : ConstraintLayout {
         }
 
         binding.sendMessageButtonEnabled.isEnabled = isSendButtonEnabled
+    }
+
+    /**
+     * Switches the input to command mode using the provided command.
+     *
+     * You can use this method to provide a shortcut to a certain command instead of
+     * activating it by selecting it from the list of suggestions.
+     *
+     * @param command The command used to switch the mode.
+     * Different commands transform the message input in different ways.
+     */
+    public fun switchToCommandMode(command: Command) {
+        binding.messageInputFieldView.mode = MessageInputFieldView.Mode.CommandMode(command)
     }
 
     private fun configTextInput() {
@@ -1282,13 +1304,23 @@ public class MessageInputView : ConstraintLayout {
     }
 
     /**
-     * Functional interface for a listener on the attachment button clicks.
+     * Functional interface for a listener set on the attachment button.
      */
     public fun interface AttachmentButtonClickListener {
         /**
          * Function to be invoked when a click on the attachment button happens.
          */
         public fun onAttachmentButtonClicked()
+    }
+
+    /**
+     * Functional interface for a listener set on the commands button.
+     */
+    public fun interface CommandsButtonClickListener {
+        /**
+         * Function to be invoked when a click on the commands button happens.
+         */
+        public fun onCommandsButtonClicked()
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Allow users to switch to command mode manually so they can create shortcuts to certain commands.

closes #3370 
closes #3371 

### 🛠 Implementation details

Exposed a public method `switchToCommandMode()` inside `MessageInputView`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![output](https://user-images.githubusercontent.com/37080097/168333254-cc70ad52-9bcd-4f5d-b592-82eeced861cd.gif) | ![output0](https://user-images.githubusercontent.com/37080097/168333259-53ed5c9c-ffc7-4830-b926-df507930fc57.gif) |

### 🧪 Testing

1. Apply the patch provided below
2. Launch the UI Components Sample App
3. Enter a channel that allows sending Giphys (most if not all channels in the sample app)
4. Click on the Giphy command button

Expected result: The button should immediately activate command mode with Giphys in mind

<details>
  <summary>Git Patch implementing changes seen in the after video</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(revision 8703f0ab6dd75c14f7eb690c304e3e19515d2a2d)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatViewModel.kt	(date 1652460044112)
@@ -22,6 +22,7 @@
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.models.Command
 import io.getstream.chat.android.client.models.Member
 import io.getstream.chat.android.livedata.utils.Event
 import io.getstream.chat.android.offline.extensions.watchChannelAsState
@@ -30,6 +31,7 @@
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
 
 class ChatViewModel(
     private val cid: String,
@@ -47,6 +49,18 @@
 
     val members: LiveData<List<Member>> = channelState.filterNotNull().flatMapLatest { it.members }.asLiveData()
 
+    /**
+     * We check if the given channel allows sending Giphys.
+     * This way we can effectively control the button from the
+     * config.
+     */
+    val giphyCommand: LiveData<Command?> =
+        channelState
+            .filterNotNull()
+            .flatMapLatest { it.channelConfig }
+            .map { it.commands.firstOrNull { command -> command.name.contains("giphy") } }
+            .asLiveData()
+
     fun onAction(action: Action) {
         when (action) {
             is Action.HeaderClicked -> {
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision 8703f0ab6dd75c14f7eb690c304e3e19515d2a2d)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1652460044102)
@@ -80,6 +80,24 @@
         initMessagesViewModel()
         initMessageInputViewModel()
         configureBackButtonHandling()
+        setCommandButtonOnClick()
+    }
+
+    /**
+     * Enable the Giphy button once we have the confirmation
+     * sending Giphys is allowed in this channel.
+     */
+    private fun setCommandButtonOnClick() {
+        chatViewModel.giphyCommand.observe(viewLifecycleOwner) { giphyCommand ->
+            if (giphyCommand != null) {
+                with(binding.messageInputView) {
+                    this.setCommandsEnabled(true)
+                    this.setCommandsButtonClickListener {
+                        switchToCommandMode(giphyCommand)
+                    }
+                }
+            }
+        }
     }
 
     override fun onResume() {
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 8703f0ab6dd75c14f7eb690c304e3e19515d2a2d)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1652459580948)
@@ -36,6 +36,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
+        app:streamUiCommandsEnabled="false"
+        app:streamUiLightningButtonIcon="@drawable/stream_ui_ic_giphy"
         app:layout_constraintTop_toBottomOf="@+id/messageListView"
         />
```

</details>
 

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![robot_command](https://user-images.githubusercontent.com/37080097/168329798-376ab1c6-9e4c-4e3c-9328-8af99306f004.gif)

