### PR TITLE
[3496] Fix upload progress text getting ellipsized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved displaying the upload progress of files being uploaded. Now the upload progress text is less likely to get ellipsized. [#3618](https://github.com/GetStream/stream-chat-android/pull/3618)
 
 ### ✅ Added
 - Added way to customize quoted attachments through `QuotedAttachmentFactory` and updated custom attachments guide for the new feature. [#3592](https://github.com/GetStream/stream-chat-android/pull/3592)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
@@ -250,12 +250,14 @@ private class FileAttachmentViewHolder(
                 item.uploadState is Attachment.UploadState.InProgress ||
                 (item.uploadState is Attachment.UploadState.Success && item.fileSize == 0)
             ) {
-                actionButton.setImageDrawable(null)
+                actionButton.visibility = View.GONE
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
             } else if (item.uploadState is Attachment.UploadState.Failed || item.fileSize == 0) {
+                actionButton.visibility = View.VISIBLE
                 actionButton.setImageDrawable(style.failedAttachmentIcon)
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
             } else {
+                actionButton.visibility = View.VISIBLE
                 actionButton.setImageDrawable(style.actionButtonIcon)
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.fileSize.toLong())
             }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
@@ -20,14 +20,14 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:foreground="?selectableItemBackground"
-    android:padding="8dp"
+    android:padding="6dp"
     >
 
     <ImageView
         android:id="@+id/fileTypeIcon"
         android:layout_width="@dimen/stream_ui_attachment_dialog_file_type_width"
         android:layout_height="@dimen/stream_ui_attachment_dialog_file_type_height"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="6dp"
         android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -56,7 +56,7 @@
         android:id="@+id/fileSize"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="6dp"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
@@ -72,8 +72,8 @@
 
     <ProgressBar
         android:id="@+id/progressBar"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
+        android:layout_width="12dp"
+        android:layout_height="12dp"
         android:indeterminateDrawable="@drawable/stream_ui_rotating_indeterminate_progress_gradient"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@id/fileTitle"


### PR DESCRIPTION
### 🎯 Goal

The upload progress text does not have enough space to properly unfurl and often gets ellipsized.

closes #3496

### 🛠 Implementation details

- Set the visibility of `actionButton` to gone while the file is being uploaded
- Trim the padding of stream_ui_item_file_attachment.xml so that the text has more space

### 🎨 UI Changes

| Before | After |
| --- | --- |
| https://user-images.githubusercontent.com/37080097/170707652-a7a4eb24-e963-40f7-badc-f6feff052568.mp4 | https://user-images.githubusercontent.com/37080097/170707660-c17db614-9142-4550-8d48-4ff7e494c5a8.mp4 |

### 🧪 Testing

1. Upload a file
2. Observe the progress text saying " y MB / x MB"

Expected: The text should not be clipped / ellipsized.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![progress](https://user-images.githubusercontent.com/37080097/170711358-5cd298d5-f0db-4042-a57e-cd8454bf5561.gif)
