### PR TITLE
[3519] Allow customization of message actions

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -847,6 +847,10 @@ public final class io/getstream/chat/android/common/composer/MessageComposerStat
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/common/state/BlockUser : io/getstream/chat/android/common/state/MessageAction {
+	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
+}
+
 public final class io/getstream/chat/android/common/state/Copy : io/getstream/chat/android/common/state/MessageAction {
 	public fun <init> (Lio/getstream/chat/android/client/models/Message;)V
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageAction.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/state/MessageAction.kt
@@ -82,6 +82,11 @@ public class Flag(message: Message) : MessageAction(message)
 public class MuteUser(message: Message) : MessageAction(message)
 
 /**
+ * Block the user who sent the message.
+ */
+public class BlockUser(message: Message) : MessageAction(message)
+
+/**
  * User-customizable action, with any number of extra properties.
  *
  * @param extraProperties Map of key-value pairs that let you store extra data for this action.

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1692,6 +1692,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListView : a
 	public final fun setConfirmDeleteMessageHandler (Lio/getstream/chat/android/ui/message/list/MessageListView$ConfirmDeleteMessageHandler;)V
 	public final fun setConfirmFlagMessageHandler (Lio/getstream/chat/android/ui/message/list/MessageListView$ConfirmFlagMessageHandler;)V
 	public final fun setCopyMessageEnabled (Z)V
+	public final fun setCustomActionHandler (Lio/getstream/chat/android/ui/message/list/MessageListView$CustomActionHandler;)V
 	public final fun setCustomLinearLayoutManager (Landroidx/recyclerview/widget/LinearLayoutManager;)V
 	public final fun setDeleteMessageConfirmationEnabled (Z)V
 	public final fun setDeleteMessageEnabled (Z)V
@@ -1773,6 +1774,10 @@ public abstract interface class io/getstream/chat/android/ui/message/list/Messag
 
 public abstract interface class io/getstream/chat/android/ui/message/list/MessageListView$ConfirmFlagMessageHandler {
 	public abstract fun onConfirmFlagMessage (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function0;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/list/MessageListView$CustomActionHandler {
+	public abstract fun onCustomAction (Lio/getstream/chat/android/client/models/Message;Ljava/util/Map;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/list/MessageListView$EndRegionReachedHandler {
@@ -2355,6 +2360,38 @@ public final class io/getstream/chat/android/ui/message/list/header/viewmodel/Me
 
 public final class io/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModelBinding {
 	public static final fun bind (Lio/getstream/chat/android/ui/message/list/header/viewmodel/MessageListHeaderViewModel;Lio/getstream/chat/android/ui/message/list/header/MessageListHeaderView;Landroidx/lifecycle/LifecycleOwner;)V
+}
+
+public class io/getstream/chat/android/ui/message/list/options/message/DefaultMessageOptionItemsFactory : io/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory {
+	public fun <init> (Landroid/content/Context;)V
+	public fun createMessageOptionItems (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;ZLjava/util/Set;Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;)Ljava/util/List;
+}
+
+public final class io/getstream/chat/android/ui/message/list/options/message/MessageOptionItem {
+	public fun <init> (Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/common/state/MessageAction;Z)V
+	public synthetic fun <init> (Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/common/state/MessageAction;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Landroid/graphics/drawable/Drawable;
+	public final fun component3 ()Lio/getstream/chat/android/common/state/MessageAction;
+	public final fun component4 ()Z
+	public final fun copy (Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/common/state/MessageAction;Z)Lio/getstream/chat/android/ui/message/list/options/message/MessageOptionItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/options/message/MessageOptionItem;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/common/state/MessageAction;ZILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/options/message/MessageOptionItem;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessageAction ()Lio/getstream/chat/android/common/state/MessageAction;
+	public final fun getOptionIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getOptionText ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun isWarningItem ()Z
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory {
+	public static final field Companion Lio/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory$Companion;
+	public abstract fun createMessageOptionItems (Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/User;ZLjava/util/Set;Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;)Ljava/util/List;
+}
+
+public final class io/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory$Companion {
+	public final fun defaultFactory (Landroid/content/Context;)Lio/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory;
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/list/reactions/ReactionClickListener {

--- a/stream-chat-android-ui-components/detekt-baseline.xml
+++ b/stream-chat-android-ui-components/detekt-baseline.xml
@@ -6,11 +6,15 @@
     <ID>ComplexCondition:FileAttachmentsView.kt$FileAttachmentViewHolder$item.uploadState is Attachment.UploadState.Idle || item.uploadState is Attachment.UploadState.InProgress || (item.uploadState is Attachment.UploadState.Success &amp;&amp; item.fileSize == 0)</ID>
     <ID>ComplexCondition:MessageInputFieldView.kt$MessageInputFieldView$!hasValidContent() &amp;&amp; (mode is Mode.CustomAttachmentMode || mode is Mode.FileAttachmentMode || mode is Mode.MediaAttachmentMode)</ID>
     <ID>ComplexCondition:MessageListScrollHelper.kt$MessageListScrollHelper$isInitialList || isLastMessageMine() || isAtBottom || alwaysScrollToBottom</ID>
+    <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.deleteMessageEnabled &amp;&amp; (canDeleteAnyMessage || (isOwnMessage &amp;&amp; canDeleteOwnMessage))</ID>
+    <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.editMessageEnabled &amp;&amp; ((isOwnMessage &amp;&amp; canEditOwnMessage) || canEditAnyMessage) &amp;&amp; selectedMessage.command != ModelType.attach_giphy</ID>
+    <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.threadsEnabled &amp;&amp; !isInThread &amp;&amp; isMessageSynced &amp;&amp; canReplyToMessage</ID>
     <ID>ComplexMethod:AttachmentDestination.kt$AttachmentDestination$public fun showAttachment(message: Message, attachment: Attachment)</ID>
     <ID>ComplexMethod:MessageInputViewStyle.kt$MessageInputViewStyle.Companion$internal operator fun invoke(context: Context, attrs: AttributeSet?): MessageInputViewStyle</ID>
     <ID>ComplexMethod:MessageListItemDiffCallback.kt$MessageListItemDiffCallback$override fun areContentsTheSame(oldItem: MessageListItem, newItem: MessageListItem): Boolean</ID>
     <ID>ComplexMethod:MessageListItemViewHolderFactory.kt$MessageListItemViewHolderFactory$ public open fun createViewHolder( parentView: ViewGroup, viewType: Int, ): BaseMessageItemViewHolder&lt;out MessageListItem></ID>
-    <ID>ComplexMethod:MessageOptionsView.kt$MessageOptionsView$internal fun configure( configuration: Configuration, style: MessageListViewStyle, isMessageTheirs: Boolean, syncStatus: SyncStatus, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>
+    <ID>ComplexMethod:MessageListView.kt$MessageListView$ private fun handleMessageAction(messageAction: MessageAction)</ID>
+    <ID>ComplexMethod:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$ override fun createMessageOptionItems( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, style: MessageListViewStyle, ): List&lt;MessageOptionItem></ID>
     <ID>ComplexMethod:MessageReplyView.kt$MessageReplyView$ private fun setReplyBackground(message: Message, isMine: Boolean, style: MessageReplyStyle?)</ID>
     <ID>EmptyFunctionBlock:SuggestionListControllerListener.kt$DefaultSuggestionListControllerListener${}</ID>
     <ID>ForbiddenComment:MediaAttachmentGridView.kt$MediaAttachmentGridView.SharedMediaSpaceItemDecorator$// TODO: leaves empty space after pagination</ID>
@@ -29,8 +33,7 @@
     <ID>LongMethod:MessageListItemStyle.kt$MessageListItemStyle.Builder$fun build(): MessageListItemStyle</ID>
     <ID>LongMethod:MessageListViewModelBinding.kt$ @JvmName("bind") public fun MessageListViewModel.bindView( view: MessageListView, lifecycleOwner: LifecycleOwner, enforceUniqueReactions: Boolean = true, )</ID>
     <ID>LongMethod:MessageListViewStyle.kt$MessageListViewStyle.Companion$operator fun invoke(context: Context, attrs: AttributeSet?): MessageListViewStyle</ID>
-    <ID>LongMethod:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment$private fun setupOptionsClickListeners( messageOptionsHandlers: MessageOptionsHandlers, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>
-    <ID>LongMethod:MessageOptionsView.kt$MessageOptionsView$internal fun configure( configuration: Configuration, style: MessageListViewStyle, isMessageTheirs: Boolean, syncStatus: SyncStatus, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>
+    <ID>LongMethod:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$ override fun createMessageOptionItems( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, style: MessageListViewStyle, ): List&lt;MessageOptionItem></ID>
     <ID>LongMethod:MessageReplyStyle.kt$MessageReplyStyle.Companion$operator fun invoke(attributes: TypedArray, context: Context): MessageReplyStyle</ID>
     <ID>LongMethod:PinnedMessageListViewStyle.kt$PinnedMessageListViewStyle.Companion$operator fun invoke(context: Context, attrs: AttributeSet?): PinnedMessageListViewStyle</ID>
     <ID>LongMethod:SearchResultListViewStyle.kt$SearchResultListViewStyle.Companion$operator fun invoke(context: Context, attrs: AttributeSet?): SearchResultListViewStyle</ID>
@@ -38,10 +41,9 @@
     <ID>LongMethod:SwipeViewHolder.kt$SwipeViewHolder$@SuppressLint("ClickableViewAccessibility") public fun setSwipeListener(view: View, swipeListener: ChannelListView.SwipeListener?)</ID>
     <ID>LongParameterList:ChannelViewHolder.kt$ChannelViewHolder$( parent: ViewGroup, private val channelClickListener: ChannelListView.ChannelClickListener, private val channelLongClickListener: ChannelListView.ChannelLongClickListener, private val channelDeleteListener: ChannelListView.ChannelClickListener, private val channelMoreOptionsListener: ChannelListView.ChannelClickListener, private val userClickListener: ChannelListView.UserClickListener, private val swipeListener: ChannelListView.SwipeListener, private val style: ChannelListViewStyle, private val binding: StreamUiChannelListItemViewBinding = StreamUiChannelListItemViewBinding.inflate( parent.streamThemeInflater, parent, false ), private val globalState: GlobalState = ChatClient.instance().globalState, )</ID>
     <ID>LongParameterList:EditReactionsBubbleDrawer.kt$EditReactionsBubbleDrawer$( context: Context, canvas: Canvas, bubbleWidth: Int, bubbleHeight: Int, isMyMessage: Boolean, isSingleReaction: Boolean, )</ID>
-    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.Companion$( message: Message, configuration: MessageOptionsView.Configuration, style: MessageListViewStyle, messageViewHolderFactory: MessageListItemViewHolderFactory, messageBackgroundFactory: MessageBackgroundFactory, attachmentFactoryManager: AttachmentFactoryManager, showAvatarPredicate: MessageListView.ShowAvatarPredicate, )</ID>
-    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.Companion$( optionsMode: OptionsMode, message: Message, configuration: MessageOptionsView.Configuration, style: MessageListViewStyle, messageViewHolderFactory: MessageListItemViewHolderFactory, messageBackgroundFactory: MessageBackgroundFactory, attachmentFactoryManager: AttachmentFactoryManager, showAvatarPredicate: MessageListView.ShowAvatarPredicate, )</ID>
-    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.MessageOptionsHandlers$( val threadReplyHandler: MessageListView.ThreadStartHandler, val retryHandler: MessageListView.MessageRetryHandler, val editClickHandler: MessageListView.MessageEditHandler, val flagClickHandler: MessageListView.MessageFlagHandler, val pinClickHandler: MessageListView.MessagePinHandler, val unpinClickHandler: MessageListView.MessageUnpinHandler, val muteClickHandler: MessageListView.UserMuteHandler, val unmuteClickHandler: MessageListView.UserUnmuteHandler, val blockClickHandler: MessageListView.UserBlockHandler, val deleteClickHandler: MessageListView.MessageDeleteHandler, val replyClickHandler: MessageListView.MessageReplyHandler, )</ID>
-    <ID>LongParameterList:MessageOptionsView.kt$MessageOptionsView$( configuration: Configuration, style: MessageListViewStyle, isMessageTheirs: Boolean, syncStatus: SyncStatus, isMessageAuthorMuted: Boolean, isMessagePinned: Boolean, )</ID>
+    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.Companion$( message: Message, reactionsEnabled: Boolean, style: MessageListViewStyle, messageViewHolderFactory: MessageListItemViewHolderFactory, messageBackgroundFactory: MessageBackgroundFactory, attachmentFactoryManager: AttachmentFactoryManager, showAvatarPredicate: MessageListView.ShowAvatarPredicate, )</ID>
+    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.Companion$( message: Message, reactionsEnabled: Boolean, style: MessageListViewStyle, messageViewHolderFactory: MessageListItemViewHolderFactory, messageBackgroundFactory: MessageBackgroundFactory, attachmentFactoryManager: AttachmentFactoryManager, showAvatarPredicate: MessageListView.ShowAvatarPredicate, messageOptionItems: List&lt;MessageOptionItem>, )</ID>
+    <ID>LongParameterList:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment.Companion$( optionsMode: OptionsMode, message: Message, reactionsEnabled: Boolean, style: MessageListViewStyle, messageViewHolderFactory: MessageListItemViewHolderFactory, messageBackgroundFactory: MessageBackgroundFactory, attachmentFactoryManager: AttachmentFactoryManager, showAvatarPredicate: MessageListView.ShowAvatarPredicate, messageOptionItems: List&lt;MessageOptionItem>, )</ID>
     <ID>MagicNumber:AttachmentGalleryActivity.kt$AttachmentGalleryActivity$500</ID>
     <ID>MagicNumber:AvatarBitmapCombiner.kt$AvatarBitmapCombiner$3</ID>
     <ID>MagicNumber:AvatarBitmapFactory.kt$AvatarBitmapFactory$4</ID>
@@ -127,8 +129,6 @@
     <ID>MaxLineLength:MessageListView.kt$MessageListView.NewMessagesBehaviour.Companion$?:</ID>
     <ID>MaxLineLength:MessageListViewModelFactory.kt$MessageListViewModelFactory$?:</ID>
     <ID>MaxLineLength:MessageListViewStyle.kt$MessageListViewStyle$*</ID>
-    <ID>MaxLineLength:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment$return ChatClient.instance().globalState.user.value?.mutes?.any { mute -> mute.target.id == message.user.id } == true</ID>
-    <ID>MaxLineLength:MessageOptionsView.kt$MessageOptionsView.Configuration.Companion$reactionsEnabled</ID>
     <ID>MaxLineLength:MessageReplyStyle.kt$MessageReplyStyle$*</ID>
     <ID>MaxLineLength:MessageReplyView.kt$MessageReplyView$setStrokeTint(style?.messageStrokeColorTheirs ?: context.getColorCompat(R.color.stream_ui_grey_whisper))</ID>
     <ID>MaxLineLength:MessageReplyView.kt$MessageReplyView$val tintColor = style?.messageBackgroundColorTheirs ?: context.getColorCompat(R.color.stream_ui_white)</ID>
@@ -155,8 +155,6 @@
     <ID>ReturnCount:ChatFontsImpl.kt$ChatFontsImpl$private fun getFont(@FontRes fontRes: Int): Typeface?</ID>
     <ID>ReturnCount:ChatFontsImpl.kt$ChatFontsImpl$private fun getFont(fontPath: String): Typeface?</ID>
     <ID>ReturnCount:DefaultUserLookupHandler.kt$private fun levenshtein(search: CharSequence, target: CharSequence): Int</ID>
-    <ID>SerialVersionUIDInSerializableClass:MessageOptionsDialogFragment.kt$MessageOptionsDialogFragment$MessageOptionsHandlers : Serializable</ID>
-    <ID>SerialVersionUIDInSerializableClass:MessageOptionsView.kt$MessageOptionsView$Configuration : Serializable</ID>
     <ID>SerialVersionUIDInSerializableClass:TextStyle.kt$TextStyle : Serializable</ID>
     <ID>SwallowedException:WebLinkDestination.kt$WebLinkDestination$e: ActivityNotFoundException</ID>
     <ID>TooGenericExceptionCaught:AttachmentGalleryActivity.kt$AttachmentGalleryActivity$e: Exception</ID>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionItem.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.message.list.options.message
+
+import android.graphics.drawable.Drawable
+import io.getstream.chat.android.common.state.MessageAction
+
+/**
+ * UI representation of a Message option, when the user selects a message in the list.
+ *
+ * @param optionText The text of the option item.
+ * @param optionIcon The icon of the option item.
+ * @param messageAction The [MessageAction] the option represents.
+ * @param isWarningItem If the option item is dangerous.
+ */
+public data class MessageOptionItem(
+    public val optionText: String,
+    public val optionIcon: Drawable,
+    public val messageAction: MessageAction,
+    public val isWarningItem: Boolean = false,
+)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionItemsFactory.kt
@@ -1,0 +1,202 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.message.list.options.message
+
+import android.content.Context
+import com.getstream.sdk.chat.model.ModelType
+import io.getstream.chat.android.client.models.ChannelCapabilities
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.utils.SyncStatus
+import io.getstream.chat.android.common.state.Copy
+import io.getstream.chat.android.common.state.Delete
+import io.getstream.chat.android.common.state.Edit
+import io.getstream.chat.android.common.state.Flag
+import io.getstream.chat.android.common.state.MuteUser
+import io.getstream.chat.android.common.state.Pin
+import io.getstream.chat.android.common.state.Reply
+import io.getstream.chat.android.common.state.Resend
+import io.getstream.chat.android.common.state.ThreadReply
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.extensions.internal.getDrawableCompat
+import io.getstream.chat.android.ui.common.extensions.internal.hasLink
+import io.getstream.chat.android.ui.message.list.MessageListViewStyle
+
+/**
+ * An interface that allows the creation of message option items.
+ */
+public interface MessageOptionItemsFactory {
+
+    /**
+     * Creates [MessageOptionItem]s for the selected message.
+     *
+     * @param selectedMessage The currently selected message.
+     * @param currentUser The currently logged in user.
+     * @param isInThread If the message is being displayed in a thread.
+     * @param ownCapabilities Set of capabilities the user is given for the current channel.
+     * @param style The style to be applied to the view.
+     * @return The list of message option items to display.
+     */
+    public fun createMessageOptionItems(
+        selectedMessage: Message,
+        currentUser: User?,
+        isInThread: Boolean,
+        ownCapabilities: Set<String>,
+        style: MessageListViewStyle,
+    ): List<MessageOptionItem>
+
+    public companion object {
+        /**
+         * Builds the default message option items factory.
+         *
+         * @return The default implementation of [MessageOptionItemsFactory].
+         */
+        public fun defaultFactory(context: Context): MessageOptionItemsFactory {
+            return DefaultMessageOptionItemsFactory(context)
+        }
+    }
+}
+
+/**
+ * The default implementation of [MessageOptionItemsFactory].
+ *
+ * @param context The context to load resources.
+ */
+public open class DefaultMessageOptionItemsFactory(
+    private val context: Context,
+) : MessageOptionItemsFactory {
+
+    /**
+     * Creates [MessageOptionItem]s for the selected message.
+     *
+     * @param selectedMessage The currently selected message.
+     * @param currentUser The currently logged in user.
+     * @param isInThread If the message is being displayed in a thread.
+     * @param ownCapabilities Set of capabilities the user is given for the current channel.
+     * @param style The style to be applied to the view.
+     * @return The list of message option items to display.
+     */
+    override fun createMessageOptionItems(
+        selectedMessage: Message,
+        currentUser: User?,
+        isInThread: Boolean,
+        ownCapabilities: Set<String>,
+        style: MessageListViewStyle,
+    ): List<MessageOptionItem> {
+        if (selectedMessage.id.isEmpty()) {
+            return emptyList()
+        }
+
+        val selectedMessageUserId = selectedMessage.user.id
+
+        val isTextOnlyMessage = selectedMessage.text.isNotEmpty() && selectedMessage.attachments.isEmpty()
+        val hasLinks = selectedMessage.attachments.any { it.hasLink() && it.type != ModelType.attach_giphy }
+        val isOwnMessage = selectedMessageUserId == currentUser?.id
+        val isUserMuted = currentUser?.mutes?.any { it.target.id == selectedMessageUserId } ?: false
+        val isMessageSynced = selectedMessage.syncStatus == SyncStatus.COMPLETED
+        val isMessageFailed = selectedMessage.syncStatus == SyncStatus.FAILED_PERMANENTLY
+
+        // user capabilities
+        val canReplyToMessage = ownCapabilities.contains(ChannelCapabilities.SEND_REPLY)
+        val canPinMessage = ownCapabilities.contains(ChannelCapabilities.PIN_MESSAGE)
+        val canDeleteOwnMessage = ownCapabilities.contains(ChannelCapabilities.DELETE_OWN_MESSAGE)
+        val canDeleteAnyMessage = ownCapabilities.contains(ChannelCapabilities.DELETE_ANY_MESSAGE)
+        val canEditOwnMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_OWN_MESSAGE)
+        val canEditAnyMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_ANY_MESSAGE)
+
+        return listOfNotNull(
+            if (style.retryMessageEnabled && isOwnMessage && isMessageFailed) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_resend_message),
+                    optionIcon = context.getDrawableCompat(style.retryIcon)!!,
+                    messageAction = Resend(selectedMessage),
+                )
+            } else null,
+            if (style.replyEnabled && isMessageSynced && canReplyToMessage) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_reply),
+                    optionIcon = context.getDrawableCompat(style.replyIcon)!!,
+                    messageAction = Reply(selectedMessage),
+                )
+            } else null,
+            if (style.threadsEnabled && !isInThread && isMessageSynced && canReplyToMessage) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_thread_reply),
+                    optionIcon = context.getDrawableCompat(style.threadReplyIcon)!!,
+                    messageAction = ThreadReply(selectedMessage),
+                )
+            } else null,
+            if (style.copyTextEnabled && (isTextOnlyMessage || hasLinks)) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_copy_message),
+                    optionIcon = context.getDrawableCompat(style.copyIcon)!!,
+                    messageAction = Copy(selectedMessage),
+                )
+            } else null,
+            if (style.editMessageEnabled && ((isOwnMessage && canEditOwnMessage) || canEditAnyMessage) &&
+                selectedMessage.command != ModelType.attach_giphy
+            ) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_edit_message),
+                    optionIcon = context.getDrawableCompat(style.editIcon)!!,
+                    messageAction = Edit(selectedMessage),
+                )
+            } else null,
+            if (style.flagEnabled && !isOwnMessage) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_flag_message),
+                    optionIcon = context.getDrawableCompat(style.flagIcon)!!,
+                    messageAction = Flag(selectedMessage),
+                )
+            } else null,
+            if (style.pinMessageEnabled && isMessageSynced && canPinMessage) {
+                val (pinText, pinIcon) = if (selectedMessage.pinned) {
+                    R.string.stream_ui_message_list_unpin_message to style.unpinIcon
+                } else {
+                    R.string.stream_ui_message_list_pin_message to style.pinIcon
+                }
+
+                MessageOptionItem(
+                    optionText = context.getString(pinText),
+                    optionIcon = context.getDrawableCompat(pinIcon)!!,
+                    messageAction = Pin(selectedMessage),
+                )
+            } else null,
+            if (style.deleteMessageEnabled && (canDeleteAnyMessage || (isOwnMessage && canDeleteOwnMessage))) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_delete_message),
+                    optionIcon = context.getDrawableCompat(style.deleteIcon)!!,
+                    messageAction = Delete(selectedMessage),
+                    isWarningItem = true,
+                )
+            } else null,
+            if (style.muteEnabled && !isOwnMessage) {
+                val (muteText, muteIcon) = if (isUserMuted) {
+                    R.string.stream_ui_message_list_unmute_user to style.unmuteIcon
+                } else {
+                    R.string.stream_ui_message_list_mute_user to style.muteIcon
+                }
+
+                MessageOptionItem(
+                    optionText = context.getString(muteText),
+                    optionIcon = context.getDrawableCompat(muteIcon)!!,
+                    messageAction = MuteUser(selectedMessage),
+                )
+            } else null
+        )
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsDialogFragment.kt
@@ -32,9 +32,9 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.common.state.MessageAction
 import io.getstream.chat.android.offline.extensions.globalState
 import io.getstream.chat.android.ui.R
-import io.getstream.chat.android.ui.common.extensions.internal.copyToClipboard
 import io.getstream.chat.android.ui.common.extensions.internal.getDimension
 import io.getstream.chat.android.ui.common.internal.FullScreenDialogFragment
 import io.getstream.chat.android.ui.databinding.StreamUiDialogMessageOptionsBinding
@@ -51,7 +51,7 @@ import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.Ima
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.LinkAttachmentsViewHolder
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.message.list.background.MessageBackgroundFactory
-import java.io.Serializable
+import io.getstream.chat.android.ui.message.list.options.message.MessageOptionItem
 
 @Suppress("TooManyFunctions")
 internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
@@ -62,15 +62,15 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private val optionsMode: OptionsMode by lazy {
         requireArguments().getSerializable(ARG_OPTIONS_MODE) as OptionsMode
     }
+    private val reactionsEnabled: Boolean by lazy {
+        requireArguments().getBoolean(ARG_REACTIONS_ENABLED)
+    }
 
     private val style by lazy { messageListViewStyle!! }
 
     private val viewHolderFactory by lazy { messageViewHolderFactory!! }
     private val decoratorProvider by lazy { messageOptionsDecoratorProvider!! }
-
-    private val configuration by lazy {
-        requireArguments().getSerializable(ARG_OPTIONS_CONFIG) as MessageOptionsView.Configuration
-    }
+    private val messageOptions by lazy { messageOptionItems }
 
     private val optionsOffset: Int by lazy { requireContext().getDimension(R.dimen.stream_ui_spacing_medium) }
 
@@ -86,10 +86,8 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private lateinit var viewHolder: BaseMessageItemViewHolder<out MessageListItem>
 
     private var reactionClickHandler: ReactionClickHandler? = null
-    private var confirmDeleteMessageClickHandler: ConfirmDeleteMessageClickHandler? = null
-    private var confirmFlagMessageClickHandler: ConfirmFlagMessageClickHandler? = null
-    private var messageOptionsHandlers: MessageOptionsHandlers? = null
     private var userReactionClickHandler: UserReactionClickHandler? = null
+    private var messageActionClickHandler: MessageActionClickHandler? = null
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -125,10 +123,8 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     override fun onDestroy() {
         super.onDestroy()
         reactionClickHandler = null
-        messageOptionsHandlers = null
-        confirmDeleteMessageClickHandler = null
-        confirmFlagMessageClickHandler = null
         userReactionClickHandler = null
+        messageActionClickHandler = null
     }
 
     fun setReactionClickHandler(reactionClickHandler: ReactionClickHandler) {
@@ -139,16 +135,8 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         this.userReactionClickHandler = userReactionClickHandler
     }
 
-    fun setConfirmDeleteMessageClickHandler(confirmDeleteMessageClickHandler: ConfirmDeleteMessageClickHandler) {
-        this.confirmDeleteMessageClickHandler = confirmDeleteMessageClickHandler
-    }
-
-    fun setConfirmFlagMessageClickHandler(confirmFlagMessageClickHandler: ConfirmFlagMessageClickHandler) {
-        this.confirmFlagMessageClickHandler = confirmFlagMessageClickHandler
-    }
-
-    fun setMessageOptionsHandlers(messageOptionsHandlers: MessageOptionsHandlers) {
-        this.messageOptionsHandlers = messageOptionsHandlers
+    fun setMessageActionClickHandler(messageActionClickHandler: MessageActionClickHandler) {
+        this.messageActionClickHandler = messageActionClickHandler
     }
 
     private fun consumeMessageArg() {
@@ -175,7 +163,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private fun setupEditReactionsView() {
         with(binding.editReactionsView) {
             applyStyle(style.itemStyle.editReactionsViewStyle)
-            if (configuration.reactionsEnabled) {
+            if (reactionsEnabled) {
                 setMessage(message, messageItem.isMine)
                 setReactionClickListener {
                     reactionClickHandler?.onReactionClick(message, it)
@@ -223,31 +211,12 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         }
     }
 
-    private fun isMessageAuthorMuted(): Boolean {
-        return ChatClient.instance().globalState.user.value?.mutes?.any { mute -> mute.target.id == message.user.id } == true
-    }
-
     private fun setupMessageOptions() {
         with(binding.messageOptionsView) {
             isVisible = true
-            val isMessageAuthorMuted = isMessageAuthorMuted()
-            configure(
-                configuration = configuration,
-                style = style,
-                isMessageTheirs = messageItem.isTheirs,
-                syncStatus = messageItem.message.syncStatus,
-                isMessageAuthorMuted = isMessageAuthorMuted,
-                isMessagePinned = message.pinned
-            )
+
             updateLayoutParams<LinearLayout.LayoutParams> {
                 gravity = if (messageItem.isMine) Gravity.END else Gravity.START
-            }
-            messageOptionsHandlers?.let { messageOptionsHandlers ->
-                setupOptionsClickListeners(
-                    messageOptionsHandlers = messageOptionsHandlers,
-                    isMessageAuthorMuted = isMessageAuthorMuted,
-                    isMessagePinned = message.pinned
-                )
             }
 
             updateLayoutParams<ViewGroup.MarginLayoutParams> {
@@ -257,73 +226,11 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                     marginStart = style.itemStyle.messageStartMargin + optionsOffset
                 }
             }
-        }
-    }
 
-    private fun setupOptionsClickListeners(
-        messageOptionsHandlers: MessageOptionsHandlers,
-        isMessageAuthorMuted: Boolean,
-        isMessagePinned: Boolean,
-    ) {
-        binding.messageOptionsView.run {
-            setThreadListener {
-                messageOptionsHandlers.threadReplyHandler.onStartThread(message)
-                dismiss()
-            }
-            setRetryListener {
-                messageOptionsHandlers.retryHandler.onMessageRetry(message)
-                dismiss()
-            }
-            setCopyListener {
-                context.copyToClipboard(message.text)
-                dismiss()
-            }
-            setEditMessageListener {
-                messageOptionsHandlers.editClickHandler.onMessageEdit(message)
-                dismiss()
-            }
-            setFlagMessageListener {
-                if (style.flagMessageConfirmationEnabled) {
-                    confirmFlagMessageClickHandler?.onConfirmFlagMessage(message) {
-                        messageOptionsHandlers.flagClickHandler.onMessageFlag(message)
-                    }
-                } else {
-                    messageOptionsHandlers.flagClickHandler.onMessageFlag(message)
-                }
-                dismiss()
-            }
-            setPinMessageListener {
-                if (isMessagePinned) {
-                    messageOptionsHandlers.unpinClickHandler.onMessageUnpin(message)
-                } else {
-                    messageOptionsHandlers.pinClickHandler.onMessagePin(message)
-                }
-                dismiss()
-            }
-            setMuteUserListener {
-                if (isMessageAuthorMuted) {
-                    messageOptionsHandlers.unmuteClickHandler.onUserUnmute(message.user)
-                } else {
-                    messageOptionsHandlers.muteClickHandler.onUserMute(message.user)
-                }
-                dismiss()
-            }
-            setBlockUserListener {
-                messageOptionsHandlers.blockClickHandler.onUserBlock(message.user, message.cid)
-                dismiss()
-            }
-            setReplyListener {
-                messageOptionsHandlers.replyClickHandler.onMessageReply(messageItem.message.cid, messageItem.message)
-                dismiss()
-            }
-            setDeleteMessageListener {
-                if (style.deleteConfirmationEnabled) {
-                    confirmDeleteMessageClickHandler?.onConfirmDeleteMessage(message) {
-                        messageOptionsHandlers.deleteClickHandler.onMessageDelete(message)
-                    }
-                } else {
-                    messageOptionsHandlers.deleteClickHandler.onMessageDelete(message)
-                }
+            setMessageOptions(messageOptions, style)
+
+            setMessageActionClickListener { messageAction ->
+                messageActionClickHandler?.onMessageActionClick(messageAction)
                 dismiss()
             }
         }
@@ -364,34 +271,9 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         fun onUserReactionClick(message: Message, user: User, reaction: Reaction)
     }
 
-    internal fun interface ConfirmDeleteMessageClickHandler {
-        fun onConfirmDeleteMessage(
-            message: Message,
-            callback: ConfirmDeleteMessageCallback,
-        )
-
-        fun interface ConfirmDeleteMessageCallback {
-            fun onConfirmDeleteMessage()
-        }
+    internal fun interface MessageActionClickHandler {
+        fun onMessageActionClick(messageAction: MessageAction)
     }
-
-    internal fun interface ConfirmFlagMessageClickHandler {
-        fun onConfirmFlagMessage(message: Message, confirmCallback: () -> Unit)
-    }
-
-    internal class MessageOptionsHandlers(
-        val threadReplyHandler: MessageListView.ThreadStartHandler,
-        val retryHandler: MessageListView.MessageRetryHandler,
-        val editClickHandler: MessageListView.MessageEditHandler,
-        val flagClickHandler: MessageListView.MessageFlagHandler,
-        val pinClickHandler: MessageListView.MessagePinHandler,
-        val unpinClickHandler: MessageListView.MessageUnpinHandler,
-        val muteClickHandler: MessageListView.UserMuteHandler,
-        val unmuteClickHandler: MessageListView.UserUnmuteHandler,
-        val blockClickHandler: MessageListView.UserBlockHandler,
-        val deleteClickHandler: MessageListView.MessageDeleteHandler,
-        val replyClickHandler: MessageListView.MessageReplyHandler,
-    ) : Serializable
 
     internal enum class OptionsMode {
         MESSAGE_OPTIONS,
@@ -402,7 +284,7 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         const val TAG = "MessageOptionsDialogFragment"
 
         private const val ARG_OPTIONS_MODE = "optionsMode"
-        private const val ARG_OPTIONS_CONFIG = "optionsConfig"
+        private const val ARG_REACTIONS_ENABLED = "reactionsEnabled"
 
         internal var messageListViewStyle: MessageListViewStyle? = null
 
@@ -410,10 +292,11 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         var messageViewHolderFactory: MessageListItemViewHolderFactory? = null
         var messageOptionsDecoratorProvider: MessageOptionsDecoratorProvider? = null
         var attachmentFactoryManager: AttachmentFactoryManager = AttachmentFactoryManager()
+        var messageOptionItems: List<MessageOptionItem> = emptyList()
 
         fun newReactionOptionsInstance(
             message: Message,
-            configuration: MessageOptionsView.Configuration,
+            reactionsEnabled: Boolean,
             style: MessageListViewStyle,
             messageViewHolderFactory: MessageListItemViewHolderFactory,
             messageBackgroundFactory: MessageBackgroundFactory,
@@ -423,45 +306,49 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             return newInstance(
                 OptionsMode.REACTION_OPTIONS,
                 message,
-                configuration,
+                reactionsEnabled,
                 style,
                 messageViewHolderFactory,
                 messageBackgroundFactory,
                 attachmentFactoryManager,
-                showAvatarPredicate
+                showAvatarPredicate,
+                emptyList(),
             )
         }
 
         fun newMessageOptionsInstance(
             message: Message,
-            configuration: MessageOptionsView.Configuration,
+            reactionsEnabled: Boolean,
             style: MessageListViewStyle,
             messageViewHolderFactory: MessageListItemViewHolderFactory,
             messageBackgroundFactory: MessageBackgroundFactory,
             attachmentFactoryManager: AttachmentFactoryManager,
             showAvatarPredicate: MessageListView.ShowAvatarPredicate,
+            messageOptionItems: List<MessageOptionItem>,
         ): MessageOptionsDialogFragment {
             return newInstance(
                 OptionsMode.MESSAGE_OPTIONS,
                 message,
-                configuration,
+                reactionsEnabled,
                 style,
                 messageViewHolderFactory,
                 messageBackgroundFactory,
                 attachmentFactoryManager,
-                showAvatarPredicate
+                showAvatarPredicate,
+                messageOptionItems,
             )
         }
 
         private fun newInstance(
             optionsMode: OptionsMode,
             message: Message,
-            configuration: MessageOptionsView.Configuration,
+            reactionsEnabled: Boolean,
             style: MessageListViewStyle,
             messageViewHolderFactory: MessageListItemViewHolderFactory,
             messageBackgroundFactory: MessageBackgroundFactory,
             attachmentFactoryManager: AttachmentFactoryManager,
             showAvatarPredicate: MessageListView.ShowAvatarPredicate,
+            messageOptionItems: List<MessageOptionItem>,
         ): MessageOptionsDialogFragment {
             this.messageListViewStyle = style
             this.attachmentFactoryManager = attachmentFactoryManager
@@ -472,10 +359,11 @@ internal class MessageOptionsDialogFragment : FullScreenDialogFragment() {
                 messageBackgroundFactory,
                 showAvatarPredicate
             )
+            this.messageOptionItems = messageOptionItems
             return MessageOptionsDialogFragment().apply {
                 arguments = bundleOf(
                     ARG_OPTIONS_MODE to optionsMode,
-                    ARG_OPTIONS_CONFIG to configuration,
+                    ARG_REACTIONS_ENABLED to reactionsEnabled,
                 )
                 // pass message via static field
                 messageArg = message

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/internal/MessageOptionsView.kt
@@ -20,23 +20,26 @@ import android.content.Context
 import android.util.AttributeSet
 import android.widget.FrameLayout
 import android.widget.TextView
-import androidx.core.view.isVisible
-import io.getstream.chat.android.client.models.ChannelCapabilities
-import io.getstream.chat.android.client.models.Config
-import io.getstream.chat.android.client.utils.SyncStatus
+import com.getstream.sdk.chat.utils.extensions.inflater
+import io.getstream.chat.android.common.state.MessageAction
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.createStreamThemeWrapper
 import io.getstream.chat.android.ui.common.extensions.internal.setStartDrawable
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
-import io.getstream.chat.android.ui.common.style.TextStyle
 import io.getstream.chat.android.ui.common.style.setTextStyle
 import io.getstream.chat.android.ui.databinding.StreamUiMessageOptionsViewBinding
+import io.getstream.chat.android.ui.message.list.MessageListView
 import io.getstream.chat.android.ui.message.list.MessageListViewStyle
-import java.io.Serializable
+import io.getstream.chat.android.ui.message.list.options.message.MessageOptionItem
 
+/**
+ * Displays all available message actions a user can execute on a message.
+ */
 internal class MessageOptionsView : FrameLayout {
 
     private val binding = StreamUiMessageOptionsViewBinding.inflate(streamThemeInflater, this, true)
+
+    private var listener: MessageActionClickListener? = null
 
     constructor(context: Context) : this(context, null, 0)
 
@@ -48,238 +51,56 @@ internal class MessageOptionsView : FrameLayout {
         defStyleAttr
     )
 
-    internal fun configure(
-        configuration: Configuration,
+    /**
+     * Sets a click listener for message option item clicks.
+     *
+     * @param listener The callback to be invoked when an option item is clicked.
+     */
+    fun setMessageActionClickListener(listener: MessageActionClickListener) {
+        this.listener = listener
+    }
+
+    /**
+     * Initializes the view with a set of message option items.
+     *
+     * @param messageOptions The list of message option items to display.
+     * @param style Style for [MessageListView].
+     */
+    fun setMessageOptions(
+        messageOptions: List<MessageOptionItem>,
         style: MessageListViewStyle,
-        isMessageTheirs: Boolean,
-        syncStatus: SyncStatus,
-        isMessageAuthorMuted: Boolean,
-        isMessagePinned: Boolean,
     ) {
-        val isMessageMine = !isMessageTheirs
-        val isMessageSynced = syncStatus == SyncStatus.COMPLETED
-        val ownCapabilities = configuration.ownCapabilities
-
-        configureMessageOption(
-            isVisible = isMessageMine && syncStatus == SyncStatus.FAILED_PERMANENTLY,
-            textView = binding.retryTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.retryIcon,
-        )
-
-        configureMessageOption(
-            isVisible = configuration.replyEnabled && isMessageSynced,
-            textView = binding.replyTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.replyIcon,
-        )
-
-        configureMessageOption(
-            isVisible = configuration.threadsEnabled && isMessageSynced,
-            textView = binding.threadReplyTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.threadReplyIcon,
-        )
-
-        configureMessageOption(
-            isVisible = configuration.copyTextEnabled,
-            textView = binding.copyTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.copyIcon,
-        )
-
-        val userCanEditOwnMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_OWN_MESSAGE)
-        val userCalEditAnyMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_ANY_MESSAGE)
-
-        configureMessageOption(
-            isVisible = configuration.editMessageEnabled &&
-                (userCalEditAnyMessage || (userCanEditOwnMessage && isMessageMine)),
-            textView = binding.editTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.editIcon,
-        )
-
-        configureMessageOption(
-            isVisible = configuration.flagEnabled && isMessageTheirs,
-            textView = binding.flagTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.flagIcon,
-        )
-
-        val (pinText, pinIcon) = if (isMessagePinned) {
-            R.string.stream_ui_message_list_unpin_message to style.unpinIcon
-        } else {
-            R.string.stream_ui_message_list_pin_message to style.pinIcon
-        }
-
-        configureMessageOption(
-            isVisible = configuration.pinMessageEnabled && isMessageSynced,
-            textView = binding.pinTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = pinIcon,
-            optionText = pinText,
-        )
-
-        val userCanDeleteOwnMessage = ownCapabilities.contains(ChannelCapabilities.DELETE_OWN_MESSAGE)
-        val userCanDeleteAnyMessage = ownCapabilities.contains(ChannelCapabilities.DELETE_ANY_MESSAGE)
-
-        configureMessageOption(
-            isVisible = configuration.deleteMessageEnabled &&
-                (userCanDeleteAnyMessage || (userCanDeleteOwnMessage && isMessageMine)),
-            textView = binding.deleteTV,
-            textStyle = style.warningMessageOptionsText,
-            optionIcon = style.deleteIcon,
-        )
-
-        val (muteText, muteIcon) = if (isMessageAuthorMuted) {
-            R.string.stream_ui_message_list_unmute_user to style.unmuteIcon
-        } else {
-            R.string.stream_ui_message_list_mute_user to style.muteIcon
-        }
-        configureMessageOption(
-            isVisible = configuration.muteEnabled && isMessageTheirs,
-            textView = binding.muteTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = muteIcon,
-            optionText = muteText,
-        )
-
-        configureMessageOption(
-            isVisible = configuration.blockEnabled && isMessageTheirs,
-            textView = binding.blockTV,
-            textStyle = style.messageOptionsText,
-            optionIcon = style.blockIcon,
-        )
-
         binding.messageOptionsContainer.setCardBackgroundColor(style.messageOptionsBackgroundColor)
-    }
 
-    internal data class Configuration(
-        val replyEnabled: Boolean,
-        val threadsEnabled: Boolean,
-        val editMessageEnabled: Boolean,
-        val deleteMessageEnabled: Boolean,
-        val copyTextEnabled: Boolean,
-        val deleteConfirmationEnabled: Boolean,
-        val reactionsEnabled: Boolean,
-        val flagEnabled: Boolean,
-        val pinMessageEnabled: Boolean,
-        val muteEnabled: Boolean,
-        val blockEnabled: Boolean,
-        val retryMessageEnabled: Boolean,
-        val ownCapabilities: Set<String>,
-    ) : Serializable {
-        internal companion object {
-            operator fun invoke(
-                viewStyle: MessageListViewStyle,
-                channelConfig: Config,
-                hasTextToCopy: Boolean,
-                suppressThreads: Boolean,
-                ownCapabilities: Set<String>,
-            ): Configuration {
-                val userCanReply = ownCapabilities.contains(ChannelCapabilities.SEND_REPLY)
-                val userCanPinMessage = ownCapabilities.contains(ChannelCapabilities.PIN_MESSAGE)
-                val userCanBlockMembers = ownCapabilities.contains(ChannelCapabilities.BAN_CHANNEL_MEMBERS)
+        binding.optionListContainer.removeAllViews()
+        messageOptions.forEach { option ->
+            val messageOptionTextView = inflater.inflate(
+                R.layout.stream_ui_message_option_item,
+                this,
+                false
+            ) as TextView
 
-                return Configuration(
-                    replyEnabled = viewStyle.replyEnabled && userCanReply,
-                    threadsEnabled = if (suppressThreads) {
-                        false
-                    } else {
-                        viewStyle.threadsEnabled && channelConfig.isThreadEnabled && userCanReply
-                    },
-                    editMessageEnabled = viewStyle.editMessageEnabled,
-                    deleteMessageEnabled = viewStyle.deleteMessageEnabled,
-                    copyTextEnabled = viewStyle.copyTextEnabled && hasTextToCopy,
-                    deleteConfirmationEnabled = viewStyle.deleteConfirmationEnabled,
-                    reactionsEnabled = viewStyle.reactionsEnabled && channelConfig.isReactionsEnabled && ownCapabilities.contains(
-                        ChannelCapabilities.SEND_REACTION
-                    ),
-                    flagEnabled = viewStyle.flagEnabled,
-                    pinMessageEnabled = viewStyle.pinMessageEnabled && userCanPinMessage,
-                    muteEnabled = viewStyle.muteEnabled,
-                    blockEnabled = viewStyle.blockEnabled && userCanBlockMembers,
-                    retryMessageEnabled = viewStyle.retryMessageEnabled,
-                    ownCapabilities = ownCapabilities
-                )
+            messageOptionTextView.text = option.optionText
+            messageOptionTextView.setStartDrawable(option.optionIcon)
+            messageOptionTextView.setOnClickListener {
+                listener?.onMessageActionClick(option.messageAction)
             }
+
+            val textStyle = if (option.isWarningItem) {
+                style.warningMessageOptionsText
+            } else {
+                style.messageOptionsText
+            }
+            messageOptionTextView.setTextStyle(textStyle)
+
+            binding.optionListContainer.addView(messageOptionTextView)
         }
     }
 
-    fun setReplyListener(onReplyListener: () -> Unit) {
-        binding.replyTV.setOnClickListener {
-            onReplyListener()
-        }
-    }
-
-    fun setThreadListener(onThreadReply: () -> Unit) {
-        binding.threadReplyTV.setOnClickListener {
-            onThreadReply()
-        }
-    }
-
-    fun setRetryListener(onRetry: () -> Unit) {
-        binding.retryTV.setOnClickListener {
-            onRetry()
-        }
-    }
-
-    fun setCopyListener(onCopy: () -> Unit) {
-        binding.copyTV.setOnClickListener {
-            onCopy()
-        }
-    }
-
-    fun setEditMessageListener(onEdit: () -> Unit) {
-        binding.editTV.setOnClickListener {
-            onEdit()
-        }
-    }
-
-    fun setFlagMessageListener(onFlag: () -> Unit) {
-        binding.flagTV.setOnClickListener {
-            onFlag()
-        }
-    }
-
-    fun setPinMessageListener(onPin: () -> Unit) {
-        binding.pinTV.setOnClickListener {
-            onPin()
-        }
-    }
-
-    fun setDeleteMessageListener(onDelete: () -> Unit) {
-        binding.deleteTV.setOnClickListener {
-            onDelete()
-        }
-    }
-
-    fun setMuteUserListener(onMute: () -> Unit) {
-        binding.muteTV.setOnClickListener {
-            onMute()
-        }
-    }
-
-    fun setBlockUserListener(onBlock: () -> Unit) {
-        binding.blockTV.setOnClickListener {
-            onBlock()
-        }
-    }
-
-    private fun configureMessageOption(
-        isVisible: Boolean,
-        textView: TextView,
-        textStyle: TextStyle,
-        optionIcon: Int,
-        optionText: Int? = null,
-    ) {
-        if (isVisible) {
-            textView.isVisible = true
-            textView.setStartDrawable(optionIcon)
-            textView.setTextStyle(textStyle)
-            optionText?.let { textView.text = context.getString(optionText) }
-        } else {
-            textView.isVisible = false
-        }
+    /**
+     * Click listener for message option items.
+     */
+    fun interface MessageActionClickListener {
+        fun onMessageActionClick(messageAction: MessageAction)
     }
 }

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_option_item.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_option_item.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    style="@style/StreamUiMessageOptionItem"
+    android:textDirection="locale"
+    tools:drawableStart="@drawable/stream_ui_ic_user_block"
+    tools:text="@string/stream_ui_message_list_block_user"
+    tools:visibility="visible"
+    />

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_options_view.xml
@@ -16,7 +16,6 @@
 -->
 <androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/messageOptionsContainer"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
@@ -31,100 +30,6 @@
         android:divider="@drawable/stream_ui_divider"
         android:orientation="vertical"
         android:showDividers="middle"
-        >
-
-        <TextView
-            android:id="@+id/replyTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_reply"
-            android:textDirection="locale"
-            tools:drawableStart="@drawable/stream_ui_ic_arrow_curve_left_grey"
-            />
-
-        <TextView
-            android:id="@+id/threadReplyTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_thread_reply"
-            android:textDirection="locale"
-            tools:drawableStart="@drawable/stream_ui_ic_thread_reply"
-            />
-
-        <TextView
-            android:id="@+id/retryTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_resend_message"
-            android:textDirection="locale"
-            android:visibility="gone"
-            tools:drawableStart="@drawable/stream_ui_ic_send"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/copyTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_copy_message"
-            android:textDirection="locale"
-            tools:drawableStart="@drawable/stream_ui_ic_copy"
-            />
-
-        <TextView
-            android:id="@+id/editTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_edit_message"
-            android:textDirection="locale"
-            android:visibility="visible"
-            tools:drawableStart="@drawable/stream_ui_ic_edit"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/flagTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_flag_message"
-            android:textDirection="locale"
-            android:visibility="visible"
-            tools:drawableStart="@drawable/stream_ui_ic_flag"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/pinTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_pin_message"
-            android:textDirection="locale"
-            android:visibility="visible"
-            tools:drawableStart="@drawable/stream_ui_ic_pin"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/muteTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_mute_user"
-            android:textDirection="locale"
-            android:visibility="visible"
-            tools:drawableStart="@drawable/stream_ui_ic_mute"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/blockTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_block_user"
-            android:textDirection="locale"
-            android:visibility="visible"
-            tools:drawableStart="@drawable/stream_ui_ic_user_block"
-            tools:visibility="visible"
-            />
-
-        <TextView
-            android:id="@+id/deleteTV"
-            style="@style/StreamUiMessageOptionItem"
-            android:text="@string/stream_ui_message_list_delete_message"
-            android:textDirection="locale"
-            tools:drawableStart="@drawable/stream_ui_ic_delete"
-            />
-
-    </LinearLayout>
+        />
 
 </androidx.cardview.widget.CardView>


### PR DESCRIPTION
### 🎯 Goal

Closes #3519 

Add support for custom message action in UI Components.

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
