### PR TITLE
[3682] improve app startup using coroutines (fire and forget)

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
@@ -30,17 +30,8 @@ import kotlinx.coroutines.launch
 public class ThreeTenInitializer : Initializer<Unit> {
 
     override fun create(context: Context) {
-        CoroutineScope(DispatcherProvider.IO).initThreeTen(context)
-    }
-
-    /**
-     * Initializes ThreeTen in a coroutine for faster
-     * initialization. Cancels the scope afterwards.
-     */
-    private fun CoroutineScope.initThreeTen(context: Context) {
-        launch {
+        CoroutineScope(DispatcherProvider.IO).launch {
             AndroidThreeTen.init(context)
-            this@initThreeTen.cancel()
         }
     }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
@@ -19,13 +19,29 @@ package com.getstream.sdk.chat.startup
 import android.content.Context
 import androidx.startup.Initializer
 import com.jakewharton.threetenabp.AndroidThreeTen
+import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 /**
  * Jetpack Startup Initializer for the TreeTenABP library.
  */
 public class ThreeTenInitializer : Initializer<Unit> {
+
     override fun create(context: Context) {
-        AndroidThreeTen.init(context)
+        CoroutineScope(DispatcherProvider.IO).initThreeTen(context)
+    }
+
+    /**
+     * Initializes ThreeTen in a coroutine for faster
+     * initialization. Cancels the scope afterwards.
+     */
+    private fun CoroutineScope.initThreeTen(context: Context) {
+        launch {
+            AndroidThreeTen.init(context)
+            this@initThreeTen.cancel()
+        }
     }
 
     override fun dependencies(): List<Class<out Initializer<*>>> = emptyList()

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/startup/ThreeTenInitializer.kt
@@ -21,7 +21,6 @@ import androidx.startup.Initializer
 import com.jakewharton.threetenabp.AndroidThreeTen
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 /**

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -710,8 +710,8 @@ public final class io/getstream/chat/android/ui/common/ChannelNameFormatter$Comp
 
 public final class io/getstream/chat/android/ui/common/ChatUIInitializer : androidx/startup/Initializer {
 	public fun <init> ()V
-	public fun create (Landroid/content/Context;)Lio/getstream/chat/android/ui/ChatUI;
 	public synthetic fun create (Landroid/content/Context;)Ljava/lang/Object;
+	public fun create (Landroid/content/Context;)V
 	public fun dependencies ()Ljava/util/List;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
@@ -29,7 +29,6 @@ import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.common.internal.AvatarFetcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 
 /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
@@ -25,33 +25,47 @@ import com.getstream.sdk.chat.coil.StreamCoil
 import com.getstream.sdk.chat.coil.StreamImageLoaderFactory
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.header.VersionPrefixHeader
+import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.common.internal.AvatarFetcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 
 /**
  * Jetpack Startup Initializer for Stream's Chat UI Components.
  */
-public class ChatUIInitializer : Initializer<ChatUI> {
-    override fun create(context: Context): ChatUI {
+public class ChatUIInitializer : Initializer<Unit> {
+
+    override fun create(context: Context) {
         ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.UI_COMPONENTS
         ChatUI.appContext = context
 
-        val imageLoaderFactory = StreamImageLoaderFactory(context) {
-            componentRegistry {
-                // duplicated as we can not extend component
-                // registry of existing image loader builder
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                    add(ImageDecoderDecoder(context))
-                } else {
-                    add(GifDecoder())
+        CoroutineScope(DispatcherProvider.IO).setImageLoader(context)
+    }
+
+    /**
+     * Sets the image loader in a coroutine for faster
+     * initialization. Cancels the scope afterwards.
+     */
+    private fun CoroutineScope.setImageLoader(context: Context) {
+        launch {
+            val imageLoaderFactory = StreamImageLoaderFactory(context) {
+                componentRegistry {
+                    // duplicated as we can not extend component
+                    // registry of existing image loader builder
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                        add(ImageDecoderDecoder(context))
+                    } else {
+                        add(GifDecoder())
+                    }
+
+                    add(AvatarFetcher())
                 }
-
-                add(AvatarFetcher())
             }
+            StreamCoil.setImageLoader(imageLoaderFactory)
+            this@setImageLoader.cancel()
         }
-        StreamCoil.setImageLoader(imageLoaderFactory)
-
-        return ChatUI
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> = mutableListOf()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
@@ -41,31 +41,24 @@ public class ChatUIInitializer : Initializer<Unit> {
         ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.UI_COMPONENTS
         ChatUI.appContext = context
 
-        CoroutineScope(DispatcherProvider.IO).setImageLoader(context)
+        CoroutineScope(DispatcherProvider.IO).launch { setImageLoader(context) }
     }
 
-    /**
-     * Sets the image loader in a coroutine for faster
-     * initialization. Cancels the scope afterwards.
-     */
-    private fun CoroutineScope.setImageLoader(context: Context) {
-        launch {
-            val imageLoaderFactory = StreamImageLoaderFactory(context) {
-                componentRegistry {
-                    // duplicated as we can not extend component
-                    // registry of existing image loader builder
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-                        add(ImageDecoderDecoder(context))
-                    } else {
-                        add(GifDecoder())
-                    }
-
-                    add(AvatarFetcher())
+    private fun setImageLoader(context: Context) {
+        val imageLoaderFactory = StreamImageLoaderFactory(context) {
+            componentRegistry {
+                // duplicated as we can not extend component
+                // registry of existing image loader builder
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                    add(ImageDecoderDecoder(context))
+                } else {
+                    add(GifDecoder())
                 }
+
+                add(AvatarFetcher())
             }
-            StreamCoil.setImageLoader(imageLoaderFactory)
-            this@setImageLoader.cancel()
         }
+        StreamCoil.setImageLoader(imageLoaderFactory)
     }
 
     override fun dependencies(): MutableList<Class<out Initializer<*>>> = mutableListOf()


### PR DESCRIPTION
### 🎯 Goal

Our initialization cost is high on low end devices. While high end devices suffer only about 10-20% initialization cost, low end devices can suffer up to 100%. 

In this PR we aim to use coroutines to initialize COIL and ThreeTen

### 🛠 Implementation details

Wrap COIL and ThreeTen initialization inside of Coroutines.

### 🧪 Testing

Testing can be done in multiple steps.

1. Test that nothing has broken

- Use the app and pay special attention to image loading and gif playing
- Watch out for date operations which are potentially use ThreeTen

2. Validate performance uplift

- Connect a physical device to your PC. Preferably an older lower powered device as these show more of a difference.
- Clone the following repo: https://github.com/MarinTolic/MacrobenchmarkStartup

In the repo there are three branches:

- master: Contains a full UI Comp chat experience
- only_stream_import: Contains all UI Comp related imports as named in the tutorial (stream ui comp, coil, activity kx and lifecycle runtime)
- no_stream_imports: Pretty much a vanilla new project with an empty activity

You can now navigate to a class called `ExampleStartupBenchmark` and benchmark any or all of the given scenarios by running the app.

Now you can checkout the branch from this PR and generate a local build using the patch below along with `./gradlew publishToMavenLocal`

<details>
<summary>Remove publish signing</summary>

```
Index: scripts/publish-module.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/scripts/publish-module.gradle b/scripts/publish-module.gradle
--- a/scripts/publish-module.gradle	(revision 21ab55c4b25b48170e2d098d525efb6f1452b6e0)
+++ b/scripts/publish-module.gradle	(date 1655213538846)
@@ -111,11 +111,3 @@
     }
 }
 
-signing {
-    useInMemoryPgpKeys(
-            rootProject.ext["signing.keyId"],
-            rootProject.ext["signing.key"],
-            rootProject.ext["signing.password"],
-    )
-    sign publishing.publications
-}
```

</details>

Now in the `MacrobenchmarkStartup` project go to `settings.gradle` and uncomment the line containing `mavenLocal()` 

After you've done this, re benchmark `master` and `only_stream_import` branches.

### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
