### PR TITLE
[3622] Refactor emoji only messages in compose

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.buildAnnotatedMessageText
 import io.getstream.chat.android.compose.ui.util.isEmojiOnly
+import io.getstream.chat.android.compose.ui.util.isEmojiOnlyWithoutBubble
 import io.getstream.chat.android.compose.ui.util.isSingleEmoji
 
 /**
@@ -149,13 +150,10 @@ public fun MessageText(
     val styledText = buildAnnotatedMessageText(message)
     val annotations = styledText.getStringAnnotations(0, styledText.lastIndex)
 
-    val isEmojiOnly = message.isEmojiOnly()
-    val isSingleEmoji = message.isSingleEmoji()
-
     // TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808
     val style = when {
-        isSingleEmoji -> ChatTheme.typography.singleEmoji
-        isEmojiOnly -> ChatTheme.typography.emojiOnly
+        message.isSingleEmoji() -> ChatTheme.typography.singleEmoji
+        message.isEmojiOnlyWithoutBubble() -> ChatTheme.typography.emojiOnly
         else -> ChatTheme.typography.bodyBold
     }
 
@@ -186,14 +184,13 @@ public fun MessageText(
             }
         }
     } else {
-        val horizontalPadding = if (isEmojiOnly) 0.dp else 12.dp
+        val horizontalPadding = if (message.isEmojiOnlyWithoutBubble()) 0.dp else 12.dp
+        val verticalPadding = if (message.isEmojiOnlyWithoutBubble()) 0.dp else 8.dp
         Text(
             modifier = modifier
                 .padding(
-                    start = horizontalPadding,
-                    end = horizontalPadding,
-                    top = if (isEmojiOnly) 0.dp else 8.dp,
-                    bottom = if (isEmojiOnly) 0.dp else 8.dp
+                    horizontal = horizontalPadding,
+                    vertical = verticalPadding
                 )
                 .clipToBounds(),
             text = styledText,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -28,7 +28,9 @@ import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.buildAnnotatedMessageText
+import io.getstream.chat.android.compose.ui.util.isEmojiOnlyWithoutBubble
 import io.getstream.chat.android.compose.ui.util.isFile
+import io.getstream.chat.android.compose.ui.util.isSingleEmoji
 
 /**
  * Default text element for quoted messages, with extra styling and padding for the chat bubble.
@@ -44,6 +46,13 @@ public fun QuotedMessageText(
     quoteMaxLines: Int = DefaultQuoteMaxLines,
 ) {
     val attachment = message.attachments.firstOrNull()
+
+    // TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808
+    val style = when {
+        message.isSingleEmoji() -> ChatTheme.typography.singleEmoji
+        message.isEmojiOnlyWithoutBubble() -> ChatTheme.typography.emojiOnly
+        else -> ChatTheme.typography.bodyBold
+    }
 
     val quotedMessageText = when {
         message.text.isNotBlank() -> message.text
@@ -85,7 +94,7 @@ public fun QuotedMessageText(
             )
             .clipToBounds(),
         text = styledText,
-        style = ChatTheme.typography.bodyBold,
+        style = style,
         maxLines = quoteMaxLines,
         overflow = TextOverflow.Ellipsis
     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -75,7 +75,7 @@ import io.getstream.chat.android.compose.ui.components.messages.UploadingFooter
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.hasThread
 import io.getstream.chat.android.compose.ui.util.isDeleted
-import io.getstream.chat.android.compose.ui.util.isEmojiOnly
+import io.getstream.chat.android.compose.ui.util.isEmojiOnlyWithoutBubble
 import io.getstream.chat.android.compose.ui.util.isFailed
 import io.getstream.chat.android.compose.ui.util.isGiphyEphemeral
 import io.getstream.chat.android.compose.ui.util.isUploading
@@ -397,7 +397,7 @@ internal fun DefaultMessageItemCenterContent(
     onImagePreviewResult: (ImagePreviewResult?) -> Unit = {},
 ) {
     val modifier = Modifier.widthIn(max = ChatTheme.dimens.messageItemMaxWidth)
-    if (messageItem.message.isEmojiOnly()) {
+    if (messageItem.message.isEmojiOnlyWithoutBubble()) {
         EmojiMessageContent(
             modifier = modifier,
             messageItem = messageItem,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamTypography.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamTypography.kt
@@ -130,11 +130,11 @@ public data class StreamTypography(
                 fontFamily = fontFamily
             ),
             singleEmoji = TextStyle(
-                fontSize = 36.sp,
+                fontSize = 50.sp,
                 fontFamily = fontFamily
             ),
             emojiOnly = TextStyle(
-                fontSize = 28.sp,
+                fontSize = 50.sp,
                 fontFamily = fontFamily
             )
         )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageUtils.kt
@@ -91,3 +91,20 @@ internal fun Message.isEmojiOnly(): Boolean = EmojiUtil.isEmojiOnly(this)
  * @return If the message is single emoji only or not.
  */
 internal fun Message.isSingleEmoji(): Boolean = EmojiUtil.isSingleEmoji(this)
+
+/**
+ * @return If the emoji should be inside bubble or not.
+ */
+internal fun Message.getEmojiCount(): Int = EmojiUtil.getEmojiCount(this)
+
+/**
+ * @return If the message is emoji only and shoudl be shown without message buble or not.
+ */
+internal fun Message.isEmojiOnlyWithoutBubble(): Boolean = isEmojiOnly() &&
+    getEmojiCount() <= MaxFullSizeEmoji &&
+    replyTo == null
+
+/**
+ * Max number of emoji without showing it inside a bubble.
+ */
+internal const val MaxFullSizeEmoji: Int = 3

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/EmojiUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/EmojiUtil.kt
@@ -31,8 +31,7 @@ public object EmojiUtil {
      * @param message The message that was sent/received by user.
      */
     public fun isEmojiOnly(message: Message): Boolean {
-        if (message.replyTo != null || message.attachments.isNotEmpty() || message.deletedAt != null) return false
-        return message.text.replace(EMOJI_REGEX, "").isEmpty()
+        return message.text.replace(EMOJI_REGEX, "").isEmpty() && message.deletedAt == null
     }
 
     /**
@@ -42,6 +41,19 @@ public object EmojiUtil {
      */
     public fun isSingleEmoji(message: Message): Boolean {
         return isEmojiOnly(message) && message.text.replaceFirst(EMOJI_REGEX, "").isEmpty()
+    }
+
+    /**
+     * Counts the number of emoji inside a message.
+     *
+     * @return The number of emojis inside a message.
+     */
+    public fun getEmojiCount(message: Message): Int {
+        var emojiOnlyMessage = message.text
+        message.text.replace(EMOJI_REGEX, "").split(" ").forEach {
+            emojiOnlyMessage = emojiOnlyMessage.replace(it, "")
+        }
+        return emojiOnlyMessage.replace(EMOJI_REGEX, ".").count()
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Refactor emoji so they align with design.

### 🛠 Implementation details

Emojis up to 3 are shown bigger without the bubble, over 4 are regular size and inside a bubble. Also the quoted emojis now preview in the right size depending on count.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_20220610_133402](https://user-images.githubusercontent.com/38032787/173056955-31e53b45-aa19-4620-9011-d3ec8c568080.png) | ![Screenshot_20220610_132136](https://user-images.githubusercontent.com/38032787/173056965-e2970764-7cc0-43a3-b8a6-ad8e288ad25a.png) |

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/38032787/173056869-23f45fa0-ea77-4698-9e7d-220f197f1ad0.gif)