### PR TITLE
Use SharedFlow with buffer for WebSocket events

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/ws/WebSocketEventObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/ws/WebSocketEventObserver.kt
@@ -17,18 +17,19 @@
 package io.getstream.chat.android.client.experimental.socket.ws
 
 import io.getstream.chat.android.client.experimental.socket.ShutdownReason
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.MutableSharedFlow
 import okhttp3.Response
 import okhttp3.WebSocket
 import okhttp3.WebSocketListener
 import okio.ByteString
 import io.getstream.chat.android.client.experimental.socket.Event.WebSocket as WebSocketEvent
 
-internal class WebSocketEventObserver : WebSocketListener() {
-    private val _eventsFlow = MutableStateFlow<WebSocketEvent?>(null)
+private const val EVENTS_BUFFER_SIZE = 100
 
-    val eventsFlow = _eventsFlow.filterNotNull()
+internal class WebSocketEventObserver : WebSocketListener() {
+    private val _eventsFlow = MutableSharedFlow<WebSocketEvent>(extraBufferCapacity = EVENTS_BUFFER_SIZE)
+
+    val eventsFlow = _eventsFlow
 
     fun terminate() = _eventsFlow.tryEmit(WebSocketEvent.Terminate)
 


### PR DESCRIPTION
Closes #3738 
### 🎯 Goal

When the WebSocket receives too many events and the subscriber is busy handling those events, we miss a few events. It happens because `StateFlow` only keeps the last event. We need to change the events flow type to `SharedFlow`.

### 🛠 Implementation details

- Replaced `StateFlow` with `SharedFlow` for events flow.

### 🧪 Testing
- Run the sample app on two devices.
- Remove a user from any channel on device A.
- On device B, you must receive 6 events inside `EventHandler`.
- You can check the logs with tag `Chat:SocketEvent` that must have those six events similar to following:
```
2022-06-22 17:57:55.168 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: notification.mark_read
2022-06-22 17:57:55.197 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: notification.removed_from_channel
2022-06-22 17:57:55.204 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: member.removed
2022-06-22 17:57:55.221 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: channel.updated
2022-06-22 17:57:55.267 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: message.new
2022-06-22 17:57:55.269 19633-19633/io.getstream.chat.ui.sample.debug V/Chat:SocketEvent: (main:2) [onSocketEventReceived] event.type: channel.kicked
```

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
