### PR TITLE
Check if lastSyncAt is no later than 30 days when calling sync endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Offline data is clear after the user is disconnect by calling `ChatClient.disconnect(true)`. [#3917](https://github.com/GetStream/stream-chat-android/pull/3917)
 
 ### ✅ Added
+- Added a check if `lastSyncedAt` is no later than 30 days when calling `ChatClient::getSyncHistory`. []()
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -171,7 +171,7 @@ import okhttp3.OkHttpClient
 import java.io.File
 import java.util.Calendar
 import java.util.Date
-import java.util.concurrent.TimeUnit
+import kotlin.time.Duration.Companion.days
 import io.getstream.chat.android.client.experimental.socket.ChatSocket as ChatSocketExperimental
 
 /**
@@ -2781,7 +2781,7 @@ internal constructor(
         private const val KEY_MESSAGE_ACTION = "image_action"
         private const val MESSAGE_ACTION_SEND = "send"
         private const val MESSAGE_ACTION_SHUFFLE = "shuffle"
-        private val THIRTY_DAYS_IN_MILLISECONDS = 30 * TimeUnit.DAYS.toMillis(1)
+        private val THIRTY_DAYS_IN_MILLISECONDS = 30.days.inWholeMilliseconds
 
         private const val ARG_TYPING_PARENT_ID = "parent_id"
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -72,6 +72,7 @@ import io.getstream.chat.android.client.events.UserEvent
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_FILE
 import io.getstream.chat.android.client.extensions.ATTACHMENT_TYPE_IMAGE
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.extensions.internal.isLaterThanDays
 import io.getstream.chat.android.client.extensions.retry
 import io.getstream.chat.android.client.header.VersionPrefixHeader
 import io.getstream.chat.android.client.helpers.AppSettingManager
@@ -170,6 +171,7 @@ import okhttp3.OkHttpClient
 import java.io.File
 import java.util.Calendar
 import java.util.Date
+import java.util.concurrent.TimeUnit
 import io.getstream.chat.android.client.experimental.socket.ChatSocket as ChatSocketExperimental
 
 /**
@@ -2292,8 +2294,8 @@ internal constructor(
      * Returns all events that happened for a list of channels since last sync (while the user was not
      * connected to the web-socket).
      *
-     * @param channelsIds The list of channel CIDs
-     * @param lastSyncAt The last time the user was online and in sync
+     * @param channelsIds The list of channel CIDs. Cannot be empty.
+     * @param lastSyncAt The last time the user was online and in sync. Shouldn't be later than 30 days.
      *
      * @return Executable async [Call] responsible for obtaining missing events.
      */
@@ -2304,11 +2306,27 @@ internal constructor(
     ): Call<List<ChatEvent>> {
         return api.getSyncHistory(channelsIds, lastSyncAt)
             .withPrecondition(scope) {
-                when (channelsIds.isEmpty()) {
-                    true -> Result.error(ChatError("channelsIds must contain at least 1 id."))
-                    else -> Result.success(Unit)
-                }
+                checkSyncHistoryPreconditions(channelsIds, lastSyncAt)
             }
+    }
+
+    /**
+     * Checks if sync history request parameters meet preconditions:
+     * 1. If [channelsIds] is not empty.
+     * 2. If [lastSyncAt] is no later than 30 days
+     */
+    private fun checkSyncHistoryPreconditions(channelsIds: List<String>, lastSyncAt: Date): Result<Unit> {
+        return when {
+            channelsIds.isEmpty() -> {
+                Result.error(ChatError("channelsIds must contain at least 1 id."))
+            }
+            lastSyncAt.isLaterThanDays(THIRTY_DAYS_IN_MILLISECONDS) -> {
+                Result.error(ChatError("lastSyncAt cannot by later than 30 days."))
+            }
+            else -> {
+                Result.success(Unit)
+            }
+        }
     }
 
     /**
@@ -2763,6 +2781,7 @@ internal constructor(
         private const val KEY_MESSAGE_ACTION = "image_action"
         private const val MESSAGE_ACTION_SEND = "send"
         private const val MESSAGE_ACTION_SHUFFLE = "shuffle"
+        private val THIRTY_DAYS_IN_MILLISECONDS = 30 * TimeUnit.DAYS.toMillis(1)
 
         private const val ARG_TYPING_PARENT_ID = "parent_id"
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Date.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.extensions.internal
+
+import java.util.Date
+
+/**
+ * Checks if the Date is later than [daysInMillis].
+ */
+internal fun Date.isLaterThanDays(daysInMillis: Long): Boolean {
+    val now = Date()
+    return now.time - time > daysInMillis
+}


### PR DESCRIPTION
closes #3902 

### 🎯 Goal
Check if `lastSyncAt` is no later than 30 days when calling the sync endpoint.

### 🧪 Testing

1. Run the sample apps and filter `syncHistory`logs. Make sure the channel syncs correctly
2. Apply the patch and rebuild the app. Search for the same logs which should now log an error.

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt	(revision 67b433009a10215f0f5aa7e7d77edec8ec5466f1)
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/sync/internal/SyncManager.kt	(date 1658402127852)
@@ -48,6 +48,7 @@
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.Date
+import java.util.concurrent.TimeUnit
 
 private const val QUERIES_TO_RETRY = 3
 
@@ -71,8 +72,12 @@
     internal val syncStateFlow: MutableStateFlow<SyncState?> = MutableStateFlow(null)
     private var firstConnect = true
 
+    companion object {
+        private const val TEST_DAYS = 31
+    }
+
     internal suspend fun getSortedSyncHistory(cids: List<String>): Result<List<ChatEvent>> {
-        val lastSyncAt = syncStateFlow.value?.lastSyncedAt ?: Date()
+        val lastSyncAt = Date(Date().time - TEST_DAYS * TimeUnit.DAYS.toMillis(1))
         return chatClient.getSyncHistory(cids, lastSyncAt).await()
             .map { events -> events.sortedBy { it.createdAt } }
             .onSuccessSuspend { sortedEvents ->

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
