### PR TITLE
[3539] Show progress bar when a video is loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@
 
 ### ✅ Added
 - Added the public method `switchToCommandMode(command: Command)` inside `MessageInputView`. This method allows switching the input to command mode using the desired command directly, instead of having to select it from the dialog. An example of its usage is provided inside the patch within the linked PR. [#3515](https://github.com/GetStream/stream-chat-android/pull/3515)
+- Added loading indicator to the media preview screen. [#3549](https://github.com/GetStream/stream-chat-android/pull/3549)
+- Added `streamUiMediaActivityProgressBarStyle` theme attribute to customize the appearance of loading indicator on the media preview screen. [#3549](https://github.com/GetStream/stream-chat-android/pull/3549)
 
 ### ⚠️ Changed
 
@@ -72,6 +74,7 @@
 ### ✅ Added
 - Added scroll to quoted message on click. [#3472](https://github.com/GetStream/stream-chat-android/pull/3472)
 - Added guides for `QuotedAttachmentFactory`. [You can read about it here](https://getstream.io/chat/docs/sdk/android/compose/guides/adding-custom-attachments/#quoted-messages)
+- Added loading indicator to the media preview screen. [#3549](https://github.com/GetStream/stream-chat-android/pull/3549)
 
 ### ⚠️ Changed
 - Changed `QuotedMessage` design by adding `QuotedAttachmentFactory`, `ImageAttachmentQuotedContent` and `FileAttachmentQuotedContent`. [#3472](https://github.com/GetStream/stream-chat-android/pull/3472)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
@@ -25,6 +25,7 @@ import android.view.KeyEvent
 import android.view.ViewGroup
 import android.widget.FrameLayout
 import android.widget.MediaController
+import android.widget.ProgressBar
 import android.widget.Toast
 import android.widget.VideoView
 import androidx.activity.compose.BackHandler
@@ -50,6 +51,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.view.isVisible
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -201,14 +203,27 @@ public class MediaPreviewActivity : AppCompatActivity() {
                 )
             }
 
+            val progressBar = ProgressBar(context).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ViewGroup.LayoutParams.WRAP_CONTENT
+                ).apply {
+                    gravity = Gravity.CENTER
+                }
+            }
+
+            progressBar.isVisible = true
+
             val videoView = VideoView(context).apply {
                 setVideoURI(Uri.parse(url))
                 setMediaController(mediaController)
                 setOnErrorListener { _, _, _ ->
+                    progressBar.isVisible = false
                     onPlaybackError()
                     true
                 }
                 setOnPreparedListener {
+                    progressBar.isVisible = false
                     start()
                     mediaController.show()
                 }
@@ -222,7 +237,10 @@ public class MediaPreviewActivity : AppCompatActivity() {
                 }
             }
 
-            frameLayout.apply { addView(videoView) }
+            frameLayout.apply {
+                addView(videoView)
+                addView(progressBar)
+            }
         }
 
         AndroidView(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentMediaActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentMediaActivity.kt
@@ -52,11 +52,7 @@ public class AttachmentMediaActivity : AppCompatActivity() {
 
         if ((type.isNullOrEmpty() && mimeType.isNullOrEmpty()) || url.isNullOrEmpty()) {
             logger.logE("This file can't be displayed. The TYPE or the URL are null")
-            Toast.makeText(
-                this,
-                R.string.stream_ui_message_list_attachment_display_error,
-                Toast.LENGTH_SHORT
-            ).show()
+            showPlaybackError()
             return
         }
 
@@ -71,7 +67,7 @@ public class AttachmentMediaActivity : AppCompatActivity() {
     private fun setupViews() {
         binding.headerLeftActionButton.setOnClickListener { onBackPressed() }
         binding.headerTitleTextView.text = title
-        binding.ivAudio.isVisible = type?.contains("audio") == true || mimeType?.contains("audio") == true
+        binding.audioImageView.isVisible = type?.contains("audio") == true || mimeType?.contains("audio") == true
     }
 
     /**
@@ -89,14 +85,32 @@ public class AttachmentMediaActivity : AppCompatActivity() {
         val mediaController = createMediaController(this)
         mediaController.setAnchorView(binding.contentContainer)
 
+        binding.progressBar.isVisible = true
         binding.videoView.apply {
             setMediaController(mediaController)
             setOnPreparedListener {
+                binding.progressBar.isVisible = false
                 start()
                 mediaController.show()
             }
+            setOnErrorListener { _, _, _ ->
+                binding.progressBar.isVisible = false
+                showPlaybackError()
+                true
+            }
             setVideoURI(Uri.parse(url))
         }
+    }
+
+    /**
+     * Displays a Toast with a error if there was an issue playing the video.
+     */
+    private fun showPlaybackError() {
+        Toast.makeText(
+            this,
+            R.string.stream_ui_message_list_attachment_display_error,
+            Toast.LENGTH_SHORT
+        ).show()
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentMediaActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/gallery/AttachmentMediaActivity.kt
@@ -103,7 +103,7 @@ public class AttachmentMediaActivity : AppCompatActivity() {
     }
 
     /**
-     * Displays a Toast with a error if there was an issue playing the video.
+     * Displays a Toast with an error if there was an issue playing the video.
      */
     private fun showPlaybackError() {
         Toast.makeText(

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_media.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_media.xml
@@ -82,9 +82,18 @@
             />
 
         <ImageView
-            android:id="@+id/ivAudio"
+            android:id="@+id/audioImageView"
             style="?attr/streamUiMediaActivityIconStyle"
             android:layout_gravity="center"
+            />
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?attr/streamUiMediaActivityProgressBarStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:visibility="gone"
             />
 
     </FrameLayout>

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_media_activity.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_media_activity.xml
@@ -20,5 +20,6 @@
         <attr name="streamUiMediaActivityHeader" format="reference" />
         <attr name="streamUiMediaActivityHeaderLeftActionButtonStyle" format="reference" />
         <attr name="streamUiMediaActivityHeaderTitleStyle" format="reference" />
+        <attr name="streamUiMediaActivityProgressBarStyle" format="reference"/>
     </declare-styleable>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -228,7 +228,7 @@
         <item name="android:textColor">@color/stream_ui_literal_white</item>
         <item name="android:textDirection">locale</item>
     </style>
-    
+
     <style name="StreamUiTheme" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="streamUiValidTheme">true</item>
         <item name="streamUiAttachmentActivityProgressBarStyle">@style/StreamUi.AttachmentActivity.ProgressBar</item>
@@ -238,6 +238,7 @@
         <item name="streamUiMediaActivityHeader">@style/StreamUi.MediaActivity.Header</item>
         <item name="streamUiMediaActivityHeaderLeftActionButtonStyle">@style/StreamUi.MediaActivity.HeaderLeftActionButton</item>
         <item name="streamUiMediaActivityHeaderTitleStyle">@style/StreamUi.MediaActivity.HeaderTitle</item>
+        <item name="streamUiMediaActivityProgressBarStyle">@style/StreamUi.MediaActivity.ProgressBar</item>
         <item name="streamUiAttachmentGalleryOptionsStyle">@style/StreamUi.AttachmentGallery.Options</item>
         <item name="streamUiAttachmentGalleryCloseButtonStyle">@style/StreamUi.AttachmentGallery.CloseButton</item>
         <item name="streamUiAttachmentGalleryTitleStyle">@style/StreamUi.AttachmentGallery.Title</item>
@@ -901,6 +902,11 @@
 
     <style name="StreamUi.MediaActivity.HeaderTitle" parent="StreamUi">
         <item name="android:textAppearance">@style/StreamUiTextAppearance.MediaActivityHeaderTitle</item>
+    </style>
+
+    <style name="StreamUi.MediaActivity.ProgressBar" parent="StreamUi">
+        <item name="android:layout_width">wrap_content</item>
+        <item name="android:layout_height">wrap_content</item>
     </style>
 
     <style name="StreamUi.SuggestionListView"  parent="StreamUi">


### PR DESCRIPTION
### 🎯 Goal

Closes #3539

Currently, the media preview screen remains black while the video is loading. We should provide a loading indicator not to confuse users.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>UI Components</th>
<th>Compose</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/169530400-ac94847e-7856-4dc5-bb7a-620029fd9104.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/169530409-8eda0bba-d317-4e0e-9952-ba6dfa53d311.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

1. Click on a message with video attachment
2. Ensure that a progress indicator is displayed before the playback

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
