### PR TITLE
Initialise toggle service before ChatClient

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
@@ -31,10 +31,10 @@ class ChatApp : Application() {
         credentialsRepository = UserCredentialsRepository(this)
         dateFormatter = DateFormatter.from(this)
 
+        initializeToggleService()
+
         // Initialize Stream SDK
         ChatHelper.initializeSdk(this, getApiKey())
-
-        initializeToggleService()
     }
 
     private fun getApiKey(): String {

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
@@ -36,6 +36,7 @@ class App : Application() {
 
     override fun onCreate() {
         super.onCreate()
+        initializeToggleService()
         chatInitializer.init(getApiKey())
         instance = this
         DebugMetricsHelper.init()
@@ -51,7 +52,6 @@ class App : Application() {
             }.build()
         )
         ApplicationConfigurator.configureApp(this)
-        initializeToggleService()
     }
 
     private fun getApiKey(): String {


### PR DESCRIPTION
### 🎯 Goal

The toggle service should be initialized before ChatClient otherwise components inside ChatClient are not initialized properly.

### 🛠 Implementation details
- Changed the order of initialization of toggle service.

### 🧪 Testing

- Do a fresh installation of the sample app or clean the storage before installation.
- Check if the socket connection is working as expected or not.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
