### PR TITLE
Not try to remove an observer if the observer wasn't added

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -43,11 +43,13 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
     }
 
     fun dispose() {
-        @OptIn(DelicateCoroutinesApi::class)
-        GlobalScope.launch(DispatcherProvider.Main) {
-            ProcessLifecycleOwner.get()
-                .lifecycle
-                .removeObserver(this@StreamLifecycleObserver)
+        if (isObserving) {
+            @OptIn(DelicateCoroutinesApi::class)
+            GlobalScope.launch(DispatcherProvider.Main) {
+                ProcessLifecycleOwner.get()
+                    .lifecycle
+                    .removeObserver(this@StreamLifecycleObserver)
+            }
         }
         isObserving = false
         recurringResumeEvent = false


### PR DESCRIPTION
### 🎯 Goal
Verify an observer was added before trying to remove it from the `lifecycle` owner, because on the case it wasn't added the internal implementation throws an exception.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media4.giphy.com/media/Owg21Ouyllq48ngO3n/giphy.webp)
