### PR TITLE
Not clearing instances of registries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed initializing channels state when DB is empty and API requests fails. [3870](https://github.com/GetStream/stream-chat-android/pull/3870)
+- Fixed that causes a crash while reconnecting to the SDK multiple times. [#3888](https://github.com/GetStream/stream-chat-android/pull/3888)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -359,6 +359,7 @@ internal constructor(
         val userState = userStateService.state
 
         ClientState.get().toMutableState()?.setUser(user)
+        initializationCoordinator.userConnectionRequest(user)
 
         return when {
             tokenUtils.getUserId(cacheableTokenProvider.loadToken()) != user.id -> {
@@ -425,7 +426,6 @@ internal constructor(
         tokenProvider: CacheableTokenProvider,
         isAnonymous: Boolean,
     ) {
-        initializationCoordinator.userConnected(user)
         // fire a handler here that the chatDomain and chatUI can use
         config.isAnonymous = isAnonymous
         tokenManager.setTokenProvider(tokenProvider)
@@ -2597,7 +2597,7 @@ internal constructor(
         }
 
         private fun configureInitializer(chatClient: ChatClient) {
-            chatClient.initializationCoordinator.addUserConnectedListener { user ->
+            chatClient.initializationCoordinator.addUserConnectionRequestListener { user ->
                 chatClient.addPlugins(
                     pluginFactories.map { pluginFactory ->
                         pluginFactory.get(user)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/SocketStateService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/SocketStateService.kt
@@ -47,7 +47,7 @@ internal class SocketStateService {
             initialState(SocketState.Idle)
 
             defaultHandler { state, event ->
-                logger.e { "Cannot handle event $event while being in inappropriate state $this" }
+                logger.e { "Cannot handle event $event while being in inappropriate state: $state" }
                 state
             }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/clientstate/UserStateService.kt
@@ -24,10 +24,12 @@ internal class UserStateService {
     private val logger = StreamLog.getLogger("Chat:UserStateService")
 
     fun onUserUpdated(user: User) {
+        logger.d { "[onUserUpdated] user id: ${user.id}" }
         fsm.sendEvent(UserStateEvent.UserUpdated(user))
     }
 
     fun onSetUser(user: User, isAnonymous: Boolean) {
+        logger.d { "[onSetUser] user id: ${user.id}" }
         if (isAnonymous) {
             fsm.sendEvent(UserStateEvent.ConnectAnonymous(user))
         } else {
@@ -36,10 +38,12 @@ internal class UserStateService {
     }
 
     fun onLogout() {
+        logger.d { "[onLogout]" }
         fsm.sendEvent(UserStateEvent.UnsetUser)
     }
 
     fun onSocketUnrecoverableError() {
+        logger.d { "[onSocketUnrecoverableError]" }
         fsm.sendEvent(UserStateEvent.UnsetUser)
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/InitializationCoordinator.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/InitializationCoordinator.kt
@@ -32,7 +32,7 @@ public class InitializationCoordinator private constructor() {
     /**
      * Adds a listener to user connection.
      */
-    internal fun addUserConnectedListener(listener: (User) -> Unit) {
+    internal fun addUserConnectionRequestListener(listener: (User) -> Unit) {
         userConnectedListeners.add(listener)
     }
 
@@ -46,7 +46,7 @@ public class InitializationCoordinator private constructor() {
     /**
      * Notifies user connection
      */
-    internal fun userConnected(user: User) {
+    internal fun userConnectionRequest(user: User) {
         userConnectedListeners.forEach { function -> function.invoke(user) }
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -62,7 +62,8 @@ internal class WhenConnectUser : BaseChatClientTest() {
         verifyNoMoreInteractions(socket)
         verifyNoMoreInteractions(userStateService)
         verifyNoInteractions(tokenManager)
-        verifyNoInteractions(listener)
+        // Listeners should always be called
+        verify(listener).invoke(any())
         result `should be equal to` Result.error(ChatError("Failed to connect user. Please check you haven't connected a user already."))
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenConnectUser.kt
@@ -195,7 +195,7 @@ internal class WhenConnectUser : BaseChatClientTest() {
         }
 
         fun givenPreSetUserListener(listener: (User) -> Unit) = apply {
-            initializationCoordinator.addUserConnectedListener(listener)
+            initializationCoordinator.addUserConnectionRequestListener(listener)
         }
 
         fun givenUserAndToken(user: User, token: String) = apply {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -145,7 +145,6 @@ internal class LogicRegistry internal constructor(
         queryChannels.clear()
         channels.clear()
         threads.clear()
-        instance = null
     }
 
     internal companion object {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
@@ -130,7 +130,6 @@ public class StateRegistry private constructor(
         queryChannels.clear()
         channels.clear()
         threads.clear()
-        instance = null
     }
 
     public companion object {


### PR DESCRIPTION
### 🎯 Goal

Don't clear Registries instances when clearing its state. If the SDK is disconnected, but `StateRegistry` or `LogicRegistry` are requested, the SDK will crash because their instance was cleared. 

### 🧪 Testing

The problem is hard to reproduce but happens with one customer. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
