### PR TITLE
Feature/handle login error paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+-. `ChatClient::connectUser` as a new optional argument to configure a timeout to be waiting until the connection is established, in another case an error will be returned [#3605](https://github.com/GetStream/stream-chat-android/pull/3605)
+-. `ChatClient::connectAnonymousUser` as a new optional argument to configure a timeout to be waiting until the connection is established, in another case an error will be returned [#3605](https://github.com/GetStream/stream-chat-android/pull/3605)
+-. `ChatClient::connectGuestUser` as a new optional argument to configure a timeout to be waiting until the connection is established, in another case an error will be returned [#3605](https://github.com/GetStream/stream-chat-android/pull/3605)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -19,9 +19,17 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun channel (Ljava/lang/String;)Lio/getstream/chat/android/client/channel/ChannelClient;
 	public final fun channel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/channel/ChannelClient;
 	public final fun connectAnonymousUser ()Lio/getstream/chat/android/client/call/Call;
+	public final fun connectAnonymousUser (Ljava/lang/Long;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun connectAnonymousUser$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun connectGuestUser (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun connectGuestUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun connectGuestUser$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun connectUser (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;)Lio/getstream/chat/android/client/call/Call;
+	public final fun connectUser (Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;Ljava/lang/Long;)Lio/getstream/chat/android/client/call/Call;
 	public final fun connectUser (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
+	public final fun connectUser (Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/Long;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun connectUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Lio/getstream/chat/android/client/token/TokenProvider;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
+	public static synthetic fun connectUser$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/models/User;Ljava/lang/String;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun createChannel (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun deleteDevice (Lio/getstream/chat/android/client/models/Device;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -309,16 +309,18 @@ internal constructor(
         timeoutMilliseconds: Long?,
     ): Result<ConnectionData> {
         val cacheableTokenProvider = CacheableTokenProvider(tokenProvider)
-        if (tokenUtils.getUserId(cacheableTokenProvider.loadToken()) != user.id) {
-            logger.logE("The user_id provided on the JWT token doesn't match with the current user you try to connect")
-            return Result.error(
-                ChatError(
-                    "The user_id provided on the JWT token doesn't match with the current user you try to connect"
-                )
-            )
-        }
         val userState = userStateService.state
         return when {
+            tokenUtils.getUserId(cacheableTokenProvider.loadToken()) != user.id -> {
+                logger.logE(
+                    "The user_id provided on the JWT token doesn't match with the current user you try to connect"
+                )
+                Result.error(
+                    ChatError(
+                        "The user_id provided on the JWT token doesn't match with the current user you try to connect"
+                    )
+                )
+            }
             userState is UserState.NotSet -> {
                 logger.logV("[setUser] user is NotSet")
                 initializeClientWithUser(user, cacheableTokenProvider)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -36,6 +36,7 @@ import org.mockito.kotlin.clearInvocations
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -56,8 +57,10 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         val result = sut.connectUser(user, "token").await()
 
-        verify(userStateService).state
-        verifyNoInteractions(socket)
+        verify(userStateService, times(2)).state
+        verify(userStateService).onLogout()
+        verify(socket).disconnect()
+        verifyNoMoreInteractions(socket)
         verifyNoMoreInteractions(userStateService)
         verifyNoInteractions(tokenManager)
         verifyNoInteractions(listener)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -58,6 +58,7 @@ import org.junit.After
 import org.junit.Before
 import org.junit.Rule
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -166,7 +167,7 @@ internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
                 Result(data.reaction1)
             )
         }
-        whenever(client.connectUser(any(), any<String>())) doAnswer {
+        whenever(client.connectUser(any(), any<String>(), anyOrNull())) doAnswer {
             TestCall(Result(ConnectionData(it.arguments[0] as User, randomString())))
         }
 


### PR DESCRIPTION
### 🎯 Goal
During the `ConnectUser()` process, we weren't handling it properly if there was any error, keeping our `ChatClient` instance in an inconsistent state. `ChatClient` should keep in a consistent state and our customers to be notified about any error that happens.

Fix https://github.com/GetStream/stream-chat-android/issues/3424

### 🛠 Implementation details
Whenever an error happens during the `ConnectUser()` process is run, the `ChatClient` is disconnected keeping it in a good state.
An extra optional argument has been added to `connectUser()` to be able to configure a `timeout` period while the connection is being established. If the connection is not established on that time, the `ChatClient` abort the connection process and return an error that is notified to our customers. By default no timeout is configured to our connection process, allowing our customers to connect an user during it is offline.

Same implementation has been provided to `ChatClient::connectGuestUser()` and `ChatClient::connectAnonymousUser`

### 🧪 Testing
<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(revision 11d4a2eccbbd3c08bc5e58402cedb83dbdb5dc1e)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(revision 5c65bc95cda92c82205e2623d8bbd7e9b17e6815)
@@ -70,14 +70,15 @@
      */
     fun connectUser(
         userCredentials: UserCredentials,
+        timeoutMilliseconds: Long?,
         onSuccess: () -> Unit = {},
         onError: (ChatError) -> Unit = {},
     ) {
-        ChatApp.credentialsRepository.saveUserCredentials(userCredentials)
 
-        ChatClient.instance().connectUser(userCredentials.user, userCredentials.token)
+        ChatClient.instance().connectUser(userCredentials.user, userCredentials.token, timeoutMilliseconds)
             .enqueue { result ->
                 if (result.isSuccess) {
+                    ChatApp.credentialsRepository.saveUserCredentials(userCredentials)
                     onSuccess()
                 } else {
                     onError(result.error())
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt	(revision 11d4a2eccbbd3c08bc5e58402cedb83dbdb5dc1e)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt	(revision 5c65bc95cda92c82205e2623d8bbd7e9b17e6815)
@@ -41,7 +41,7 @@
         val userCredentials = ChatApp.credentialsRepository.loadUserCredentials()
         if (userCredentials != null) {
             // Ensure that the user is connected
-            ChatHelper.connectUser(userCredentials)
+            ChatHelper.connectUser(userCredentials, null)
 
             if (intent.hasExtra(KEY_CHANNEL_ID)) {
                 // Navigating from push, route to the messages screen
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt	(revision 11d4a2eccbbd3c08bc5e58402cedb83dbdb5dc1e)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt	(revision 5c65bc95cda92c82205e2623d8bbd7e9b17e6815)
@@ -78,6 +78,7 @@
 
                         ChatHelper.connectUser(
                             userCredentials = userCredentials,
+                            timeoutMilliseconds = null,
                             onSuccess = ::openChannels,
                             onError = ::showError
                         )
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt	(revision 11d4a2eccbbd3c08bc5e58402cedb83dbdb5dc1e)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt	(revision 5c65bc95cda92c82205e2623d8bbd7e9b17e6815)
@@ -85,18 +85,20 @@
                             ChatHelper.initializeSdk(applicationContext, userCredentials.apiKey)
                         }
                         ChatHelper.connectUser(
-                            userCredentials = userCredentials.copy(token = userCredentials.token + "a"),
+                            userCredentials = userCredentials.copy(token = userCredentials.token),
+                            timeoutMilliseconds = 1L,
                             onSuccess = {
                                 logger.logW("This message shouldn't be shown because we are using an invalid token")
                                 openChannels()
                             },
                             onError = {
-                                logger.logD("Login failed because token was invalid: $it")
+                                logger.logD("Login failed because token was invalid: ${it.message}")
                                 GlobalScope.launch {
                                     logger.logD("Waiting some seconds to do login again")
-                                    delay(6000)
+                                    delay(2000)
                                     ChatHelper.connectUser(
                                         userCredentials = userCredentials.copy(token = userCredentials.token),
+                                        timeoutMilliseconds = null,
                                         onSuccess = {
                                             logger.logD("Token is valie, so Login should be successful")
                                             openChannels()

```

</details>

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media3.giphy.com/media/CZGcUfnAy3ayJw2eZX/giphy.webp)
