### PR TITLE
Improve disconnect method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 ### ⚠️ Changed
 -. `Call` interface provides an `await()` suspend function implemented on every subclass and is not needed to use the extension function anymore. [#3807](https://github.com/GetStream/stream-chat-android/pull/3807)
 - `ChatLoggerHandler` has a new function named `logV`. [#3869](https://github.com/GetStream/stream-chat-android/pull/3869)
+- `ChatClient.disconnect()` is deprecated and a new `ChatClient.disconnect(Boolean)` method with a boolean argument is created. This method return a `Call` to be invoked for disconnection. [#3817](https://github.com/GetStream/stream-chat-android/pull/3817)
 
 ### ❌ Removed
 - 🚨 Breaking change: Removed the `Member.role` field. [3851](https://github.com/GetStream/stream-chat-android/pull/3851)

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `ChatClient::disconnect` | 2022.07.19 <br/>5.6.0 | 2022.08.19 ⌛ | 2022.09.19 ⌛ | Use `ChatClient.disconnect(Boolean)` instead. |
 | `Messages` | 2022.07.19<br/>5.6.0 | 2022.08.16 ⌛ | 2022.09.13 ⌛ | Use new implementation of `Messages` composable. |
 | `MesageListViewModel.loadMore` | 2022.07.19<br/>5.6.0 | 2022.08.16 ⌛ | 2022.09.13 ⌛ | Use `MessageListViewModel.loadOlderMessages` to achieve the same effect in compose. |
 | `ChatLogger` | 2022.07.13 <br/>5.6.0 | 2022.08.13 ⌛ | 2022.09.13 ⌛ | Use `StreamLog` instead.|

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -43,6 +43,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun devToken (Ljava/lang/String;)Ljava/lang/String;
 	public final fun disableSlowMode (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;
 	public final fun disconnect ()V
+	public final fun disconnect (Z)Lio/getstream/chat/android/client/call/Call;
 	public final fun disconnectSocket ()V
 	public final fun enableSlowMode (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun flagMessage (Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -237,7 +237,7 @@ internal constructor(
                     val connectionId = event.connectionId
                     if (ToggleService.isSocketExperimental().not()) {
                         socketStateService.onConnected(connectionId)
-                        lifecycleObserver.observe()
+                        runBlocking(context = scope.coroutineContext) { lifecycleObserver.observe() }
                     }
                     api.setConnection(user.id, connectionId)
                     notifications.onSetUser()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1051,6 +1051,13 @@ internal constructor(
     /**
      * Disconnect the current user, stop all observers and clear user data
      */
+    @Deprecated(
+        message = "It is a blocking method that shouldn't be used from the Main Thread.\n" +
+            "Instead of that, you can use `ChatClient.disconnect(true)` that return a `Call` " +
+            "and run it safe using coroutines.",
+        replaceWith = ReplaceWith("this.disconnect(true).await()"),
+        level = DeprecationLevel.WARNING
+    )
     @WorkerThread
     public fun disconnect() {
         disconnect(true).execute()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/StreamLifecycleObserver.kt
@@ -20,9 +20,7 @@ import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 internal class StreamLifecycleObserver(
     private val lifecycle: Lifecycle,
@@ -33,20 +31,18 @@ internal class StreamLifecycleObserver(
     @Volatile
     private var isObserving = false
 
-    fun observe() {
+    suspend fun observe() {
         if (isObserving.not()) {
             isObserving = true
-            @OptIn(DelicateCoroutinesApi::class)
-            GlobalScope.launch(DispatcherProvider.Main) {
+            withContext(DispatcherProvider.Main) {
                 lifecycle.addObserver(this@StreamLifecycleObserver)
             }
         }
     }
 
-    fun dispose() {
+    suspend fun dispose() {
         if (isObserving) {
-            @OptIn(DelicateCoroutinesApi::class)
-            GlobalScope.launch(DispatcherProvider.Main) {
+            withContext(DispatcherProvider.Main) {
                 lifecycle.addObserver(this@StreamLifecycleObserver)
             }
         }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/ChatNotifications.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/ChatNotifications.kt
@@ -37,7 +37,7 @@ public interface ChatNotifications {
     public fun setDevice(device: Device)
     public fun onPushMessage(message: PushMessage, pushNotificationReceivedListener: PushNotificationReceivedListener)
     public fun onNewMessageEvent(newMessageEvent: NewMessageEvent)
-    public fun onLogout()
+    public suspend fun onLogout()
     public fun displayNotification(channel: Channel, message: Message)
     public fun dismissChannelNotifications(channelType: String, channelId: String)
 }
@@ -92,7 +92,7 @@ internal class ChatNotificationsImpl constructor(
         }
     }
 
-    override fun onLogout() {
+    override suspend fun onLogout() {
         handler.dismissAllNotifications()
         removeStoredDevice()
         cancelLoadDataWork()
@@ -140,10 +140,8 @@ internal class ChatNotificationsImpl constructor(
         }
     }
 
-    private fun removeStoredDevice() {
-        scope.launch {
-            pushTokenUpdateHandler.removeStoredDevice()
-        }
+    private suspend fun removeStoredDevice() {
+        pushTokenUpdateHandler.removeStoredDevice()
     }
 }
 
@@ -156,7 +154,7 @@ internal object NoOpChatNotifications : ChatNotifications {
     ) = Unit
 
     override fun onNewMessageEvent(newMessageEvent: NewMessageEvent) = Unit
-    override fun onLogout() = Unit
+    override suspend fun onLogout() = Unit
     override fun displayNotification(channel: Channel, message: Message) = Unit
     override fun dismissChannelNotifications(channelType: String, channelId: String) = Unit
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
@@ -97,9 +97,9 @@ object ChatHelper {
     /**
      * Logs out the user and removes their credentials from the persistent storage.
      */
-    fun disconnectUser() {
+    suspend fun disconnectUser() {
         ChatApp.credentialsRepository.clearCredentials()
 
-        ChatClient.instance().disconnect()
+        ChatClient.instance().disconnect(false).await()
     }
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.models.Channel
@@ -62,6 +63,7 @@ import io.getstream.chat.android.compose.ui.components.SearchInput
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.channels.ChannelListViewModel
 import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFactory
+import kotlinx.coroutines.launch
 
 class ChannelsActivity : BaseConnectedActivity() {
 
@@ -94,9 +96,10 @@ class ChannelsActivity : BaseConnectedActivity() {
                     onItemClick = ::openMessages,
                     onBackPressed = ::finish,
                     onHeaderAvatarClick = {
-                        ChatHelper.disconnectUser()
-
-                        openUserLogin()
+                        listViewModel.viewModelScope.launch {
+                            ChatHelper.disconnectUser()
+                            openUserLogin()
+                        }
                     }
                 )
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/cms/ClientAndUsers.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/cms/ClientAndUsers.java
@@ -72,7 +72,7 @@ public class ClientAndUsers {
          * @see <a href="https://getstream.io/chat/docs/init_and_users/?language=java#websocket-connections">Websocket Connections</a>
          */
         public void disconnect() {
-            ChatClient.instance().disconnect();
+            ChatClient.instance().disconnect(true).enqueue();
         }
     }
 
@@ -115,8 +115,14 @@ public class ClientAndUsers {
         }
 
         public void loggingOutAndSwitchingUsers(User user, String token) {
-            client.disconnect();
-            client.connectUser(user, token).enqueue(result -> { /* ... */ });
+            client.disconnect(true).enqueue(disconnectResult -> {
+                if(disconnectResult.isSuccess()) {
+                    client.connectUser(user, token).enqueue(result -> { /* ... */ });
+                } else {
+                    // Handle result.error()
+                }
+            });
+
         }
     }
 
@@ -202,8 +208,13 @@ public class ClientAndUsers {
             User user = new User();
             String token = "token";
 
-            client.disconnect();
-            client.connectUser(user, token).enqueue(result -> { /* ... */ });
+            client.disconnect(true).enqueue(disconnectResult -> {
+                if (disconnectResult.isSuccess()) {
+                    client.connectUser(user, token).enqueue(loginResult -> { /* ... */ });
+                } else {
+                    // Handle result.error()
+                }
+            });
         }
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragmentViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/home/HomeFragmentViewModel.kt
@@ -21,11 +21,13 @@ import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.livedata.utils.Event
 import io.getstream.chat.android.offline.extensions.globalState
 import io.getstream.chat.ui.sample.application.App
+import kotlinx.coroutines.launch
 
 class HomeFragmentViewModel : ViewModel() {
 
@@ -53,9 +55,11 @@ class HomeFragmentViewModel : ViewModel() {
     fun onUiAction(action: UiAction) {
         when (action) {
             is UiAction.LogoutClicked -> {
-                ChatClient.instance().disconnect()
-                App.instance.userRepository.clearUser()
-                _events.value = Event(UiEvent.NavigateToLoginScreen)
+                viewModelScope.launch {
+                    ChatClient.instance().disconnect(false).await()
+                    App.instance.userRepository.clearUser()
+                    _events.value = Event(UiEvent.NavigateToLoginScreen)
+                }
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal
Fix #3643
Ensure `disconnect()` process is completed before any other action can be run to avoid any race-condition in our `ChatClient`.
On the other hand, a new `ChatClient.disconnect()` method is created that return a `Call` instance to be run properly.

### 🧪 Testing
Run sample apps and verify login/logout work properly. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media4.giphy.com/media/ftvphb1LgYP9SgoNGn/giphy.webp)
