### PR TITLE
Fixed the way we build items and data in the message list

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -173,15 +173,13 @@ internal class MessageListItemLiveData(
     internal fun messagesChanged(messages: List<Message>, currentUserId: String): MessageListItemWrapper {
         messageItemsBase = groupMessages(messages, currentUserId)
         messageItemsWithReads = addReads(messageItemsBase, readsLd.value, currentUserId)
-        val out = getLoadingMoreItems() + messageItemsWithReads + typingItems
-        return wrapMessages(out, hasNewMessages)
+        return wrapMessages(buildItemsList(), hasNewMessages)
     }
 
     @UiThread
     internal fun readsChanged(reads: List<ChannelUserRead>, currentUserId: String): MessageListItemWrapper {
         messageItemsWithReads = addReads(messageItemsBase, reads, currentUserId)
-        val out = getLoadingMoreItems() + messageItemsWithReads + typingItems
-        return wrapMessages(out)
+        return wrapMessages(buildItemsList())
     }
 
     /**
@@ -192,7 +190,7 @@ internal class MessageListItemLiveData(
     internal fun typingChanged(newTypingUsers: List<User>): MessageListItemWrapper {
         typingUsers = newTypingUsers
         typingItems = usersAsTypingItems(newTypingUsers)
-        return wrapMessages(getLoadingMoreItems() + messageItemsWithReads + typingItems)
+        return wrapMessages(buildItemsList())
     }
 
     /**
@@ -205,8 +203,20 @@ internal class MessageListItemLiveData(
         messageItemsWithReads = messageItemsWithReads.filter {
             it !is MessageListItem.LoadingMoreIndicatorItem
         }
-        val out = getLoadingMoreItems() + messageItemsWithReads
-        value = wrapMessages(out)
+
+        value = wrapMessages(buildItemsList())
+    }
+
+    /**
+     * Builds a list of items we show in the View, based on the current state.
+     *
+     * We add the loading item at the top, if we're currently loading more data and the typing item at the bottom, if
+     * there are users who are typing.
+     *
+     * @return Full list of [MessageListItem] to represent the state.
+     */
+    private fun buildItemsList(): List<MessageListItem> {
+        return getLoadingMoreItems() + messageItemsWithReads + typingItems
     }
 
     private fun getLoadingMoreItems() = if (loadingMoreInProgress) {


### PR DESCRIPTION
### 🎯 Goal

When showing the typing items in the list, sometimes when scrolling up and down the typing item disappears.

This fixes #3783 

### 🛠 Implementation details

Just added the typing item when we trigger loading more events to make it consistent with everything else.

### 🧪 Testing

Before testing, apply the patch below.

Testing the broken behavior:
1. Run the XML sample on `develop` branch on 2 devices with 2 different users A & B
2. Enter the same channel that has many messages in the history (don't paginate or load them yet)
3. With user A keep typing to trigger typing items.
4. With user B scroll up to trigger pagination and then down, multiple times, while typing with user A.

After some time, or a few times scrolling, the typing item will disappear and not work until state reset.

Testing the fix:
First clear the data of both apps and completely reinstall them.

1. Run the XML sample on `this` branch on 2 devices with 2 different users A & B
2. Enter the same channel that has many messages in the history (don't paginate or load them yet)
3. With user A keep typing to trigger typing items.
4. With user B scroll up to trigger pagination and then down, multiple times, while typing with user A.

In this scenario, regardless of the scrolling, the typing indicator should remain at the bottom, for as long as the user is typing or we have keystroke events.

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/rootContainer"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    >
+
+    <TextView
+        android:id="@+id/typingText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>
\ No newline at end of file
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/TypingIndicatorViewHolder.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/TypingIndicatorViewHolder.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/TypingIndicatorViewHolder.kt
new file mode 100644
--- /dev/null	(date 1656411523308)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/TypingIndicatorViewHolder.kt	(date 1656411523308)
@@ -0,0 +1,52 @@
+package io.getstream.chat.android.ui.message
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.getstream.sdk.chat.adapter.MessageListItem
+import io.getstream.chat.android.ui.databinding.TypingIndicatorViewBinding
+import io.getstream.chat.android.ui.message.list.adapter.BaseMessageItemViewHolder
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemPayloadDiff
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewHolderFactory
+import io.getstream.chat.android.ui.message.list.adapter.MessageListItemViewType
+
+internal class TypingIndicatorViewHolder(
+    parentView: ViewGroup,
+    private val binding: TypingIndicatorViewBinding = TypingIndicatorViewBinding.inflate(
+        LayoutInflater.from(parentView.context),
+        parentView,
+        false
+    )
+) : BaseMessageItemViewHolder<MessageListItem.TypingItem>(binding.root) {
+
+    override fun bindData(data: MessageListItem.TypingItem, diff: MessageListItemPayloadDiff?) {
+        binding.typingText.text = data.users.joinToString { "${it.name}, " }
+    }
+}
+
+internal class MessageViewHolderFactory(
+) : MessageListItemViewHolderFactory() {
+
+    companion object {
+        private const val PROCORE_TYPING_INDICATOR_VIEW_HOLDER_TYPE = 1
+    }
+
+    override fun getItemViewType(item: MessageListItem): Int {
+        return when (val streamChatViewType = super.getItemViewType(item)) {
+
+            MessageListItemViewType.TYPING_INDICATOR -> PROCORE_TYPING_INDICATOR_VIEW_HOLDER_TYPE
+
+            else -> streamChatViewType
+        }
+    }
+
+    override fun createViewHolder(
+        parentView: ViewGroup,
+        viewType: Int,
+    ): BaseMessageItemViewHolder<out MessageListItem> {
+        return when (viewType) {
+            PROCORE_TYPING_INDICATOR_VIEW_HOLDER_TYPE -> TypingIndicatorViewHolder(parentView)
+
+            else -> super.createViewHolder(parentView, viewType)
+        }
+    }
+}
```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs