### PR TITLE
Bugfix/3731 cant log  in with an anonymous user

### DIFF
--- a/docusaurus/docs/Android/02-client/01-users.mdx
+++ b/docusaurus/docs/Android/02-client/01-users.mdx
@@ -116,7 +116,7 @@ When you connect to chat using anonymously you receive a special user back with 
 
 ```xml
 {
-	"id": "!anon",
+	"id": "anon",
 	"role": "anonymous",
 	"roles": [],
 	"created_at": "0001-01-01T00:00:00Z",

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2650,7 +2650,7 @@ internal constructor(
         @JvmField
         public val DEFAULT_SORT: QuerySorter<Member> = QuerySortByField.descByName("last_updated")
 
-        private const val ANONYMOUS_USER_ID = "!anon"
+        private const val ANONYMOUS_USER_ID = "anon"
         private val anonUser by lazy { User(id = ANONYMOUS_USER_ID) }
 
         @JvmStatic

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
@@ -234,7 +234,7 @@ internal class ConnectUserTest {
     @Test
     fun `Connect an anonymous user when no previous connection was performed should return a success`() = testCoroutines.runTest {
         /* Given */
-        val user = User(id = "!anon")
+        val user = User(id = "anon")
         val connectionId = randomString()
         val event = ConnectedEvent(EventType.HEALTH_CHECK, Date(), user, connectionId)
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/clientstate/UserStateServiceTests.kt
@@ -78,7 +78,7 @@ internal class UserStateServiceTests {
     fun `Given user not set state When set anonymous Should move to anonymous user state`() {
         val sut = Fixture().please()
 
-        val anonymousUser = User(id = "!anon")
+        val anonymousUser = User(id = "anon")
         sut.onSetUser(anonymousUser, true)
 
         sut.state.shouldBeInstanceOf<UserState.AnonymousUserSet>()
@@ -136,7 +136,7 @@ internal class UserStateServiceTests {
 
         fun givenUserSetState(user: User = Mother.randomUser()) = apply { userStateService.onSetUser(user, false) }
 
-        fun givenAnonymousPendingState() = apply { userStateService.onSetUser(User(id = "!anon"), true) }
+        fun givenAnonymousPendingState() = apply { userStateService.onSetUser(User(id = "anon"), true) }
 
         fun givenAnonymousUserState(user: User = Mother.randomUser()) = apply {
             givenAnonymousPendingState()

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
@@ -24,7 +24,6 @@ import coil.decode.GifDecoder
 import coil.decode.ImageDecoderDecoder
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
-import io.getstream.chat.ui.sample.BuildConfig
 import io.getstream.chat.ui.sample.data.user.SampleUser
 import io.getstream.chat.ui.sample.data.user.UserRepository
 


### PR DESCRIPTION
### 🎯 Goal

Due to the user id containing an exclamation mark, we couldn't log in with an anonymous user.

### 🛠 Implementation details

Remove '!' from `ANONYMOUS_USER_ID`.

### 🧪 Testing

1. Checkout develop
2. Apply patch below
3. Try logging in as an anonymous user in both samples by clicking on any normal user (the patch will always log you in as an anonymous user)

Result: Errors out. Will display toast in UI Comp sample app, and print to log in the Compose sample app.

1. Checkout the branch from the current PR
2. Apply patch below
3. Try logging in as an anonymous user in both samples by clicking on any normal user (the patch will always log you in as an anonymous user)

Result:  Logs in and displays a list of livestream channels (filters were changed in the patch) in both apps.

<details>

<summary>Patch that allows you to log in with an anonymous user</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt	(date 1655835081811)
@@ -59,16 +59,16 @@
             name = user.name
         }
 
-        ChatClient.instance().connectUser(chatUser, user.token)
+        ChatClient.instance().connectAnonymousUser()
             .enqueue { result ->
                 if (result.isSuccess) {
                     logger.logD("User set successfully")
+                    _events.postValue(Event(UiEvent.RedirectToChannels))
                 } else {
                     _events.postValue(Event(UiEvent.Error(result.error().message)))
                     logger.logD("Failed to set user ${result.error()}")
                 }
             }
-        _events.postValue(Event(UiEvent.RedirectToChannels))
     }
 
     sealed class State {
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/App.kt	(date 1655835081804)
@@ -64,7 +64,7 @@
 
     @OptIn(InternalStreamChatApi::class)
     private fun initializeToggleService() {
-        ToggleService.init(applicationContext, mapOf(ToggleService.TOGGLE_KEY_SOCKET_REFACTOR to BuildConfig.DEBUG))
+        ToggleService.init(applicationContext, mapOf())
     }
 
     companion object {
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt	(date 1655835081787)
@@ -43,7 +43,7 @@
 
     @OptIn(InternalStreamChatApi::class)
     private fun initializeToggleService() {
-        ToggleService.init(applicationContext, mapOf(ToggleService.TOGGLE_KEY_SOCKET_REFACTOR to BuildConfig.DEBUG))
+        ToggleService.init(applicationContext, mapOf())
     }
 
     companion object {
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(date 1655835081794)
@@ -74,7 +74,7 @@
         onError: (ChatError) -> Unit = {},
     ) {
 
-        ChatClient.instance().connectUser(userCredentials.user, userCredentials.token)
+        ChatClient.instance().connectAnonymousUser()
             .enqueue { result ->
                 if (result.isSuccess) {
                     ChatApp.credentialsRepository.saveUserCredentials(userCredentials)
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(date 1655835159981)
@@ -58,10 +58,9 @@
 
         ChannelListViewModelFactory(
             filter = Filters.and(
-                Filters.eq("type", "messaging"),
-                Filters.`in`("members", listOf(userId)),
-                Filters.or(Filters.notExists("draft"), Filters.eq("draft", false)),
-            ),
+                Filters.eq("type", "livestream"),
+
+                ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),
         )
     }
Index: stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt	(revision 5b77b945976e51380a8209c8f6fb998a40b4a82a)
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/extensions/Filters.kt	(date 1655835150188)
@@ -27,8 +27,7 @@
         null
     } else {
         and(
-            eq("type", "messaging"),
-            `in`("members", listOf(user.id)),
+            eq("type", "livestream"),
         )
     }
 }
```

</details>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~ (no need, this bug was not released)
- [x] New code is covered by unit tests (updated tests)
- [ ] ~~Comparison screenshots added for visual changes~~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![anonymous](https://user-images.githubusercontent.com/37080097/174869068-98d49ad7-3399-49ff-bede-d1557d8e5f93.gif)

