### PR TITLE
[3529 & 3770] Optimize calls to mark read 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,8 +56,10 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Channels will now be marked as read only when the latest message is reached. Previously they were marked read whenever an unread message was read, regardless of its position in the list. [#3772](https://github.com/GetStream/stream-chat-android/pull/3772)
 
 ### ⬆️ Improved
+- Improved `Messages` recomposition when marking messages as read. It will now avoid going into a recomposition loop in certain situations such as when you have two or more failed messages visible in the list. [#3772](https://github.com/GetStream/stream-chat-android/pull/3772)
 
 ### ✅ Added
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -94,8 +94,9 @@ public fun Messages(
     val density = LocalDensity.current
 
     /** Marks the bottom most item as read every time it changes. **/
-    OnLastVisibleItemChanged(lazyListState) {
-        val message = messagesState.messageItems[it]
+    OnLastVisibleItemChanged(lazyListState) { messageIndex ->
+        val message = messagesState.messageItems[messageIndex]
+
         if (message is MessageItemState) {
             onLastVisibleMessageChanged(message.message)
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -95,7 +95,7 @@ public fun Messages(
 
     /** Marks the bottom most item as read every time it changes. **/
     OnLastVisibleItemChanged(lazyListState) { messageIndex ->
-        val message = messagesState.messageItems[messageIndex]
+        val message = messagesState.messageItems.getOrNull(messageIndex)
 
         if (message is MessageItemState) {
             onLastVisibleMessageChanged(message.message)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -93,6 +93,14 @@ public fun Messages(
     var parentSize by remember { mutableStateOf(IntSize(0, 0)) }
     val density = LocalDensity.current
 
+    /** Marks the bottom most item as read every time it changes. **/
+    OnLastVisibleItemChanged(lazyListState) {
+        val message = messagesState.messageItems[it]
+        if (message is MessageItemState) {
+            onLastVisibleMessageChanged(message.message)
+        }
+    }
+
     Box(modifier = modifier) {
         LazyColumn(
             modifier = Modifier
@@ -135,10 +143,6 @@ public fun Messages(
                 Box(modifier = messageItemModifier) {
                     itemContent(item)
 
-                    if (item is MessageItemState) {
-                        onLastVisibleMessageChanged(item.message)
-                    }
-
                     if (index == 0 && lazyListState.isScrollInProgress) {
                         onScrolledToBottom()
                     }
@@ -161,6 +165,15 @@ public fun Messages(
 
         helperContent()
     }
+}
+
+/**
+ * Used to hoist state in a way that defers reads to a lambda,
+ * hence skipping unnecessary recomposition of the parent composable.
+ */
+@Composable
+private fun OnLastVisibleItemChanged(lazyListState: LazyListState, onChanged: (firstVisibleItemIndex: Int) -> Unit) {
+    onChanged(lazyListState.firstVisibleItemIndex)
 }
 
 /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -481,7 +481,14 @@ public class MessageListViewModel(
         }
 
         val (channelType, id) = channelId.cidToTypeAndId()
-        chatClient.markRead(channelType, id).enqueue()
+
+        val latestMessage: MessageItemState? = currentMessagesState.messageItems.firstOrNull { messageItem ->
+            messageItem is MessageItemState
+        } as? MessageItemState
+
+        if (currentMessage.id == latestMessage?.message?.id) {
+            chatClient.markRead(channelType, id).enqueue()
+        }
     }
 
     /**
@@ -535,7 +542,7 @@ public class MessageListViewModel(
         val cid = channelState.value?.cid
         if (cid == null || chatClient.globalState.isOffline()) return
 
-        chatClient.loadMessageById(cid, message.id, DefaultMessageLimit, DefaultMessageLimit).enqueue()
+        chatClient.loadMessageById(cid, message.id).enqueue()
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

closes #3529
closes #3770 

### 🛠 Implementation details

#3529

Extracted marking as read into a separate function that triggers a lambda when a new item is visible. 

The benefit of this is that only the newly visible item will call mark as read, where as previously any recomposed item would call mark as read.

#3770

Compare the IDs of the messages that are marked as read, marking the channel as read only when the last item is reached.

### 🧪 Testing

#3529 

#### on `develop`:

1. Log in as Marton
2. Enter a channel named `Marton is banned here`
3. Send a few messages (you need at least two failed messages in order for compose to enter a loop)
4. Observe Logcat

Result: Compose will enter a recomposition loop and start making repeated unnecessary calls to mark read

#### on the branch featured in this PR:

1. Log in as Marton
2. Enter a channel named `Marton is banned here`
3. Send a few messages (you need at least two failed messages in order for compose to enter a loop)
4. Observe Logcat

Result: No vicious loop entered.

**Note**:  Since this also touches upon functionalities such as focusing on a message, etc, please also test scenarios such as:

- Navigating to a quoted message
- Opening a push notification
- Other similar actions you can think of

#3770

#### on `develop`: 

1. Launch the app on two separate devices while logging in with two different users
2. Observe the same channel with both users
3. Using the Observer user (user A), scroll up so that you can no longer see the first 5 or 6 messages
4. Using the Poster user (User A), post many messages (it's best to number up or down,  making the individual message text such as 10, 9, 8...)
5. Slowly scroll down using the Observer user and notice when the channel gets marked as read on the Poster user's app

Result: The channel will get marked as read when it hits the first visible (not the most recent) message

#### on the branch featured in this PR:

1. Launch the app on two separate devices while logging in with two different users
2. Observe the same channel with both users
3. Using the Observer user (user A), scroll up so that you can no longer see the first 5 or 6 messages
4. Using the Poster user (User A), post many messages (it's best to number up or down,  making the individual message text such as 10, 9, 8...)
5. Slowly scroll down using the Observer user and notice when the channel gets marked as read on the Poster user's app

Result: The channel will get marked as read when it hits the most recent message

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![catread](https://user-images.githubusercontent.com/37080097/175974150-f738f8b8-22df-4e58-bc6f-e26972b733e5.gif)

