### PR TITLE
Extract `devToken()` outside of `ChatClient`

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2297,6 +2297,11 @@ internal constructor(
 
     private fun isUserSet() = userStateService.state !is UserState.NotSet
 
+    /**
+     * Generate a developer token that can be used to connect users while the app is using a development environment.
+     *
+     * @param userId the desired id of the user to be connected.
+     */
     public fun devToken(userId: String): String = tokenUtils.devToken(userId)
 
     internal fun <R, T : Any> Call<T>.precondition(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.client
 
 import android.content.Context
 import android.os.Build
-import android.util.Base64
 import android.util.Log
 import androidx.annotation.CheckResult
 import androidx.annotation.VisibleForTesting
@@ -157,7 +156,6 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import java.io.File
-import java.nio.charset.StandardCharsets
 import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.Executor
@@ -2299,14 +2297,7 @@ internal constructor(
 
     private fun isUserSet() = userStateService.state !is UserState.NotSet
 
-    public fun devToken(userId: String): String {
-        require(userId.isNotEmpty()) { "User id must not be empty" }
-        val header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" //  {"alg": "HS256", "typ": "JWT"}
-        val devSignature = "devtoken"
-        val payload: String =
-            Base64.encodeToString("{\"user_id\":\"$userId\"}".toByteArray(StandardCharsets.UTF_8), Base64.NO_WRAP)
-        return "$header.$payload.$devSignature"
-    }
+    public fun devToken(userId: String): String = tokenUtils.devToken(userId)
 
     internal fun <R, T : Any> Call<T>.precondition(
         pluginsList: List<R>,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/TokenUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/TokenUtils.kt
@@ -42,4 +42,13 @@ internal object TokenUtils {
         logger.logE("Unable to obtain userId from JWT Token Payload", e)
         ""
     }
+
+    fun devToken(userId: String): String {
+        require(userId.isNotEmpty()) { "User id must not be empty" }
+        val header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" //  {"alg": "HS256", "typ": "JWT"}
+        val devSignature = "devtoken"
+        val payload: String =
+            Base64.encodeToString("{\"user_id\":\"$userId\"}".toByteArray(StandardCharsets.UTF_8), Base64.NO_WRAP)
+        return "$header.$payload.$devSignature"
+    }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/TokenUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/TokenUtils.kt
@@ -43,6 +43,11 @@ internal object TokenUtils {
         ""
     }
 
+    /**
+     * Generate a developer token that can be used to connect users while the app is using a development environment.
+     *
+     * @param userId the desired id of the user to be connected.
+     */
     fun devToken(userId: String): String {
         require(userId.isNotEmpty()) { "User id must not be empty" }
         val header = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" //  {"alg": "HS256", "typ": "JWT"}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
@@ -16,56 +16,22 @@
 
 package io.getstream.chat.android.client.utils
 
-import androidx.lifecycle.testing.TestLifecycleOwner
-import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.clientstate.SocketStateService
-import io.getstream.chat.android.client.clientstate.UserStateService
-import io.getstream.chat.android.client.helpers.QueryChannelsPostponeHelper
-import io.getstream.chat.android.client.token.FakeTokenManager
-import io.getstream.chat.android.client.utils.retry.NoRetryPolicy
-import io.getstream.chat.android.test.TestCoroutineExtension
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
-import org.mockito.kotlin.mock
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 internal class DevTokenTest(private val userId: String, private val expectedToken: String) {
-
-    val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
-    private val socketStateService = SocketStateService()
-    private val userStateService: UserStateService = UserStateService()
-    private val queryChannelsPostponeHelper = QueryChannelsPostponeHelper(socketStateService, testCoroutines.scope)
-    private val client = ChatClient(
-        config = mock(),
-        api = mock(),
-        socket = mock(),
-        notifications = mock(),
-        tokenManager = FakeTokenManager(""),
-        socketStateService = socketStateService,
-        queryChannelsPostponeHelper = queryChannelsPostponeHelper,
-        userCredentialStorage = mock(),
-        userStateService = userStateService,
-        scope = testCoroutines.scope,
-        retryPolicy = NoRetryPolicy(),
-        appSettingsManager = mock(),
-        chatSocketExperimental = mock(),
-        lifecycle = lifecycleOwner.lifecycle,
-    )
-
+    
     @Test
     fun `Should return valid dev token`() {
-        client.devToken(userId) `should be equal to` expectedToken
+        TokenUtils.devToken(userId) `should be equal to` expectedToken
     }
 
     companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
 
         @JvmStatic
         @ParameterizedRobolectricTestRunner.Parameters(name = "{index}: {0} => {1}")

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/DevTokenTest.kt
@@ -25,7 +25,7 @@ import org.robolectric.annotation.Config
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @Config(manifest = Config.NONE)
 internal class DevTokenTest(private val userId: String, private val expectedToken: String) {
-    
+
     @Test
     fun `Should return valid dev token`() {
         TokenUtils.devToken(userId) `should be equal to` expectedToken


### PR DESCRIPTION
### 🎯 Goal
Extract `devToken()` outside of `ChatClient`. Move the implementation to `TokenUtils` and test it properly

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![](https://media0.giphy.com/media/ibdzGNrhl8eH5kt0on/giphy.webp?cid=dda24d5020c2a7cbe9f5111346d3558469b2a930248c2fbe&rid=giphy.webp&ct=g)