### PR TITLE
[3658] Improve unnecessary `MessagesScreen` recompositions

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.compose.ui.messages
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -30,6 +31,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -39,6 +41,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -63,6 +66,7 @@ import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemS
 import io.getstream.chat.android.compose.state.messages.SelectedMessageOptionsState
 import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsPickerState
 import io.getstream.chat.android.compose.state.messages.SelectedMessageReactionsState
+import io.getstream.chat.android.compose.state.messages.SelectedMessageState
 import io.getstream.chat.android.compose.ui.components.SimpleDialog
 import io.getstream.chat.android.compose.ui.components.messageoptions.defaultMessageOptionsState
 import io.getstream.chat.android.compose.ui.components.reactionpicker.ReactionsPicker
@@ -99,11 +103,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * back button.
  * @param onHeaderActionClick Handler for when the user taps on the header action.
  */
-@OptIn(
-    ExperimentalAnimationApi::class,
-    ExperimentalFoundationApi::class,
-    ExperimentalCoroutinesApi::class
-)
+@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 public fun MessagesScreen(
     channelId: String,
@@ -133,16 +133,6 @@ public fun MessagesScreen(
     val attachmentsPickerViewModel =
         viewModel(AttachmentsPickerViewModel::class.java, factory = factory)
 
-    val currentState = listViewModel.currentMessagesState
-    val messageActions = listViewModel.messageActions
-
-    val selectedMessageState = currentState.selectedMessageState
-    val messageMode = listViewModel.messageMode
-    val isShowingAttachments = attachmentsPickerViewModel.isShowingAttachments
-
-    val connectionState by listViewModel.connectionState.collectAsState()
-    val user by listViewModel.user.collectAsState()
-
     val backAction = {
         val isInThread = listViewModel.isInThread
         val isShowingOverlay = listViewModel.isShowingOverlay
@@ -161,10 +151,15 @@ public fun MessagesScreen(
     BackHandler(enabled = true, onBack = backAction)
 
     Box(modifier = Modifier.fillMaxSize()) {
+
         Scaffold(
             modifier = Modifier.fillMaxSize(),
             topBar = {
                 if (showHeader) {
+                    val messageMode = listViewModel.messageMode
+                    val connectionState by listViewModel.connectionState.collectAsState()
+                    val user by listViewModel.user.collectAsState()
+
                     MessageListHeader(
                         modifier = Modifier
                             .height(56.dp),
@@ -192,8 +187,12 @@ public fun MessagesScreen(
                         composerViewModel.dismissMessageActions()
                     }
                 )
+
+                Log.d("Recomposed", "MessageComposer")
             }
         ) {
+            val currentState = listViewModel.currentMessagesState
+
             MessageList(
                 modifier = Modifier
                     .fillMaxSize()
@@ -224,170 +223,263 @@ public fun MessagesScreen(
             )
         }
 
-        val selectedMessage = selectedMessageState?.message ?: Message()
-        val ownCapabilities = selectedMessageState?.ownCapabilities ?: setOf()
-
-        val newMessageOptions = defaultMessageOptionsState(
-            selectedMessage = selectedMessage,
-            currentUser = user,
-            isInThread = listViewModel.isInThread,
-            ownCapabilities = ownCapabilities
+        Rest(
+            listViewModel = listViewModel,
+            composerViewModel = composerViewModel
         )
-
-        var messageOptions by remember { mutableStateOf<List<MessageOptionItemState>>(emptyList()) }
-
-        if (newMessageOptions.isNotEmpty()) {
-            messageOptions = newMessageOptions
-        }
-
-        AnimatedVisibility(
-            visible = selectedMessageState is SelectedMessageOptionsState && selectedMessage.id.isNotEmpty(),
-            enter = fadeIn(),
-            exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
-        ) {
-            SelectedMessageMenu(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .animateEnterExit(
-                        enter = slideInVertically(
-                            initialOffsetY = { height -> height },
-                            animationSpec = tween()
-                        ),
-                        exit = slideOutVertically(
-                            targetOffsetY = { height -> height },
-                            animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
-                        )
-                    ),
-                messageOptions = messageOptions,
-                message = selectedMessage,
-                ownCapabilities = ownCapabilities,
-                onMessageAction = { action ->
-                    composerViewModel.performMessageAction(action)
-                    listViewModel.performMessageAction(action)
-                },
-                onShowMoreReactionsSelected = {
-                    listViewModel.selectExtendedReactions(selectedMessage)
-                },
-                onDismiss = { listViewModel.removeOverlay() }
-            )
-        }
-
-        AnimatedVisibility(
-            visible = selectedMessageState is SelectedMessageReactionsState && selectedMessage.id.isNotEmpty(),
-            enter = fadeIn(),
-            exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
-        ) {
-            SelectedReactionsMenu(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .animateEnterExit(
-                        enter = slideInVertically(
-                            initialOffsetY = { height -> height },
-                            animationSpec = tween()
-                        ),
-                        exit = slideOutVertically(
-                            targetOffsetY = { height -> height },
-                            animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
-                        )
-                    ),
-                currentUser = user,
-                message = selectedMessage,
-                onMessageAction = { action ->
-                    composerViewModel.performMessageAction(action)
-                    listViewModel.performMessageAction(action)
-                },
-                onShowMoreReactionsSelected = {
-                    listViewModel.selectExtendedReactions(selectedMessage)
-                },
-                onDismiss = { listViewModel.removeOverlay() },
-                ownCapabilities = selectedMessageState?.ownCapabilities ?: setOf()
-            )
-        }
-
-        AnimatedVisibility(
-            visible = selectedMessageState is SelectedMessageReactionsPickerState && selectedMessage.id.isNotEmpty(),
-            enter = fadeIn(),
-            exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
-        ) {
-            ReactionsPicker(
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .heightIn(max = 400.dp)
-                    .wrapContentHeight()
-                    .animateEnterExit(
-                        enter = slideInVertically(
-                            initialOffsetY = { height -> height },
-                            animationSpec = tween()
-                        ),
-                        exit = slideOutVertically(
-                            targetOffsetY = { height -> height },
-                            animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
-                        )
-                    ),
-                message = selectedMessage,
-                onMessageAction = { action ->
-                    composerViewModel.performMessageAction(action)
-                    listViewModel.performMessageAction(action)
-                },
-                onDismiss = { listViewModel.removeOverlay() }
-            )
-        }
-
-        AnimatedVisibility(
-            visible = isShowingAttachments,
-            enter = fadeIn(),
-            exit = fadeOut(animationSpec = tween(delayMillis = AnimationConstants.DefaultDurationMillis / 2))
-        ) {
-            AttachmentsPicker(
-                attachmentsPickerViewModel = attachmentsPickerViewModel,
-                modifier = Modifier
-                    .align(Alignment.BottomCenter)
-                    .height(350.dp)
-                    .animateEnterExit(
-                        enter = slideInVertically(
-                            initialOffsetY = { height -> height },
-                            animationSpec = tween()
-                        ),
-                        exit = slideOutVertically(
-                            targetOffsetY = { height -> height },
-                            animationSpec = tween(delayMillis = AnimationConstants.DefaultDurationMillis / 2)
-                        )
-                    ),
-                onAttachmentsSelected = { attachments ->
-                    attachmentsPickerViewModel.changeAttachmentState(false)
-                    composerViewModel.addSelectedAttachments(attachments)
-                },
-                onDismiss = {
-                    attachmentsPickerViewModel.changeAttachmentState(false)
-                    attachmentsPickerViewModel.dismissAttachments()
-                }
-            )
-        }
-
-        val deleteAction = messageActions.firstOrNull { it is Delete }
-
-        if (deleteAction != null) {
-            SimpleDialog(
-                modifier = Modifier.padding(16.dp),
-                title = stringResource(id = R.string.stream_compose_delete_message_title),
-                message = stringResource(id = R.string.stream_compose_delete_message_text),
-                onPositiveAction = { listViewModel.deleteMessage(deleteAction.message) },
-                onDismiss = { listViewModel.dismissMessageAction(deleteAction) }
-            )
-        }
-
-        val flagAction = messageActions.firstOrNull { it is Flag }
-
-        if (flagAction != null) {
-            SimpleDialog(
-                modifier = Modifier.padding(16.dp),
-                title = stringResource(id = R.string.stream_compose_flag_message_title),
-                message = stringResource(id = R.string.stream_compose_flag_message_text),
-                onPositiveAction = { listViewModel.flagMessage(flagAction.message) },
-                onDismiss = { listViewModel.dismissMessageAction(flagAction) }
-            )
-        }
+        AttachmentsPickerMenu(
+            attachmentsPickerViewModel = attachmentsPickerViewModel,
+            composerViewModel = composerViewModel
+        )
+        DeleteMessageDialog(listViewModel = listViewModel)
+        FlagMessageDialog(listViewModel = listViewModel)
     }
+    Log.d("Recomposed", "MessagesScreen")
+}
+
+@Composable
+private fun BoxScope.Rest(
+    listViewModel: MessageListViewModel,
+    composerViewModel: MessageComposerViewModel,
+) {
+    val currentState = listViewModel.currentMessagesState
+
+    val selectedMessageState by remember(currentState.selectedMessageState) {
+        derivedStateOf { currentState.selectedMessageState }
+    }
+
+    val selectedMessage = selectedMessageState?.message ?: Message()
+
+    MessagesScreenMenus(
+        listViewModel = listViewModel,
+        composerViewModel = composerViewModel,
+        selectedMessageState = selectedMessageState,
+        selectedMessage = selectedMessage
+    )
+
+    MessagesScreenReactionsPicker(
+        selectedMessageState = selectedMessageState,
+        selectedMessage = selectedMessage,
+        composerViewModel = composerViewModel,
+        listViewModel = listViewModel
+    )
+    Log.d("Recomposed", "Rest")
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+private fun BoxScope.MessagesScreenMenus(
+    listViewModel: MessageListViewModel,
+    composerViewModel: MessageComposerViewModel,
+    selectedMessageState: SelectedMessageState?,
+    selectedMessage: Message,
+) {
+
+    val user by listViewModel.user.collectAsState()
+
+    val ownCapabilities = selectedMessageState?.ownCapabilities ?: setOf()
+
+    val isInThread = remember {
+        mutableStateOf(listViewModel.isInThread)
+    }
+
+    val newMessageOptions = defaultMessageOptionsState(
+        selectedMessage = selectedMessage,
+        currentUser = user,
+        isInThread = isInThread.value,
+        ownCapabilities = ownCapabilities
+    )
+
+    var messageOptions by remember { mutableStateOf<List<MessageOptionItemState>>(emptyList()) }
+
+    if (newMessageOptions.isNotEmpty()) {
+        messageOptions = newMessageOptions
+    }
+
+    AnimatedVisibility(
+        visible = selectedMessageState is SelectedMessageOptionsState && selectedMessage.id.isNotEmpty(),
+        enter = fadeIn(),
+        exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
+    ) {
+        SelectedMessageMenu(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .animateEnterExit(
+                    enter = slideInVertically(
+                        initialOffsetY = { height -> height },
+                        animationSpec = tween()
+                    ),
+                    exit = slideOutVertically(
+                        targetOffsetY = { height -> height },
+                        animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
+                    )
+                ),
+            messageOptions = messageOptions,
+            message = selectedMessage,
+            ownCapabilities = ownCapabilities,
+            onMessageAction = { action ->
+                composerViewModel.performMessageAction(action)
+                listViewModel.performMessageAction(action)
+            },
+            onShowMoreReactionsSelected = {
+                listViewModel.selectExtendedReactions(selectedMessage)
+            },
+            onDismiss = { listViewModel.removeOverlay() }
+        )
+    }
+
+
+    AnimatedVisibility(
+        visible = selectedMessageState is SelectedMessageReactionsState && selectedMessage.id.isNotEmpty(),
+        enter = fadeIn(),
+        exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
+    ) {
+        SelectedReactionsMenu(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .animateEnterExit(
+                    enter = slideInVertically(
+                        initialOffsetY = { height -> height },
+                        animationSpec = tween()
+                    ),
+                    exit = slideOutVertically(
+                        targetOffsetY = { height -> height },
+                        animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
+                    )
+                ),
+            currentUser = user,
+            message = selectedMessage,
+            onMessageAction = { action ->
+                composerViewModel.performMessageAction(action)
+                listViewModel.performMessageAction(action)
+            },
+            onShowMoreReactionsSelected = {
+                listViewModel.selectExtendedReactions(selectedMessage)
+            },
+            onDismiss = { listViewModel.removeOverlay() },
+            ownCapabilities = selectedMessageState?.ownCapabilities ?: setOf()
+        )
+    }
+    Log.d("Recomposed", "MessagesScreenMenus")
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalAnimationApi::class)
+@Composable
+private fun BoxScope.MessagesScreenReactionsPicker(
+    selectedMessageState: SelectedMessageState?,
+    selectedMessage: Message,
+    composerViewModel: MessageComposerViewModel,
+    listViewModel: MessageListViewModel,
+) {
+
+    AnimatedVisibility(
+        visible = selectedMessageState is SelectedMessageReactionsPickerState && selectedMessage.id.isNotEmpty(),
+        enter = fadeIn(),
+        exit = fadeOut(animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2))
+    ) {
+        ReactionsPicker(
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .heightIn(max = 400.dp)
+                .wrapContentHeight()
+                .animateEnterExit(
+                    enter = slideInVertically(
+                        initialOffsetY = { height -> height },
+                        animationSpec = tween()
+                    ),
+                    exit = slideOutVertically(
+                        targetOffsetY = { height -> height },
+                        animationSpec = tween(durationMillis = AnimationConstants.DefaultDurationMillis / 2)
+                    )
+                ),
+            message = selectedMessage,
+            onMessageAction = { action ->
+                composerViewModel.performMessageAction(action)
+                listViewModel.performMessageAction(action)
+            },
+            onDismiss = { listViewModel.removeOverlay() }
+        )
+    }
+    Log.d("Recomposed", "MessagesScreenReactionsPicker")
+}
+
+@OptIn(ExperimentalAnimationApi::class)
+@Composable
+private fun BoxScope.AttachmentsPickerMenu(
+    attachmentsPickerViewModel: AttachmentsPickerViewModel,
+    composerViewModel: MessageComposerViewModel,
+) {
+
+    val isShowingAttachments = attachmentsPickerViewModel.isShowingAttachments
+
+    AnimatedVisibility(
+        visible = isShowingAttachments,
+        enter = fadeIn(),
+        exit = fadeOut(animationSpec = tween(delayMillis = AnimationConstants.DefaultDurationMillis / 2))
+    ) {
+        AttachmentsPicker(
+            attachmentsPickerViewModel = attachmentsPickerViewModel,
+            modifier = Modifier
+                .align(Alignment.BottomCenter)
+                .height(350.dp)
+                .animateEnterExit(
+                    enter = slideInVertically(
+                        initialOffsetY = { height -> height },
+                        animationSpec = tween()
+                    ),
+                    exit = slideOutVertically(
+                        targetOffsetY = { height -> height },
+                        animationSpec = tween(delayMillis = AnimationConstants.DefaultDurationMillis / 2)
+                    )
+                ),
+            onAttachmentsSelected = { attachments ->
+                attachmentsPickerViewModel.changeAttachmentState(false)
+                composerViewModel.addSelectedAttachments(attachments)
+            },
+            onDismiss = {
+                attachmentsPickerViewModel.changeAttachmentState(false)
+                attachmentsPickerViewModel.dismissAttachments()
+            }
+        )
+    }
+    Log.d("Recomposed", "AttachmentsPickerMenu")
+}
+
+@Composable
+private fun DeleteMessageDialog(listViewModel: MessageListViewModel) {
+
+    val messageActions = listViewModel.messageActions
+
+    val deleteAction = messageActions.firstOrNull { it is Delete }
+
+    if (deleteAction != null) {
+        SimpleDialog(
+            modifier = Modifier.padding(16.dp),
+            title = stringResource(id = R.string.stream_compose_delete_message_title),
+            message = stringResource(id = R.string.stream_compose_delete_message_text),
+            onPositiveAction = { listViewModel.deleteMessage(deleteAction.message) },
+            onDismiss = { listViewModel.dismissMessageAction(deleteAction) }
+        )
+    }
+    Log.d("Recomposed", "DeleteMessageDialog")
+}
+
+@Composable
+private fun FlagMessageDialog(listViewModel: MessageListViewModel) {
+    val messageActions = listViewModel.messageActions
+
+    val flagAction = messageActions.firstOrNull { it is Flag }
+
+    if (flagAction != null) {
+        SimpleDialog(
+            modifier = Modifier.padding(16.dp),
+            title = stringResource(id = R.string.stream_compose_flag_message_title),
+            message = stringResource(id = R.string.stream_compose_flag_message_text),
+            onPositiveAction = { listViewModel.flagMessage(flagAction.message) },
+            onDismiss = { listViewModel.dismissMessageAction(flagAction) }
+        )
+    }
+    Log.d("Recomposed", "FlagMessageDialog")
 }
 
 /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -328,7 +328,6 @@ private fun BoxScope.MessagesScreenMenus(
         )
     }
 
-
     AnimatedVisibility(
         visible = selectedMessageState is SelectedMessageReactionsState && selectedMessage.id.isNotEmpty(),
         enter = fadeIn(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -103,6 +103,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
  * back button.
  * @param onHeaderActionClick Handler for when the user taps on the header action.
  */
+@Suppress("LongMethod")
 @OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 public fun MessagesScreen(
@@ -266,6 +267,7 @@ private fun BoxScope.Rest(
     Log.d("Recomposed", "Rest")
 }
 
+@Suppress("LongMethod")
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun BoxScope.MessagesScreenMenus(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.compose.ui.messages
 
 import android.content.ClipboardManager
 import android.content.Context
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -41,7 +40,6 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -188,8 +186,6 @@ public fun MessagesScreen(
                         composerViewModel.dismissMessageActions()
                     }
                 )
-
-                Log.d("Recomposed", "MessageComposer")
             }
         ) {
             val currentState = listViewModel.currentMessagesState
@@ -224,7 +220,7 @@ public fun MessagesScreen(
             )
         }
 
-        Rest(
+        MessageMenus(
             listViewModel = listViewModel,
             composerViewModel = composerViewModel
         )
@@ -232,22 +228,23 @@ public fun MessagesScreen(
             attachmentsPickerViewModel = attachmentsPickerViewModel,
             composerViewModel = composerViewModel
         )
-        DeleteMessageDialog(listViewModel = listViewModel)
-        FlagMessageDialog(listViewModel = listViewModel)
+        MessageDialogs(listViewModel = listViewModel)
     }
-    Log.d("Recomposed", "MessagesScreen")
 }
 
+/**
+ * Contains the various menus and pickers the user
+ * can use to interact with messages.
+ *
+ * @param listViewModel The [MessageListViewModel] used to read state from.
+ * @param composerViewModel The [MessageComposerViewModel] used to read state from.
+ */
 @Composable
-private fun BoxScope.Rest(
+private fun BoxScope.MessageMenus(
     listViewModel: MessageListViewModel,
     composerViewModel: MessageComposerViewModel,
 ) {
-    val currentState = listViewModel.currentMessagesState
-
-    val selectedMessageState by remember(currentState.selectedMessageState) {
-        derivedStateOf { currentState.selectedMessageState }
-    }
+    val selectedMessageState = listViewModel.currentMessagesState.selectedMessageState
 
     val selectedMessage = selectedMessageState?.message ?: Message()
 
@@ -259,14 +256,24 @@ private fun BoxScope.Rest(
     )
 
     MessagesScreenReactionsPicker(
+        listViewModel = listViewModel,
+        composerViewModel = composerViewModel,
         selectedMessageState = selectedMessageState,
         selectedMessage = selectedMessage,
-        composerViewModel = composerViewModel,
-        listViewModel = listViewModel
     )
-    Log.d("Recomposed", "Rest")
 }
 
+/**
+ * Contains selected message and reactions menus
+ * wrapped inside an animated composable.
+ *
+ * @param listViewModel The [MessageListViewModel] used to read state and
+ * perform actions.
+ * @param composerViewModel The [MessageComposerViewModel] used to read state and
+ * perform actions.
+ * @param selectedMessageState The state of the currently selected message.
+ * @param selectedMessage The currently selected message.
+ */
 @Suppress("LongMethod")
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
@@ -361,16 +368,26 @@ private fun BoxScope.MessagesScreenMenus(
             ownCapabilities = selectedMessageState?.ownCapabilities ?: setOf()
         )
     }
-    Log.d("Recomposed", "MessagesScreenMenus")
 }
 
+/**
+ * Contains the reactions picker wrapped inside
+ * of an animated composable.
+ *
+ * @param listViewModel The [MessageListViewModel] used to read state and
+ * perform actions.
+ * @param composerViewModel [MessageComposerViewModel] used to read state and
+ * perform actions.
+ * @param selectedMessageState The state of the currently selected message.
+ * @param selectedMessage The currently selected message.
+ */
 @OptIn(ExperimentalFoundationApi::class, ExperimentalAnimationApi::class)
 @Composable
 private fun BoxScope.MessagesScreenReactionsPicker(
+    listViewModel: MessageListViewModel,
+    composerViewModel: MessageComposerViewModel,
     selectedMessageState: SelectedMessageState?,
     selectedMessage: Message,
-    composerViewModel: MessageComposerViewModel,
-    listViewModel: MessageListViewModel,
 ) {
 
     AnimatedVisibility(
@@ -401,9 +418,17 @@ private fun BoxScope.MessagesScreenReactionsPicker(
             onDismiss = { listViewModel.removeOverlay() }
         )
     }
-    Log.d("Recomposed", "MessagesScreenReactionsPicker")
 }
 
+/**
+ * Contains the attachments picker menu wrapped inside
+ * of an animated composable.
+ *
+ * @param attachmentsPickerViewModel The [AttachmentsPickerViewModel] used to read state and
+ * perform actions.
+ * @param composerViewModel The [MessageComposerViewModel] used to read state and
+ * perform actions.
+ */
 @OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun BoxScope.AttachmentsPickerMenu(
@@ -443,11 +468,17 @@ private fun BoxScope.AttachmentsPickerMenu(
             }
         )
     }
-    Log.d("Recomposed", "AttachmentsPickerMenu")
 }
 
+/**
+ * Contains the message dialogs used to prompt the
+ * user with message flagging and deletion actions
+ *
+ * @param listViewModel The [MessageListViewModel] used to read state and
+ * perform actions.
+ */
 @Composable
-private fun DeleteMessageDialog(listViewModel: MessageListViewModel) {
+private fun MessageDialogs(listViewModel: MessageListViewModel) {
 
     val messageActions = listViewModel.messageActions
 
@@ -462,12 +493,6 @@ private fun DeleteMessageDialog(listViewModel: MessageListViewModel) {
             onDismiss = { listViewModel.dismissMessageAction(deleteAction) }
         )
     }
-    Log.d("Recomposed", "DeleteMessageDialog")
-}
-
-@Composable
-private fun FlagMessageDialog(listViewModel: MessageListViewModel) {
-    val messageActions = listViewModel.messageActions
 
     val flagAction = messageActions.firstOrNull { it is Flag }
 
@@ -480,7 +505,6 @@ private fun FlagMessageDialog(listViewModel: MessageListViewModel) {
             onDismiss = { listViewModel.dismissMessageAction(flagAction) }
         )
     }
-    Log.d("Recomposed", "FlagMessageDialog")
 }
 
 /**


### PR DESCRIPTION
### 🎯 Goal

Our `MessagesScreen` was reading state too high, causing all of it's children to unnecessarily recompose.

This PR lowers state reads to the farthest possible place without introducing duplication of read states etc.

Please note that in order to achieve more favorable recomposition some code aesthetics were sacrificed.

No breaking changes were made to the API.

### 🛠 Implementation details

- Break down `MessagesScreen` into smaller composables with state reads at the appropriate places

### 🎨 UI Changes

// TODO - Add recomposition snippets

| Before | After |
| --- | --- |
| img | img |

### 🧪 Testing

Please test thoroughly all message screens features such as

- Exercising all message options
- opening the reactions picker and exercising all option
- Deleting and flagging messages to raise prompts
- sending a message without attachments
- sending a message with attachments
- Displaying commands
- Opening previews
- Navigating back and forth 

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
