### PR TITLE
[3796] Set unread count `TextView` layout width to `wrap_content`

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_scroll_button_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_scroll_button_view.xml
@@ -40,7 +40,7 @@
 
     <TextView
         android:id="@+id/unreadCountTextView"
-        android:layout_width="@dimen/stream_ui_scroll_button_unread_badge_size"
+        android:layout_width="wrap_content"
         android:layout_height="@dimen/stream_ui_scroll_button_unread_badge_size"
         android:layout_gravity="center_horizontal"
         android:background="@drawable/stream_ui_shape_scroll_button_badge"


### PR DESCRIPTION
### 🎯 Goal

closes #3796

### 🛠 Implementation details

Use `wrap_content` as the unread count `TextView` parameter instead of a fixed width.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![before_unread_count](https://user-images.githubusercontent.com/37080097/176212115-b264a160-3cbe-43f6-82ad-835451f7f438.png) | ![after_unread](https://user-images.githubusercontent.com/37080097/176212106-2413c8e2-f2a8-4fb1-b3c4-96b8b5bd1ff6.png) |

### 🧪 Testing

Scenario 1:

1. Launch the XML sample app on two different devices with two different users
2. Enter the same channel with both users, and scroll upwards on one device until the scroll helper button appears
3. From the other device send a double-digit (at least 10) amount of messages 

Expectation: The unread count should disappear on develop, but remain readable on the PR branch.

Scenario 2:

Since we're touching something that was worked on in #3634, if you want to make sure there was no regression you can test the following as well:

If you want to test the scroll button layout breaking, use the patch below to deploy the app to a Pixel 2 emulator running API 29 and compare the differences between this branch and develop

<details>

<summary>Patch that introduces scroll button layout clipping</summary>

```
Index: stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt
--- a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt	(revision 4b9d2fd38053954923be95ed1b69855002c72c80)
+++ b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/DebugMetricsHelper.kt	(date 1654092049601)
@@ -33,7 +33,6 @@
             .detectLeakedSqlLiteObjects()
             .detectLeakedClosableObjects()
             .penaltyLog()
-            .penaltyDeath()
             .build()
             .apply {
                 StrictMode.setVmPolicy(this)
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 4b9d2fd38053954923be95ed1b69855002c72c80)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1654092761186)
@@ -23,7 +23,8 @@
     <io.getstream.chat.android.ui.message.list.header.MessageListHeaderView
         android:id="@+id/messagesHeaderView"
         android:layout_width="0dp"
-        android:layout_height="wrap_content"
+        android:layout_height="280dp"
+        android:foreground="@color/stream_gray_dark"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
```

</details>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media4.giphy.com/media/fxHwi5ia9NgTCrl92Z/giphy.gif?cid=ecf05e472lnazp240ttxqzcerul6xfhkg7255em7v2qo8aix&rid=giphy.gif&ct=g)
