### PR TITLE
[3546] Channel list loads stale data from the DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fix the stale Channel data being stored into database. [3650](https://github.com/GetStream/stream-chat-android/pull/3650)
 
 ### ⬆️ Improved
 - Added logs of all properties available in a class and which one was searched for then QuerySort fails to find a field. [3597](https://github.com/GetStream/stream-chat-android/pull/3597)

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3555,6 +3555,9 @@ public final class io/getstream/chat/android/client/utils/internal/toggle/Toggle
 	public static synthetic fun init$default (Lio/getstream/chat/android/client/utils/internal/toggle/ToggleService$Companion;Landroid/content/Context;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/client/utils/internal/toggle/ToggleService;
 }
 
+public final class io/getstream/chat/android/client/utils/message/MessageUtils {
+}
+
 public abstract interface class io/getstream/chat/android/client/utils/observable/Disposable {
 	public abstract fun dispose ()V
 	public abstract fun isDisposed ()Z

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:JvmName("MessageUtils")
+
+package io.getstream.chat.android.client.utils.message
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.core.utils.date.after
+
+private const val ITEM_COUNT_OF_TWO: Int = 2
+
+/**
+ * Peeks the latest message from the sorted [List] of messages.
+ */
+@InternalStreamChatApi
+public fun List<Message>.latestOrNull(): Message? = when (size >= ITEM_COUNT_OF_TWO) {
+    true -> {
+        val first = first()
+        val last = last()
+        when (last.createdAfter(first)) {
+            true -> last
+            else -> first
+        }
+    }
+    else -> lastOrNull()
+}
+
+/**
+ * Tests if [this] message was created after [that] message.
+ */
+@InternalStreamChatApi
+public fun Message.createdAfter(that: Message): Boolean {
+    val thisDate = this.createdAt ?: this.createdLocallyAt
+    val thatDate = that.createdAt ?: that.createdLocallyAt
+    return thisDate after thatDate
+}

--- a/stream-chat-android-compose-sample/detekt-baseline.xml
+++ b/stream-chat-android-compose-sample/detekt-baseline.xml
@@ -11,6 +11,7 @@
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYmVsYWwifQ.a0DwMMb0V1Lona_1dIB7a4GtNl4oQ_WCp-W-UP3_CUQ"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG1pdHJpaSJ9._j7pM2kqj46ztls0tG1DiUMl45l54VOLvl8jp5VCmZU"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZmlsaXAifQ.WKqTjU6fHHjtFej-sUqS2ml3Rvdqn4Ptrf7jfKqzFgU"</ID>
+    <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamFld29vbmcifQ.d-7AREGaSirn7TjxwLyAUvOU-nz2_LL5oMTycZvcnQc"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ.2_5Hae3LKjVSfA0gQxXlZn54Bq6xDlhjPx2J7azUNB4"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2xlZyJ9.ZucjlxjiNewCORdCLwpKwZw2nNtRC_Bv17TjHlitdLU"</ID>

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
@@ -146,6 +146,15 @@ object PredefinedUserCredentials {
         UserCredentials(
             apiKey = API_KEY,
             user = User().apply {
+                id = "kanat"
+                name = "Kanat"
+                image = "https://ca.slack-edge.com/T02RM6X6B-U034NG4FPNG-688fab30cc42-72"
+            },
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw"
+        ),
+        UserCredentials(
+            apiKey = API_KEY,
+            user = User().apply {
                 id = "qatest1"
                 name = "QA Test 1"
                 image = "https://getstream.imgix.net/images/random_svg/QT.png"

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -92,3 +92,6 @@ public final class io/getstream/chat/android/core/internal/fsm/FiniteStateMachin
 	public final fun invoke (Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/core/internal/fsm/FiniteStateMachine;
 }
 
+public final class io/getstream/chat/android/core/utils/date/DateUtils {
+}
+

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/utils/date/DateUtils.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/utils/date/DateUtils.kt
@@ -14,20 +14,30 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.offline.event.handler.internal.batch
+@file:JvmName("DateUtils")
 
-import io.getstream.chat.android.client.events.ChatEvent
-import kotlin.math.absoluteValue
-import kotlin.random.Random
+package io.getstream.chat.android.core.utils.date
+
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import java.util.Date
 
 /**
- * Events container to represent the source of the received events.
+ * Tests if [this] date is after [that] date.
  */
-internal class BatchEvent(
-    val id: Int = Random.nextInt().absoluteValue,
-    val sortedEvents: List<ChatEvent>,
-    val isFromHistorySync: Boolean,
-) {
-    val size: Int = sortedEvents.size
-    val isFromSocketConnection: Boolean = !isFromHistorySync
+@InternalStreamChatApi
+public infix fun Date?.after(that: Date?): Boolean {
+    return when {
+        this == null -> false
+        that == null -> true
+        else -> this.after(that)
+    }
+}
+
+/**
+ * Returns the greater of two dates.
+ */
+@InternalStreamChatApi
+public fun max(dateA: Date?, dateB: Date?): Date? = when (dateA after dateB) {
+    true -> dateA
+    else -> dateB
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/handler/internal/batch/SocketEventCollector.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/event/handler/internal/batch/SocketEventCollector.kt
@@ -97,7 +97,7 @@ internal class SocketEventCollector(
         postponed.clear()
         timeoutJob.reset()
         fireEvent(
-            BatchEvent(sortedEvents, isFromHistorySync = false)
+            BatchEvent(sortedEvents = sortedEvents, isFromHistorySync = false)
         )
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/builder/internal/RepositoryFacade.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/builder/internal/RepositoryFacade.kt
@@ -72,6 +72,8 @@ internal class RepositoryFacade(
     ): List<Channel> {
         // fetch the channel entities from room
         val channels = channelsRepository.selectChannels(channelIds, forceCache)
+        // TODO why it is not compared this way?
+        //  pagination?.isRequestingMoreThanLastMessage() == true
         val messagesMap = if (pagination?.isRequestingMoreThanLastMessage() != false) {
             // with postgres this could be optimized into a single query instead of N, not sure about sqlite on android
             // sqlite has window functions: https://sqlite.org/windowfunctions.html
@@ -83,7 +85,9 @@ internal class RepositoryFacade(
             emptyMap()
         }
 
-        return channels.onEach { it.enrichChannel(messagesMap, defaultConfig) }
+        return channels.onEach { channel ->
+            channel.enrichChannel(messagesMap, defaultConfig)
+        }
     }
 
     @VisibleForTesting

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelEntityUtils.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/ChannelEntityUtils.kt
@@ -14,20 +14,13 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.offline.event.handler.internal.batch
+package io.getstream.chat.android.offline.repository.domain.channel
 
-import io.getstream.chat.android.client.events.ChatEvent
-import kotlin.math.absoluteValue
-import kotlin.random.Random
+import io.getstream.chat.android.offline.repository.domain.channel.internal.ChannelEntity
 
 /**
- * Events container to represent the source of the received events.
+ * Composes a short version of [ChannelEntity.toString] with the last message information only.
  */
-internal class BatchEvent(
-    val id: Int = Random.nextInt().absoluteValue,
-    val sortedEvents: List<ChatEvent>,
-    val isFromHistorySync: Boolean,
-) {
-    val size: Int = sortedEvents.size
-    val isFromSocketConnection: Boolean = !isFromHistorySync
+internal fun ChannelEntity.lastMessageInfo(): String {
+    return "ChannelEntity(lastMessageId: $lastMessageId, lastMessageAt: $lastMessageAt, cid: $cid)"
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
@@ -23,8 +23,10 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.persistance.repository.ChannelRepository
 import io.getstream.chat.android.offline.extensions.internal.lastMessage
+import io.getstream.chat.android.offline.repository.domain.channel.lastMessageInfo
 import io.getstream.chat.android.offline.repository.domain.channel.member.internal.toEntity
 import io.getstream.chat.android.offline.repository.domain.channel.member.internal.toModel
+import io.getstream.logging.StreamLog
 import java.util.Date
 
 /**
@@ -37,6 +39,9 @@ internal class DatabaseChannelRepository(
     private val getMessage: suspend (messageId: String) -> Message?,
     cacheSize: Int = 100,
 ) : ChannelRepository {
+
+    private val logger = StreamLog.getLogger("Chat:ChannelRepository")
+
     // the channel cache is simple, just keeps the last several users in memory
     private val channelCache = LruCache<String, Channel>(cacheSize)
 
@@ -46,8 +51,10 @@ internal class DatabaseChannelRepository(
      * @param channel [Channel]
      */
     override suspend fun insertChannel(channel: Channel) {
+        val entity = channel.toEntity()
+        logger.v { "[insertChannel] entity: ${entity.lastMessageInfo()}" }
         updateCache(listOf(channel))
-        channelDao.insert(channel.toEntity())
+        channelDao.insert(entity)
     }
 
     /**
@@ -57,8 +64,10 @@ internal class DatabaseChannelRepository(
      */
     override suspend fun insertChannels(channels: Collection<Channel>) {
         if (channels.isEmpty()) return
+        val entities = channels.map(Channel::toEntity)
+        logger.v { "[insertChannels] entities.size: ${entities.size}" }
         updateCache(channels)
-        channelDao.insertMany(channels.map(Channel::toEntity))
+        channelDao.insertMany(entities)
     }
 
     /**
@@ -67,6 +76,7 @@ internal class DatabaseChannelRepository(
      * @param cid String
      */
     override suspend fun deleteChannel(cid: String) {
+        logger.v { "[deleteChannel] cid: $cid" }
         channelCache.remove(cid)
         channelDao.delete(cid)
     }
@@ -77,7 +87,8 @@ internal class DatabaseChannelRepository(
      * @param cid String
      */
     override suspend fun selectChannelWithoutMessages(cid: String): Channel? {
-        return selectChannelsByCids(listOf(cid)).getOrNull(0)
+        val entity = channelDao.select(cid = cid)
+        return entity?.toModel(getUser, getMessage)
     }
 
     /**
@@ -201,10 +212,12 @@ internal class DatabaseChannelRepository(
     }
 
     override suspend fun evictChannel(cid: String) {
+        logger.v { "[evictChannel] cid: $cid" }
         channelCache.remove(cid)
     }
 
     override fun clearChannelCache() {
+        logger.v { "[clearChannelCache] no args" }
         channelCache.evictAll()
     }
 
@@ -213,6 +226,7 @@ internal class DatabaseChannelRepository(
     }
 
     private fun updateCache(channels: Collection<Channel>) {
+        logger.v { "[updateCache] channels.size: ${channels.size}" }
         for (channel in channels) {
             channelCache.put(channel.cid, channel)
         }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
@@ -71,7 +71,7 @@ internal class ChannelRepositoryImplTest {
         val outdatedMessage = randomMessage(id = "messageId1", createdAt = before)
         val newLastMessage = randomMessage(id = "messageId2", createdAt = after)
         val channel = randomChannel(messages = listOf(outdatedMessage), lastMessageAt = before)
-        whenever(channelDao.select(listOf("cid"))) doReturn listOf(channel.toEntity())
+        whenever(channelDao.select(cid = "cid")) doReturn channel.toEntity()
 
         channelRepository.updateLastMessageForChannel("cid", newLastMessage)
 
@@ -92,7 +92,7 @@ internal class ChannelRepositoryImplTest {
         val outdatedMessage = randomMessage(id = "messageId1", createdAt = before)
         val newLastMessage = randomMessage(id = "messageId2", createdAt = after)
         val channel = randomChannel(messages = listOf(newLastMessage), lastMessageAt = after)
-        whenever(channelDao.select(listOf("cid"))) doReturn listOf(channel.toEntity())
+        whenever(channelDao.select(cid = "cid")) doReturn channel.toEntity()
 
         channelRepository.updateLastMessageForChannel("cid", outdatedMessage)
 

--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -118,6 +118,13 @@ object AppConfig {
         ),
         SampleUser(
             apiKey = apiKey,
+            id = "kanat",
+            name = "Kanat",
+            image = "https://ca.slack-edge.com/T02RM6X6B-U034NG4FPNG-688fab30cc42-72",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw"
+        ),
+        SampleUser(
+            apiKey = apiKey,
             id = "qatest1",
             name = "QA Test 1",
             image = "https://getstream.imgix.net/images/random_svg/QT.png",


### PR DESCRIPTION
Closes: https://github.com/GetStream/stream-chat-android/issues/3546
Related PR: https://github.com/GetStream/stream-chat-android/pull/3524

### 🎯 Goal

Show the latest actual data in offline mode.

### 🧪 Testing

1. Open either sample app while online
2. Stay on the channel list
3. Take a screenshot of the channel list
4. Kill the app
5. Go offline
6. Re-open the app while offline and stay on the channel list
7. Take a screenshot
8. Compare screenshots

Expected: The channel list shows the latest previously seen online state.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
