### PR TITLE
Fixing reply inside notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - The channel will now be marked as read once the latest message inside `MessagesListView` is reached. Previously scrolling down to it would not trigger this action. [#3620](https://github.com/GetStream/stream-chat-android/pull/3620)
 - Now the options button is not displayed on the gallery screen if there are no options available. [#3696](https://github.com/GetStream/stream-chat-android/pull/3696)
 - Fixed `app:streamUiMessageInputHintText` not getting applied properly in `MessageInputView`. [#3749](https://github.com/GetStream/stream-chat-android/pull/3749)
+- Fixed reply messages inside notification. [#3756](https://github.com/GetStream/stream-chat-android/pull/3756)
 
 ### ⬆️ Improved
 - Improved displaying the upload progress of files being uploaded. Now the upload progress text is less likely to get ellipsized. [#3618](https://github.com/GetStream/stream-chat-android/pull/3618)
@@ -95,6 +96,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fixed the display of `ChannelAvatar` for a channel with two members and neither of them is the current user. [3598](https://github.com/GetStream/stream-chat-android/pull/3598)
+- Fixed reply messages inside notification. [#3756](https://github.com/GetStream/stream-chat-android/pull/3756)
 
 ### ⬆️ Improved
 - Improved padding customization options of `InputField`. [#3596](https://github.com/GetStream/stream-chat-android/pull/3596)

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImpl.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImpl.kt
@@ -75,29 +75,15 @@ internal class SendMessageInterceptorImpl(
         }
 
         return if (!isRetrying) {
-            prepareNewMessageWithAttachments(message, channelType, channelId)
+            val preparedMessage = prepareNewMessage(message, channelType, channelId)
+
+            if (preparedMessage.hasPendingAttachments()) {
+                uploadAttachments(preparedMessage, channelType, channelId)
+            } else {
+                Result.success(preparedMessage)
+            }
         } else {
             retryMessage(message, channelType, channelId)
-        }
-    }
-
-    /**
-     * Prepares message and upload its attachments if it has any.
-     *
-     * @param message [Message] to be sent.
-     *
-     * @return [Result] with a prepared message.
-     */
-    private suspend fun prepareNewMessageWithAttachments(
-        message: Message,
-        channelType: String,
-        channelId: String,
-    ): Result<Message> {
-        val preparedMessage = prepareNewMessage(message, channelType, channelId)
-        return if (preparedMessage.hasPendingAttachments()) {
-            uploadAttachments(preparedMessage, channelType, channelId)
-        } else {
-            Result.success(preparedMessage)
         }
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImplTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.offline.interceptor.internal
+
+import io.getstream.chat.android.offline.model.message.attachments.UploadAttachmentsNetworkType
+import io.getstream.chat.android.offline.plugin.logic.channel.internal.ChannelLogic
+import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
+import io.getstream.chat.android.offline.plugin.state.global.GlobalState
+import io.getstream.chat.android.offline.randomChannel
+import io.getstream.chat.android.offline.randomMessage
+import io.getstream.chat.android.offline.randomUser
+import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class SendMessageInterceptorImplTest {
+    private val globalState: GlobalState = mock {
+        on(it.user) doReturn MutableStateFlow(randomUser())
+    }
+
+    private val channelLogic: ChannelLogic = mock {
+        on(it.toChannel()) doReturn randomChannel()
+    }
+
+    private val logic: LogicRegistry = mock {
+        on(it.channel(any(), any())) doReturn channelLogic
+    }
+
+    private val sendMessageInterceptorImpl = SendMessageInterceptorImpl(
+        context = mock(),
+        logic = logic,
+        globalState = globalState,
+        channelRepository = mock(),
+        messageRepository = mock(),
+        attachmentRepository = mock(),
+        scope = TestScope(),
+        networkType = UploadAttachmentsNetworkType.NOT_ROAMING,
+    )
+
+    @Test
+    fun `when socket is not connected and there is no attachments result should be success`() = runTest {
+        val result = sendMessageInterceptorImpl.interceptMessage(
+            randomString(),
+            randomString(),
+            randomMessage(attachments = mutableListOf()),
+            isRetrying = false
+        )
+
+        result.isSuccess `should be` true
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Fix reply inside notification

### 🛠 Implementation details

When there are no attachments to be sent, return a `Result.success` instead of `Result.error`. An error doesn't make sense in this case, because nothing wrong happens, there were just no attachments to be sent. This way it is possible to send messages without attachments even when the socket is not connected. 

### 🎨 UI Changes

_Add relevant screenshots_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/175353664-294061c6-c0ac-4da8-aef4-f3fa9a15a8b5.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/175353629-0da059c9-5792-4417-b3ea-6bc0faef7773.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

</details>

### 🧪 Testing

Reply messages using the notification

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] ~PR is linked to the GitHub issue it resolves~. **This was found while running tests in the SDK.**

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (2)](https://user-images.githubusercontent.com/10619102/175355571-fcd83b01-92ba-45bb-9f77-b4468e49e669.gif)
_I need my reply!!_
