### PR TITLE
Set anonymous user correctly in `onSetUser`

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -328,7 +328,7 @@ internal constructor(
             userState is UserState.NotSet -> {
                 logger.logV("[setUser] user is NotSet")
                 initializeClientWithUser(user, cacheableTokenProvider, isAnonymous)
-                userStateService.onSetUser(user)
+                userStateService.onSetUser(user, isAnonymous)
                 socketStateService.onConnectionRequested()
                 socket.connectUser(user, isAnonymous)
                 waitFirstConnection(timeoutMilliseconds)
@@ -804,7 +804,7 @@ internal constructor(
         when (socketStateService.state) {
             is SocketState.Disconnected -> when (val userState = userStateService.state) {
                 is UserState.UserSet -> socket.reconnectUser(userState.user, false)
-                is UserState.Anonymous.AnonymousUserSet -> socket.reconnectUser(userState.anonymousUser, true)
+                is UserState.AnonymousUserSet -> socket.reconnectUser(userState.anonymousUser, true)
                 else -> error("Invalid user state $userState without user being set!")
             }
             else -> Unit

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserState.kt
@@ -21,14 +21,11 @@ import io.getstream.chat.android.client.models.User as UserModel
 internal sealed class UserState {
     object NotSet : UserState()
     class UserSet(val user: UserModel) : UserState()
-    sealed class Anonymous : UserState() {
-        object Pending : Anonymous()
-        class AnonymousUserSet(val anonymousUser: UserModel) : Anonymous()
-    }
+    class AnonymousUserSet(val anonymousUser: UserModel) : UserState()
 
     internal fun userOrError(): UserModel = when (this) {
         is UserSet -> user
-        is Anonymous.AnonymousUserSet -> anonymousUser
+        is AnonymousUserSet -> anonymousUser
         else -> error("This state doesn't contain user!")
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
@@ -27,12 +27,12 @@ internal class UserStateService {
         fsm.sendEvent(UserStateEvent.UserUpdated(user))
     }
 
-    fun onSetUser(user: User) {
-        fsm.sendEvent(UserStateEvent.ConnectUser(user))
-    }
-
-    fun onSetAnonymous() {
-        fsm.sendEvent(UserStateEvent.ConnectAnonymous)
+    fun onSetUser(user: User, isAnonymous: Boolean) {
+        if (isAnonymous) {
+            fsm.sendEvent(UserStateEvent.ConnectAnonymous(user))
+        } else {
+            fsm.sendEvent(UserStateEvent.ConnectUser(user))
+        }
     }
 
     fun onLogout() {
@@ -54,18 +54,14 @@ internal class UserStateService {
         initialState(UserState.NotSet)
         state<UserState.NotSet> {
             onEvent<UserStateEvent.ConnectUser> { event -> UserState.UserSet(event.user) }
-            onEvent<UserStateEvent.ConnectAnonymous> { UserState.Anonymous.Pending }
+            onEvent<UserStateEvent.ConnectAnonymous> { event -> UserState.AnonymousUserSet(event.user) }
         }
         state<UserState.UserSet> {
             onEvent<UserStateEvent.UserUpdated> { event -> UserState.UserSet(event.user) }
             onEvent<UserStateEvent.UnsetUser> { UserState.NotSet }
         }
-        state<UserState.Anonymous.Pending> {
-            onEvent<UserStateEvent.UserUpdated> { event -> UserState.Anonymous.AnonymousUserSet(event.user) }
-            onEvent<UserStateEvent.UnsetUser> { UserState.NotSet }
-        }
-        state<UserState.Anonymous.AnonymousUserSet> {
-            onEvent<UserStateEvent.UserUpdated> { event -> UserState.Anonymous.AnonymousUserSet(event.user) }
+        state<UserState.AnonymousUserSet> {
+            onEvent<UserStateEvent.UserUpdated> { event -> UserState.AnonymousUserSet(event.user) }
             onEvent<UserStateEvent.UnsetUser> { UserState.NotSet }
         }
     }
@@ -73,7 +69,7 @@ internal class UserStateService {
     private sealed class UserStateEvent {
         class ConnectUser(val user: User) : UserStateEvent()
         class UserUpdated(val user: User) : UserStateEvent()
-        object ConnectAnonymous : UserStateEvent()
+        class ConnectAnonymous(val user: User) : UserStateEvent()
         object UnsetUser : UserStateEvent()
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
@@ -151,7 +151,7 @@ internal class ConnectUserTest {
     fun `Where there is an ongoing connection with the same user, an error should be propagated`() = testCoroutines.runTest {
         /* Given */
         val user = User(id = "jc")
-        userStateService.onSetUser(user)
+        userStateService.onSetUser(user, false)
         val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
 
         /* When */
@@ -180,7 +180,7 @@ internal class ConnectUserTest {
     fun `When there is an user connected and try to connect a different user, an error should be propagated`() = testCoroutines.runTest {
         /* Given */
         val user = User(id = "jc")
-        userStateService.onSetUser(user)
+        userStateService.onSetUser(user, false)
         val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
 
         /* When */
@@ -266,7 +266,7 @@ internal class ConnectUserTest {
     }
 
     private fun prepareAliveConnection(user: User, connectionId: String) {
-        userStateService.onSetUser(user)
+        userStateService.onSetUser(user, false)
         socketStateService.onConnectionRequested()
         socketStateService.onConnected(connectionId)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -92,7 +92,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
 
         sut.connectUser(user, "token").enqueue()
 
-        verify(userStateService).onSetUser(user)
+        verify(userStateService).onSetUser(user, false)
     }
 
     @Test
@@ -184,11 +184,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
         }
 
         fun givenAnonymousUserSetState() = apply {
-            whenever(userStateService.state) doReturn UserState.Anonymous.AnonymousUserSet(Mother.randomUser())
-        }
-
-        fun givenAnonymousPendingState() = apply {
-            whenever(userStateService.state) doReturn UserState.Anonymous.Pending
+            whenever(userStateService.state) doReturn UserState.AnonymousUserSet(Mother.randomUser())
         }
 
         fun givenUserNotSetState() = apply {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
@@ -80,13 +80,6 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
     }
 
     @Test
-    fun `Given disconnected connection state And anonymous pending state Should throw exception`() {
-        val sut = Fixture().givenDisconnectedConnectionState().givenAnonymousPendingState().get()
-
-        invoking { sut.reconnectSocket() }.shouldThrow(IllegalStateException::class)
-    }
-
-    @Test
     fun `Given disconnected connection state And user not set state Should throw exception`() {
         val sut = Fixture().givenDisconnectedConnectionState().givenUserNotSetState().get()
 
@@ -115,15 +108,11 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
         }
 
         fun givenAnonymousUserSetState() = apply {
-            whenever(userStateService.state) doReturn UserState.Anonymous.AnonymousUserSet(Mother.randomUser())
+            whenever(userStateService.state) doReturn UserState.AnonymousUserSet(Mother.randomUser())
         }
 
         fun givenAnonymousUserSetState(user: User) = apply {
-            whenever(userStateService.state) doReturn UserState.Anonymous.AnonymousUserSet(user)
-        }
-
-        fun givenAnonymousPendingState() = apply {
-            whenever(userStateService.state) doReturn UserState.Anonymous.Pending
+            whenever(userStateService.state) doReturn UserState.AnonymousUserSet(user)
         }
 
         fun givenUserNotSetState() = apply {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
@@ -29,7 +29,7 @@ internal class UserStateServiceTests {
         val user = Mother.randomUser()
         val sut = Fixture().please()
 
-        sut.onSetUser(user)
+        sut.onSetUser(user, false)
 
         sut.state.shouldBeInstanceOf<UserState.UserSet>()
         sut.state.userOrError() shouldBeEqualTo user
@@ -78,9 +78,11 @@ internal class UserStateServiceTests {
     fun `Given user not set state When set anonymous Should move to anonymous pending state`() {
         val sut = Fixture().please()
 
-        sut.onSetAnonymous()
+        val anonymousUser = User(id = "!anon")
+        sut.onSetUser(anonymousUser, true)
 
-        sut.state shouldBeEqualTo UserState.Anonymous.Pending
+        sut.state.shouldBeInstanceOf<UserState.AnonymousUserSet>()
+        sut.state.userOrError() shouldBeEqualTo anonymousUser
     }
 
     @Test
@@ -126,15 +128,15 @@ internal class UserStateServiceTests {
 
         sut.onUserUpdated(user)
 
-        sut.state.shouldBeInstanceOf<UserState.Anonymous.AnonymousUserSet>()
+        sut.state.shouldBeInstanceOf<UserState.AnonymousUserSet>()
     }
 
     private class Fixture {
         private val userStateService = UserStateService()
 
-        fun givenUserSetState(user: User = Mother.randomUser()) = apply { userStateService.onSetUser(user) }
+        fun givenUserSetState(user: User = Mother.randomUser()) = apply { userStateService.onSetUser(user, false) }
 
-        fun givenAnonymousPendingState() = apply { userStateService.onSetAnonymous() }
+        fun givenAnonymousPendingState() = apply { userStateService.onSetUser(User(id = "!anon"), true) }
 
         fun givenAnonymousUserState(user: User = Mother.randomUser()) = apply {
             givenAnonymousPendingState()


### PR DESCRIPTION
### 🎯 Goal

In current implementation, we don't set `AnonymousUser` correctly. 

### 🛠 Implementation details

- Simplified the `AnonymousUserState`.
- Added a check in `onSetUser()` to set correct user state. 

### 🧪 Testing

- Connect normal users and anonymous users in our sample app.
- Behaviour of the app should be the same as expected.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
