### PR TITLE
[3558] Fix license header reformatting

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -26,6 +26,9 @@
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>
+    <XML>
+      <option name="XML_KEEP_LINE_BREAKS" value="true" />
+    </XML>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />


### PR DESCRIPTION
### 🎯 Goal

Closes #3558 

Reformatting an XML file in Android Studio removes line breaks before comments:

```xml
<?xml version="1.0" encoding="utf-8"?>
<!--
    Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
    ....
-->
```

->

```xml
<?xml version="1.0" encoding="utf-8"?><!--
    Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
    ....
-->
```

As a result, the code above doesn't pass `./gradlew spotlessCheck`. We need to adjust Android Studio code style settings so that auto formatting doesn't affect the license header.

### 🛠 Implementation details

Turning on the "Keep line breaks" setting for XML files.

### 🧪 Testing

1. Restart Android Studio for the changes to take effect
2. Open any XML file with our license header
3. Press `Option + Command + L` to reformat the code
4. The license header should remain intact

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/9600921/169710079-d667083b-2a86-4e6f-92d5-37ec71a0520e.gif)

