### PR TITLE
Feature/improve coroutine tests

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChannelsApiCallsTests.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client
 
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Message
@@ -26,6 +27,7 @@ import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -51,7 +53,7 @@ internal class ChannelsApiCallsTests {
     }
 
     @Test
-    fun queryChannelSuccess() {
+    fun queryChannelSuccess() = runTest {
         val response = Channel()
 
         val request = QueryChannelRequest()
@@ -64,13 +66,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroSuccess(response).toRetrofitCall())
 
-        val result = client.queryChannel(mock.channelType, mock.channelId, request).execute()
+        val result = client.queryChannel(mock.channelType, mock.channelId, request).await()
 
         verifySuccess(result, response)
     }
 
     @Test
-    fun queryChannelError() {
+    fun queryChannelError() = runTest {
         val request = QueryChannelRequest()
 
         Mockito.`when`(
@@ -82,13 +84,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroError<Channel>(mock.serverErrorCode).toRetrofitCall())
 
         val result =
-            client.queryChannel(mock.channelType, mock.channelId, request).execute()
+            client.queryChannel(mock.channelType, mock.channelId, request).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun showChannelSuccess() {
+    fun showChannelSuccess() = runTest {
         Mockito.`when`(
             mock.api.showChannel(
                 mock.channelType,
@@ -96,13 +98,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.showChannel(mock.channelType, mock.channelId).execute()
+        val result = client.showChannel(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun showChannelError() {
+    fun showChannelError() = runTest {
         Mockito.`when`(
             mock.api.showChannel(
                 mock.channelType,
@@ -110,13 +112,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.showChannel(mock.channelType, mock.channelId).execute()
+        val result = client.showChannel(mock.channelType, mock.channelId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun deleteChannelSuccess() {
+    fun deleteChannelSuccess() = runTest {
         val response = Channel()
 
         Mockito.`when`(
@@ -126,13 +128,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroSuccess(response).toRetrofitCall())
 
-        val result = client.deleteChannel(mock.channelType, mock.channelId).execute()
+        val result = client.deleteChannel(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, response)
     }
 
     @Test
-    fun deleteChannelError() {
+    fun deleteChannelError() = runTest {
 
         Mockito.`when`(
             mock.api.deleteChannel(
@@ -141,13 +143,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroError<Channel>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.deleteChannel(mock.channelType, mock.channelId).execute()
+        val result = client.deleteChannel(mock.channelType, mock.channelId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun hideChannelSuccess() {
+    fun hideChannelSuccess() = runTest {
         Mockito.`when`(
             mock.api.hideChannel(
                 mock.channelType,
@@ -156,13 +158,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.hideChannel(mock.channelType, mock.channelId).execute()
+        val result = client.hideChannel(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun hideChannelError() {
+    fun hideChannelError() = runTest {
         Mockito.`when`(
             mock.api.hideChannel(
                 mock.channelType,
@@ -171,13 +173,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.hideChannel(mock.channelType, mock.channelId).execute()
+        val result = client.hideChannel(mock.channelType, mock.channelId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun updateChannelSuccess() {
+    fun updateChannelSuccess() = runTest {
         val updateMessage = Message()
             .apply { text = "update-message" }
         val updateChannelData = mapOf<String, Any>()
@@ -194,13 +196,13 @@ internal class ChannelsApiCallsTests {
 
         val result =
             client.updateChannel(mock.channelType, mock.channelId, updateMessage, updateChannelData)
-                .execute()
+                .await()
 
         verifySuccess(result, responseChannel)
     }
 
     @Test
-    fun updateChannelError() {
+    fun updateChannelError() = runTest {
         val updateMessage = Message()
             .apply { text = "update-message" }
         val updateChannelData = mapOf<String, Any>()
@@ -216,13 +218,13 @@ internal class ChannelsApiCallsTests {
 
         val result =
             client.updateChannel(mock.channelType, mock.channelId, updateMessage, updateChannelData)
-                .execute()
+                .await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun acceptInviteSuccess() {
+    fun acceptInviteSuccess() = runTest {
         val responseChannel = Channel()
         val acceptInviteMessage = "accept-message"
 
@@ -235,13 +237,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroSuccess(responseChannel).toRetrofitCall())
 
         val result =
-            client.acceptInvite(mock.channelType, mock.channelId, acceptInviteMessage).execute()
+            client.acceptInvite(mock.channelType, mock.channelId, acceptInviteMessage).await()
 
         verifySuccess(result, responseChannel)
     }
 
     @Test
-    fun acceptInviteError() {
+    fun acceptInviteError() = runTest {
         val acceptInviteMessage = "accept-message"
 
         Mockito.`when`(
@@ -253,13 +255,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroError<Channel>(mock.serverErrorCode).toRetrofitCall())
 
         val result =
-            client.acceptInvite(mock.channelType, mock.channelId, acceptInviteMessage).execute()
+            client.acceptInvite(mock.channelType, mock.channelId, acceptInviteMessage).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun rejectInviteSuccess() {
+    fun rejectInviteSuccess() = runTest {
         val responseChannel = Channel()
 
         Mockito.`when`(
@@ -270,13 +272,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroSuccess(responseChannel).toRetrofitCall())
 
         val result =
-            client.rejectInvite(mock.channelType, mock.channelId).execute()
+            client.rejectInvite(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, responseChannel)
     }
 
     @Test
-    fun rejectInviteError() {
+    fun rejectInviteError() = runTest {
         Mockito.`when`(
             mock.api.rejectInvite(
                 mock.channelType,
@@ -285,35 +287,35 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroError<Channel>(mock.serverErrorCode).toRetrofitCall())
 
         val result =
-            client.rejectInvite(mock.channelType, mock.channelId).execute()
+            client.rejectInvite(mock.channelType, mock.channelId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun markAllReadSuccess() {
+    fun markAllReadSuccess() = runTest {
         Mockito.`when`(
             mock.api.markAllRead()
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.markAllRead().execute()
+        val result = client.markAllRead().await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun markAllReadError() {
+    fun markAllReadError() = runTest {
         Mockito.`when`(
             mock.api.markAllRead()
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.markAllRead().execute()
+        val result = client.markAllRead().await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun markReadSuccess() {
+    fun markReadSuccess() = runTest {
         val messageId = "message-id"
 
         Mockito.`when`(
@@ -325,13 +327,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
         val result =
-            client.markMessageRead(mock.channelType, mock.channelId, messageId).execute()
+            client.markMessageRead(mock.channelType, mock.channelId, messageId).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun markReadError() {
+    fun markReadError() = runTest {
         val messageId = "message-id"
 
         Mockito.`when`(
@@ -343,13 +345,13 @@ internal class ChannelsApiCallsTests {
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
         val result =
-            client.markMessageRead(mock.channelType, mock.channelId, messageId).execute()
+            client.markMessageRead(mock.channelType, mock.channelId, messageId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun queryChannelsSuccess() {
+    fun queryChannelsSuccess() = runTest {
         val offset = 0
         val limit = 1
         val channel = Channel()
@@ -365,13 +367,13 @@ internal class ChannelsApiCallsTests {
             mock.api.queryChannels(request)
         ).thenReturn(RetroSuccess(listOf(channel)).toRetrofitCall())
 
-        val result = client.queryChannels(request).execute()
+        val result = client.queryChannels(request).await()
 
         verifySuccess(result, listOf(channel))
     }
 
     @Test
-    fun queryChannelsError() {
+    fun queryChannelsError() = runTest {
         val offset = 0
         val limit = 1
 
@@ -385,13 +387,13 @@ internal class ChannelsApiCallsTests {
             mock.api.queryChannels(request)
         ).thenReturn(RetroError<List<Channel>>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.queryChannels(request).execute()
+        val result = client.queryChannels(request).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun stopWatchingSuccess() {
+    fun stopWatchingSuccess() = runTest {
         Mockito.`when`(
             mock.api.stopWatching(
                 mock.channelType,
@@ -399,13 +401,13 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.stopWatching(mock.channelType, mock.channelId).execute()
+        val result = client.stopWatching(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun stopWatchingError() {
+    fun stopWatchingError() = runTest {
         Mockito.`when`(
             mock.api.stopWatching(
                 mock.channelType,
@@ -413,29 +415,29 @@ internal class ChannelsApiCallsTests {
             )
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.stopWatching(mock.channelType, mock.channelId).execute()
+        val result = client.stopWatching(mock.channelType, mock.channelId).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun `Given mute channel api call succeeds When muting a channel Should return a result with success`() {
+    fun `Given mute channel api call succeeds When muting a channel Should return a result with success`() = runTest {
         whenever(
             mock.api.muteChannel(mock.channelType, mock.channelId, null)
         ) doReturn RetroSuccess(Unit).toRetrofitCall()
 
-        val result = client.muteChannel(mock.channelType, mock.channelId).execute()
+        val result = client.muteChannel(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun `Given unmute channel api call succeeds When unmuting a channel Should return a result with success`() {
+    fun `Given unmute channel api call succeeds When unmuting a channel Should return a result with success`() = runTest {
         whenever(
             mock.api.unmuteChannel(mock.channelType, mock.channelId)
         ) doReturn RetroSuccess(Unit).toRetrofitCall()
 
-        val result = client.unmuteChannel(mock.channelType, mock.channelId).execute()
+        val result = client.unmuteChannel(mock.channelType, mock.channelId).await()
 
         verifySuccess(result, Unit)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -123,7 +123,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Simple subscribe for one event`() {
+    fun `Simple subscribe for one event`() = runTest {
         client.subscribe {
             result.add(it)
         }
@@ -134,7 +134,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Simple subscribe for multiple events`() {
+    fun `Simple subscribe for multiple events`() = runTest {
         client.subscribe {
             result.add(it)
         }
@@ -162,7 +162,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Subscribe for Java Class event types`() {
+    fun `Subscribe for Java Class event types`() = runTest {
         client.subscribeFor(eventA::class.java, eventC::class.java) {
             result.add(it)
         }
@@ -175,7 +175,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Subscribe for KClass event types`() {
+    fun `Subscribe for KClass event types`() = runTest {
         client.subscribeFor(eventA::class, eventC::class) {
             result.add(it)
         }
@@ -188,7 +188,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Subscribe for event types with type parameter`() {
+    fun `Subscribe for event types with type parameter`() = runTest {
         client.subscribeFor<ConnectedEvent> {
             result.add(it)
         }
@@ -201,7 +201,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Subscribe for single event, with event type as type parameter`() {
+    fun `Subscribe for single event, with event type as type parameter`() = runTest {
         client.subscribeForSingle<ConnectedEvent> {
             result.add(it)
         }
@@ -214,7 +214,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Unsubscribe from events`() {
+    fun `Unsubscribe from events`() = runTest {
         val disposable = client.subscribe {
             result.add(it)
         }
@@ -230,7 +230,7 @@ internal class ChatClientTest {
     }
 
     @Test
-    fun `Given connected user When handle event with updated user Should updated user value`() {
+    fun `Given connected user When handle event with updated user Should updated user value`() = runTest {
         val updateUser = user.copy(extraData = mutableMapOf()).apply { name = "updateUserName" }
 
         socket.sendEvent(Mother.randomUserPresenceChangedEvent(updateUser))
@@ -260,7 +260,6 @@ internal class ChatClientTest {
     }
 
     @Test
-    @ExperimentalCoroutinesApi
     fun `Sync with nonempty cids`() = runTest {
         /* Given */
         val date = Date()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ConnectUserTest.kt
@@ -17,7 +17,6 @@
 package io.getstream.chat.android.client
 
 import androidx.lifecycle.testing.TestLifecycleOwner
-import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.client.api.ChatApi
 import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.clientstate.SocketStateService
@@ -29,41 +28,50 @@ import io.getstream.chat.android.client.models.ConnectionData
 import io.getstream.chat.android.client.models.EventType
 import io.getstream.chat.android.client.models.GuestUser
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.utils.TokenUtils
 import io.getstream.chat.android.client.utils.observable.FakeSocket
-import io.getstream.chat.android.test.TestCoroutineRule
+import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.test.randomString
-import io.getstream.chat.android.test.runTest
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.async
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import org.robolectric.annotation.Config
 import java.util.Date
 
-@OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(AndroidJUnit4::class)
-@Config(manifest = Config.NONE)
 internal class ConnectUserTest {
 
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     private lateinit var socket: FakeSocket
     private lateinit var chatApi: ChatApi
     private lateinit var userStateService: UserStateService
     private lateinit var socketStateService: SocketStateService
     private lateinit var client: ChatClient
+    private val tokenUtils: TokenUtils = mock()
+    private val userId = randomString()
+    private val jwt = randomString()
+    private val anonjwt = randomString()
+    private val user = User(id = userId)
+    private val anonId = "!anon"
+    private val anonUser = User(id = anonId)
 
-    @Before
+    @BeforeEach
     fun setup() {
-        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.testDispatcher)
+        whenever(tokenUtils.devToken(eq(anonId))) doReturn anonjwt
+        whenever(tokenUtils.getUserId(jwt)) doReturn userId
+        whenever(tokenUtils.getUserId(anonjwt)) doReturn anonId
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
         socket = FakeSocket()
         chatApi = mock()
         userStateService = UserStateService()
@@ -78,6 +86,7 @@ internal class ConnectUserTest {
             queryChannelsPostponeHelper = mock(),
             userCredentialStorage = mock(),
             userStateService = userStateService,
+            tokenUtils = tokenUtils,
             scope = testCoroutines.scope,
             retryPolicy = mock(),
             appSettingsManager = mock(),
@@ -87,11 +96,10 @@ internal class ConnectUserTest {
     }
 
     @Test
-    fun `Connect an user with a different userId than the one into the JWT should return an error`() {
-        val user = User(id = "asdf")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Connect an user with a different userId than the one into the JWT should return an error`() = runTest {
+        whenever(tokenUtils.getUserId(eq(jwt))) doReturn randomString()
 
-        val result = client.connectUser(user, jwt).execute()
+        val result = client.connectUser(user, jwt).await()
 
         result.isError `should be equal to` true
         result.error().message `should be equal to`
@@ -99,172 +107,125 @@ internal class ConnectUserTest {
     }
 
     @Test
-    fun `Connect an user when alive connection exists with the same user should return a success`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Connect an user when alive connection exists with the same user should return a success`() = runTest {
         val connectionId = randomString()
         prepareAliveConnection(user, connectionId)
 
-        /* When */
         val result = client.connectUser(user, jwt).await()
 
-        /* Then */
         result.isSuccess `should be equal to` true
         result.data() `should be equal to` ConnectionData(user, connectionId)
     }
 
     @Test
-    fun `Connect an user when no previous connection was performed should return a success`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Connect an user when no previous connection was performed should return a success`() = runTest {
         val connectionId = randomString()
         val event = ConnectedEvent(EventType.HEALTH_CHECK, Date(), user, connectionId)
 
-        /* When */
-        val deferred = async { client.connectUser(user, jwt).await() }
+        val deferred = testCoroutines.scope.async { client.connectUser(user, jwt).await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
         socket.verifyUserToConnect(user)
         result.isSuccess `should be equal to` true
         result.data() `should be equal to` ConnectionData(user, connectionId)
     }
 
     @Test
-    fun `Where there is a connection error connecting an user, it should be propagated`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Where there is a connection error connecting an user, it should be propagated`() = runTest {
         val messageError = randomString()
         val event = ErrorEvent(EventType.HEALTH_CHECK, Date(), ChatError(message = messageError))
 
-        /* When */
-        val deferred = async { client.connectUser(user, jwt).await() }
+        val deferred = testCoroutines.scope.async { client.connectUser(user, jwt).await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` messageError
     }
 
     @Test
-    fun `Where there is an ongoing connection with the same user, an error should be propagated`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
+    fun `When there is an ongoing connection with the same user, an error should be propagated`() = runTest {
         userStateService.onSetUser(user, false)
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
 
-        /* When */
         val result = client.connectUser(user, jwt).await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` "Failed to connect user. Please check you haven't connected a user already."
     }
 
     @Test
-    fun `When connection take more time than expected an error should be propagated`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `When connection take more time than expected an error should be propagated`() = runTest {
 
-        /* When */
         val result = client.connectUser(user, jwt, 1).await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` "Connection wasn't established in 1ms"
     }
 
     @Test
-    fun `When there is an user connected and try to connect a different user, an error should be propagated`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
+    fun `When there is an user connected and try to connect a different user, an error should be propagated`() = runTest {
         userStateService.onSetUser(user, false)
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
 
-        /* When */
         val result = client.connectUser(user, jwt).await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` "Failed to connect user. Please check you haven't connected a user already."
     }
 
     @Test
-    fun `Connect a guest user when no previous connection was performed should return a success`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc", name = "Jc M")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Connect a guest user when no previous connection was performed should return a success`() = runTest {
         val connectionId = randomString()
         val event = ConnectedEvent(EventType.HEALTH_CHECK, Date(), user, connectionId)
 
-        /* When */
         whenever(chatApi.getGuestUser(user.id, user.name)) doReturn GuestUser(user, jwt).asCall()
-        val deferred = async { client.connectGuestUser(user.id, user.name).await() }
+        val deferred = testCoroutines.scope.async { client.connectGuestUser(user.id, user.name).await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
         socket.verifyUserToConnect(user)
         result.isSuccess `should be equal to` true
         result.data() `should be equal to` ConnectionData(user, connectionId)
     }
 
     @Test
-    fun `Where there is a connection error connecting a guest user, it should be propagated`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "jc")
-        val jwt = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ==.devtoken"
+    fun `Where there is a connection error connecting a guest user, it should be propagated`() = runTest {
         val messageError = randomString()
         val event = ErrorEvent(EventType.HEALTH_CHECK, Date(), ChatError(message = messageError))
 
-        /* When */
         whenever(chatApi.getGuestUser(user.id, user.name)) doReturn GuestUser(user, jwt).asCall()
-        val deferred = async { client.connectGuestUser(user.id, user.name).await() }
+        val deferred = testCoroutines.scope.async { client.connectGuestUser(user.id, user.name).await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` messageError
     }
 
     @Test
-    fun `Connect an anonymous user when no previous connection was performed should return a success`() = testCoroutines.runTest {
-        /* Given */
-        val user = User(id = "!anon")
+    fun `Connect an anonymous user when no previous connection was performed should return a success`() = runTest {
         val connectionId = randomString()
-        val event = ConnectedEvent(EventType.HEALTH_CHECK, Date(), user, connectionId)
+        val event = ConnectedEvent(EventType.HEALTH_CHECK, Date(), anonUser, connectionId)
 
-        /* When */
-        val deferred = async { client.connectAnonymousUser().await() }
+        val deferred = testCoroutines.scope.async { client.connectAnonymousUser().await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
-        socket.verifyUserToConnect(user)
+        socket.verifyUserToConnect(anonUser)
         result.isSuccess `should be equal to` true
-        result.data() `should be equal to` ConnectionData(user, connectionId)
-        userStateService.state.userOrError() `should be equal to` user
+        result.data() `should be equal to` ConnectionData(anonUser, connectionId)
+        userStateService.state.userOrError() `should be equal to` anonUser
     }
 
     @Test
-    fun `Where there is a connection error connecting an anonymous user, it should be propagated`() = testCoroutines.runTest {
-        /* Given */
+    fun `Where there is a connection error connecting an anonymous user, it should be propagated`() = runTest {
         val messageError = randomString()
         val event = ErrorEvent(EventType.HEALTH_CHECK, Date(), ChatError(message = messageError))
 
-        /* When */
-        val deferred = async { client.connectAnonymousUser().await() }
+        val deferred = testCoroutines.scope.async { client.connectAnonymousUser().await() }
         socket.sendEvent(event)
         val result = deferred.await()
 
-        /* Then */
         result.isError `should be equal to` true
         result.error().message `should be equal to` messageError
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DevicesApiCallsTests.kt
@@ -17,12 +17,14 @@
 package io.getstream.chat.android.client
 
 import io.getstream.chat.android.client.Mother.randomDevice
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Device
 import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -46,7 +48,7 @@ internal class DevicesApiCallsTests {
     }
 
     @Test
-    fun getDevicesSuccess() {
+    fun getDevicesSuccess() = runTest {
         val devices = List(10) { randomDevice() }
 
         Mockito.`when`(
@@ -55,70 +57,70 @@ internal class DevicesApiCallsTests {
             RetroSuccess(devices).toRetrofitCall()
         )
 
-        val result = client.getDevices().execute()
+        val result = client.getDevices().await()
 
         verifySuccess(result, devices)
     }
 
     @Test
-    fun getDevicesError() {
+    fun getDevicesError() = runTest {
         Mockito.`when`(
             mock.api.getDevices()
         ).thenReturn(RetroError<List<Device>>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.getDevices().execute()
+        val result = client.getDevices().await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun addDevicesSuccess() {
+    fun addDevicesSuccess() = runTest {
         val device = randomDevice()
 
         Mockito.`when`(
             mock.api.addDevice(device)
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.addDevice(device).execute()
+        val result = client.addDevice(device).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun addDevicesError() {
+    fun addDevicesError() = runTest {
         val device = randomDevice()
 
         Mockito.`when`(
             mock.api.addDevice(device)
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.addDevice(device).execute()
+        val result = client.addDevice(device).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun deleteDeviceSuccess() {
+    fun deleteDeviceSuccess() = runTest {
         val device = randomDevice()
 
         Mockito.`when`(
             mock.api.deleteDevice(device)
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.deleteDevice(device).execute()
+        val result = client.deleteDevice(device).await()
 
         verifySuccess(result, Unit)
     }
 
     @Test
-    fun deleteDeviceError() {
+    fun deleteDeviceError() = runTest {
         val device = randomDevice()
 
         Mockito.`when`(
             mock.api.deleteDevice(device)
         ).thenReturn(RetroError<Unit>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.deleteDevice(device).execute()
+        val result = client.deleteDevice(device).await()
 
         verifyError(result, mock.serverErrorCode)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/MessagesApiCallsTests.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client
 
 import io.getstream.chat.android.client.api.models.SendActionRequest
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
@@ -27,6 +28,7 @@ import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifyError
 import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -50,7 +52,7 @@ internal class MessagesApiCallsTests {
     }
 
     @Test
-    fun getMessageSuccess() {
+    fun getMessageSuccess() = runTest {
         val messageId = "message-id"
         val message = Message(text = "a-message")
 
@@ -60,13 +62,13 @@ internal class MessagesApiCallsTests {
             RetroSuccess(message).toRetrofitCall()
         )
 
-        val result = client.getMessage(messageId).execute()
+        val result = client.getMessage(messageId).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun getMessageError() {
+    fun getMessageError() = runTest {
         val messageId = "message-id"
 
         Mockito.`when`(
@@ -75,7 +77,7 @@ internal class MessagesApiCallsTests {
             RetroError<Message>(mock.serverErrorCode).toRetrofitCall()
         )
 
-        val result = client.getMessage(messageId).execute()
+        val result = client.getMessage(messageId).await()
 
         verifyError(
             result,
@@ -84,7 +86,7 @@ internal class MessagesApiCallsTests {
     }
 
     @Test
-    fun deleteMessageSuccess() {
+    fun deleteMessageSuccess() = runTest {
         val messageId = "message-id"
         val message = Message(text = "a-message")
 
@@ -94,13 +96,13 @@ internal class MessagesApiCallsTests {
             RetroSuccess(message).toRetrofitCall()
         )
 
-        val result = client.deleteMessage(messageId).execute()
+        val result = client.deleteMessage(messageId).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun deleteMessageError() {
+    fun deleteMessageError() = runTest {
         val messageId = "message-id"
 
         Mockito.`when`(
@@ -109,7 +111,7 @@ internal class MessagesApiCallsTests {
             RetroError<Message>(mock.serverErrorCode).toRetrofitCall()
         )
 
-        val result = client.deleteMessage(messageId).execute()
+        val result = client.deleteMessage(messageId).await()
 
         verifyError(
             result,
@@ -118,7 +120,7 @@ internal class MessagesApiCallsTests {
     }
 
     @Test
-    fun searchMessageSuccess() {
+    fun searchMessageSuccess() = runTest {
         val messageText = "message-a"
         val user = User()
         val message = Message(
@@ -142,7 +144,7 @@ internal class MessagesApiCallsTests {
             ).toRetrofitCall()
         )
 
-        val result = client.searchMessages(channelFilter, messageFilter, 0, 1).execute()
+        val result = client.searchMessages(channelFilter, messageFilter, 0, 1).await()
 
         verifySuccess(
             result,
@@ -151,7 +153,7 @@ internal class MessagesApiCallsTests {
     }
 
     @Test
-    fun searchMessageError() {
+    fun searchMessageError() = runTest {
         val messageFilter = Filters.eq("text", "search-text")
         val channelFilter = Filters.eq("cid", "cid")
 
@@ -159,13 +161,13 @@ internal class MessagesApiCallsTests {
             mock.api.searchMessages(channelFilter, messageFilter, 0, 1, null, null)
         ).thenReturn(RetroError<SearchMessagesResult>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.searchMessages(channelFilter, messageFilter, 0, 1).execute()
+        val result = client.searchMessages(channelFilter, messageFilter, 0, 1).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun sendMessageSuccess() {
+    fun sendMessageSuccess() = runTest {
         val messageText = "message-a"
         val message = Message(text = messageText)
 
@@ -177,13 +179,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroSuccess(message).toRetrofitCall())
 
-        val result = client.sendMessage(mock.channelType, mock.channelId, message).execute()
+        val result = client.sendMessage(mock.channelType, mock.channelId, message).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun sendMessageError() {
+    fun sendMessageError() = runTest {
         val messageText = "message-a"
         val message = Message(text = messageText)
 
@@ -195,13 +197,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroError<Message>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.sendMessage(mock.channelType, mock.channelId, message).execute()
+        val result = client.sendMessage(mock.channelType, mock.channelId, message).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun sendActionSuccess() {
+    fun sendActionSuccess() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(text = messageText)
@@ -212,13 +214,13 @@ internal class MessagesApiCallsTests {
             mock.api.sendAction(request)
         ).thenReturn(RetroSuccess(message).toRetrofitCall())
 
-        val result = client.sendAction(request).execute()
+        val result = client.sendAction(request).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun sendActionError() {
+    fun sendActionError() = runTest {
         val messageId = "message-id"
         val request = SendActionRequest(mock.channelId, messageId, "type", emptyMap())
 
@@ -226,13 +228,13 @@ internal class MessagesApiCallsTests {
             mock.api.sendAction(request)
         ).thenReturn(RetroError<Message>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.sendAction(request).execute()
+        val result = client.sendAction(request).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun getRepliesSuccess() {
+    fun getRepliesSuccess() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(text = messageText)
@@ -245,13 +247,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroSuccess(listOf(message)).toRetrofitCall())
 
-        val result = client.getReplies(messageId, limit).execute()
+        val result = client.getReplies(messageId, limit).await()
 
         verifySuccess(result, listOf(message))
     }
 
     @Test
-    fun getRepliesError() {
+    fun getRepliesError() = runTest {
         val messageId = "message-id"
         val limit = 10
 
@@ -262,13 +264,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroError<List<Message>>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.getReplies(messageId, limit).execute()
+        val result = client.getReplies(messageId, limit).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun getRepliesMoreSuccess() {
+    fun getRepliesMoreSuccess() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(text = messageText)
@@ -283,13 +285,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroSuccess(listOf(message)).toRetrofitCall())
 
-        val result = client.getRepliesMore(messageId, firstId, limit).execute()
+        val result = client.getRepliesMore(messageId, firstId, limit).await()
 
         verifySuccess(result, listOf(message))
     }
 
     @Test
-    fun getRepliesMoreError() {
+    fun getRepliesMoreError() = runTest {
         val messageId = "message-id"
         val limit = 10
         val firstId = "first-id"
@@ -302,13 +304,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroError<List<Message>>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.getRepliesMore(messageId, firstId, limit).execute()
+        val result = client.getRepliesMore(messageId, firstId, limit).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun deleteReactionSuccess() {
+    fun deleteReactionSuccess() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(text = messageText)
@@ -321,13 +323,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroSuccess(message).toRetrofitCall())
 
-        val result = client.deleteReaction(messageId, reactionType).execute()
+        val result = client.deleteReaction(messageId, reactionType).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun deleteReactionError() {
+    fun deleteReactionError() = runTest {
         val messageId = "message-id"
         val reactionType = "reactionType"
 
@@ -338,13 +340,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroError<Message>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.deleteReaction(messageId, reactionType).execute()
+        val result = client.deleteReaction(messageId, reactionType).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun getReactionsSuccess() {
+    fun getReactionsSuccess() = runTest {
         val messageId = "message-id"
         val reactionType = "reaction-type"
         val score = 10
@@ -360,13 +362,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroSuccess(listOf(reaction)).toRetrofitCall())
 
-        val result = client.getReactions(messageId, offset, limit).execute()
+        val result = client.getReactions(messageId, offset, limit).await()
 
         verifySuccess(result, listOf(reaction))
     }
 
     @Test
-    fun getReactionsError() {
+    fun getReactionsError() = runTest {
         val messageId = "message-id"
         val offset = 0
         val limit = 1
@@ -379,13 +381,13 @@ internal class MessagesApiCallsTests {
             )
         ).thenReturn(RetroError<List<Reaction>>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.getReactions(messageId, offset, limit).execute()
+        val result = client.getReactions(messageId, offset, limit).await()
 
         verifyError(result, mock.serverErrorCode)
     }
 
     @Test
-    fun updateMessageSuccess() {
+    fun updateMessageSuccess() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(
@@ -397,13 +399,13 @@ internal class MessagesApiCallsTests {
             mock.api.updateMessage(message)
         ).thenReturn(RetroSuccess(message).toRetrofitCall())
 
-        val result = client.updateMessage(message).execute()
+        val result = client.updateMessage(message).await()
 
         verifySuccess(result, message)
     }
 
     @Test
-    fun updateMessageError() {
+    fun updateMessageError() = runTest {
         val messageId = "message-id"
         val messageText = "message-a"
         val message = Message(
@@ -415,7 +417,7 @@ internal class MessagesApiCallsTests {
             mock.api.updateMessage(message)
         ).thenReturn(RetroError<Message>(mock.serverErrorCode).toRetrofitCall())
 
-        val result = client.updateMessage(message).execute()
+        val result = client.updateMessage(message).await()
 
         verifyError(result, mock.serverErrorCode)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client
 
 import io.getstream.chat.android.client.api.models.QueryUsersRequest
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.Flag
@@ -25,6 +26,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.test.TestCoroutineExtension
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -49,7 +51,7 @@ internal class UsersApiCallsTests {
     }
 
     @Test
-    fun banSuccess() {
+    fun banSuccess() = runTest {
         val targetUserId = "target-id"
         val timeout = 13
         val reason = "reason"
@@ -71,7 +73,7 @@ internal class UsersApiCallsTests {
             mock.channelId,
             reason,
             timeout
-        ).execute()
+        ).await()
 
         verifySuccess(
             result,
@@ -80,7 +82,7 @@ internal class UsersApiCallsTests {
     }
 
     @Test
-    fun unbanSuccess() {
+    fun unbanSuccess() = runTest {
         val targetUserId = "target-id"
 
         Mockito.`when`(
@@ -96,7 +98,7 @@ internal class UsersApiCallsTests {
             targetUserId,
             mock.channelType,
             mock.channelId
-        ).execute()
+        ).await()
 
         verifySuccess(
             result,
@@ -105,7 +107,7 @@ internal class UsersApiCallsTests {
     }
 
     @Test
-    fun flagSuccess() {
+    fun flagSuccess() = runTest {
         val targetUserId = "target-id"
         val user = User("user-id")
         val targetUser = User(targetUserId)
@@ -127,13 +129,13 @@ internal class UsersApiCallsTests {
             mock.api.flagUser(targetUserId)
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagUser(targetUserId).execute()
+        val result = client.flagUser(targetUserId).await()
 
         verifySuccess(result, flag)
     }
 
     @Test
-    fun flagUserSuccess() {
+    fun flagUserSuccess() = runTest {
         val targetUserId = "target-id"
         val user = User("user-id")
         val targetUser = User(targetUserId)
@@ -155,13 +157,13 @@ internal class UsersApiCallsTests {
             mock.api.flagUser(targetUserId)
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagUser(targetUserId).execute()
+        val result = client.flagUser(targetUserId).await()
 
         verifySuccess(result, flag)
     }
 
     @Test
-    fun flagMessageSuccess() {
+    fun flagMessageSuccess() = runTest {
         val targetMessageId = "message-id"
         val user = User("user-id")
         val date = Date()
@@ -182,13 +184,13 @@ internal class UsersApiCallsTests {
             mock.api.flagMessage(targetMessageId)
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagMessage(targetMessageId).execute()
+        val result = client.flagMessage(targetMessageId).await()
 
         verifySuccess(result, flag)
     }
 
     @Test
-    fun getUsersSuccess() {
+    fun getUsersSuccess() = runTest {
         val user = User().apply { id = "a-user" }
 
         val request = QueryUsersRequest(Filters.eq("id", "1"), 0, 1)
@@ -199,13 +201,13 @@ internal class UsersApiCallsTests {
 
         val result = client.queryUsers(
             request
-        ).execute()
+        ).await()
 
         verifySuccess(result, listOf(user))
     }
 
     @Test
-    fun removeMembersSuccess() {
+    fun removeMembersSuccess() = runTest {
         val channel = Channel()
             .apply { id = "a-channel" }
 
@@ -219,13 +221,13 @@ internal class UsersApiCallsTests {
         ).thenReturn(RetroSuccess(channel).toRetrofitCall())
 
         val result =
-            client.removeMembers(mock.channelType, mock.channelId, listOf("a-id", "b-id")).execute()
+            client.removeMembers(mock.channelType, mock.channelId, listOf("a-id", "b-id")).await()
 
         verifySuccess(result, channel)
     }
 
     @Test
-    fun muteUserSuccess() {
+    fun muteUserSuccess() = runTest {
         val targetUser = User().apply { id = "target-id" }
         val mute = Mute(
             mock.user,
@@ -241,20 +243,20 @@ internal class UsersApiCallsTests {
             )
         ).thenReturn(RetroSuccess(mute).toRetrofitCall())
 
-        val result = client.muteUser(targetUser.id).execute()
+        val result = client.muteUser(targetUser.id).await()
 
         verifySuccess(result, mute)
     }
 
     @Test
-    fun unmuteUserSuccess() {
+    fun unmuteUserSuccess() = runTest {
         val targetUser = User().apply { id = "target-id" }
 
         Mockito.`when`(
             mock.api.unmuteUser(targetUser.id)
         ).thenReturn(RetroSuccess(Unit).toRetrofitCall())
 
-        val result = client.unmuteUser(targetUser.id).execute()
+        val result = client.unmuteUser(targetUser.id).await()
 
         verifySuccess(result, Unit)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/ExtraDataValidatorTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/ExtraDataValidatorTests.kt
@@ -21,14 +21,17 @@ import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeFalse
-import org.junit.Test
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
+@ExtendWith(TestCoroutineExtension::class)
 internal class ExtraDataValidatorTests {
 
     private val chatApi: ChatApi = mock()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/ExtraDataValidatorTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/ExtraDataValidatorTests.kt
@@ -17,12 +17,14 @@
 package io.getstream.chat.android.client.api.internal
 
 import io.getstream.chat.android.client.api.ChatApi
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeFalse
 import org.junit.jupiter.api.Test
@@ -38,7 +40,7 @@ internal class ExtraDataValidatorTests {
     private val validator = ExtraDataValidator(chatApi)
 
     @Test
-    fun testUpdateChannel() {
+    fun testUpdateChannel() = runTest {
         /* Given */
         val channel: Channel = mock()
         val channelId = "channel-id"
@@ -54,7 +56,7 @@ internal class ExtraDataValidatorTests {
             channelType = channelType,
             extraData = extraData,
             updateMessage = updateMessage
-        ).execute()
+        ).await()
 
         /* Then */
         println("[testUpdateChannel] error.message: \"${result.error().message}\"")
@@ -63,7 +65,7 @@ internal class ExtraDataValidatorTests {
     }
 
     @Test
-    fun testUpdateChannelPartial() {
+    fun testUpdateChannelPartial() = runTest {
         /* Given */
         val channel: Channel = mock()
         val channelId = "channel-id"
@@ -79,7 +81,7 @@ internal class ExtraDataValidatorTests {
             channelType = channelType,
             set = set,
             unset = unset
-        ).execute()
+        ).await()
 
         /* Then */
         println("[testUpdateChannelPartial] error.message: \"${result.error().message}\"")
@@ -88,7 +90,7 @@ internal class ExtraDataValidatorTests {
     }
 
     @Test
-    fun testUpdateMessage() {
+    fun testUpdateMessage() = runTest {
         /* Given */
         val message: Message = mock()
         val extraData: MutableMap<String, Any> = mutableMapOf("cid" to "another-cid")
@@ -97,7 +99,7 @@ internal class ExtraDataValidatorTests {
         whenever(chatApi.updateMessage(message)) doReturn message.asCall()
 
         /* When */
-        val result: Result<Message> = validator.updateMessage(message).execute()
+        val result: Result<Message> = validator.updateMessage(message).await()
 
         /* Then */
         println("[testUpdateMessage] error.message: \"${result.error().message}\"")
@@ -106,7 +108,7 @@ internal class ExtraDataValidatorTests {
     }
 
     @Test
-    fun testPartialUpdateMessage() {
+    fun testPartialUpdateMessage() = runTest {
         /* Given */
         val messageId = "message-id"
         val message: Message = mock()
@@ -116,7 +118,7 @@ internal class ExtraDataValidatorTests {
         whenever(chatApi.partialUpdateMessage(messageId, set, unset)) doReturn message.asCall()
 
         /* When */
-        val result: Result<Message> = validator.partialUpdateMessage(messageId, set, unset).execute()
+        val result: Result<Message> = validator.partialUpdateMessage(messageId, set, unset).await()
 
         /* Then */
         println("[testPartialUpdateMessage] error.message: \"${result.error().message}\"")
@@ -125,7 +127,7 @@ internal class ExtraDataValidatorTests {
     }
 
     @Test
-    fun testUpdateUsers() {
+    fun testUpdateUsers() = runTest {
         /* Given */
         val user: User = mock()
         val users = listOf(user)
@@ -137,7 +139,7 @@ internal class ExtraDataValidatorTests {
         whenever(chatApi.updateUsers(users)) doReturn users.asCall()
 
         /* When */
-        val result: Result<List<User>> = validator.updateUsers(users).execute()
+        val result: Result<List<User>> = validator.updateUsers(users).await()
 
         /* Then */
         println("[testUpdateUsers] error.message: \"${result.error().message}\"")
@@ -147,7 +149,7 @@ internal class ExtraDataValidatorTests {
     }
 
     @Test
-    fun testPartialUpdateUser() {
+    fun testPartialUpdateUser() = runTest {
         /* Given */
         val userId = "user-id"
         val user: User = mock()
@@ -159,7 +161,7 @@ internal class ExtraDataValidatorTests {
         whenever(chatApi.partialUpdateUser(userId, set, unset)) doReturn user.asCall()
 
         /* When */
-        val result: Result<User> = validator.partialUpdateUser(userId, set, unset).execute()
+        val result: Result<User> = validator.partialUpdateUser(userId, set, unset).await()
 
         /* Then */
         println("[testPartialUpdateUser] error.message: \"${result.error().message}\"")

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/BaseChatClientTest.kt
@@ -29,19 +29,20 @@ import io.getstream.chat.android.client.token.TokenManager
 import io.getstream.chat.android.client.utils.TokenUtils
 import io.getstream.chat.android.client.utils.retry.NoRetryPolicy
 import io.getstream.chat.android.test.TestCoroutineExtension
-import io.getstream.chat.android.test.TestCoroutineRule
-import org.junit.Rule
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.mockito.kotlin.mock
 
-@ExtendWith(value = [TestCoroutineExtension::class])
 internal open class BaseChatClientTest {
-    @get:Rule
-    val coroutineRule = TestCoroutineRule()
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     @Mock
     protected lateinit var socketStateService: SocketStateService
@@ -70,7 +71,7 @@ internal open class BaseChatClientTest {
 
     @BeforeEach
     fun before() {
-        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = coroutineRule.testDispatcher)
+        val lifecycleOwner = TestLifecycleOwner(coroutineDispatcher = testCoroutines.dispatcher)
         MockitoAnnotations.openMocks(this)
         plugins = mutableListOf()
         chatClient = ChatClient(
@@ -84,7 +85,7 @@ internal open class BaseChatClientTest {
             userCredentialStorage = mock(),
             userStateService = userStateService,
             tokenUtils = tokenUtils,
-            scope = coroutineRule.scope,
+            scope = testCoroutines.scope,
             retryPolicy = NoRetryPolicy(),
             initializationCoordinator = initializationCoordinator,
             appSettingsManager = mock(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenMarkReadChannel.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenMarkReadChannel.kt
@@ -17,11 +17,13 @@
 package io.getstream.chat.android.client.chatclient
 
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.test.asCall
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be`
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -32,26 +34,26 @@ import org.mockito.kotlin.whenever
 internal class WhenMarkReadChannel : BaseChatClientTest() {
 
     @Test
-    fun `Given offline plugin with failing precondition Should not make API call and return error result`() {
+    fun `Given offline plugin with failing precondition Should not make API call and return error result`() = runTest {
         val plugin = mock<ChannelMarkReadListenerPlugin> {
             onBlocking { it.onChannelMarkReadPrecondition(any(), any()) } doReturn Result.error(ChatError())
         }
         val sut = Fixture().givenPlugin(plugin).get()
 
-        val result = sut.markRead("channelType", "channelId").execute()
+        val result = sut.markRead("channelType", "channelId").await()
 
         result.isError `should be` true
         result.isSuccess `should be` false
     }
 
     @Test
-    fun `Given offline plugin with success precondition Should invoke API call`() {
+    fun `Given offline plugin with success precondition Should invoke API call`() = runTest {
         val plugin = mock<ChannelMarkReadListenerPlugin> {
             onBlocking { it.onChannelMarkReadPrecondition(any(), any()) } doReturn Result.success(Unit)
         }
         val sut = Fixture().givenPlugin(plugin).get()
 
-        val result = sut.markRead("channelType", "channelId").execute()
+        val result = sut.markRead("channelType", "channelId").await()
 
         result.isError `should be` false
         result.isSuccess `should be` true

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryChannel.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryChannel.kt
@@ -104,7 +104,7 @@ internal class WhenQueryChannel : BaseChatClientTest() {
 
         fun givenChannelResponse(channelProvider: () -> Channel) = apply {
             whenever(api.queryChannel(any(), any(), any())) doAnswer {
-                CoroutineCall(coroutineRule.scope) {
+                CoroutineCall(testCoroutines.scope) {
                     Result.success(channelProvider())
                 }
             }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryChannel.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryChannel.kt
@@ -19,12 +19,14 @@ package io.getstream.chat.android.client.chatclient
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.call.CoroutineCall
+import io.getstream.chat.android.client.call.await
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.test.asCall
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
@@ -37,35 +39,35 @@ import org.mockito.kotlin.whenever
 internal class WhenQueryChannel : BaseChatClientTest() {
 
     @Test
-    fun `Given offline plugin with failing precondition Should not make API call and return error result`() {
+    fun `Given offline plugin with failing precondition Should not make API call and return error result`() = runTest {
         val plugin = mock<QueryChannelListenerPlugin> {
             onBlocking { it.onQueryChannelPrecondition(any(), any(), any()) } doReturn Result.error(ChatError())
         }
         var isNetworkApiCalled = false
         val sut = Fixture().givenPlugin(plugin).givenChannelResponse { isNetworkApiCalled = true; mock() }.get()
 
-        val result = sut.queryChannel("channelType", "channelId", QueryChannelRequest()).execute()
+        val result = sut.queryChannel("channelType", "channelId", QueryChannelRequest()).await()
 
         result.isError `should be` true
         isNetworkApiCalled `should be` false
     }
 
     @Test
-    fun `Given offline plugin with success precondition Should make API call and return it's result`() {
+    fun `Given offline plugin with success precondition Should make API call and return it's result`() = runTest {
         val plugin = mock<QueryChannelListenerPlugin> {
             onBlocking { it.onQueryChannelPrecondition(any(), any(), any()) } doReturn Result.success(Unit)
         }
         var isNetworkApiCalled = false
         val sut = Fixture().givenPlugin(plugin).givenChannelResponse { isNetworkApiCalled = true; mock() }.get()
 
-        val result = sut.queryChannel("channelType", "channelId", QueryChannelRequest()).execute()
+        val result = sut.queryChannel("channelType", "channelId", QueryChannelRequest()).await()
 
         result.isSuccess `should be` true
         isNetworkApiCalled `should be` true
     }
 
     @Test
-    fun `Given offline plugin with success precondition Should invoke methods in right order`() {
+    fun `Given offline plugin with success precondition Should invoke methods in right order`() = runTest {
         val list = mutableListOf<Int>()
         val plugin = mock<QueryChannelListenerPlugin> {
             onBlocking { it.onQueryChannelPrecondition(any(), any(), any()) } doAnswer {
@@ -87,7 +89,7 @@ internal class WhenQueryChannel : BaseChatClientTest() {
             mock()
         }.get()
 
-        sut.queryChannel("channelType", "channelId", QueryChannelRequest()).execute()
+        sut.queryChannel("channelType", "channelId", QueryChannelRequest()).await()
 
         list `should be equal to` listOf(1, 2, 3, 4)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/TokenUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/TokenUtilsTest.kt
@@ -16,11 +16,9 @@
 
 package io.getstream.chat.android.client.utils
 
-import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.randomString
 import org.amshove.kluent.`should be equal to`
 import org.junit.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.runner.RunWith
 import org.robolectric.ParameterizedRobolectricTestRunner
 import org.robolectric.annotation.Config
@@ -38,9 +36,6 @@ internal class TokenUtilsTest(
     }
 
     companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
 
         @Suppress("MaxLineLength")
         @JvmStatic

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -40,7 +40,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -52,6 +52,7 @@ import org.mockito.kotlin.whenever
 import java.util.Date
 
 @ExperimentalCoroutinesApi
+@ExtendWith(TestCoroutineExtension::class)
 internal class ChannelListViewModelTest {
 
     @Test
@@ -335,9 +336,6 @@ internal class ChannelListViewModelTest {
     }
 
     companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
 
         private val queryFilter = Filters.and(
             Filters.eq("type", "messaging"),

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModelTest.kt
@@ -25,7 +25,7 @@ import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -34,6 +34,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
+@ExtendWith(TestCoroutineExtension::class)
 internal class AttachmentsPickerViewModelTest {
 
     @Test
@@ -126,9 +127,6 @@ internal class AttachmentsPickerViewModelTest {
     }
 
     companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
 
         private val imageAttachment1 = AttachmentMetaData(
             mimeType = "image/jpeg",

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -42,7 +42,7 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be instance of`
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
@@ -52,6 +52,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
+@ExtendWith(TestCoroutineExtension::class)
 internal class MessageComposerViewModelTest {
 
     @Test
@@ -390,9 +391,6 @@ internal class MessageComposerViewModelTest {
     }
 
     companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
 
         val user1 = User(
             id = "Jc",

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
@@ -74,7 +74,7 @@ import io.getstream.chat.android.test.randomDate
 import io.getstream.chat.android.test.randomFile
 import io.getstream.chat.android.test.randomInt
 import io.getstream.chat.android.test.randomString
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.asExecutor
 import java.util.Date
 import java.util.concurrent.Executors
@@ -782,13 +782,13 @@ internal fun randomQueryChannelsEntity(
     cids: List<String> = emptyList(),
 ): QueryChannelsEntity = QueryChannelsEntity(id, filter, querySort, cids)
 
-internal fun createRoomDB(dispatcher: CoroutineDispatcher): ChatDatabase =
+internal fun createRoomDB(): ChatDatabase =
     Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext(), ChatDatabase::class.java)
         .allowMainThreadQueries()
         // Use a separate thread for Room transactions to avoid deadlocks. This means that tests that run Room
         // transactions can't use testCoroutines.scope.runBlockingTest, and have to simply use runBlocking instead.
         .setTransactionExecutor(Executors.newSingleThreadExecutor())
-        .setQueryExecutor(dispatcher.asExecutor())
+        .setQueryExecutor(Dispatchers.IO.asExecutor())
         .build()
 
 internal fun randomNotificationAddedToChannelEvent(

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/SynchronizedCoroutineTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/SynchronizedCoroutineTest.kt
@@ -19,7 +19,6 @@ package io.getstream.chat.android.offline
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 
@@ -34,7 +33,7 @@ internal interface SynchronizedCoroutineTest {
     fun getTestScope(): TestScope
 
     /** Helper function that synchronize test scope and run your test in another scope blocking. */
-    fun coroutineTest(block: suspend CoroutineScope.() -> Unit): Unit = runBlocking {
+    fun coroutineTest(block: suspend CoroutineScope.() -> Unit): Unit = runTest {
         getTestScope().launch(block = block).join()
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/CreateChannelTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/CreateChannelTests.kt
@@ -27,12 +27,10 @@ import io.getstream.chat.android.offline.randomChannel
 import io.getstream.chat.android.offline.randomMember
 import io.getstream.chat.android.offline.randomUser
 import io.getstream.chat.android.offline.repository.builder.internal.RepositoryFacade
-import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -41,11 +39,6 @@ import org.mockito.kotlin.whenever
 
 @OptIn(ExperimentalCoroutinesApi::class)
 internal class CreateChannelTests {
-    companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
-    }
 
     @Test
     fun `Given offline user When creating channel Should mark it with sync needed and store in database`(): Unit =

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeTrue
 import org.junit.Before
@@ -82,7 +82,7 @@ internal class UploadAttachmentsIntegrationTests : BaseRepositoryFacadeIntegrati
 
     @Test
     fun `Given a message with attachments When upload fails Should store the correct upload state`(): Unit =
-        runBlocking {
+        runTest {
             val attachments = randomAttachmentsWithFile().map {
                 it.copy(uploadState = Attachment.UploadState.Idle)
             }.toMutableList()
@@ -101,7 +101,7 @@ internal class UploadAttachmentsIntegrationTests : BaseRepositoryFacadeIntegrati
 
     @Test
     fun `Given a message with attachments When upload succeeds Should store the correct upload state`(): Unit =
-        runBlocking {
+        runTest {
             val attachments = randomAttachmentsWithFile().map {
                 it.copy(uploadState = Attachment.UploadState.Idle)
             }.toMutableList()

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/event/TotalUnreadCountTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/event/TotalUnreadCountTest.kt
@@ -30,7 +30,6 @@ import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.logging.StreamLog
 import io.getstream.logging.kotlin.KotlinStreamLogger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.BeforeAll
@@ -164,7 +163,7 @@ internal class TotalUnreadCountTest {
         }
 
         fun givenMockedRepositories(): Fixture {
-            runBlocking {
+            runTest {
                 whenever(repos.selectMessages(any(), any())) doReturn emptyList()
                 whenever(repos.selectChannels(any(), any<Boolean>())) doReturn emptyList()
             }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/events/TypingEventsTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/events/TypingEventsTest.kt
@@ -24,13 +24,11 @@ import io.getstream.chat.android.offline.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.plugin.state.channel.internal.toMutableState
 import io.getstream.chat.android.offline.randomUser
 import io.getstream.chat.android.test.TestCoroutineExtension
-import io.getstream.chat.android.test.TestCoroutineRule
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
-import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.mock
@@ -38,9 +36,6 @@ import java.util.Date
 
 @ExperimentalCoroutinesApi
 internal class TypingEventsTest {
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
-
     companion object {
         @JvmField
         @RegisterExtension

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -48,6 +48,7 @@ import io.getstream.chat.android.offline.utils.TestDataHelper
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
 import kotlinx.coroutines.runBlocking
@@ -185,7 +186,7 @@ internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
             // This means that tests that run Room transactions can't use testCoroutines.scope.runBlockingTest,
             // and have to simply use runBlocking instead
             .setTransactionExecutor(Executors.newSingleThreadExecutor())
-            .setQueryExecutor(testCoroutines.ioDispatcher.asExecutor())
+            .setQueryExecutor(Dispatchers.IO.asExecutor())
             .build()
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -51,8 +51,8 @@ import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.asExecutor
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeFalse
 import org.amshove.kluent.shouldBeTrue
 import org.junit.After
@@ -108,7 +108,7 @@ internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
     }
 
     @After
-    open fun tearDown() = runBlocking {
+    open fun tearDown() = runTest {
         db.close()
     }
 
@@ -190,7 +190,7 @@ internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
             .build()
     }
 
-    private fun createChatDomain(client: ChatClient, db: ChatDatabase): Unit = runBlocking {
+    private fun createChatDomain(client: ChatClient, db: ChatDatabase): Unit = runTest {
         val context = ApplicationProvider.getApplicationContext() as Context
 
         repos = RepositoryFacade.create(

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseRepositoryFacadeIntegrationTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseRepositoryFacadeIntegrationTest.kt
@@ -49,7 +49,7 @@ internal open class BaseRepositoryFacadeIntegrationTest {
     @Before
     @CallSuper
     open fun setup() {
-        chatDatabase = createRoomDB(testCoroutines.ioDispatcher)
+        chatDatabase = createRoomDB()
         repositoryFacade = createRepositoryFacade()
     }
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/reactions/DeleteReactionsTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/reactions/DeleteReactionsTests.kt
@@ -34,7 +34,6 @@ import io.getstream.chat.android.offline.plugin.state.global.internal.MutableGlo
 import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.offline.repository.builder.internal.RepositoryFacade
 import io.getstream.chat.android.test.TestCoroutineExtension
-import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.randomCID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -42,7 +41,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
-import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.argThat
@@ -53,8 +51,6 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 internal class DeleteReactionsTests {
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
 
     companion object {
         @JvmField

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/reactions/SendReactionsTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/reactions/SendReactionsTests.kt
@@ -31,7 +31,6 @@ import io.getstream.chat.android.offline.plugin.state.channel.internal.toMutable
 import io.getstream.chat.android.offline.plugin.state.global.internal.MutableGlobalState
 import io.getstream.chat.android.offline.repository.builder.internal.RepositoryFacade
 import io.getstream.chat.android.test.TestCoroutineExtension
-import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.randomCID
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -39,7 +38,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
-import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.doReturn
@@ -48,8 +46,6 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 internal class SendReactionsTests {
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
 
     companion object {
         @JvmField

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ChannelRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ChannelRepositoryTest.kt
@@ -18,7 +18,7 @@ package io.getstream.chat.android.offline.repository
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.offline.integration.BaseDomainTest2
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
 import org.junit.Test
@@ -29,7 +29,7 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
     private val helper by lazy { repos }
 
     @Test
-    fun `inserting a channel and reading it should be equal`(): Unit = runBlocking {
+    fun `inserting a channel and reading it should be equal`(): Unit = runTest {
         helper.insertChannels(listOf(data.channel1))
         helper.clearChannelCache()
         val channel = helper.selectChannelWithoutMessages(data.channel1.cid)!!
@@ -39,7 +39,7 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
     }
 
     @Test
-    fun `deleting a channel should work`(): Unit = runBlocking {
+    fun `deleting a channel should work`(): Unit = runTest {
         helper.insertChannels(listOf(data.channel1))
         helper.deleteChannel(data.channel1.cid)
         val entity = helper.selectChannelWithoutMessages(data.channel1.cid)
@@ -48,7 +48,7 @@ internal class ChannelRepositoryTest : BaseDomainTest2() {
     }
 
     @Test
-    fun `updating a channel should work as intended`(): Unit = runBlocking {
+    fun `updating a channel should work as intended`(): Unit = runTest {
         helper.insertChannels(listOf(data.channel1, data.channel1Updated))
         val channel = helper.selectChannelWithoutMessages(data.channel1.cid)!!
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ReactionRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ReactionRepositoryTest.kt
@@ -27,7 +27,6 @@ import io.getstream.chat.android.offline.repository.domain.reaction.internal.toE
 import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.coInvoking
 import org.amshove.kluent.`should be equal to`
@@ -52,7 +51,7 @@ internal class ReactionRepositoryTest {
 
     @BeforeEach
     fun setup() {
-        runBlocking {
+        runTest {
             currentUser = randomUser()
             reactionDao = mock()
             reactionRepo = DatabaseReactionRepository(reactionDao) { currentUser }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/BaseRepositoryFacadeTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/BaseRepositoryFacadeTest.kt
@@ -26,13 +26,20 @@ import io.getstream.chat.android.client.persistance.repository.ReactionRepositor
 import io.getstream.chat.android.client.persistance.repository.SyncStateRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.offline.repository.builder.internal.RepositoryFacade
+import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.TestScope
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.mock
 
 @ExperimentalCoroutinesApi
 internal open class BaseRepositoryFacadeTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+    }
 
     protected lateinit var users: UserRepository
     protected lateinit var configs: ChannelConfigRepository
@@ -42,8 +49,6 @@ internal open class BaseRepositoryFacadeTest {
     protected lateinit var reactions: ReactionRepository
     protected lateinit var syncState: SyncStateRepository
     protected lateinit var attachmentRepository: AttachmentRepository
-
-    protected val scope = TestScope()
 
     protected lateinit var sut: RepositoryFacade
 
@@ -68,7 +73,7 @@ internal open class BaseRepositoryFacadeTest {
             reactionsRepository = reactions,
             syncStateRepository = syncState,
             attachmentRepository = attachmentRepository,
-            scope = scope,
+            scope = testCoroutines.scope,
             defaultConfig = mock(),
         )
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeIntegrationTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeIntegrationTests.kt
@@ -24,7 +24,7 @@ import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.offline.randomReaction
 import io.getstream.chat.android.offline.randomUser
 import io.getstream.chat.android.test.randomString
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeNull
@@ -38,7 +38,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
 
     @Test
     fun `Given a message in the database When persisting the updated message Should store the update`(): Unit =
-        runBlocking {
+        runTest {
             val id = randomString()
             val originalMessage = randomMessage(id = id)
             val updatedText = randomString()
@@ -53,7 +53,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
         }
 
     @Test
-    fun `Given a message When persisting the message Should store required fields`(): Unit = runBlocking {
+    fun `Given a message When persisting the message Should store required fields`(): Unit = runTest {
         val message = randomMessage(
             user = randomUser(
                 // ignoring fields that are not persisted on purpose
@@ -78,7 +78,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
 
     @Test
     fun `Given a message with theirs reaction When querying message Should return massage without own reactions`(): Unit =
-        runBlocking {
+        runTest {
             val messageId = randomString()
             val theirsUser = randomUser(
                 // ignoring fields that are not persisted on purpose
@@ -110,7 +110,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
 
     @Test
     fun `Given a message with deleted own reaction When querying message Should return massage without own reactions`(): Unit =
-        runBlocking {
+        runTest {
             val messageId = randomString()
             val mineDeletedReaction = randomReaction(
                 messageId = messageId,
@@ -135,7 +135,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
 
     @Test
     fun `Given a message without channel info When querying message Should return message with null channel info`() =
-        runBlocking {
+        runTest {
             val message = randomMessage(channelInfo = null)
 
             repositoryFacade.insertMessages(listOf(message), cache = false)
@@ -146,7 +146,7 @@ internal class RepositoryFacadeIntegrationTests : BaseRepositoryFacadeIntegratio
 
     @Test
     fun `Given a message with channel info When querying message Should return message with the same channel info`(): Unit =
-        runBlocking {
+        runTest {
             val channelInfo = randomChannelInfo()
             val message = randomMessage(channelInfo = channelInfo)
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
@@ -29,7 +29,6 @@ import io.getstream.chat.android.offline.randomMember
 import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.offline.randomReaction
 import io.getstream.chat.android.offline.randomUser
-import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.positiveRandomInt
 import io.getstream.chat.android.test.randomBoolean
 import io.getstream.chat.android.test.randomCID
@@ -39,7 +38,6 @@ import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain same`
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.check
@@ -52,8 +50,6 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
 
     @Test
     fun `Given request less than last message When select channels Should return channels from DB with empty messages`() =

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/RepositoryFacadeTests.kt
@@ -33,7 +33,6 @@ import io.getstream.chat.android.test.positiveRandomInt
 import io.getstream.chat.android.test.randomBoolean
 import io.getstream.chat.android.test.randomCID
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should contain same`
@@ -69,8 +68,8 @@ internal class RepositoryFacadeTests : BaseRepositoryFacadeTest() {
         }
 
     @Test
-    fun `Given request more than last message When select channels Should return channels from DB with messages`() =
-        runBlocking {
+    fun `Given request more than last message When select channels Should return channels from DB with messages`(): Unit =
+        runTest {
             val paginationRequest = AnyChannelPaginationRequest(100)
             val user = randomUser(id = "userId")
             whenever(users.selectUser("userId")) doReturn user

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/WhenUpdateLastMessage.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/facade/WhenUpdateLastMessage.kt
@@ -18,10 +18,8 @@ package io.getstream.chat.android.offline.repository.facade
 
 import io.getstream.chat.android.offline.randomChannel
 import io.getstream.chat.android.offline.randomMessage
-import io.getstream.chat.android.test.TestCoroutineRule
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -33,8 +31,6 @@ import java.util.Date
 
 @ExperimentalCoroutinesApi
 internal class WhenUpdateLastMessage : BaseRepositoryFacadeTest() {
-    @get:Rule
-    val testCoroutines: TestCoroutineRule = TestCoroutineRule()
 
     @Test
     fun `Given no channel in DB Should not do insert`() = runTest {

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/integration/MessageRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/integration/MessageRepositoryTest.kt
@@ -22,7 +22,7 @@ import io.getstream.chat.android.offline.integration.BaseDomainTest2
 import io.getstream.chat.android.offline.randomAttachment
 import io.getstream.chat.android.offline.randomMessage
 import io.getstream.chat.android.test.randomString
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.coInvoking
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldNotThrow
@@ -34,7 +34,7 @@ internal class MessageRepositoryTest : BaseDomainTest2() {
 
     @Test
     fun `Given message with 3 attachments When update it in DB Should keep only 3 newer attachments`(): Unit =
-        runBlocking {
+        runTest {
             val attachment1 = randomAttachment { url = "url1" }
             val attachment2 = randomAttachment { url = "url2" }
             val attachment3 = randomAttachment { url = "url3" }
@@ -56,12 +56,12 @@ internal class MessageRepositoryTest : BaseDomainTest2() {
         }
 
     @Test
-    fun `When selecting more than 999 messages Should not throw SQLiteException`(): Unit = runBlocking {
+    fun `When selecting more than 999 messages Should not throw SQLiteException`(): Unit = runTest {
         coInvoking { repos.selectMessages(List(1000) { randomString() }) } shouldNotThrow (SQLiteException::class)
     }
 
     @Test
-    fun `When inserting more than 999 messages Should not throw SQLiteException`(): Unit = runBlocking {
+    fun `When inserting more than 999 messages Should not throw SQLiteException`(): Unit = runTest {
         coInvoking { repos.insertMessages(List(1000) { randomMessage() }) } shouldNotThrow (SQLiteException::class)
     }
 }

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineExtension.kt
@@ -20,6 +20,7 @@ package io.getstream.chat.android.test
 
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -28,13 +29,15 @@ import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
+import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
-public class TestCoroutineExtension : BeforeAllCallback, AfterEachCallback, AfterAllCallback {
+public class TestCoroutineExtension : BeforeEachCallback, BeforeAllCallback, AfterEachCallback, AfterAllCallback {
 
-    public val dispatcher: TestDispatcher = UnconfinedTestDispatcher()
-    public val scope: TestScope = TestScope(dispatcher)
-
+    private var _scope: TestScope? = null
+    public val dispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+    public val scope: TestScope
+        get() = requireNotNull(_scope)
     private var beforeAllCalled: Boolean = false
 
     override fun beforeAll(context: ExtensionContext) {
@@ -53,5 +56,10 @@ public class TestCoroutineExtension : BeforeAllCallback, AfterEachCallback, Afte
     override fun afterAll(context: ExtensionContext) {
         Dispatchers.resetMain()
         DispatcherProvider.reset()
+        _scope = null
+    }
+
+    override fun beforeEach(context: ExtensionContext?) {
+        _scope = TestScope(dispatcher)
     }
 }

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
@@ -22,11 +22,9 @@ import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
@@ -51,6 +49,3 @@ public class TestCoroutineRule : TestWatcher() {
         DispatcherProvider.reset()
     }
 }
-
-public fun TestCoroutineRule.runTest(testBody: suspend TestScope.() -> Unit): TestResult =
-    scope.runTest(testBody = testBody)

--- a/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
+++ b/stream-chat-android-test/src/main/java/io/getstream/chat/android/test/TestCoroutineRule.kt
@@ -19,8 +19,8 @@
 package io.getstream.chat.android.test
 
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.TestScope
@@ -33,8 +33,7 @@ import org.junit.runner.Description
 
 public class TestCoroutineRule : TestWatcher() {
 
-    public val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
-    public val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    public val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
     public val scope: TestScope = TestScope(testDispatcher)
 
     override fun starting(description: Description) {

--- a/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/com/getstream/sdk/chat/utils/StartStopBufferTest.kt
@@ -21,16 +21,11 @@ import io.getstream.chat.android.test.randomString
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.extension.RegisterExtension
+import org.junit.jupiter.api.extension.ExtendWith
 
 @ExperimentalCoroutinesApi
+@ExtendWith(TestCoroutineExtension::class)
 internal class StartStopBufferTest {
-
-    companion object {
-        @JvmField
-        @RegisterExtension
-        val testCoroutines = TestCoroutineExtension()
-    }
 
     @Test
     fun `data should only be propagated when enqueueData and subscribe are done`() {


### PR DESCRIPTION
### 🎯 Goal
~**Depend on:** #3771 and #3773~
Our SDK does a heavy use of coroutines, but we weren't running them properly into our tests, having multiple ways to run them (`runBlocking{ }`, creating multiple `TestScopes`, executing it synchronous that didn't skip any `delay()` or other coroutine internal calls...) and sometimes the scope wasn't configure properly

### 🛠 Implementation details
-. Refactor our rules and extensions to provide proper `Dispatchers` and `scopes` to our tests.
-. Avoid any `runBlocking{}` code in our tests and replace them by `runTest{}`
-. Run asynchronous tests with `runTest{}` 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media1.giphy.com/media/xUA7aUNw61j9Vdzs0U/giphy.webp)
