### PR TITLE
Add runtime filter change functionality

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -591,6 +591,7 @@ public final class io/getstream/chat/android/ui/channel/list/viewmodel/ChannelLi
 	public final fun leaveChannel (Lio/getstream/chat/android/client/models/Channel;)V
 	public final fun markAllRead ()V
 	public final fun onAction (Lio/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel$Action;)V
+	public final fun setFilters (Lio/getstream/chat/android/client/api/models/FilterObject;)V
 }
 
 public abstract class io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel$Action {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/viewmodel/ChannelListViewModel.kt
@@ -48,11 +48,15 @@ import io.getstream.chat.android.offline.plugin.state.querychannels.ChannelsStat
 import io.getstream.chat.android.offline.plugin.state.querychannels.QueryChannelsState
 import io.getstream.chat.android.ui.common.extensions.internal.EXTRA_DATA_MUTED
 import io.getstream.chat.android.ui.common.extensions.internal.isMuted
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
 /**
@@ -78,8 +82,10 @@ public class ChannelListViewModel(
     private val memberLimit: Int = 30,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(),
     private val chatClient: ChatClient = ChatClient.instance(),
-    private val globalState: GlobalState = chatClient.globalState
+    private val globalState: GlobalState = chatClient.globalState,
 ) : ViewModel() {
+
+    private var queryJob: Job? = null
 
     /**
      * Represents the current state containing channel list
@@ -129,9 +135,7 @@ public class ChannelListViewModel(
     /**
      * Filters the requested channels.
      */
-    private val filterLiveData: LiveData<FilterObject?> =
-        filter?.let(::MutableLiveData) ?: globalState.user.map(Filters::defaultChannelListFilter)
-            .asLiveData()
+    private val filterLiveData: MutableLiveData<FilterObject?> = MutableLiveData(filter)
 
     /**
      * Represents the current state of the channels query.
@@ -139,11 +143,26 @@ public class ChannelListViewModel(
     private var queryChannelsState: StateFlow<QueryChannelsState?> = MutableStateFlow(null)
 
     init {
+        if (filter == null) {
+            viewModelScope.launch {
+                val filter = buildDefaultFilter().first()
+
+                this@ChannelListViewModel.filterLiveData.value = filter
+            }
+        }
+
         stateMerger.addSource(filterLiveData) { filter ->
             if (filter != null) {
                 initData(filter)
             }
         }
+    }
+
+    /**
+     * Builds the default channel filter, which represents "messaging" channels that the current user is a part of.
+     */
+    private fun buildDefaultFilter(): Flow<FilterObject> {
+        return chatClient.globalState.user.map(Filters::defaultChannelListFilter).filterNotNull()
     }
 
     /**
@@ -168,9 +187,22 @@ public class ChannelListViewModel(
                 memberLimit = memberLimit,
             )
         queryChannelsState = chatClient.queryChannelsAsState(queryChannelsRequest, viewModelScope)
-        viewModelScope.launch {
+
+        /**
+         * We clean up any previous loads to make sure the current one is the only one running.
+         */
+        if (queryJob != null) {
+            queryJob?.cancel()
+        }
+
+        queryJob = viewModelScope.launch {
             queryChannelsState.filterNotNull().collectLatest { queryChannelsState ->
-                queryChannelsState.chatEventHandler = chatEventHandlerFactory.chatEventHandler(queryChannelsState.channels)
+                if (!isActive) {
+                    return@collectLatest
+                }
+
+                queryChannelsState.chatEventHandler =
+                    chatEventHandlerFactory.chatEventHandler(queryChannelsState.channels)
                 stateMerger.addSource(queryChannelsState.channelsStateData.asLiveData()) { channelsState ->
                     stateMerger.value = handleChannelStateNews(channelsState, globalState.channelMutes.value)
                 }
@@ -308,6 +340,15 @@ public class ChannelListViewModel(
                 }
             }
         }
+    }
+
+    /**
+     * Allows us to change the filter based on our requirements.
+     *
+     * @param filterObject The new filter to be applied to the query which lets us fetch different data.
+     */
+    public fun setFilters(filterObject: FilterObject) {
+        this.filterLiveData.value = filterObject
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Fixes #3675 

As an effort to give our users the customization option of changing filters in runtime, we exposed a way to do so that incorporates the default behavior.

### 🛠 Implementation details

Added a function to change the filters in runtime, as well as to handle null based filters in a way that allows us to change them at any point in time.

### 🎨 UI Changes

Video of showcasing the behavior (hardcoded 5 sec delayed filter changes):


https://user-images.githubusercontent.com/17215808/174014475-5df85096-ec36-47af-b5c4-f7a3e81d7f48.mp4

The video is a bit longer as I tried to record 

### 🧪 Testing

1. Apply the patch and run the app on this branch, log in as Belal.
2. You should see the initial filters showing X set of channels.
3. After 5 secs, you should see new filters that only look for channels in which JC is a member (more specific).
4. After 5 more seconds, you should see the original list X.

**Note**: Sometimes I had received some flaky behavior (IDK if it's a race condition on the core side or the emulator being wonky), where the list was refreshed but it updates in a weird way - shows loading more and then loads more items.

I feel like this is a combination of the core caching (we might want to clear the query channel cache when changing filters) and the fact that the state mergers and channels logic is just very complex. We don't have this issue on Compose. :]

Maybe we can pull out the logic from Compose, and reuse/recreate a controller that shares the behavior of state updates in the future.

**_I still propose that even if the flaky behavior is there, we go with this change, as otherwise this improvement might be blocked until we improve the core caching logic, but that's up for debate._**


<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(revision a8805a8864e91c54c580a75e61a5eceaa507d076)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(date 1655297649592)
@@ -27,6 +27,7 @@
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.findNavController
 import com.getstream.sdk.chat.utils.Utils
 import io.getstream.chat.android.client.ChatClient
@@ -45,6 +46,8 @@
 import io.getstream.chat.ui.sample.databinding.FragmentChannelsBinding
 import io.getstream.chat.ui.sample.feature.common.ConfirmationDialogFragment
 import io.getstream.chat.ui.sample.feature.home.HomeFragmentDirections
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 class ChannelListFragment : Fragment() {
 
@@ -150,6 +153,27 @@
             requireActivity().findNavController(R.id.hostFragmentContainer)
                 .navigateSafely(HomeFragmentDirections.actionOpenChat(message.cid, message.id))
         }
+
+        lifecycleScope.launch {
+            delay(5000)
+
+            viewModel.setFilters(
+                Filters.and(
+                    Filters.eq("type", "messaging"),
+                    Filters.`in`("members", listOf("jc")),
+                )
+            )
+
+            delay(5000)
+
+            viewModel.setFilters(
+                Filters.and(
+                    Filters.eq("type", "messaging"),
+                    Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: "")),
+                    Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
+                )
+            )
+        }
     }
 
     @OptIn(InternalStreamChatApi::class)

```

</details>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
