### PR TITLE
[Chore] Fix a link that was redirecting to localhost instead of the g…

### DIFF
--- a/docusaurus/docs/Android/01-basics/02-choosing-the-correct-sdk.mdx
+++ b/docusaurus/docs/Android/01-basics/02-choosing-the-correct-sdk.mdx
@@ -60,7 +60,7 @@ In just a few simple lines, you can leverage Compose to re-order and customize t
 
 ![Custom MessageListHeader component](../assets/compose_custom_message_list_header_component.png)
 
-If you're curious about the code powering these changes, you can read more about it [here](http://localhost:3000/chat/docs/sdk/android/compose/message-components/message-list-header/#customization).
+If you're curious about the code powering these changes, you can read more about it [here](https://getstream.io/chat/docs/sdk/android/compose/message-components/message-list-header/#customization).
 
 `MessageListHeader` is not the only Composable we offer that uses slots, in fact, most of our major components such as `MessageComposer`, `MessageList`, various menus, dialogs and others make extensive use of slots.
 This level of customization is miles above anything we can offer you with UI Components.


### PR DESCRIPTION
### 🎯 Goal

Fix a broken link in the docs that was pointing to localhost instead of the live stream page.

### 🧪 Testing

1. Build the docs using Docusaurus
2. Open the 'Choosing The Right SDK' page
3. Click on the link that was changes in the PR and make sure it is pointing to the live stream page and not to the local build

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~
- [ ] ~~New code is covered by unit tests~~
- [ ] ~~Comparison screenshots added for visual changes~~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] Check that the link in docusaurus works and is pointing to the correct live page

### 🎉 GIF

![jeff](https://user-images.githubusercontent.com/37080097/169560146-0586aae1-f987-4e17-aada-3a984c4fed16.gif)