### PR TITLE
Fix connecting user in sample apps

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
@@ -73,16 +73,21 @@ object ChatHelper {
         onSuccess: () -> Unit = {},
         onError: (ChatError) -> Unit = {},
     ) {
-
-        ChatClient.instance().connectUser(userCredentials.user, userCredentials.token)
-            .enqueue { result ->
-                if (result.isSuccess) {
-                    ChatApp.credentialsRepository.saveUserCredentials(userCredentials)
-                    onSuccess()
-                } else {
-                    onError(result.error())
-                }
+        ChatClient.instance().run {
+            if (getCurrentUser() == null) {
+                connectUser(userCredentials.user, userCredentials.token)
+                    .enqueue { result ->
+                        if (result.isSuccess) {
+                            ChatApp.credentialsRepository.saveUserCredentials(userCredentials)
+                            onSuccess()
+                        } else {
+                            onError(result.error())
+                        }
+                    }
+            } else {
+                onSuccess()
             }
+        }
     }
 
     /**

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/UserLoginActivity.kt
@@ -78,10 +78,8 @@ class UserLoginActivity : AppCompatActivity() {
                             // login screen then we need to reinitialize the SDK with our API key.
                             ChatHelper.initializeSdk(applicationContext, userCredentials.apiKey)
                         }
-                        ChatHelper.connectUser(
-                            userCredentials = userCredentials,
-                            onSuccess = ::openChannels,
-                        )
+                        ChatHelper.connectUser(userCredentials = userCredentials)
+                        openChannels()
                     },
                     onCustomLoginClick = ::openCustomLogin
                 )

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/user_login/UserLoginViewModel.kt
@@ -59,15 +59,20 @@ class UserLoginViewModel : ViewModel() {
             name = user.name
         }
 
-        ChatClient.instance().connectUser(chatUser, user.token)
-            .enqueue { result ->
-                if (result.isSuccess) {
-                    logger.logD("User set successfully")
-                } else {
-                    _events.postValue(Event(UiEvent.Error(result.error().message)))
-                    logger.logD("Failed to set user ${result.error()}")
-                }
+        ChatClient.instance().run {
+            if (getCurrentUser() == null) {
+                connectUser(chatUser, user.token)
+                    .enqueue { result ->
+                        if (result.isSuccess) {
+                            logger.logD("User set successfully")
+                        } else {
+                            _events.postValue(Event(UiEvent.Error(result.error().message)))
+                            logger.logD("Failed to set user ${result.error()}")
+                        }
+                    }
             }
+        }
+
         _events.postValue(Event(UiEvent.RedirectToChannels))
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix connecting users in sample apps.

### 🛠 Implementation details

We don't need to connect a user if they were already connected.

### 🧪 Testing

1. Open a sample app
2. Go to bg
3. Send a message from another device
4. Tap on push notification
5. You should be able to see messages and app should be in connected state

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
