### PR TITLE
[3692] Reinstate missing chat bubble

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/EmojiUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/EmojiUtil.kt
@@ -31,7 +31,7 @@ public object EmojiUtil {
      * @param message The message that was sent/received by user.
      */
     public fun isEmojiOnly(message: Message): Boolean {
-        return message.text.replace(EMOJI_REGEX, "").isEmpty() && message.deletedAt == null
+        return message.text.isNotBlank() && message.text.replace(EMOJI_REGEX, "").isEmpty() && message.deletedAt == null
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Messages with a single file attachment and no text are missing the chat bubble

### 🛠 Implementation details

Modify the function designed to check if the message is emoji only so that it does not register messages with empty text as emoji only.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![emoji_before](https://user-images.githubusercontent.com/37080097/174281432-14655d71-162b-4381-a874-5eeabdb56bb6.png) | ![emoji_after](https://user-images.githubusercontent.com/37080097/174281439-064b0ac1-23d4-4576-b3fa-9f3e81178a0a.png) |


### 🧪 Testing

1. Check that this has the bubble correctly displayed for messages with a single file attachment
2. Check that quoting above mentioned messages produces the expected result
3. Check that the emojis are displayed as instructed in [#3665](https://github.com/GetStream/stream-chat-android/pull/3665)

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~ (this bug was not on released)
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)

### 🎉 GIF

![kitty_bubble](https://user-images.githubusercontent.com/37080097/174282269-c6f3800d-bfe5-4dbb-b4de-6609c6c568bb.gif)
