### PR TITLE
Fix initializing OP when connecting anonymous user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### 🐞 Fixed
 - Fixed proccess sync offline message when a push is received. [#3518](https://github.com/GetStream/stream-chat-android/pull/3518)
 - Fixed syncing the channel after bringing the app from background. [#3548](https://github.com/GetStream/stream-chat-android/pull/3548)
+- Fixed initializing `OfflinePlugin` when connecting annonymous user. It fixes the issue when after connecting headers stay in `Disconnected` state. [#3553](https://github.com/GetStream/stream-chat-android/pull/3553)
 
 ### ⬆️ Improved
 - Change the order of offline message so it matches the order of online messages. Now the reshufling of messages when switching from offline to online doesn't happen anymore. [3524](https://github.com/GetStream/stream-chat-android/pull/3524)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -449,11 +449,8 @@ internal constructor(
             config.isAnonymous = true
             warmUp()
             socket.connectAnonymously()
-            waitConnection.first().also { result ->
-                if (result.isSuccess) {
-                    initializationCoordinator.userConnected(result.data().user)
-                }
-            }
+            initializationCoordinator.userConnected(User(id = ANONYMOUS_USER_ID))
+            waitConnection.first()
         } else {
             logger.logE("Failed to connect user. Please check you don't have connected user already")
             Result.error(ChatError("User cannot be set until previous one is disconnected."))
@@ -2453,6 +2450,8 @@ internal constructor(
 
         @JvmField
         public val DEFAULT_SORT: QuerySort<Member> = QuerySort.desc("last_updated")
+
+        private const val ANONYMOUS_USER_ID = "!anon"
 
         @JvmStatic
         public fun instance(): ChatClient {

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -61,7 +61,6 @@ import io.getstream.chat.android.offline.sync.messages.internal.OfflineSyncFireb
 import io.getstream.chat.android.offline.utils.internal.ChannelMarkReadHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 
 /**
@@ -137,8 +136,7 @@ public class StreamOfflinePluginFactory(
             repositoryFactory(repositoryFactory)
         }.build()
 
-        val userStateFlow = MutableStateFlow(ChatClient.instance().getCurrentUser())
-        val stateRegistry = StateRegistry.create(job, scope, userStateFlow, repos, repos.observeLatestUsers())
+        val stateRegistry = StateRegistry.create(job, scope, globalState._user, repos, repos.observeLatestUsers())
         val logic = LogicRegistry.create(stateRegistry, globalState, config.userPresence, repos, chatClient)
 
         val sendMessageInterceptor = SendMessageInterceptorImpl(


### PR DESCRIPTION
### 🎯 Goal

Fix initializing `OfflinePlugin` when connecting anonymous user.

### 🛠 Implementation details
When connecting anonymous users, we were calling `initializationCoordinator.userConnected()` after receiving the first `ConnectedEvent` because we didn't have the `User` object earlier.
The problem is that with this approach, `OfflinePlugin` won't receive `ConnectingEvent` and `ConnectedEvent` because the listener won't be set yet.
Changed the approach to match regular user connection with providing "fake" anonymous user object

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/17440581/169562194-3c0747ef-cf17-422b-8992-5cfcb7f67fe7.mp4
" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/17440581/169562180-d5c17d2a-22ee-4942-8eba-8309c3e510a2.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing

Apply the patch:
<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt	(revision e37c80da5467580dc5c17b5053b6687ddaeba669)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt	(date 1653060023959)
@@ -47,6 +47,7 @@
     fun onUiAction(action: UiAction) {
         when (action) {
             is UiAction.UserClicked -> authenticateUser(action.user)
+            is UiAction.AnonymousUserClicked -> connectAnonymousUser()
             is UiAction.ComponentBrowserClicked -> _events.postValue(Event(UiEvent.RedirectToComponentBrowser))
         }
     }
@@ -70,6 +71,17 @@
             }
         _events.postValue(Event(UiEvent.RedirectToChannels))
     }
+
+    private fun connectAnonymousUser() {
+        ChatClient.instance().connectAnonymousUser().enqueue { result ->
+            if (result.isSuccess) {
+                _events.postValue(Event(UiEvent.RedirectToChannels))
+            } else {
+                _events.postValue(Event(UiEvent.Error(result.error().message)))
+                logger.logD("Failed to set anonymous user ${result.error()}")
+            }
+        }
+    }
 
     sealed class State {
         data class AvailableUsers(val availableUsers: List<SampleUser>) : State()
@@ -77,6 +89,7 @@
 
     sealed class UiAction {
         data class UserClicked(val user: SampleUser) : UiAction()
+        object AnonymousUserClicked : UiAction()
         object ComponentBrowserClicked : UiAction()
     }
 

```
</details>

1. Sign in as anonymous user (scroll to the bottom)
2. You should see correct connection status in headers

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
