### PR TITLE
Fixing NullPointerException when deleting reactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - Fix race condition problem that allowed multiple threads to increment unread count, which could cause a mistake in the number of unread messages. [3656](https://github.com/GetStream/stream-chat-android/pull/3656)
 - A new optional argument `useSequentialEventHandler` has been added to `Config` class of offline plugin to enable a sequential event handling mechanism. [3659](https://github.com/GetStream/stream-chat-android/pull/3659)
 - Fix channel mutes being dropped on user updates [3728](https://github.com/GetStream/stream-chat-android/pull/3728)
+- Bug fix when deleting reactions without internet connection. [#3753](https://github.com/GetStream/stream-chat-android/pull/3753)
 
 ### ⬆️ Improved
 - Added logs of all properties available in a class and which one was searched for then QuerySort fails to find a field. [3597](https://github.com/GetStream/stream-chat-android/pull/3597)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImpl.kt
@@ -61,15 +61,17 @@ internal class DeleteReactionErrorHandlerImpl(
     ): ReturnOnErrorCall<Message> {
         return originalCall.onErrorReturn(scope) { originalError ->
             if (cid == null || globalState.isOnline()) {
-                Result.error<Message>(originalError)
-            }
-            val (channelType, channelId) = cid!!.cidToTypeAndId()
-            val cachedMessage = logic.channel(channelType = channelType, channelId = channelId).getMessage(messageId)
-
-            if (cachedMessage != null) {
-                Result.success(cachedMessage)
+                Result.error(originalError)
             } else {
-                Result.error(ChatError(message = "Local message was not found."))
+                val (channelType, channelId) = cid.cidToTypeAndId()
+                val cachedMessage =
+                    logic.channel(channelType = channelType, channelId = channelId).getMessage(messageId)
+
+                if (cachedMessage != null) {
+                    Result.success(cachedMessage)
+                } else {
+                    Result.error(ChatError(message = "Local message was not found."))
+                }
             }
         }
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImplTest.kt
@@ -1,0 +1,22 @@
+package io.getstream.chat.android.offline.errorhandler.internal
+
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.offline.randomMessage
+import io.getstream.chat.android.test.TestCall
+import io.getstream.chat.android.test.randomString
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+
+internal class DeleteReactionErrorHandlerImplTest {
+
+    @Test
+    fun `when passing null as cid, no crash should happen`() {
+        //We would like to check that no exceptions happens, so there's no need to assert anything.
+        DeleteReactionErrorHandlerImpl(mock(), mock(), mock())
+            .onDeleteReactionError(
+                TestCall(Result(randomMessage())),
+                null,
+                randomString()
+            )
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/errorhandler/internal/DeleteReactionErrorHandlerImplTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.offline.errorhandler.internal
 
 import io.getstream.chat.android.client.utils.Result
@@ -11,7 +27,7 @@ internal class DeleteReactionErrorHandlerImplTest {
 
     @Test
     fun `when passing null as cid, no crash should happen`() {
-        //We would like to check that no exceptions happens, so there's no need to assert anything.
+        // We would like to check that no exceptions happens, so there's no need to assert anything.
         DeleteReactionErrorHandlerImpl(mock(), mock(), mock())
             .onDeleteReactionError(
                 TestCall(Result(randomMessage())),


### PR DESCRIPTION
### 🎯 Goal

Fixing `NullPointerException` when deleting reactions. 

### 🛠 Implementation details

Returning errors when `cid` is null. Checking the git history of this class, this was the intended behavior. This bug was inserted (by me, ops) in a code refactor.

### 🎨 UI Changes

### 🧪 Testing

This causes a crash in older versions of the SDK. It is not crashing anymore, but I believe this is the cause of problems of syncing messages and reactions when the connection is regained in the SDK.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~. **This is a problem found when running tests for the SDK.**

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (1)](https://user-images.githubusercontent.com/10619102/175322354-ecb3affb-ef21-4963-9c3c-b02a458d5e87.gif)
_Pointer!_
