### PR TITLE
[3828] fix redundant query channel requests

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1449,8 +1449,10 @@ internal constructor(
      */
     @CheckResult
     @InternalStreamChatApi
-    public fun queryChannelsInternal(request: QueryChannelsRequest): Call<List<Channel>> =
-        callPostponeHelper.postponeCall { api.queryChannels(request) }
+    public fun queryChannelsInternal(request: QueryChannelsRequest): Call<List<Channel>> {
+        logger.logD("[queryChannelsInternal] request: $request")
+        return callPostponeHelper.postponeCall { api.queryChannels(request) }
+    }
 
     @CheckResult
     @InternalStreamChatApi
@@ -1459,7 +1461,7 @@ internal constructor(
         channelId: String,
         request: QueryChannelRequest,
     ): Call<Channel> {
-        logger.logD("Querying channel")
+        logger.logD("[queryChannelInternal] cid: $channelType:$channelId, request: $request")
         return api.queryChannel(channelType, channelId, request)
     }
 
@@ -1494,12 +1496,12 @@ internal constructor(
         }
         return queryChannelCall.doOnStart(scope) {
             relevantPlugins.forEach { plugin ->
-                logger.logD("[queryChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}")
+                logger.logV("[queryChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}")
                 plugin.onQueryChannelRequest(channelType, channelId, request)
             }
         }.doOnResult(scope) { result ->
             relevantPlugins.forEach { plugin ->
-                logger.logD("[queryChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}")
+                logger.logV("[queryChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}")
                 plugin.onQueryChannelResult(result, channelType, channelId, request)
             }
         }.precondition(relevantPlugins) {
@@ -1519,7 +1521,7 @@ internal constructor(
      */
     @CheckResult
     public fun queryChannels(request: QueryChannelsRequest): Call<List<Channel>> {
-        logger.logD("Querying channels")
+        logger.logD("[queryChannels] request: $request")
 
         val relevantPluginsLazy = { plugins.filterIsInstance<QueryChannelsListener>() }
         logPlugins(relevantPluginsLazy())
@@ -1528,12 +1530,12 @@ internal constructor(
             api.queryChannels(request)
         }.doOnStart(scope) {
             relevantPluginsLazy().forEach { listener ->
-                logger.logD("Applying ${listener::class.qualifiedName}.onQueryChannelsRequest")
+                logger.logV("[queryChannels] #doOnStart; plugin: ${listener::class.qualifiedName}")
                 listener.onQueryChannelsRequest(request)
             }
         }.doOnResult(scope) { result ->
             relevantPluginsLazy().forEach { listener ->
-                logger.logD("Applying ${listener::class.qualifiedName}.onQueryChannelsResult")
+                logger.logV("[queryChannels] #doOnResult; plugin: ${listener::class.qualifiedName}")
                 listener.onQueryChannelsResult(result, request)
             }
         }.precondition(relevantPluginsLazy()) {

--- a/stream-chat-android-state/detekt-baseline.xml
+++ b/stream-chat-android-state/detekt-baseline.xml
@@ -70,8 +70,6 @@
     <ID>MaxLineLength:GlobalMutableState.kt$GlobalMutableState.Companion$*</ID>
     <ID>MaxLineLength:Mapper.kt$internal</ID>
     <ID>MaxLineLength:NonMemberChatEventHandler.kt$NonMemberChatEventHandler$*</ID>
-    <ID>MaxLineLength:QueryChannelsLogic.kt$QueryChannelsLogic$*</ID>
-    <ID>MaxLineLength:QueryChannelsLogic.kt$QueryChannelsLogic$logger.logI("storeStateForChannels stored ${channelsResponse.size} channels, ${configs.size} configs, ${users.size} users and ${messages.size} messages")</ID>
     <ID>MaxLineLength:QueryChannelsSortTest.kt$QueryChannelsSortTest.Companion$testName = "Sorting by unreadCount field reference in descending order and by memberCount field reference in ascending order"</ID>
     <ID>MaxLineLength:QueryChannelsSortTest.kt$QueryChannelsSortTest.Companion$testName = "Sorting by unread_count field name in descending order and by name extra data field in ascending order"</ID>
     <ID>MaxLineLength:RepositoryFacade.kt$RepositoryFacade.Companion$requireNotNull(userRepository.selectUser(userId)) { "User with the userId: `$userId` has not been found" }</ID>
@@ -93,7 +91,6 @@
     <ID>SwallowedException:CustomObjectFiltering.kt$e: ClassCastException</ID>
     <ID>TooGenericExceptionCaught:ChatClient.kt$exception: Exception</ID>
     <ID>TooGenericExceptionCaught:EventHandlerSequential.kt$EventHandlerSequential$e: Throwable</ID>
-    <ID>UnusedPrivateMember:EditMessageListenerImpl.kt$EditMessageListenerImpl$val isMessageModerationFailed = chatError is ChatNetworkError &amp;&amp; chatError.streamCode == ChatErrorCode.MESSAGE_MODERATION_FAILED.code</ID>
     <ID>UnusedPrivateMember:EventHandlerImpl.kt$EventHandlerImpl$user: User</ID>
     <ID>UnusedPrivateMember:QueryChannelsSortTest.kt$QueryChannelsSortTest$testName: String</ID>
     <ID>UnusedPrivateMember:StreamStatePluginFactory.kt$StreamStatePluginFactory$context: Context</ID>

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryChannelsListenerImpl.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryChannelsListenerImpl.kt
@@ -39,7 +39,7 @@ internal class QueryChannelsListenerImpl(private val logic: LogicRegistry) : Que
 
     override suspend fun onQueryChannelsRequest(request: QueryChannelsRequest) {
         logic.queryChannels(request).run {
-            setCurrentQueryChannelsRequest(request)
+            onQueryChannelsRequest(request)
             queryOffline(request.toPagination())
         }
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -32,7 +32,6 @@ import io.getstream.chat.android.client.extensions.enrichWithCid
 import io.getstream.chat.android.client.extensions.internal.applyPagination
 import io.getstream.chat.android.client.extensions.internal.toCid
 import io.getstream.chat.android.client.extensions.internal.users
-import io.getstream.chat.android.client.logger.ChatLogger
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelConfig
 import io.getstream.chat.android.client.models.Message
@@ -42,7 +41,6 @@ import io.getstream.chat.android.client.persistance.repository.ChannelRepository
 import io.getstream.chat.android.client.persistance.repository.QueryChannelsRepository
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.client.utils.map
 import io.getstream.chat.android.offline.event.handler.chat.EventHandlingResult
 import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
@@ -52,8 +50,14 @@ import io.getstream.chat.android.offline.plugin.state.querychannels.QueryChannel
 import io.getstream.chat.android.offline.plugin.state.querychannels.internal.QueryChannelsMutableState
 import io.getstream.chat.android.offline.repository.builder.internal.RepositoryFacade
 import io.getstream.chat.android.offline.utils.Event
-import io.getstream.chat.android.offline.utils.internal.ChannelFilterRequest
+import io.getstream.chat.android.offline.utils.internal.ChannelFilterRequest.filterWithOffset
+import io.getstream.logging.StreamLog
 import kotlinx.coroutines.flow.MutableStateFlow
+
+private const val MESSAGE_LIMIT = 30
+private const val MEMBER_LIMIT = 30
+private const val INITIAL_CHANNEL_OFFSET = 0
+private const val CHANNEL_LIMIT = 30
 
 @Suppress("TooManyFunctions")
 internal class QueryChannelsLogic(
@@ -65,15 +69,10 @@ internal class QueryChannelsLogic(
     private val stateRegistry: StateRegistry,
 ) {
 
-    private val logger = ChatLogger.get("QueryChannelsLogic")
+    private val logger = StreamLog.getLogger("QueryChannelsLogic")
 
-    internal val channelFilter: suspend (cid: String, FilterObject) -> Boolean = { cid, filter ->
-        ChannelFilterRequest.filter(client, cid, filter)
-            .map { channels -> channels.any { it.cid == cid } }
-            .let { filteringResult -> filteringResult.isSuccess && filteringResult.data() }
-    }
-
-    internal fun setCurrentQueryChannelsRequest(request: QueryChannelsRequest) {
+    internal fun onQueryChannelsRequest(request: QueryChannelsRequest) {
+        logger.d { "[onQueryChannelsRequest] request: $request" }
         mutableState._currentRequest.value = request
     }
 
@@ -85,7 +84,7 @@ internal class QueryChannelsLogic(
         }
 
         if (loading.value) {
-            logger.logI("Another query channels request is in progress. Ignoring this request.")
+            logger.i { "[queryOffline] another query channels request is in progress. Ignoring this request." }
             return Result(ChatError("Another query channels request is in progress. Ignoring this request."))
         }
 
@@ -116,7 +115,7 @@ internal class QueryChannelsLogic(
 
         return repos.selectChannels(query.cids.toList(), pagination)
             .applyPagination(pagination)
-            .also { logger.logI("found ${it.size} channels in offline storage") }
+            .also { logger.i { "[fetchChannelsFromCache] found ${it.size} channels in offline storage" } }
             .also { addChannels(it, repos) }
     }
 
@@ -151,16 +150,29 @@ internal class QueryChannelsLogic(
     }
 
     suspend fun onQueryChannelsResult(result: Result<List<Channel>>, request: QueryChannelsRequest) {
+        logger.d { "[onQueryChannelsResult] result.isSuccess: ${result.isSuccess}, request: $request" }
         onOnlineQueryResult(result, request, repos, globalState)
         if (result.isSuccess) {
-            updateOnlineChannels(result.data(), request.isFirstPage)
+            updateOnlineChannels(request, result.data())
         }
         val loading = loadingForCurrentRequest()
         loading.value = false
     }
 
-    internal suspend fun runQueryOnline(request: QueryChannelsRequest): Result<List<Channel>> {
-        return client.queryChannelsInternal(request).await()
+    internal suspend fun runQueryOnline(): Result<List<Channel>> {
+        logger.d { "[runQueryOnline] no args" }
+        val state = mutableState
+        val request = QueryChannelsRequest(
+            filter = state.filter,
+            offset = INITIAL_CHANNEL_OFFSET,
+            limit = CHANNEL_LIMIT,
+            querySort = state.sort,
+            messageLimit = MESSAGE_LIMIT,
+            memberLimit = MEMBER_LIMIT,
+        )
+        onQueryChannelsRequest(request)
+        return client.queryChannelsInternal(request)
+            .await()
             .also { onQueryChannelsResult(it, request) }
     }
 
@@ -181,10 +193,10 @@ internal class QueryChannelsLogic(
             // first things first, store the configs
             val channelConfigs = channelsResponse.map { ChannelConfig(it.type, it.config) }
             channelConfigRepository.insertChannelConfigs(channelConfigs)
-            logger.logI("api call returned ${channelsResponse.size} channels")
+            logger.i { "[onOnlineQueryResult] api call returned ${channelsResponse.size} channels" }
             storeStateForChannels(channelsResponse)
         } else {
-            logger.logI("Query with filter ${request.filter} failed, marking it as recovery needed")
+            logger.i { "[onOnlineQueryResult] query with filter ${request.filter} failed; recovery needed" }
             mutableState._recoveryNeeded.value = true
             globalState.setErrorEvent(Event(result.error()))
         }
@@ -214,7 +226,10 @@ internal class QueryChannelsLogic(
             messages = messages
         )
 
-        logger.logI("storeStateForChannels stored ${channelsResponse.size} channels, ${configs.size} configs, ${users.size} users and ${messages.size} messages")
+        logger.i {
+            "[storeStateForChannels] stored ${channelsResponse.size} channels, " +
+                "${configs.size} configs, ${users.size} users and ${messages.size} messages"
+        }
     }
 
     internal fun loadingForCurrentRequest(): MutableStateFlow<Boolean> {
@@ -226,31 +241,76 @@ internal class QueryChannelsLogic(
     /**
      * Updates the state based on the channels collection we received from the API.
      *
+     * If it's the first page [QueryChannelsRequest.isFirstPage] we set/replace the list of results.
+     * If it's not the first page we add to the list.
+     *
+     * @param request The [QueryChannelsRequest].
      * @param channels The list of channels to update.
-     * @param isFirstPage If it's the first page we set/replace the list of results. if it's not the first page we add to the list.
      */
-    internal suspend fun updateOnlineChannels(
+    private suspend fun updateOnlineChannels(
+        request: QueryChannelsRequest,
         channels: List<Channel>,
-        isFirstPage: Boolean,
     ) {
         val existingChannels = mutableState._channels.value
-        if (isFirstPage && !existingChannels.isNullOrEmpty()) {
-            (existingChannels - channels.map { it.cid }.toSet()).values
-                .map(Channel::cid)
-                .filterNot { cid -> channelFilter(cid, mutableState.filter) }
-                .let { removeChannels(it, repos) }
+        val currentChannelsOffset = mutableState.channelsOffset.value
+        logger.d {
+            "[updateOnlineChannels] isFirstPage: ${request.isFirstPage}, " +
+                "channels.size: ${channels.size}, " +
+                "existingChannels.size: ${existingChannels?.size}, " +
+                "currentChannelsOffset: $currentChannelsOffset"
         }
-        mutableState.channelsOffset.value += channels.size
+        if (request.isFirstPage && !existingChannels.isNullOrEmpty()) {
+            var newChannelsOffset = channels.size
+            val notUpdatedChannels = existingChannels - channels.map { it.cid }.toSet()
+            logger.v { "[updateOnlineChannels] notUpdatedChannels.size: ${notUpdatedChannels.size}" }
+            if (notUpdatedChannels.isNotEmpty()) {
+                val localCids = notUpdatedChannels.values.map { it.cid }
+                val remoteCids = getRemoteCids(request.filter, request.limit, request.limit, existingChannels.size)
+                val cidsToRemove = localCids - remoteCids.toSet()
+                logger.v { "[updateOnlineChannels] cidsToRemove.size: ${cidsToRemove.size}" }
+                removeChannels(cidsToRemove, repos)
+                newChannelsOffset += remoteCids.size
+            }
+            logger.v { "[updateOnlineChannels] newChannelsOffset: $newChannelsOffset <= $currentChannelsOffset" }
+            mutableState.channelsOffset.value = newChannelsOffset
+        } else {
+            val newChannelsOffset = mutableState.channelsOffset.value + channels.size
+            logger.v { "[updateOnlineChannels] newChannelsOffset: $newChannelsOffset <= $currentChannelsOffset" }
+            mutableState.channelsOffset.value = newChannelsOffset
+        }
         addChannels(channels, repos)
     }
 
-    internal suspend fun removeChannel(cid: String) =
+    private suspend fun getRemoteCids(
+        filter: FilterObject,
+        initialOffset: Int,
+        step: Int,
+        thresholdCount: Int,
+    ): HashSet<String> {
+        logger.d { "[getRemoteCids] initialOffset: $initialOffset, step: $step, thresholdCount: $thresholdCount" }
+        val remoteCids = hashSetOf<String>()
+        var offset = initialOffset
+
+        while (offset < thresholdCount) {
+            logger.v { "[getRemoteCids] offset: $offset, limit: $step, thresholdCount: $thresholdCount" }
+            val channels = client.filterWithOffset(filter, offset, step)
+            remoteCids.addAll(channels.map { it.cid })
+            logger.v { "[getRemoteCids] remoteCids.size: ${remoteCids.size}" }
+            offset += step
+            if (channels.size < step) {
+                return remoteCids
+            }
+        }
+        return remoteCids
+    }
+
+    private suspend fun removeChannel(cid: String) =
         removeChannels(listOf(cid), repos)
 
     private suspend fun removeChannels(cidList: List<String>, queryChannelsRepository: QueryChannelsRepository) {
         val existingChannels = mutableState._channels.value
         if (existingChannels.isNullOrEmpty()) {
-            logger.logW("Skipping remove channels as they are not loaded yet.")
+            logger.w { "[removeChannels] skipping remove channels as they are not loaded yet." }
             return
         }
 
@@ -278,7 +338,7 @@ internal class QueryChannelsLogic(
      */
     private suspend fun handleEvent(event: ChatEvent, channelRepository: ChannelRepository) {
         // update the info for that channel from the channel repo
-        logger.logI("Received channel event $event")
+        logger.i { "[handleEvent] event: $event" }
 
         val cachedChannel = if (event is CidEvent) {
             channelRepository.selectChannelWithoutMessages(event.cid)
@@ -320,7 +380,7 @@ internal class QueryChannelsLogic(
     private fun refreshChannels(cidList: Collection<String>) {
         val existingChannels = mutableState._channels.value
         if (existingChannels == null) {
-            logger.logW("Aborting refresh as channels are not available yet.")
+            logger.w { "[refreshChannels] rejected (existingChannels is null)" }
             return
         }
         mutableState._channels.value = existingChannels + mutableState.queryChannelsSpec.cids
@@ -369,7 +429,7 @@ internal class QueryChannelsLogic(
         val userId = newUser.id
         val existingChannels = mutableState._channels.value
         if (existingChannels == null) {
-            logger.logW("Aborting refresh member state as channels are not available yet.")
+            logger.w { "[refreshMembersStateForUser] rejected (existingChannels is null)" }
             return
         }
         val affectedChannels = existingChannels

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelFilterRequest.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelFilterRequest.kt
@@ -31,7 +31,7 @@ import io.getstream.chat.android.client.utils.Result
 * @param filter - the filter to be included with the cid.
 */
 internal object ChannelFilterRequest {
-    suspend fun filter(client: ChatClient, cid: String, filter: FilterObject): Result<List<Channel>> =
+    suspend fun filterByCid(client: ChatClient, cid: String, filter: FilterObject): Result<List<Channel>> =
         client.queryChannelsInternal(
             QueryChannelsRequest(
                 filter = Filters.and(
@@ -44,4 +44,24 @@ internal object ChannelFilterRequest {
                 memberLimit = 0,
             )
         ).await()
+
+    suspend fun ChatClient.filterWithOffset(
+        filter: FilterObject,
+        offset: Int,
+        limit: Int
+    ): List<Channel> {
+        val request = QueryChannelsRequest(
+            filter = filter,
+            offset = offset,
+            limit = limit,
+            messageLimit = 0,
+            memberLimit = 0,
+        )
+        return queryChannelsInternal(request).await().let {
+            when (it.isSuccess) {
+                true -> it.data()
+                else -> emptyList()
+            }
+        }
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

Leave just necessary requests

### 🧪 Testing

- login with user who has lots of channels
- scroll down and load 2 pages more
- background the app
- foreground the app
- observe the logs (or proxy tool)

Make sure we're not bombarding `QueryChannelsRequest` per each channel.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
