### PR TITLE
Fix GlobalState initialization

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -72,7 +72,7 @@ public val ChatClient.state: StateRegistry
  * [GlobalState] instance that contains information about the current user, unreads, etc.
  */
 public val ChatClient.globalState: GlobalState
-    get() = GlobalMutableState.create(clientState)
+    get() = GlobalMutableState.getOrCreate(clientState)
 
 /**
  * Performs [ChatClient.queryChannels] under the hood and returns [QueryChannelsState] associated with the query.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -72,7 +72,7 @@ public val ChatClient.state: StateRegistry
  * [GlobalState] instance that contains information about the current user, unreads, etc.
  */
 public val ChatClient.globalState: GlobalState
-    get() = GlobalMutableState.get()
+    get() = GlobalMutableState.create(clientState)
 
 /**
  * Performs [ChatClient.queryChannels] under the hood and returns [QueryChannelsState] associated with the query.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -72,7 +72,7 @@ public val ChatClient.state: StateRegistry
  * [GlobalState] instance that contains information about the current user, unreads, etc.
  */
 public val ChatClient.globalState: GlobalState
-    get() = GlobalMutableState.getOrCreate(clientState)
+    get() = GlobalMutableState.get(clientState)
 
 /**
  * Performs [ChatClient.queryChannels] under the hood and returns [QueryChannelsState] associated with the query.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
@@ -150,6 +150,7 @@ public class GlobalMutableState private constructor(
     public companion object {
         @InternalStreamChatApi
         @VisibleForTesting
+        @Volatile
         public var instance: GlobalMutableState? = null
 
         /**
@@ -157,8 +158,10 @@ public class GlobalMutableState private constructor(
          */
         @InternalStreamChatApi
         public fun get(clientState: ClientState): GlobalMutableState {
-            return instance ?: GlobalMutableState(clientState).also { globalState ->
-                instance = globalState
+            return instance ?: synchronized(this) {
+                GlobalMutableState(clientState).also { globalState ->
+                    instance = globalState
+                }
             }
         }
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
@@ -156,7 +156,7 @@ public class GlobalMutableState private constructor(
          * Gets the singleton of [GlobalMutableState] or creates it in the first call.
          */
         @InternalStreamChatApi
-        public fun getOrCreate(clientState: ClientState): GlobalMutableState {
+        public fun get(clientState: ClientState): GlobalMutableState {
             return instance ?: GlobalMutableState(clientState).also { globalState ->
                 instance = globalState
             }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
@@ -159,7 +159,7 @@ public class GlobalMutableState private constructor(
         @InternalStreamChatApi
         public fun get(clientState: ClientState): GlobalMutableState {
             return instance ?: synchronized(this) {
-                GlobalMutableState(clientState).also { globalState ->
+                instance ?: GlobalMutableState(clientState).also { globalState ->
                     instance = globalState
                 }
             }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/global/internal/GlobalMutableState.kt
@@ -156,19 +156,10 @@ public class GlobalMutableState private constructor(
          * Gets the singleton of [GlobalMutableState] or creates it in the first call.
          */
         @InternalStreamChatApi
-        public fun create(clientState: ClientState): GlobalMutableState {
+        public fun getOrCreate(clientState: ClientState): GlobalMutableState {
             return instance ?: GlobalMutableState(clientState).also { globalState ->
                 instance = globalState
             }
-        }
-
-        /**
-         * Gets the current Singleton of GlobalState. If the initialization is not done yet, it returns null.
-         */
-        @Throws(IllegalArgumentException::class)
-        internal fun get(): GlobalMutableState = requireNotNull(instance) {
-            "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
-                "PluginFactory to be able to use GlobalState from the SDK"
         }
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
@@ -26,7 +26,7 @@ import io.getstream.chat.android.offline.plugin.state.global.internal.GlobalMuta
  * @param cid CID of the channel currently being checked.
  */
 internal fun isChannelMutedForCurrentUser(cid: String, chatClient: ChatClient = ChatClient.instance()): Boolean {
-    return GlobalMutableState.getOrCreate(chatClient.clientState)
+    return GlobalMutableState.get(chatClient.clientState)
         .channelMutes.value.any { mutedChannel -> mutedChannel.channel.cid == cid }
 }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.offline.utils.internal
 
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.offline.plugin.state.global.internal.GlobalMutableState
 
 /**
@@ -24,8 +25,10 @@ import io.getstream.chat.android.offline.plugin.state.global.internal.GlobalMuta
  *
  * @param cid CID of the channel currently being checked.
  */
-internal fun isChannelMutedForCurrentUser(cid: String): Boolean =
-    GlobalMutableState.get().channelMutes.value.any { mutedChannel -> mutedChannel.channel.cid == cid }
+internal fun isChannelMutedForCurrentUser(cid: String, chatClient: ChatClient = ChatClient.instance()): Boolean {
+    return GlobalMutableState.getOrCreate(chatClient.clientState)
+        .channelMutes.value.any { mutedChannel -> mutedChannel.channel.cid == cid }
+}
 
 /**
  * Generates the channel id based on the member ids if provided [channelId] is empty.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -128,7 +128,7 @@ public class StreamStatePluginFactory(
         val clientState = chatClient.clientState.also { clientState ->
             clientState.clearState()
         }
-        val globalState = GlobalMutableState.create(chatClient.clientState).apply {
+        val globalState = GlobalMutableState.getOrCreate(chatClient.clientState).apply {
             clearState()
         }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -128,7 +128,7 @@ public class StreamStatePluginFactory(
         val clientState = chatClient.clientState.also { clientState ->
             clientState.clearState()
         }
-        val globalState = GlobalMutableState.getOrCreate(chatClient.clientState).apply {
+        val globalState = GlobalMutableState.get(chatClient.clientState).apply {
             clearState()
         }
 


### PR DESCRIPTION
### 🎯 Goal

Fix `GlobalState` initialization.

### 🧪 Testing

Run sample apps and make sure there are no crashes when going to `ChannelList` or `MessageList`


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
