### PR TITLE
[3635] Sync history only when necessary

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2143,8 +2143,10 @@ internal constructor(
     ): Call<List<ChatEvent>> {
         return api.getSyncHistory(channelsIds, lastSyncAt)
             .withPrecondition(scope) {
-                if (channelsIds.isNotEmpty()) Result.success(Unit)
-                else Result.error(ChatError("channelsIds must contain at least 1 id"))
+                when (channelsIds.isEmpty()) {
+                    true -> Result.error(ChatError("channelsIds must contain at least 1 id."))
+                    else -> Result.success(Unit)
+                }
             }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2142,6 +2142,10 @@ internal constructor(
         lastSyncAt: Date,
     ): Call<List<ChatEvent>> {
         return api.getSyncHistory(channelsIds, lastSyncAt)
+            .withPrecondition(scope) {
+                if (channelsIds.isNotEmpty()) Result.success(Unit)
+                else Result.error(ChatError("channelsIds must contain at least 1 id"))
+            }
     }
 
     /**

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -252,7 +252,7 @@ internal class ChatClientTest {
         val result = client.getSyncHistory(emptyList(), Date()).await()
 
         /* Then */
-        result shouldBeEqualTo Result.error(ChatError("channelsIds must contain at least 1 id"))
+        result shouldBeEqualTo Result.error(ChatError("channelsIds must contain at least 1 id."))
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -16,9 +16,13 @@
 
 package io.getstream.chat.android.client
 
+import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ChatClientConfig
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.clientstate.SocketStateService
 import io.getstream.chat.android.client.clientstate.UserStateService
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.errors.ChatNetworkError
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
 import io.getstream.chat.android.client.events.DisconnectedEvent
@@ -31,15 +35,20 @@ import io.getstream.chat.android.client.models.EventType
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.token.FakeTokenManager
+import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.TokenUtils
 import io.getstream.chat.android.client.utils.observable.FakeSocket
 import io.getstream.chat.android.client.utils.retry.NoRetryPolicy
+import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -61,6 +70,7 @@ internal class ChatClientTest {
         val eventF = UnknownEvent("f", Date(), null, emptyMap<Any, Any>())
     }
 
+    lateinit var api: ChatApi
     lateinit var socket: FakeSocket
     lateinit var client: ChatClient
     lateinit var result: MutableList<ChatEvent>
@@ -82,13 +92,14 @@ internal class ChatClientTest {
             false
         )
         whenever(tokenUtils.getUserId(token)) doReturn userId
+        api = mock()
         socket = FakeSocket()
         val socketStateService = SocketStateService()
         val userStateService = UserStateService()
         val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(socketStateService, testCoroutines.scope)
         client = ChatClient(
             config = config,
-            api = mock(),
+            api = api,
             socket = socket,
             notifications = mock(),
             tokenManager = FakeTokenManager(""),
@@ -220,5 +231,23 @@ internal class ChatClientTest {
         socket.sendEvent(Mother.randomUserPresenceChangedEvent(updateUser))
 
         client.getCurrentUser() shouldBeEqualTo updateUser
+    }
+
+    @Test
+    @ExperimentalCoroutinesApi
+    fun `Sync with empty cids`() = runTest {
+        whenever(api.getSyncHistory(any(), any())) doReturn TestCall(
+            Result.error(
+                ChatNetworkError.create(
+                    statusCode = 400,
+                    streamCode = 4,
+                    description = "channel_cids must contain at least 1 item"
+                )
+            )
+        )
+
+        client.getSyncHistory(emptyList(), Date()).await() shouldBeEqualTo Result.error(
+            ChatError("channelsIds must contain at least 1 id")
+        )
     }
 }


### PR DESCRIPTION
Closes: https://github.com/GetStream/stream-chat-android/issues/3635

### 🎯 Goal

Avoid `sync history` request being fired if `cids` list is empty.

### 🧪 Testing

Connect user who has no channels.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~
- [x] New code is covered by unit tests
- [ ] ~~Comparison screenshots added for visual changes~~
- [ ] ~~Affected documentation updated (KDocs, docusaurus, tutorial)~~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
