### PR TITLE
Fixing nullability problems of ChannelLogic.mutableState._read.value

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
@@ -410,15 +410,16 @@ internal class ChannelLogic(
      * @param message [Message].
      */
     private fun incrementUnreadCountIfNecessary(message: Message) {
-        val currentUserId = globalMutableState.user.value?.id ?: return
+        val user = globalMutableState.user.value ?: return
+        val currentUserId = user.id ?: return
 
         /* Only one thread can access this logic per time. If two messages pass the shouldIncrementUnreadCount at the
          * same time, one increment can be lost.
          */
         synchronized(this) {
-            val readState = mutableState._read.value?.copy()
-            val unreadCount: Int = readState?.unreadMessages ?: 0
-            val lastMessageSeenDate = readState?.lastMessageSeenDate
+            val readState = mutableState._read.value?.copy() ?: ChannelUserRead(user)
+            val unreadCount: Int = readState.unreadMessages
+            val lastMessageSeenDate = readState.lastMessageSeenDate
 
             val shouldIncrementUnreadCount =
                 message.shouldIncrementUnreadCount(
@@ -435,7 +436,10 @@ internal class ChannelLogic(
                         "New unread count: ${unreadCount + 1}"
                 )
 
-                mutableState._read.value = readState.apply { this?.unreadMessages = unreadCount + 1 }
+                mutableState._read.value = readState.apply {
+                    this.unreadMessages = unreadCount + 1
+                    this.lastMessageSeenDate = message.createdAt
+                }
                 mutableState._reads.value = mutableState._reads.value.apply {
                     this[currentUserId]?.lastMessageSeenDate = message.createdAt
                     this[currentUserId]?.unreadMessages = unreadCount + 1

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
@@ -411,7 +411,7 @@ internal class ChannelLogic(
      */
     private fun incrementUnreadCountIfNecessary(message: Message) {
         val user = globalMutableState.user.value ?: return
-        val currentUserId = user.id ?: return
+        val currentUserId = user.id
 
         /* Only one thread can access this logic per time. If two messages pass the shouldIncrementUnreadCount at the
          * same time, one increment can be lost.


### PR DESCRIPTION
### 🎯 Goal

Fix counting of unread messages for newly created channels.

### 🛠 Implementation details

Initializing `mutableState._read.value` if it is ready. This code: 

```
mutableState._read.value = readState.apply { this?.unreadMessages = unreadCount + 1 }
```
Was rewriting null to `mutableState._read` if it wasn't initiated. Now it initializes it when it is null. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/175085321-8c413c7c-af03-4e12-830e-fbd6c81a9eba.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/175085270-45c0a33a-7bf3-4403-90ac-0347b284fad0.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Test the counting for newly created channels.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~ This is just a correctly for a something not released yet.
- ~[ ] New code is covered by unit tests~
- [ ] Comparison screenshots added for visual changes. in a while
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/175085905-1cde1e26-205d-477e-806f-c4f31c7f665c.gif)
_Counting... uhm..._
