### PR TITLE
Remove death penalty for violating strict mode policy

### DIFF
--- a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt
+++ b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt
@@ -33,7 +33,6 @@ object DebugMetricsHelper {
             .detectLeakedSqlLiteObjects()
             .detectLeakedClosableObjects()
             .penaltyLog()
-            .penaltyDeath()
             .build()
             .apply {
                 StrictMode.setVmPolicy(this)


### PR DESCRIPTION
### 🎯 Goal

Even though it might be beneficial to leave this option enabled, looks like it produces a certain amount of false positives and the sample app crashes without a reason for that. Removing it for now.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
