### PR TITLE
Feature/merge connect user with connect anonymous

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3386,10 +3386,11 @@ public final class io/getstream/chat/android/client/uploader/StreamCdnImageMimeT
 }
 
 public final class io/getstream/chat/android/client/user/CredentialConfig {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Z)V
 	public final fun getUserId ()Ljava/lang/String;
 	public final fun getUserName ()Ljava/lang/String;
 	public final fun getUserToken ()Ljava/lang/String;
+	public final fun isAnonymous ()Z
 }
 
 public abstract interface class io/getstream/chat/android/client/user/storage/UserCredentialStorage {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -246,7 +246,11 @@ internal constructor(
             }
             currentUser?.let { updatedCurrentUser ->
                 userStateService.onUserUpdated(updatedCurrentUser)
-                storePushNotificationsConfig(updatedCurrentUser.id, updatedCurrentUser.name)
+                storePushNotificationsConfig(
+                    updatedCurrentUser.id,
+                    updatedCurrentUser.name,
+                    userStateService.state !is UserState.UserSet,
+                )
             }
         }
         logger.logI("Initialised: ${buildSdkTrackingHeaders()}")
@@ -442,6 +446,7 @@ internal constructor(
             initializeClientWithUser(
                 user = User(id = config.userId).apply { name = config.userName },
                 tokenProvider = CacheableTokenProvider(ConstantTokenProvider(config.userToken)),
+                isAnonymous = config.isAnonymous,
             )
         }
     }
@@ -451,12 +456,13 @@ internal constructor(
         return userCredentialStorage.get() != null
     }
 
-    private fun storePushNotificationsConfig(userId: String, userName: String) {
+    private fun storePushNotificationsConfig(userId: String, userName: String, isAnonymous: Boolean) {
         userCredentialStorage.put(
             CredentialConfig(
                 userToken = getCurrentToken() ?: "",
                 userId = userId,
                 userName = userName,
+                isAnonymous = isAnonymous,
             ),
         )
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -186,10 +186,10 @@ internal open class ChatSocket constructor(
     }
 
     open fun connectAnonymously() =
-        connect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey))
+        connect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, anonUser))
 
     fun reconnectAnonymously() {
-        reconnect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey))
+        reconnect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, anonUser))
     }
 
     open fun connect(user: User) =
@@ -278,6 +278,13 @@ internal open class ChatSocket constructor(
     private companion object {
         private const val RETRY_LIMIT = 3
         private const val DEFAULT_DELAY = 500
+
+        /**
+         *  It doesn't matter what user id we send to the server for anonymous user
+         *  as the server will always return the user with "!anon" user id
+         */
+        private const val ANONYMOUS_USER_ID = "anon"
+        private val anonUser by lazy { User(id = ANONYMOUS_USER_ID) }
     }
 
     @VisibleForTesting

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -203,7 +203,7 @@ internal open class ChatSocket constructor(
         )
     }
 
-    private fun connect(connectionConf: SocketFactory.ConnectionConf) {
+    protected open fun connect(connectionConf: SocketFactory.ConnectionConf) {
         val isNetworkConnected = networkStateProvider.isConnected()
         logger.logI("Connect. Network available: $isNetworkConnected")
         this.connectionConf = connectionConf

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -185,18 +185,22 @@ internal open class ChatSocket constructor(
         }
     }
 
-    open fun connectAnonymously() =
-        connect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, anonUser))
-
-    fun reconnectAnonymously() {
-        reconnect(SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, anonUser))
+    fun connectUser(user: User, isAnonymous: Boolean) {
+        connect(
+            when (isAnonymous) {
+                true -> SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, user)
+                false -> SocketFactory.ConnectionConf.UserConnectionConf(wssUrl, apiKey, user)
+            }
+        )
     }
 
-    open fun connect(user: User) =
-        connect(SocketFactory.ConnectionConf.UserConnectionConf(wssUrl, apiKey, user))
-
-    fun reconnectUser(user: User) {
-        reconnect(SocketFactory.ConnectionConf.UserConnectionConf(wssUrl, apiKey, user))
+    fun reconnectUser(user: User, isAnonymous: Boolean) {
+        reconnect(
+            when (isAnonymous) {
+                true -> SocketFactory.ConnectionConf.AnonymousConnectionConf(wssUrl, apiKey, user)
+                false -> SocketFactory.ConnectionConf.UserConnectionConf(wssUrl, apiKey, user)
+            }
+        )
     }
 
     private fun connect(connectionConf: SocketFactory.ConnectionConf) {
@@ -278,13 +282,6 @@ internal open class ChatSocket constructor(
     private companion object {
         private const val RETRY_LIMIT = 3
         private const val DEFAULT_DELAY = 500
-
-        /**
-         *  It doesn't matter what user id we send to the server for anonymous user
-         *  as the server will always return the user with "!anon" user id
-         */
-        private const val ANONYMOUS_USER_ID = "anon"
-        private val anonUser by lazy { User(id = ANONYMOUS_USER_ID) }
     }
 
     @VisibleForTesting

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -75,14 +75,6 @@ internal class SocketFactory(
         return parser.toJson(data)
     }
 
-    companion object {
-        /**
-         *  It doesn't matter what user id we send to the server for anonymous user
-         *  as the server will always return the user with "!anon" user id
-         */
-        private const val ANONYMOUS_USER_ID = "anon"
-    }
-
     /**
      * Converts the [User] object to a map of properties updated while connecting the user.
      * [User.name] and [User.image] will only be included if they are not blank.
@@ -112,9 +104,8 @@ internal class SocketFactory(
         data class AnonymousConnectionConf(
             override val endpoint: String,
             override val apiKey: String,
-        ) : ConnectionConf() {
-            override val user: User = User(ANONYMOUS_USER_ID)
-        }
+            override val user: User,
+        ) : ConnectionConf()
 
         data class UserConnectionConf(
             override val endpoint: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/user/CredentialConfig.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/user/CredentialConfig.kt
@@ -32,6 +32,10 @@ public class CredentialConfig(
      * Name of the current user.
      */
     public val userName: String,
+    /**
+     * The user is anonymous or not
+     */
+    public val isAnonymous: Boolean,
 ) {
     internal fun isValid(): Boolean = userId.isNotEmpty() && userToken.isNotEmpty() && userName.isNotEmpty()
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/user/storage/SharedPreferencesCredentialStorage.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/user/storage/SharedPreferencesCredentialStorage.kt
@@ -29,8 +29,14 @@ internal class SharedPreferencesCredentialStorage(context: Context) : UserCreden
         val userId = getString(KEY_USER_ID, "") ?: ""
         val userToken = getString(KEY_USER_TOKEN, "") ?: ""
         val userName = getString(KEY_USER_NAME, "") ?: ""
+        val isAnonymous = getBoolean(KEY_IS_ANONYMOUS, false)
 
-        val config = CredentialConfig(userId = userId, userToken = userToken, userName = userName)
+        val config = CredentialConfig(
+            userId = userId,
+            userToken = userToken,
+            userName = userName,
+            isAnonymous = isAnonymous,
+        )
 
         return config.takeIf(CredentialConfig::isValid)
     }
@@ -42,6 +48,7 @@ internal class SharedPreferencesCredentialStorage(context: Context) : UserCreden
             putString(KEY_USER_ID, credentialConfig.userId)
             putString(KEY_USER_TOKEN, credentialConfig.userToken)
             putString(KEY_USER_NAME, credentialConfig.userName)
+            putBoolean(KEY_IS_ANONYMOUS, credentialConfig.isAnonymous)
         }.apply()
     }
 
@@ -50,5 +57,6 @@ internal class SharedPreferencesCredentialStorage(context: Context) : UserCreden
         private const val KEY_USER_ID = "user_id"
         private const val KEY_USER_TOKEN = "user_token"
         private const val KEY_USER_NAME = "user_name"
+        private const val KEY_IS_ANONYMOUS = "is_anonymous"
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
@@ -130,7 +130,7 @@ internal class ClientConnectionTests {
     fun successConnection() {
         client.connectUser(user, token).enqueue()
 
-        verify(socket, times(1)).connect(user)
+        verify(socket, times(1)).connectUser(user, false)
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -77,7 +77,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         sut.connectUser(Mother.randomUser { id = "differentUserId" }, "token").enqueue()
 
-        verify(socket, never()).connect(any())
+        verify(socket, never()).connectUser(any(), any())
         verify(userStateService, never()).onUserUpdated(any())
         verify(tokenManager, never()).setTokenProvider(any())
     }
@@ -119,7 +119,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         sut.connectUser(user, "token").enqueue()
 
-        verify(socket).connect(user)
+        verify(socket).connectUser(user, isAnonymous = false)
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
@@ -66,16 +66,17 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
 
         sut.reconnectSocket()
 
-        verify(socket).reconnectUser(user)
+        verify(socket).reconnectUser(user, isAnonymous = false)
     }
 
     @Test
     fun `Given disconnected connection state And Anonymous user set state Should connect to socket anonymously`() {
-        val sut = Fixture().givenDisconnectedConnectionState().givenAnonymousUserSetState().get()
+        val user = Mother.randomUser()
+        val sut = Fixture().givenDisconnectedConnectionState().givenAnonymousUserSetState(user).get()
 
         sut.reconnectSocket()
 
-        verify(socket).reconnectAnonymously()
+        verify(socket).reconnectUser(user, isAnonymous = true)
     }
 
     @Test
@@ -115,6 +116,10 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
 
         fun givenAnonymousUserSetState() = apply {
             whenever(userStateService.state) doReturn UserState.Anonymous.AnonymousUserSet(Mother.randomUser())
+        }
+
+        fun givenAnonymousUserSetState(user: User) = apply {
+            whenever(userStateService.state) doReturn UserState.Anonymous.AnonymousUserSet(user)
         }
 
         fun givenAnonymousPendingState() = apply {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/ChatSocketTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/ChatSocketTest.kt
@@ -77,7 +77,7 @@ internal class ChatSocketTest {
     fun `Should start connecting to socket when connecting and network connectivity exists`() {
         whenever(networkStateProvider.isConnected()) doReturn true
 
-        chatSocket.connect(randomUser())
+        chatSocket.connectUser(randomUser(), isAnonymous = false)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.Connecting
     }
@@ -89,7 +89,7 @@ internal class ChatSocketTest {
             it.getArgument<NetworkStateProvider.NetworkStateListener>(0).onConnected()
         }
 
-        chatSocket.connect(randomUser())
+        chatSocket.connectUser(randomUser(), isAnonymous = false)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.Connecting
     }
@@ -98,7 +98,7 @@ internal class ChatSocketTest {
     fun `Should not start connecting to socket when connecting and there is no network connectivity`() {
         whenever(networkStateProvider.isConnected()) doReturn false
 
-        chatSocket.connect(randomUser())
+        chatSocket.connectUser(randomUser(), isAnonymous = false)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.NetworkDisconnected
     }
@@ -107,7 +107,7 @@ internal class ChatSocketTest {
     fun `Should start connecting to socket when connecting with anymous user and network connectivity exists`() {
         whenever(networkStateProvider.isConnected()) doReturn true
 
-        chatSocket.connectAnonymously()
+        chatSocket.connectUser(randomUser(), isAnonymous = true)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.Connecting
     }
@@ -119,7 +119,7 @@ internal class ChatSocketTest {
             it.getArgument<NetworkStateProvider.NetworkStateListener>(0).onConnected()
         }
 
-        chatSocket.connectAnonymously()
+        chatSocket.connectUser(randomUser(), isAnonymous = true)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.Connecting
     }
@@ -128,13 +128,14 @@ internal class ChatSocketTest {
     fun `Should not start connecting to socket when connecting with anymous user  and there is no network connectivity`() {
         whenever(networkStateProvider.isConnected()) doReturn false
 
-        chatSocket.connectAnonymously()
+        chatSocket.connectUser(randomUser(), isAnonymous = true)
 
         chatSocket.state shouldBeEqualTo ChatSocket.State.NetworkDisconnected
     }
 
     @Test
     fun `Should retry to connect`() {
+        val user = randomUser()
         whenever(networkStateProvider.isConnected()) doReturn true
 
         val networkError = ChatNetworkError.create(
@@ -143,7 +144,7 @@ internal class ChatSocketTest {
             statusCode = 500,
         )
 
-        chatSocket.connectAnonymously()
+        chatSocket.connectUser(user, isAnonymous = true)
         chatSocket.state shouldBeEqualTo ChatSocket.State.Connecting
 
         whenever(networkStateProvider.isConnected()) doReturn false
@@ -153,7 +154,7 @@ internal class ChatSocketTest {
         verify(socketFactory, times(2)).createSocket(
             any(),
             org.mockito.kotlin.check {
-                it `should be equal to` SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey)
+                it `should be equal to` SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, user)
             }
         )
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
@@ -82,10 +82,12 @@ internal class SocketFactoryTest {
                     "${endpoint}connect?json=${buildMinimumUserJson(it)}&api_key=$apiKey&authorization=$token&stream-auth-type=jwt"
                 )
             },
-            Arguments.of(
-                SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey).asReconnectionConf(),
-                "${endpoint}connect?json=${buildMinimumUserJson(User("anon"))}&api_key=$apiKey&stream-auth-type=anonymous"
-            ),
+            User("anon").let {
+                Arguments.of(
+                    SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
+                    "${endpoint}connect?json=${buildMinimumUserJson(it)}&api_key=$apiKey&stream-auth-type=anonymous"
+                )
+            }
         )
 
         private fun buildMinimumUserJson(user: User): String = encode(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocket.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocket.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.socket.ChatSocket
+import io.getstream.chat.android.client.socket.SocketFactory
 import io.getstream.chat.android.client.socket.SocketListener
 import io.getstream.chat.android.test.randomString
 import org.amshove.kluent.shouldBeEqualTo
@@ -40,6 +41,7 @@ internal class FakeSocket(
 ) {
 
     private var connectionUserId: String? = null
+    private var connectionConf: SocketFactory.ConnectionConf? = null
 
     private val listeners = mutableSetOf<SocketListener>()
 
@@ -49,12 +51,9 @@ internal class FakeSocket(
         }
     }
 
-    override fun connectAnonymously() {
-        // no-op
-    }
-
-    override fun connect(user: User) {
-        // no-op
+    override fun connect(connectionConf: SocketFactory.ConnectionConf) {
+        super.connect(connectionConf)
+        this.connectionConf = connectionConf
     }
 
     override fun disconnect() {
@@ -91,5 +90,9 @@ internal class FakeSocket(
 
     fun verifyNoConnectionUserId() {
         connectionUserId.shouldBeNull()
+    }
+
+    fun verifyUserToConnect(connectUser: User) {
+        this.connectionConf?.user shouldBeEqualTo connectUser
     }
 }


### PR DESCRIPTION
### 🎯 Goal
**Depend on: #3605**
Simplify `connectUser()` and `connectAnonymousUser()` flows by merging them.

### 🛠 Implementation details
Both flows do almost the same, but configuring extra properties. Whenever a change need to be done on `connetUser()` we need to include it on the other flow and sometime we doesn't propagate it properly. Keeping both similar flows on different methods without sharing any code logic does it hard to maintain. Because of that, `connectUser` and `connectAnonymousUser()` flows has been merged and simplified

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media4.giphy.com/media/PvDM6QHuLPCxi/giphy.webp)
