### PR TITLE
[3763] Fix pending delivery icon not rendering properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - The channel will now be marked as read once the latest message inside `MessagesListView` is reached. Previously scrolling down to it would not trigger this action. [#3620](https://github.com/GetStream/stream-chat-android/pull/3620)
 - Now the options button is not displayed on the gallery screen if there are no options available. [#3696](https://github.com/GetStream/stream-chat-android/pull/3696)
 - Fixed `app:streamUiMessageInputHintText` not getting applied properly in `MessageInputView`. [#3749](https://github.com/GetStream/stream-chat-android/pull/3749)
+- Fixed backwards compatibility of the `ChannelListView` attribute `streamUiIndicatorPendingSyncIcon` and the `MessageListView` attribute `streamUiIconIndicatorPendingSync`. These are now backwards compatible down to API 21 [#3766](https://github.com/GetStream/stream-chat-android/pull/3766)
 
 ### ⬆️ Improved
 - Improved displaying the upload progress of files being uploaded. Now the upload progress text is less likely to get ellipsized. [#3618](https://github.com/GetStream/stream-chat-android/pull/3618)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
@@ -22,6 +22,7 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import androidx.annotation.ColorInt
 import androidx.annotation.LayoutRes
+import androidx.appcompat.content.res.AppCompatResources
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.TransformStyle
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal.ChannelViewHolder
@@ -31,6 +32,7 @@ import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
 import io.getstream.chat.android.ui.common.extensions.internal.use
 import io.getstream.chat.android.ui.common.style.TextStyle
+import io.getstream.chat.android.ui.utils.extensions.getDrawableCompat
 
 /**
  * Style for [ChannelListView].
@@ -82,7 +84,7 @@ public data class ChannelListViewStyle(
     @LayoutRes public val emptyStateView: Int,
     @LayoutRes public val loadingMoreView: Int,
     @ColorInt public val edgeEffectColor: Int?,
-    public val showChannelDeliveryStatusIndicator: Boolean
+    public val showChannelDeliveryStatusIndicator: Boolean,
 ) {
 
     internal companion object {
@@ -193,8 +195,8 @@ public data class ChannelListViewStyle(
                     ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_double)!!
 
                 val indicatorPendingSyncIcon =
-                    a.getDrawable(R.styleable.ChannelListView_streamUiIndicatorPendingSyncIcon)
-                        ?: context.getDrawableCompat(R.drawable.stream_ui_ic_clock)!!
+                    a.getDrawableCompat(context, R.styleable.ChannelListView_streamUiIndicatorPendingSyncIcon)
+                        ?: AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
 
                 val foregroundLayoutColor = a.getColor(
                     R.styleable.ChannelListView_streamUiForegroundLayoutColor,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
@@ -23,6 +23,7 @@ import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
 import androidx.annotation.Px
 import androidx.annotation.StyleableRes
+import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import io.getstream.chat.android.ui.R
@@ -40,6 +41,7 @@ import io.getstream.chat.android.ui.message.list.reactions.edit.EditReactionsVie
 import io.getstream.chat.android.ui.message.list.reactions.edit.internal.EditReactionsView
 import io.getstream.chat.android.ui.message.list.reactions.view.ViewReactionsViewStyle
 import io.getstream.chat.android.ui.message.list.reactions.view.internal.ViewReactionsView
+import io.getstream.chat.android.ui.utils.extensions.getDrawableCompat
 
 /**
  * Style for view holders used inside [MessageListView].
@@ -442,9 +444,10 @@ public data class MessageListItemStyle(
             val iconIndicatorRead = attributes.getDrawable(
                 R.styleable.MessageListView_streamUiIconIndicatorRead
             ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_double)!!
-            val iconIndicatorPendingSync = attributes.getDrawable(
+            val iconIndicatorPendingSync = attributes.getDrawableCompat(
+                context,
                 R.styleable.MessageListView_streamUiIconIndicatorPendingSync
-            ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_clock)!!
+            ) ?: AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
 
             val iconOnlyVisibleToYou = attributes.getDrawable(
                 R.styleable.MessageListView_streamUiIconOnlyVisibleToYou

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/TypedArray.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/TypedArray.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.utils.extensions
+
+import android.content.Context
+import android.content.res.TypedArray
+import android.graphics.drawable.Drawable
+import androidx.annotation.StyleableRes
+import androidx.appcompat.content.res.AppCompatResources
+
+/**
+ * Retrieves the Drawable for the attribute.
+ *
+ * Unlike [TypedArray.getDrawable], gracefully handles vector drawables with tints on API 21.
+ *
+ * @param context The context to inflate against.
+ * @param id The index of attribute to retrieve.
+ * @return An object that can be used to draw this resource.
+ */
+internal fun TypedArray.getDrawableCompat(context: Context, @StyleableRes id: Int): Drawable? {
+    val resource = getResourceId(id, 0)
+    if (resource != 0) {
+        return AppCompatResources.getDrawable(context, resource)
+    }
+    return null
+}


### PR DESCRIPTION
### 🎯 Goal

Our pending delivery icon was not rendering properly due to it not being fetched by compat methods.

### 🛠 Implementation details

Fetch the icon using compat methods.

### 🎨 UI Changes

| Before (Channels Screen) | Before (Messages Screen) | After  (Channels Screen) | After (Messages Screen) |
| --- | --- | --- | --- |
| ![before_channels_screen](https://user-images.githubusercontent.com/37080097/175541010-19f8ed75-c0a6-430a-952c-677dd636d4de.png) | ![before_messages_screen](https://user-images.githubusercontent.com/37080097/175541002-37ed48bb-62ef-494c-a018-3833531ab388.png)| ![after_channels_screen](https://user-images.githubusercontent.com/37080097/175541008-d9a1dec6-b9cd-40d7-8d8a-aa299991ae2b.png)| ![after_messages_screen](https://user-images.githubusercontent.com/37080097/175541007-99d402c0-8acf-442c-904f-4bf9afe4fd36.png) |

### 🧪 Testing

Please test both on API 21 and API 31. Compare develop with the current PR branch.

1.) Testing the attribute fetching

1. Open the UI components sample app
2. Go offline
3. Post a message 
4. Take a look at the pending  delivery icon both on the messages and channels screen (note, you may have to kill and reload the app for the msg to update in the channel list)

2.) Testing programmatic drawable fetching

<details>
<summary>Patch that removes the option to read from attributes</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt	(revision 2779c58163b0a4f7b970260986bc328215741656)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/ChannelListViewStyle.kt	(date 1656074435041)
@@ -194,9 +194,7 @@
                 val indicatorReadIcon = a.getDrawable(R.styleable.ChannelListView_streamUiIndicatorReadIcon)
                     ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_double)!!
 
-                val indicatorPendingSyncIcon =
-                    a.getDrawableCompat(context, R.styleable.ChannelListView_streamUiIndicatorPendingSyncIcon)
-                        ?: AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
+                val indicatorPendingSyncIcon = AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
 
                 val foregroundLayoutColor = a.getColor(
                     R.styleable.ChannelListView_streamUiForegroundLayoutColor,
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt	(revision 2779c58163b0a4f7b970260986bc328215741656)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListItemStyle.kt	(date 1656074435028)
@@ -444,10 +444,7 @@
             val iconIndicatorRead = attributes.getDrawable(
                 R.styleable.MessageListView_streamUiIconIndicatorRead
             ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_check_double)!!
-            val iconIndicatorPendingSync = attributes.getDrawableCompat(
-                context,
-                R.styleable.MessageListView_streamUiIconIndicatorPendingSync
-            ) ?: AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
+            val iconIndicatorPendingSync =  AppCompatResources.getDrawable(context, R.drawable.stream_ui_ic_clock)!!
 
             val iconOnlyVisibleToYou = attributes.getDrawable(
                 R.styleable.MessageListView_streamUiIconOnlyVisibleToYou
Index: stream-chat-android-ui-components/src/main/res/values/styles.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/res/values/styles.xml b/stream-chat-android-ui-components/src/main/res/values/styles.xml
--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml	(revision 2779c58163b0a4f7b970260986bc328215741656)
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml	(date 1656074325195)
@@ -402,7 +402,6 @@
         <item name="streamUiShowMessageDeliveryStatusIndicator">true</item>
         <item name="streamUiIconIndicatorSent">@drawable/stream_ui_ic_check_single</item>
         <item name="streamUiIconIndicatorRead">@drawable/stream_ui_ic_check_double</item>
-        <item name="streamUiIconIndicatorPendingSync">@drawable/stream_ui_ic_clock</item>
         <item name="streamUiIconOnlyVisibleToYou">@drawable/stream_ui_ic_icon_eye_off</item>
 
         <!-- Message deleted style -->
@@ -636,7 +635,6 @@
         <item name="streamUiShowChannelDeliveryStatusIndicator">true</item>
         <item name="streamUiIndicatorSentIcon">@drawable/stream_ui_ic_check_single</item>
         <item name="streamUiIndicatorReadIcon">@drawable/stream_ui_ic_check_double</item>
-        <item name="streamUiIndicatorPendingSyncIcon">@drawable/stream_ui_ic_clock</item>
         <item name="streamUiForegroundLayoutColor">@color/stream_ui_white_snow</item>
 
         <item name="streamUiUnreadMessageCounterTextSize">@dimen/stream_ui_text_small</item>
```

</details>

1. Apply the patch from above
2. Open the UI components sample app
3. Go offline
4. Post a message 
5. Take a look at the pending  delivery icon both on the messages and channels screen (note, you may have to kill and reload the app for the msg to update in the channel list)

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![delivery](https://user-images.githubusercontent.com/37080097/175541341-5947a2ed-9e0a-4916-89c1-3e35a95a30b0.gif)


