### PR TITLE
Logging when QuerySort could not find a property for a class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Added logs of all properties available in a class and which one was searched for then QuerySort fails to find a field. [3597](https://github.com/GetStream/stream-chat-android/pull/3597)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
@@ -105,8 +105,10 @@ public class QuerySort<T : Any> {
                         if (extraDataObject != null) {
                             append(", but fields were found in extraData.")
                         } else {
-                            append(" and nothing was found in the extra data")
+                            append(" and nothing was found in the extra data.")
                         }
+                        val jointMembers = this::class.memberProperties.joinToString { it.name }
+                        append(" Options were: $jointMembers")
                     }.let { string -> logger.d { string } }
                 }
         }
@@ -176,7 +178,7 @@ public class QuerySort<T : Any> {
                                 kProperty1.name
                             }
 
-                        "[getSortFeature] A field to sort was NOT found. Using field by name: $fieldNameSortAttribute. +" +
+                        "[getSortFeature] A field to sort was NOT found. Using field by name: $fieldNameSortAttribute. " +
                             "The field searched was: ${fieldName.snakeToLowerCamelCase()}. The fields available were: " +
                             "$jointProperties"
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
@@ -102,11 +102,13 @@ public class QuerySort<T : Any> {
                 ?: (this as? CustomObject)?.extraData?.get(name).also { extraDataObject ->
                     buildString {
                         append("Could not find a member for property named: $name")
+
                         if (extraDataObject != null) {
                             append(", but fields were found in extraData.")
                         } else {
                             append(" and nothing was found in the extra data.")
                         }
+                        
                         val jointMembers = this::class.memberProperties.joinToString { it.name }
                         append(" Options were: $jointMembers")
                     }.let { string -> logger.d { string } }
@@ -178,9 +180,10 @@ public class QuerySort<T : Any> {
                                 kProperty1.name
                             }
 
-                        "[getSortFeature] A field to sort was NOT found. Using field by name: $fieldNameSortAttribute. " +
-                            "The field searched was: ${fieldName.snakeToLowerCamelCase()}. The fields available were: " +
-                            "$jointProperties"
+                        "[getSortFeature] A field to sort was NOT found. " +
+                            "Using field by name: $fieldNameSortAttribute. " +
+                            "The field searched was: ${fieldName.snakeToLowerCamelCase()}. " +
+                            "The fields available were: $jointProperties"
 
                     }
                 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
@@ -103,9 +103,9 @@ public class QuerySort<T : Any> {
                     buildString {
                         append("Could not find a member for property named: $name")
                         if (extraDataObject != null) {
-                            append(", but a fields was found in extraData.")
+                            append(", but fields were found in extraData.")
                         } else {
-                            append("and nothing was found in the extra data")
+                            append(" and nothing was found in the extra data")
                         }
                     }.let { string -> logger.d { string } }
                 }
@@ -171,7 +171,15 @@ public class QuerySort<T : Any> {
             ?: SortAttribute.FieldNameSortAttribute<T>(fieldName)
                 .also { fieldNameSortAttribute ->
                     logger.d {
-                        "[getSortFeature] A field to sort was NOT found. Using field by name: $fieldNameSortAttribute"
+                        val jointProperties = kClass.members.filterIsInstance<KProperty1<T, Comparable<*>?>>()
+                            .joinToString { kProperty1 ->
+                                kProperty1.name
+                            }
+
+                        "[getSortFeature] A field to sort was NOT found. Using field by name: $fieldNameSortAttribute. +" +
+                            "The field searched was: ${fieldName.snakeToLowerCamelCase()}. The fields available were: " +
+                            "$jointProperties"
+
                     }
                 }
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QuerySort.kt
@@ -108,7 +108,7 @@ public class QuerySort<T : Any> {
                         } else {
                             append(" and nothing was found in the extra data.")
                         }
-                        
+
                         val jointMembers = this::class.memberProperties.joinToString { it.name }
                         append(" Options were: $jointMembers")
                     }.let { string -> logger.d { string } }
@@ -184,7 +184,6 @@ public class QuerySort<T : Any> {
                             "Using field by name: $fieldNameSortAttribute. " +
                             "The field searched was: ${fieldName.snakeToLowerCamelCase()}. " +
                             "The fields available were: $jointProperties"
-
                     }
                 }
     }


### PR DESCRIPTION
### 🎯 Goal

Log all the available fields in a class and the one that was searched, when QuerySort can't find a property.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
