### PR TITLE
Fix initializing channels state when DB is empty and API request fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed initializing channels state when DB is empty and API requests fails. [3870](https://github.com/GetStream/stream-chat-android/pull/3870)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -153,9 +153,21 @@ internal class QueryChannelsLogic(
         onOnlineQueryResult(result, request, repos, globalState)
         if (result.isSuccess) {
             updateOnlineChannels(request, result.data())
+        } else {
+            initializeChannelsIfNeeded()
         }
         val loading = loadingForCurrentRequest()
         loading.value = false
+    }
+
+    /**
+     * Initializes [QueryChannelsMutableState._channels] with an empty map if it wasn't initialized yet.
+     * This might happen when we don't have any channels in the offline storage and API request fails.
+     */
+    private fun initializeChannelsIfNeeded() {
+        if (mutableState._channels.value == null) {
+            mutableState._channels.value = emptyMap()
+        }
     }
 
     /**


### PR DESCRIPTION
closes #3758 

### 🎯 Goal

Fix infinite loading state when DB doesn't contain channels.

### 🛠 Implementation details

Added initializing channels state with `emptyMap()` if it's not initialized yet and the request failed.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/17440581/178481483-b0db8a6a-c385-40ad-95eb-9a9905865b06.mp4
" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/17440581/178481461-11d61a3e-1516-4d6a-a35b-e4cd1875a3bb.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing

1. Turn on airplane mode
2. Sign in as a User (make sure the DB is empty)
3. You should be able to see empty state after the initial loading


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
