### PR TITLE
[3829] Fix sectioned avatars

### DIFF
--- a/stream-chat-android-offline/src/main/java/com/squareup/moshi/MultiMapJsonAdapter.kt
+++ b/stream-chat-android-offline/src/main/java/com/squareup/moshi/MultiMapJsonAdapter.kt
@@ -61,7 +61,7 @@ internal class MultiMapJsonAdapter<K, V>(
 
     @Throws(IOException::class)
     override fun fromJson(reader: JsonReader): Map<K?, V?> {
-        val result = hashMapOf<K?, V?>()
+        val result = linkedMapOf<K?, V?>()
         reader.beginObject()
         while (reader.hasNext()) {
             reader.promoteNameToValue()


### PR DESCRIPTION
### 🎯 Goal

Closes #3829 

Sectioned avatars are different for online and offline channels.

### 🛠 Implementation details

Deserializing json with members into a map with ordered key set. 

```
internal data class ChannelEntity(
    ...
    val members: Map<String, MemberEntity>
}    
```

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/9600921/177036455-a572362d-0825-4faa-95b7-43359fca22c8.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/9600921/177036458-bb47561b-5d1c-428e-bfc1-733f8b24fe58.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

1. Open the channels screen
2. Sectioned avatars should show first 4 members of each channel

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
