### PR TITLE
Show snackbar on file to large error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Show snackbar instead of toast when file exceeds the size limit. [#3858](https://github.com/GetStream/stream-chat-android/pull/3858)
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -658,7 +658,9 @@ private fun MessageInputValidationError(validationErrors: List<ValidationError>,
 
         val context = LocalContext.current
         LaunchedEffect(validationErrors.size) {
-            if (firstValidationError is ValidationError.ContainsLinksWhenNotAllowed) {
+            if (firstValidationError is ValidationError.ContainsLinksWhenNotAllowed ||
+                firstValidationError is ValidationError.AttachmentSizeExceeded
+            ) {
                 snackbarHostState.showSnackbar(
                     message = errorMessage,
                     actionLabel = context.getString(R.string.stream_compose_ok),


### PR DESCRIPTION
### 🎯 Goal

Closes #3493 

Show snackbar when file size exceeds the limit.

### 🛠 Implementation details

Updated check that shows the snackbar.

### 🎨 UI Changes

| XML | Before | After |
| --- | --- | --- |
| ![Screenshot_1657198101](https://user-images.githubusercontent.com/38032787/177777804-85eba6e2-9208-4472-adb8-ca990ceaeda1.png) | ![Screenshot_1657198177](https://user-images.githubusercontent.com/38032787/177777816-e65e12c2-d4b7-44c8-b96e-1ffd623dfd6d.png) | ![Screenshot_1657198210](https://user-images.githubusercontent.com/38032787/177777836-9ca3f185-0250-4096-95bd-ada3aaf981e3.png) |

### 🧪 Testing

1. Run on develop and try to upload an attachment larger than 100MB
2. Run on this branch and try to upload an attachment larger than 100MB

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy](https://user-images.githubusercontent.com/38032787/177778858-beca52f2-0a00-4590-9dc1-fc857c1c42c9.gif)