### PR TITLE
[3613] Mark last message as read when it is in view

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/internal/MessageListScrollHelper.kt
@@ -46,7 +46,21 @@ internal class MessageListScrollHelper(
 
     private var lastSeenMessageInChannel: MessageListItem? = null
     private var lastSeenMessageInThread: MessageListItem? = null
+
+    /**
+     * True when the latest message is visible.
+     *
+     * Note: This does not mean the whole message is visible,
+     * it will be true even if only a part of it is.
+     */
     private var isAtBottom = false
+        set(value) {
+            if (value) {
+                callback.onLastMessageRead()
+            }
+            field = value
+        }
+
     private var unreadCount = 0
 
     private val currentList: List<MessageListItem>
@@ -131,11 +145,11 @@ internal class MessageListScrollHelper(
                     ?.let {
                         if (message.pinned) {
                             this@MessageListScrollHelper.layoutManager
-                                ?.scrollToPositionWithOffset(it, 8.dpToPx())
+                                .scrollToPositionWithOffset(it, 8.dpToPx())
                         } else {
                             with(recyclerView) {
                                 this@MessageListScrollHelper.layoutManager
-                                    ?.scrollToPositionWithOffset(it, height / 3)
+                                    .scrollToPositionWithOffset(it, height / 3)
                                 post {
                                     findViewHolderForAdapterPosition(it)
                                         ?.safeCast<BaseMessageItemViewHolder<*>>()


### PR DESCRIPTION
### :dart: Goal

Previously, we did not activate the callback inside `MessageListScrollHelper` if the newest message was scrolled down to after it was received.

### :hammer_and_wrench: Implementation details

- activate the callback once `isAtBottom` is true

### :art: ~~UI Changes~~

No UI changes, only behavioral changes.

### :test_tube: Testing

1. Log in with User A on one phone and User B on another
2. Enter the same channel from both phones
3. As User A, scroll upwards so that the first few latest messages are not in view
4. As User B, send a new message to the channel
5. As User A, scroll down to the latest message

Expected: The new message should be marked as read on User B's phone

### :ballot_box_with_check:Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### :ballot_box_with_check:Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### :tada: GIF

![bottom](https://user-images.githubusercontent.com/37080097/170739120-67d9fbe6-a817-4642-b1aa-de36bd6ec70c.gif)