### PR TITLE
Release with correct actor

### DIFF
--- a/.github/workflows/release-start-test.yaml
+++ b/.github/workflows/release-start-test.yaml
@@ -1,4 +1,4 @@
-name: ReleaseStart
+name: ReleaseStartTest
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-start-test.yaml
+++ b/.github/workflows/release-start-test.yaml
@@ -1,0 +1,45 @@
+name: ReleaseStart
+
+on:
+  workflow_dispatch:
+    inputs:
+      force_bump_minor_version: 
+        type: boolean
+      skip_version_bump:
+        type: boolean
+      skip_changelog_update:
+        type: boolean
+      skip_github_release:
+        type: boolean
+
+jobs:
+  start_release:
+    name: Start Release
+    runs-on: ubuntu-latest
+    environment: 'publish'
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          ref: release-test
+      - name: Minor version bump
+        if: "${{ github.event.inputs.force_bump_minor_version == 'true' && github.event.inputs.skip_version_bump != 'true' }}"
+        run: ./gradlew minor-bump
+      - name: Version bump
+        if: "${{ github.event.inputs.force_bump_minor_version != 'true' && github.event.inputs.skip_version_bump != 'true' }}"
+        run: ./gradlew version-bump
+      - name: Parse release section in changelog
+        if: "${{ github.event.inputs.skip_changelog_update != 'true' }}"
+        run: ./gradlew changelog-release-section
+      - name: Commit changes
+        uses: EndBug/add-and-commit@v8
+        with:
+          add: '["CHANGELOG.md", "buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt"]'
+          message: "AUTOMATION: Version Bump and CHANGELOG Update"
+          default_author: github_actions
+          push: false
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+          branch: release-test

--- a/.github/workflows/release-start.yaml
+++ b/.github/workflows/release-start.yaml
@@ -31,12 +31,18 @@ jobs:
       - name: Parse release section in changelog
         if: "${{ github.event.inputs.skip_changelog_update != 'true' }}"
         run: ./gradlew changelog-release-section
-      - name: Push changes
+      - name: Commit changes
         uses: EndBug/add-and-commit@v8
         with:
           add: '["CHANGELOG.md", "buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt"]'
           message: "AUTOMATION: Version Bump and CHANGELOG Update"
           default_author: github_actions
+          push: false
+      - name: Push changes
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}
+          branch: release
       - name: Create GITHUB_TAG_RELEASE_VERSION 
         run: |
           ./gradlew version-print


### PR DESCRIPTION
### 🎯 Goal

Create an automation that doesn't need to change permissions in release branch to be used.

### 🛠 Implementation details

Using the correct actor now.

### 🧪 Testing

I create the `release-start-test.yaml` to test this PR. We can merge this, test it by creating a branch called `release-test` and then remove this file once it is verified.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- ~[ ] PR targets the `develop` branch~. **It targets main**
- ~[ ] PR is linked to the GitHub issue it resolves~

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/180245235-73df8f0f-f72b-471d-98b5-7da86362cbc8.gif)
_Let's use the correct actor!_
