### PR TITLE
Inject custom Lifecycle

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -98,6 +98,7 @@ object Dependencies {
     const val androidxStartup = "androidx.startup:startup-runtime:${Versions.ANDROIDX_STARTUP}"
     const val androidxTest = "androidx.test:core:${Versions.ANDROIDX_TEST}"
     const val androidxTestKtx = "androidx.test:core-ktx:${Versions.ANDROIDX_TEST}"
+    const val androidxLifecycleTesting = "androidx.lifecycle:lifecycle-runtime-testing:${Versions.ANDROIDX_LIFECYCLE}"
     const val androidxTestJunit = "androidx.test.ext:junit:${Versions.ANDROIDX_TEST_JUNIT}"
     const val androidxTestJunitKtx = "androidx.test.ext:junit-ktx:${Versions.ANDROIDX_TEST_JUNIT}"
     const val androidxViewPager2 = "androidx.viewpager2:viewpager2:${Versions.ANDROIDX_VIEW_PAGER_2}"

--- a/stream-chat-android-client/build.gradle
+++ b/stream-chat-android-client/build.gradle
@@ -82,6 +82,7 @@ dependencies {
     // Tests
     testImplementation project(':stream-chat-android-test')
     testImplementation Dependencies.androidxTestJunit
+    testImplementation Dependencies.androidxLifecycleTesting
     testImplementation Dependencies.junitJupiterApi
     testImplementation Dependencies.junitJupiterParams
     testRuntimeOnly Dependencies.junitJupiterEngine

--- a/stream-chat-android-client/src/debug/java/io/getstream/chat/android/client/di/ChatModule.kt
+++ b/stream-chat-android-client/src/debug/java/io/getstream/chat/android/client/di/ChatModule.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.di
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
 import io.getstream.chat.android.client.api.ChatClientConfig
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.client.notifications.handler.NotificationHandler
@@ -41,6 +42,7 @@ internal class ChatModule(
     tokenManager: TokenManager,
     callbackExecutor: Executor?,
     customOkHttpClient: OkHttpClient?,
+    lifecycle: Lifecycle,
 ) : BaseChatModule(
     appContext,
     config,
@@ -50,6 +52,7 @@ internal class ChatModule(
     tokenManager,
     callbackExecutor,
     customOkHttpClient,
+    lifecycle,
 ) {
 
     override fun clientBuilder(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -17,14 +17,17 @@
 package io.getstream.chat.android.client
 
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : DefaultLifecycleObserver {
+internal class StreamLifecycleObserver(
+    private val lifecycle: Lifecycle,
+    private val handler: LifecycleHandler,
+) : DefaultLifecycleObserver {
     private var recurringResumeEvent = false
 
     @Volatile
@@ -35,9 +38,7 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
             isObserving = true
             @OptIn(DelicateCoroutinesApi::class)
             GlobalScope.launch(DispatcherProvider.Main) {
-                ProcessLifecycleOwner.get()
-                    .lifecycle
-                    .addObserver(this@StreamLifecycleObserver)
+                lifecycle.addObserver(this@StreamLifecycleObserver)
             }
         }
     }
@@ -46,9 +47,7 @@ internal class StreamLifecycleObserver(private val handler: LifecycleHandler) : 
         if (isObserving) {
             @OptIn(DelicateCoroutinesApi::class)
             GlobalScope.launch(DispatcherProvider.Main) {
-                ProcessLifecycleOwner.get()
-                    .lifecycle
-                    .removeObserver(this@StreamLifecycleObserver)
+                lifecycle.addObserver(this@StreamLifecycleObserver)
             }
         }
         isObserving = false

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.di
 
 import android.content.Context
 import android.net.ConnectivityManager
+import androidx.lifecycle.Lifecycle
 import com.moczul.ok2curl.CurlInterceptor
 import io.getstream.chat.android.client.api.AnonymousApi
 import io.getstream.chat.android.client.api.AuthenticatedApi
@@ -83,6 +84,7 @@ internal open class BaseChatModule(
     private val tokenManager: TokenManager = TokenManagerImpl(),
     private val callbackExecutor: Executor?,
     private val customOkHttpClient: OkHttpClient? = null,
+    private val lifecycle: Lifecycle,
     private val httpClientConfig: (OkHttpClient.Builder) -> OkHttpClient.Builder = { it },
 ) {
 
@@ -233,7 +235,7 @@ internal open class BaseChatModule(
         networkScope,
         parser,
         listOf(
-            StreamLifecyclePublisher(),
+            StreamLifecyclePublisher(lifecycle),
             NetworkLifecyclePublisher(appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager),
         ),
     )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/lifecycle/StreamLifecyclePublisher.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/lifecycle/StreamLifecyclePublisher.kt
@@ -17,8 +17,8 @@
 package io.getstream.chat.android.client.experimental.socket.lifecycle
 
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
-import androidx.lifecycle.ProcessLifecycleOwner
 import io.getstream.chat.android.client.clientstate.DisconnectCause
 import io.getstream.chat.android.client.experimental.socket.Event
 import io.getstream.chat.android.client.experimental.socket.ShutdownReason
@@ -31,7 +31,9 @@ import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 
-internal class StreamLifecyclePublisher : DefaultLifecycleObserver, LifecyclePublisher {
+internal class StreamLifecyclePublisher(
+    private val lifecycle: Lifecycle,
+) : DefaultLifecycleObserver, LifecyclePublisher {
     private val logger = ChatLogger.get("StreamLifecycle")
 
     @Volatile
@@ -46,9 +48,7 @@ internal class StreamLifecyclePublisher : DefaultLifecycleObserver, LifecyclePub
         if (isObserving.not()) {
             isObserving = true
             withContext(DispatcherProvider.Main) {
-                ProcessLifecycleOwner.get()
-                    .lifecycle
-                    .addObserver(this@StreamLifecyclePublisher)
+                lifecycle.addObserver(this@StreamLifecyclePublisher)
             }
         }
     }
@@ -56,9 +56,7 @@ internal class StreamLifecyclePublisher : DefaultLifecycleObserver, LifecyclePub
     override suspend fun dispose() {
         if (isObserving) {
             withContext(DispatcherProvider.Main) {
-                ProcessLifecycleOwner.get()
-                    .lifecycle
-                    .removeObserver(this@StreamLifecyclePublisher)
+                lifecycle.removeObserver(this@StreamLifecyclePublisher)
             }
         }
         isObserving = false

--- a/stream-chat-android-client/src/release/java/io/getstream/chat/android/client/di/ChatModule.kt
+++ b/stream-chat-android-client/src/release/java/io/getstream/chat/android/client/di/ChatModule.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.di
 
 import android.content.Context
+import androidx.lifecycle.Lifecycle
 import io.getstream.chat.android.client.api.ChatClientConfig
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.client.notifications.handler.NotificationHandler
@@ -37,6 +38,7 @@ internal class ChatModule(
     tokenManager: TokenManager,
     callbackExecutor: Executor?,
     customOkHttpClient: OkHttpClient?,
+    lifecycle: Lifecycle,
 ) : BaseChatModule(
     appContext,
     config,
@@ -45,5 +47,6 @@ internal class ChatModule(
     uploader,
     tokenManager,
     callbackExecutor,
-    customOkHttpClient
+    customOkHttpClient,
+    lifecycle,
 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -46,7 +46,7 @@ internal class ChannelsApiCallsTests {
 
     @BeforeEach
     fun before() {
-        mock = MockClientBuilder(testCoroutines.scope)
+        mock = MockClientBuilder(testCoroutines)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client
 
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ChatClientConfig
 import io.getstream.chat.android.client.call.await
@@ -82,6 +83,7 @@ internal class ChatClientTest {
 
     @BeforeEach
     fun setUp() {
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
         val config = ChatClientConfig(
             "api-key",
             "hello.http",
@@ -113,6 +115,7 @@ internal class ChatClientTest {
             retryPolicy = NoRetryPolicy(),
             appSettingsManager = mock(),
             chatSocketExperimental = mock(),
+            lifecycle = lifecycleOwner.lifecycle,
         ).apply {
             connectUser(user, token).enqueue()
         }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client
 
+import androidx.lifecycle.testing.TestLifecycleOwner
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.call.await
@@ -62,6 +63,7 @@ internal class ConnectUserTest {
 
     @Before
     fun setup() {
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.testDispatcher)
         socket = FakeSocket()
         chatApi = mock()
         userStateService = UserStateService()
@@ -79,7 +81,8 @@ internal class ConnectUserTest {
             scope = testCoroutines.scope,
             retryPolicy = mock(),
             appSettingsManager = mock(),
-            chatSocketExperimental = mock()
+            chatSocketExperimental = mock(),
+            lifecycle = lifecycleOwner.lifecycle,
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
@@ -41,7 +41,7 @@ internal class DevicesApiCallsTests {
 
     @BeforeEach
     fun before() {
-        mock = MockClientBuilder(testCoroutines.scope)
+        mock = MockClientBuilder(testCoroutines)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
@@ -45,7 +45,7 @@ internal class MessagesApiCallsTests {
 
     @BeforeEach
     fun before() {
-        mock = MockClientBuilder(testCoroutines.scope)
+        mock = MockClientBuilder(testCoroutines)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -44,7 +44,7 @@ internal class UsersApiCallsTests {
 
     @BeforeEach
     fun before() {
-        mock = MockClientBuilder(testCoroutines.scope)
+        mock = MockClientBuilder(testCoroutines)
         client = mock.build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ClientConnectionTests.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client.api
 
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api2.MoshiChatApi
 import io.getstream.chat.android.client.call.Call
@@ -92,6 +93,7 @@ internal class ClientConnectionTests {
 
     @BeforeEach
     fun before() {
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
         val socketStateService = SocketStateService()
         val userStateService = UserStateService()
         val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(socketStateService, testCoroutines.scope)
@@ -123,7 +125,8 @@ internal class ClientConnectionTests {
             scope = testCoroutines.scope,
             retryPolicy = NoRetryPolicy(),
             appSettingsManager = mock(),
-            chatSocketExperimental = mock()
+            chatSocketExperimental = mock(),
+            lifecycle = lifecycleOwner.lifecycle,
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client.chatclient
 
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.api.ChatClientConfig
@@ -69,6 +70,7 @@ internal open class BaseChatClientTest {
 
     @BeforeEach
     fun before() {
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = coroutineRule.testDispatcher)
         MockitoAnnotations.openMocks(this)
         plugins = mutableListOf()
         chatClient = ChatClient(
@@ -86,7 +88,8 @@ internal open class BaseChatClientTest {
             retryPolicy = NoRetryPolicy(),
             initializationCoordinator = initializationCoordinator,
             appSettingsManager = mock(),
-            chatSocketExperimental = mock()
+            chatSocketExperimental = mock(),
+            lifecycle = lifecycleOwner.lifecycle,
         )
         Mockito.reset(
             socketStateService,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.client.utils
 
+import androidx.lifecycle.testing.TestLifecycleOwner
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.clientstate.SocketStateService
 import io.getstream.chat.android.client.clientstate.UserStateService
@@ -35,6 +36,7 @@ import org.robolectric.annotation.Config
 @Config(manifest = Config.NONE)
 internal class DevTokenTest(private val userId: String, private val expectedToken: String) {
 
+    val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
     private val socketStateService = SocketStateService()
     private val userStateService: UserStateService = UserStateService()
     private val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(socketStateService, testCoroutines.scope)
@@ -51,7 +53,8 @@ internal class DevTokenTest(private val userId: String, private val expectedToke
         scope = testCoroutines.scope,
         retryPolicy = NoRetryPolicy(),
         appSettingsManager = mock(),
-        chatSocketExperimental = mock()
+        chatSocketExperimental = mock(),
+        lifecycle = lifecycleOwner.lifecycle,
     )
 
     @Test


### PR DESCRIPTION
### 🎯 Goal
Inject `lifecycle` to simplify our tests and be able to test some parts of our code where we need to register/unregister `lifecycleObservers`.
For testing the `LifecycleTesting` dependency has been added

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media2.giphy.com/media/Udr7WQ2NchwyRmNPeZ/giphy.webp)
