### PR TITLE
Improve handling reads in MessageListItemLiveData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed potential NPE when disconnecting the user. [#3612](https://github.com/GetStream/stream-chat-android/pull/3612)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -134,11 +134,17 @@ internal class MessageListItemLiveData(
 
     private fun configReadsChange(readsLd: LiveData<List<ChannelUserRead>>, getCurrentUser: LiveData<User?>) {
         val readChange = getCurrentUser.changeOnUserLoaded(readsLd) { changedReads, currentUser ->
-            readsChanged(changedReads, currentUser!!.id)
+            if (currentUser != null) {
+                readsChanged(changedReads, currentUser.id)
+            } else {
+                null
+            }
         }
 
         addSource(readChange) { value ->
-            this.value = value
+            if (value != null) {
+                this.value = value
+            }
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Improve handling reads in `MessageListItemLiveData`.

### 🛠 Implementation details

Add additional null check when updating reads.

### 🧪 Testing

Run UI Components sample app and make sure `MessageListView` is updated properly.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
