### PR TITLE
Init `currentUser` only when `connectUser()` is called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed `ChatParser` failing to parse errors because it was trying to fetch the raw response from a converted body. [#3534](https://github.com/GetStream/stream-chat-android/pull/3534)
 
 ### ⬆️ Improved
+- CurrentUser is not initialized when a PN is received. [#3520](https://github.com/GetStream/stream-chat-android/pull/3520)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -319,6 +319,7 @@ internal constructor(
             userState is UserState.NotSet -> {
                 logger.logV("[setUser] user is NotSet")
                 initializeClientWithUser(user, cacheableTokenProvider)
+                userStateService.onSetUser(user)
                 socketStateService.onConnectionRequested()
                 socket.connect(user)
                 waitConnection.first()
@@ -342,7 +343,6 @@ internal constructor(
         tokenProvider: CacheableTokenProvider,
     ) {
         initializationCoordinator.userConnected(user)
-        userStateService.onSetUser(user)
         // fire a handler here that the chatDomain and chatUI can use
         config.isAnonymous = false
         tokenManager.setTokenProvider(tokenProvider)
@@ -1883,6 +1883,15 @@ internal constructor(
     }
 
     //endregion
+
+    /**
+     * Return the [User] stored on the credential storage
+     *
+     * @return The stored user or null if it was logged out
+     */
+    internal fun getStoredUser(): User? = userCredentialStorage.get()?.let {
+        User(id = it.userId, name = it.userName)
+    }
 
     @InternalStreamChatApi
     public fun setPushNotificationReceivedListener(pushNotificationReceivedListener: PushNotificationReceivedListener) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -305,17 +305,6 @@ internal constructor(
         }
         val userState = userStateService.state
         return when {
-            userState is UserState.UserSet &&
-                userState.user.id == user.id &&
-                socketStateService.state == SocketState.Idle -> {
-                logger.logV("[setUser] user is Set & socket.state is Idle")
-                userStateService.onUserUpdated(user)
-                tokenManager.setTokenProvider(cacheableTokenProvider)
-                socketStateService.onConnectionRequested()
-                socket.connect(user)
-                initializationCoordinator.userConnected(user)
-                waitConnection.first()
-            }
             userState is UserState.NotSet -> {
                 logger.logV("[setUser] user is NotSet")
                 initializeClientWithUser(user, cacheableTokenProvider)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
@@ -59,7 +59,9 @@ internal class MessagingStyleNotificationHandler(
     }
 
     override fun showNotification(channel: Channel, message: Message) {
-        val currentUser = ChatClient.instance().getCurrentUser() ?: return
+        val currentUser = ChatClient.instance().getCurrentUser()
+            ?: ChatClient.instance().getStoredUser()
+            ?: return
         val notificationId = createNotificationId(channel.type, channel.id)
         val contentPendingIntent = PendingIntent.getActivity(
             context,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/InitializationCoordinator.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/InitializationCoordinator.kt
@@ -32,7 +32,7 @@ public class InitializationCoordinator private constructor() {
     /**
      * Adds a listener to user connection.
      */
-    public fun addUserConnectedListener(listener: (User) -> Unit) {
+    internal fun addUserConnectedListener(listener: (User) -> Unit) {
         userConnectedListeners.add(listener)
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
@@ -33,6 +33,7 @@ import org.junit.Rule
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 
@@ -85,6 +86,14 @@ internal open class BaseChatClientTest {
             retryPolicy = NoRetryPolicy(),
             initializationCoordinator = initializationCoordinator,
             appSettingsManager = mock(),
+        )
+        Mockito.reset(
+            socketStateService,
+            userStateService,
+            socket,
+            tokenManager,
+            config,
+            api,
         )
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -18,12 +18,17 @@ package io.getstream.chat.android.client.chatclient
 
 import io.getstream.chat.android.client.Mother
 import io.getstream.chat.android.client.call.Call
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.clientstate.SocketState
 import io.getstream.chat.android.client.clientstate.UserState
+import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.models.ConnectionData
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.token.TokenProvider
+import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -32,36 +37,31 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 
 internal class WhenConnectUser : BaseChatClientTest() {
 
     @Test
-    fun `Given user set and socket in idle state and user with the same id Should connect socket`() {
+    fun `Given user set and socket in idle state and user with the same id Should return an error`() = runTest {
+        val listener: (User) -> Unit = mock()
         val user = Mother.randomUser { id = "userId" }
         val sut = Fixture()
             .givenUserAndToken(user, "token")
             .givenIdleConnectionState()
             .givenUserSetState(Mother.randomUser { id = "userId" })
+            .givenPreSetUserListener(listener)
             .get()
 
-        sut.connectUser(user, "token").enqueue()
+        val result = sut.connectUser(user, "token").await()
 
-        verify(socket).connect(user)
-    }
-
-    @Test
-    fun `Given user set and socket in idle state and user with the same id Should update user`() {
-        val user = Mother.randomUser { id = "userId" }
-        val sut = Fixture()
-            .givenUserAndToken(Mother.randomUser { id = "userId" }, "token")
-            .givenIdleConnectionState()
-            .givenUserSetState(Mother.randomUser { id = "userId" })
-            .get()
-
-        sut.connectUser(user, "token").enqueue()
-
-        verify(userStateService).onUserUpdated(user)
+        verify(userStateService).state
+        verifyNoInteractions(socket)
+        verifyNoMoreInteractions(userStateService)
+        verifyNoInteractions(tokenManager)
+        verifyNoInteractions(listener)
+        result `should be equal to` Result.error(ChatError("Failed to connect user. Please check you don't have connected user already."))
     }
 
     @Test
@@ -77,37 +77,6 @@ internal class WhenConnectUser : BaseChatClientTest() {
         verify(socket, never()).connect(any())
         verify(userStateService, never()).onUserUpdated(any())
         verify(tokenManager, never()).setTokenProvider(any())
-    }
-
-    @Test
-    fun `Given user set and socket in idle state and user with the same id Should update token provider`() {
-        val tokenProviderMock = mock<TokenProvider>()
-        val token = randomString()
-        whenever(tokenProviderMock.loadToken()) doReturn token
-        val sut = Fixture()
-            .givenIdleConnectionState()
-            .givenUserAndToken(Mother.randomUser { id = "userId" }, token)
-            .givenUserSetState(Mother.randomUser { id = "userId" })
-            .get()
-
-        sut.connectUser(Mother.randomUser { id = "userId" }, tokenProviderMock).enqueue()
-
-        verify(tokenManager).setTokenProvider(any())
-    }
-
-    @Test
-    fun `Given user set and socket in idle state and user with the same id Should invoke pre set listeners`() {
-        val listener: (User) -> Unit = mock()
-        val sut = Fixture()
-            .givenUserAndToken(Mother.randomUser { id = "userId" }, "token")
-            .givenIdleConnectionState()
-            .givenUserSetState(Mother.randomUser { id = "userId" })
-            .givenPreSetUserListener(listener)
-            .get()
-
-        sut.connectUser(Mother.randomUser { id = "userId" }, "token").enqueue()
-
-        verify(listener).invoke(argThat { id == "userId" })
     }
 
     @Test


### PR DESCRIPTION
### 🎯 Goal
Ensure `currentUser` is not init when a push notification is received.
Fix #3403 

### 🛠 Implementation details
Previously, when a push notification was received we initialized the `currentUser`. It was done because when the PN is received we need to do some calls to the API to receive the most updated data. Those calls need to be authenticated. To authenticate the calls we don't really need the current user to be initialized, but the token provider. With this PR I refactor the flow when a PN is received to be sure the token provider is already initialized.
On the other hand, a new internal method has been created to obtain info from the "stored user". This info is used on `MessagingStyleNotificationHandler` to display the user info on the notification 

### 🧪 Testing
-. Open the sample app and login with an user on "Device A".
-. Close and kill the app (remove it from the multi-task section).
-. In a different device ("Device B"), send a message to the user logged in on the previous device ("Device A").
-. A notification should be shown on the "Device A".
-. Open the sample app again on the "Device A" (by clicking on the PN or by clicking on the sample app icon). The connection to the WebSocket should be handled properly.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media3.giphy.com/media/hlIdj2Oxgt4jLQlij1/giphy.webp)
