### PR TITLE
Add clearing cached OP instance when disconnecting the user

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -108,7 +108,7 @@ public class StreamOfflinePluginFactory(
             logger.logI("OfflinePlugin for the user is already initialized. Returning cached instance.")
             return cachedPlugin
         } else {
-            cachedOfflinePluginInstance = null
+            clearCachedInstance()
         }
 
         val chatClient = ChatClient.instance()
@@ -204,6 +204,7 @@ public class StreamOfflinePluginFactory(
                 globalState.clearState()
                 scope.launch { syncManager.storeSyncState() }
                 eventHandler.stopListening()
+                clearCachedInstance()
             }
         }
 
@@ -236,6 +237,10 @@ public class StreamOfflinePluginFactory(
             createChannelListener = CreateChannelListenerImpl(globalState, repos),
             activeUser = user
         ).also { offlinePlugin -> cachedOfflinePluginInstance = offlinePlugin }
+    }
+
+    private fun clearCachedInstance() {
+        cachedOfflinePluginInstance = null
     }
 
     private fun createRepositoryFactory(


### PR DESCRIPTION
### 🎯 Goal

Fix issue after disconnecting and reconnecting as the same user.

### 🛠 Implementation details

Add clearing cached OP instance when disconnecting the user.
When the user calls `ChatClint::disconnect` we are deinitializing all OP-related classes and therefore we should create a new OP instance when connecting the same user again.

### 🧪 Testing

1. Sign in as a User
2. Sign out
3. Sign in as the same user

You should be able to see the channels list and interact with channels without problems.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
