### PR TITLE
Fix message preview off by 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed bug in message preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-- Fixed bug in message preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
+- Fixed preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImpl.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/interceptor/internal/SendMessageInterceptorImpl.kt
@@ -132,12 +132,14 @@ internal class SendMessageInterceptorImpl(
         }
         // Update flow in channel controller
         channel.upsertMessage(newMessage)
+
         // TODO: an event broadcasting feature for LOCAL/offline events on the LLC would be a cleaner approach
         // Update flow for currently running queries
-        logic.getActiveQueryChannelsLogic().forEach { query -> query.refreshChannel(channel.cid) }
         // we insert early to ensure we don't lose messages
         messageRepository.insertMessage(newMessage)
         channelRepository.updateLastMessageForChannel(newMessage.cid, newMessage)
+
+        logic.getActiveQueryChannelsLogic().forEach { query -> query.refreshChannel(channel.cid) }
         return newMessage
     }
 


### PR DESCRIPTION
### 🎯 Goal

Fix message preview off by one when sending messages offline problem.

### 🛠 Implementation details

Refreshing channels **after** message is inserted.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/180068769-f13cad7f-8c70-474f-9214-f3436039a04b.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/180067839-b8fa49f7-dbae-40f0-b8e7-0d57e7de5f4b.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Follow the videos =]

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
~- [ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
~- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/180068977-1940b585-51e0-41a8-b5d4-d62253ce280b.gif)
_Don't lose the count!!_
