### PR TITLE
[3613] mark last message as read when it is in view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- The channel will now be marked as read once the latest message inside `MessagesListView` is reached. Previously scrolling down to it would not trigger this action. [#3619](https://github.com/GetStream/stream-chat-android/pull/3619)
 
 ### ⬆️ Improved
 - Improved displaying the upload progress of files being uploaded. Now the upload progress text is less likely to get ellipsized. [#3618](https://github.com/GetStream/stream-chat-android/pull/3618)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved displaying the upload progress of files being uploaded. Now the upload progress text is less likely to get ellipsized. [#3618](https://github.com/GetStream/stream-chat-android/pull/3618)
 
 ### ✅ Added
 - Added way to customize quoted attachments through `QuotedAttachmentFactory` and updated custom attachments guide for the new feature. [#3592](https://github.com/GetStream/stream-chat-android/pull/3592)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/FileAttachmentsView.kt
@@ -250,12 +250,14 @@ private class FileAttachmentViewHolder(
                 item.uploadState is Attachment.UploadState.InProgress ||
                 (item.uploadState is Attachment.UploadState.Success && item.fileSize == 0)
             ) {
-                actionButton.setImageDrawable(null)
+                actionButton.visibility = View.GONE
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
             } else if (item.uploadState is Attachment.UploadState.Failed || item.fileSize == 0) {
+                actionButton.visibility = View.VISIBLE
                 actionButton.setImageDrawable(style.failedAttachmentIcon)
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.upload?.length() ?: 0L)
             } else {
+                actionButton.visibility = View.VISIBLE
                 actionButton.setImageDrawable(style.actionButtonIcon)
                 fileSize.text = MediaStringUtil.convertFileSizeByteCount(item.fileSize.toLong())
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
@@ -47,6 +47,13 @@ internal class MessageListScrollHelper(
     private var lastSeenMessageInChannel: MessageListItem? = null
     private var lastSeenMessageInThread: MessageListItem? = null
     private var isAtBottom = false
+        set(value) {
+            if (value) {
+                callback.onLastMessageRead()
+            }
+            field = value
+        }
+
     private var unreadCount = 0
 
     private val currentList: List<MessageListItem>
@@ -131,11 +138,11 @@ internal class MessageListScrollHelper(
                     ?.let {
                         if (message.pinned) {
                             this@MessageListScrollHelper.layoutManager
-                                ?.scrollToPositionWithOffset(it, 8.dpToPx())
+                                .scrollToPositionWithOffset(it, 8.dpToPx())
                         } else {
                             with(recyclerView) {
                                 this@MessageListScrollHelper.layoutManager
-                                    ?.scrollToPositionWithOffset(it, height / 3)
+                                    .scrollToPositionWithOffset(it, height / 3)
                                 post {
                                     findViewHolderForAdapterPosition(it)
                                         ?.safeCast<BaseMessageItemViewHolder<*>>()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
@@ -46,6 +46,13 @@ internal class MessageListScrollHelper(
 
     private var lastSeenMessageInChannel: MessageListItem? = null
     private var lastSeenMessageInThread: MessageListItem? = null
+
+    /**
+     * True when the latest message is visible.
+     *
+     * Note: This does not mean the whole message is visible,
+     * it will be true even if only a part of it is.
+     */
     private var isAtBottom = false
         set(value) {
             if (value) {

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_file_attachment.xml
@@ -20,14 +20,14 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:foreground="?selectableItemBackground"
-    android:padding="8dp"
+    android:padding="6dp"
     >
 
     <ImageView
         android:id="@+id/fileTypeIcon"
         android:layout_width="@dimen/stream_ui_attachment_dialog_file_type_width"
         android:layout_height="@dimen/stream_ui_attachment_dialog_file_type_height"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="6dp"
         android:scaleType="centerCrop"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -56,7 +56,7 @@
         android:id="@+id/fileSize"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="8dp"
+        android:layout_marginStart="6dp"
         android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
@@ -72,8 +72,8 @@
 
     <ProgressBar
         android:id="@+id/progressBar"
-        android:layout_width="16dp"
-        android:layout_height="16dp"
+        android:layout_width="12dp"
+        android:layout_height="12dp"
         android:indeterminateDrawable="@drawable/stream_ui_rotating_indeterminate_progress_gradient"
         android:visibility="gone"
         app:layout_constraintStart_toStartOf="@id/fileTitle"


### PR DESCRIPTION
### 🎯 Goal

Previously, we did not activate the callback inside `MessageListScrollHelper` if the newest message was scrolled down to after it was received.

### 🛠 Implementation details

- activate the callback once `isAtBottom` is true

### 🎨 ~~UI Changes~~

No UI changes, only behavioral changes.

### 🧪 Testing

1. Log in with User A on one phone and User B on another
2. Enter the same channel from both phones
3. As User A, scroll upwards so that the first few latest messages are not in view
4. As User B, send a new message to the channel
5. As User A, scroll down to the latest message

Expected: The new message should be marked as read on User B's phone

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![bottom](https://user-images.githubusercontent.com/37080097/170739120-67d9fbe6-a817-4642-b1aa-de36bd6ec70c.gif)