### PR TITLE
Run GH-Action to download localazy translations periodically

### DIFF
--- a/.github/workflows/localazy-download-manual.yml
+++ b/.github/workflows/localazy-download-manual.yml
@@ -1,12 +1,13 @@
 name: Download translations from Localazy
 
 on:
-  workflow_dispatch:
+  schedule:
+    # Every midnight
+    - cron: "0 0 * * *"
 
 jobs:
   localazy-download:
     name: Download strings from Localazy
-    if: github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -14,11 +15,14 @@ jobs:
         with:
           read_key: ${{ secrets.LOCALAZY_READ_KEY }}
           write_key: ${{ secrets.LOCALAZY_WRITE_KEY }}
+      - name: Add license headers
+        run: ./gradlew spotlessApply
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:
             commit-message: Update translations
             title: Update translations
+            delete-branch: true
             body: |
               - Translations downloaded from Localazy
 


### PR DESCRIPTION
### 🎯 Goal
Run GH-Action periodically to be up-to-date when new translations are updated on Localazy website.
The translations from Localazy don't keep the license header, so we need to run Spotless just before we create a PR with the new translations

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- ~[ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~
- [x] PR targets the `develop` branch
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media3.giphy.com/media/SsIZAm4IDC6yUQMa45/giphy.webp)
