### PR TITLE
Remove QuerySort usages from tests

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Channel.kt
@@ -110,6 +110,7 @@ public data class Channel(
             "frozen" -> frozen
             "lastMessageAt" -> lastMessageAt
             "createdAt" -> createdAt
+            "updatedAt" -> updatedAt
             "deletedAt" -> deletedAt
             "memberCount" -> memberCount
             "unreadCount" -> unreadCount
@@ -117,6 +118,7 @@ public data class Channel(
             "hidden" -> hidden
             "cooldown" -> cooldown
             "lastUpdated" -> lastUpdated
+            "hasUnread" -> hasUnread
             else -> extraData[fieldName] as? Comparable<*>
         }
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QuerySortByFieldTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QuerySortByFieldTest.kt
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.client.api.models
 
-import io.getstream.chat.android.client.api.models.QuerySort.Companion.ascByName
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField.Companion.ascByName
+import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.test.randomString
@@ -28,24 +28,24 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 
-internal class QuerySortTest {
+internal class QuerySortByFieldTest {
 
     /**
-     * [generateQuerySortInput]
+     * [generateQuerySortByFieldInput]
      */
     @ParameterizedTest
-    @MethodSource("generateQuerySortInput")
-    fun `Two QuerySort with the same content should produce the same hashcode`(
-        a: QuerySort<Any>,
-        b: QuerySort<Any>,
+    @MethodSource("generateQuerySortByFieldInput")
+    fun `Two QuerySorter with the same content should produce the same hashcode`(
+        a: QuerySorter<Any>,
+        b: QuerySorter<Any>,
     ) {
         a.hashCode() `should be equal to` b.hashCode()
     }
 
     @Test
     fun `Two same query sorts should be equal`() {
-        val sort1 = QuerySort.asc(Channel::memberCount).ascByName("created_at")
-        val sort2 = QuerySort.asc<Channel>("member_count").asc(Channel::createdAt)
+        val sort1 = QuerySortByField.ascByName<Channel>("memberCount").ascByName("createdAt")
+        val sort2 = QuerySortByField.ascByName<Channel>("memberCount").ascByName("createdAt")
 
         sort1 `should be equal to` sort2
     }
@@ -53,29 +53,29 @@ internal class QuerySortTest {
     companion object {
 
         @JvmStatic
-        fun generateQuerySortInput() = listOf(
+        fun generateQuerySortByFieldInput() = listOf(
             randomString().let {
                 Arguments.of(
-                    QuerySort.Companion.asc<Channel>(it),
-                    QuerySort.Companion.asc<Channel>(it)
+                    QuerySortByField.ascByName<Channel>(it),
+                    QuerySortByField.ascByName<Channel>(it),
                 )
             },
             randomString().let {
                 Arguments.of(
-                    QuerySort.Companion.asc<Message>(it),
-                    QuerySort.Companion.asc<Message>(it)
+                    QuerySortByField.ascByName<Message>(it),
+                    QuerySortByField.ascByName<Message>(it),
                 )
             },
             randomString().let {
                 Arguments.of(
-                    QuerySort.Companion.desc<Channel>(it),
-                    QuerySort.Companion.desc<Channel>(it)
+                    QuerySortByField.descByName<Channel>(it),
+                    QuerySortByField.descByName<Channel>(it),
                 )
             },
             randomString().let {
                 Arguments.of(
-                    QuerySort.Companion.desc<Message>(it),
-                    QuerySort.Companion.desc<Message>(it)
+                    QuerySortByField.descByName<Message>(it),
+                    QuerySortByField.descByName<Message>(it),
                 )
             },
         )

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.compose.viewmodel.channels
 
 import io.getstream.chat.android.client.ChatClient
@@ -24,7 +22,8 @@ import io.getstream.chat.android.client.api.models.AutocompleteFilterObject
 import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.OrFilterObject
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
-import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
+import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.ChannelMute
@@ -268,7 +267,7 @@ internal class ChannelListViewModelTest {
     private class Fixture(
         private val chatClient: ChatClient = mock(),
         private val channelClient: ChannelClient = mock(),
-        private val initialSort: QuerySort<Channel> = querySort,
+        private val initialSort: QuerySorter<Channel> = querySort,
         private val initialFilters: FilterObject? = queryFilter,
     ) {
         private val globalState: GlobalMutableState = mock()
@@ -346,7 +345,7 @@ internal class ChannelListViewModelTest {
             Filters.eq("type", "messaging"),
             Filters.`in`("members", "jc")
         )
-        private val querySort = QuerySort.desc<Channel>("last_updated")
+        private val querySort = QuerySortByField.descByName<Channel>("lastUpdated")
 
         private val channel1: Channel = Channel().apply {
             type = "messaging"

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/Mother.kt
@@ -14,15 +14,14 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.offline
 
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
 import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.NeutralFilterObject
-import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
+import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Channel
@@ -137,7 +136,7 @@ internal fun randomMessageEntity(
 internal fun randomQueryChannelsEntity(
     id: String = randomString(),
     filter: FilterObject = NeutralFilterObject,
-    querySort: QuerySort<Channel> = QuerySort(),
+    querySort: QuerySorter<Channel> = QuerySortByField(),
     cids: List<String> = emptyList(),
 ): QueryChannelsEntity = QueryChannelsEntity(id, filter, querySort, cids)
 

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/integration/BaseDomainTest2.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.offline.integration
 
 import android.content.Context
@@ -27,8 +25,8 @@ import androidx.test.platform.app.InstrumentationRegistry
 import androidx.work.testing.WorkManagerTestInitHelper
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.ChatEventListener
-import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.api.models.WatchChannelRequest
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.events.ConnectedEvent
@@ -210,6 +208,6 @@ internal open class BaseDomainTest2 : SynchronizedCoroutineTest {
         repos.insertChannelConfig(ChannelConfig("messaging", data.config1))
         repos.insertUsers(data.userMap.values.toList())
 
-        query = QueryChannelsSpec(data.filter1, QuerySort())
+        query = QueryChannelsSpec(data.filter1, QuerySortByField())
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/QueryChannelsImplRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/QueryChannelsImplRepositoryTest.kt
@@ -14,13 +14,11 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.offline.repository
 
 import io.getstream.chat.android.client.api.models.ContainsFilterObject
 import io.getstream.chat.android.client.api.models.NeutralFilterObject
-import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.test.randomQueryChannelsSpec
 import io.getstream.chat.android.offline.randomQueryChannelsEntity
@@ -77,11 +75,11 @@ internal class QueryChannelsImplRepositoryTest {
         whenever(dao.select(any())) doReturn randomQueryChannelsEntity(
             id = "id1",
             filter = Filters.contains("cid", "cid1"),
-            querySort = QuerySort(),
+            querySort = QuerySortByField(),
             cids = listOf("cid1")
         )
 
-        val result = sut.selectBy(Filters.contains("cid", "cid1"), QuerySort())
+        val result = sut.selectBy(Filters.contains("cid", "cid1"), QuerySortByField())
 
         result.shouldNotBeNull()
         result.filter.shouldBeInstanceOf<ContainsFilterObject>()
@@ -94,7 +92,7 @@ internal class QueryChannelsImplRepositoryTest {
     fun `Given no row in DB with such id When select by id Should return null`() = runTest {
         whenever(dao.select(any())) doReturn null
 
-        val result = sut.selectBy(NeutralFilterObject, QuerySort())
+        val result = sut.selectBy(NeutralFilterObject, QuerySortByField())
 
         result.shouldBeNull()
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/internal/extensions/ChannelExtensionsTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/internal/extensions/ChannelExtensionsTest.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.offline.internal.extensions
 
 import com.squareup.moshi.JsonAdapter
@@ -24,7 +22,6 @@ import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-import io.getstream.chat.android.client.api.models.QuerySort
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.extensions.internal.applyPagination
 import io.getstream.chat.android.client.models.Attachment
@@ -94,7 +91,7 @@ internal class ChannelExtensionsTest {
         val firstChannel = randomChannel(lastMessageAt = Date(1000))
         val secondChannel = randomChannel(lastMessageAt = Date(3000))
         val thirdChannel = randomChannel(lastMessageAt = Date(2000))
-        val sort = QuerySort<Channel>().desc(Channel::lastMessageAt)
+        val sort = QuerySortByField.descByName<Channel>("lastMessageAt")
         val queryPaginationRequest = QueryChannelsPaginationRequest(
             sort = sort,
             channelOffset = 0,
@@ -118,7 +115,7 @@ internal class ChannelExtensionsTest {
         val firstChannel = randomChannel(lastMessageAt = Date(1000))
         val secondChannel = randomChannel(lastMessageAt = Date(3000))
         val thirdChannel = randomChannel(lastMessageAt = Date(2000))
-        val sort = QuerySort<Channel>().asc(Channel::lastMessageAt)
+        val sort = QuerySortByField.ascByName<Channel>("lastMessageAt")
         val queryPaginationRequest = QueryChannelsPaginationRequest(
             sort = sort,
             channelOffset = 0,

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/QueryChannelsSortTest.kt
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-@file:Suppress("DEPRECATION_ERROR")
-
 package io.getstream.chat.android.offline.querychannels
 
-import io.getstream.chat.android.client.api.models.QuerySort
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField.Companion.ascByName
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.CustomObject
 import io.getstream.chat.android.client.test.randomChannel
@@ -36,7 +35,7 @@ internal class QueryChannelsSortTest {
     fun `Given shuffled channels When sorting the list Should return sorted channels`(
         testName: String,
         channelList: List<Channel>,
-        querySort: QuerySort<Channel>,
+        querySort: QuerySortByField<Channel>,
         expectedChannelList: List<CustomObject>,
     ) {
         val result = channelList.sortedWith(querySort.comparator)
@@ -63,7 +62,7 @@ internal class QueryChannelsSortTest {
         fun lastUpdatedSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by lastUpdated field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::lastUpdated)
+                querySort = QuerySortByField.ascByName("lastUpdated")
             ) {
                 randomChannel(
                     createdAt = dateWithOffset(offsetSeconds = -100),
@@ -72,7 +71,7 @@ internal class QueryChannelsSortTest {
             },
             sortArguments(
                 testName = "Sorting by lastUpdated field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::lastUpdated)
+                querySort = QuerySortByField.descByName("lastUpdated")
             ) {
                 randomChannel(
                     createdAt = dateWithOffset(offsetSeconds = -100),
@@ -81,7 +80,7 @@ internal class QueryChannelsSortTest {
             },
             sortArguments(
                 testName = "Sorting by last_updated field name in ascending order",
-                querySort = QuerySort<Channel>().asc("last_updated")
+                querySort = QuerySortByField.ascByName("last_updated")
             ) {
                 randomChannel(
                     createdAt = dateWithOffset(offsetSeconds = -100),
@@ -90,7 +89,7 @@ internal class QueryChannelsSortTest {
             },
             sortArguments(
                 testName = "Sorting by last_updated field name in descending order",
-                querySort = QuerySort<Channel>().desc("last_updated")
+                querySort = QuerySortByField.descByName("last_updated")
             ) {
                 randomChannel(
                     createdAt = dateWithOffset(offsetSeconds = -100),
@@ -103,25 +102,25 @@ internal class QueryChannelsSortTest {
         fun lastMessageAtSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by lastMessageAt field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::lastMessageAt)
+                querySort = QuerySortByField.ascByName("lastMessageAt")
             ) {
                 randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by lastMessageAt field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::lastMessageAt)
+                querySort = QuerySortByField.descByName("lastMessageAt")
             ) {
                 randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
             },
             sortArguments(
                 testName = "Sorting by last_message_at field name in ascending order",
-                querySort = QuerySort<Channel>().asc("last_message_at")
+                querySort = QuerySortByField.ascByName("last_message_at")
             ) {
                 randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by last_message_at field name in descending order",
-                querySort = QuerySort<Channel>().desc("last_message_at")
+                querySort = QuerySortByField.descByName("last_message_at")
             ) {
                 randomChannel(lastMessageAt = dateWithOffset(offsetSeconds = -it))
             },
@@ -131,25 +130,25 @@ internal class QueryChannelsSortTest {
         fun updatedAtSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by updatedAt field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::updatedAt)
+                querySort = QuerySortByField.ascByName("updatedAt")
             ) {
                 randomChannel(updatedAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by updatedAt field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::updatedAt)
+                querySort = QuerySortByField.descByName("updatedAt")
             ) {
                 randomChannel(updatedAt = dateWithOffset(offsetSeconds = -it))
             },
             sortArguments(
                 testName = "Sorting by updated_at field name in ascending order",
-                querySort = QuerySort<Channel>().asc("updated_at")
+                querySort = QuerySortByField.ascByName("updated_at")
             ) {
                 randomChannel(updatedAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by updated_at field name in descending order",
-                querySort = QuerySort<Channel>().desc("updated_at")
+                querySort = QuerySortByField.descByName("updated_at")
             ) {
                 randomChannel(updatedAt = dateWithOffset(offsetSeconds = -it))
             },
@@ -159,25 +158,25 @@ internal class QueryChannelsSortTest {
         fun createdAtSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by createdAt field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::createdAt)
+                querySort = QuerySortByField.ascByName("createdAt")
             ) {
                 randomChannel(createdAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by createdAt field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::createdAt)
+                querySort = QuerySortByField.descByName("createdAt")
             ) {
                 randomChannel(createdAt = dateWithOffset(offsetSeconds = -it))
             },
             sortArguments(
                 testName = "Sorting by created_at field name in ascending order",
-                querySort = QuerySort<Channel>().asc("created_at")
+                querySort = QuerySortByField.ascByName("created_at")
             ) {
                 randomChannel(createdAt = dateWithOffset(offsetSeconds = it))
             },
             sortArguments(
                 testName = "Sorting by created_at field name in descending order",
-                querySort = QuerySort<Channel>().desc("created_at")
+                querySort = QuerySortByField.descByName("created_at")
             ) {
                 randomChannel(createdAt = dateWithOffset(offsetSeconds = -it))
             }
@@ -187,25 +186,25 @@ internal class QueryChannelsSortTest {
         fun memberCountSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by memberCount field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::memberCount)
+                querySort = QuerySortByField.ascByName("memberCount")
             ) {
                 randomChannel(memberCount = it)
             },
             sortArguments(
                 testName = "Sorting by memberCount field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::memberCount)
+                querySort = QuerySortByField.descByName("memberCount")
             ) {
                 randomChannel(memberCount = 9 - it)
             },
             sortArguments(
                 testName = "Sorting by member_count field name in ascending order",
-                querySort = QuerySort<Channel>().asc("member_count")
+                querySort = QuerySortByField.ascByName("member_count")
             ) {
                 randomChannel(memberCount = it)
             },
             sortArguments(
                 testName = "Sorting by member_count field name in descending order",
-                querySort = QuerySort<Channel>().desc("member_count")
+                querySort = QuerySortByField.descByName("member_count")
             ) {
                 randomChannel(memberCount = 9 - it)
             },
@@ -215,25 +214,25 @@ internal class QueryChannelsSortTest {
         fun unreadCountSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by unreadCount field reference in ascending order",
-                querySort = QuerySort<Channel>().asc(Channel::unreadCount)
+                querySort = QuerySortByField.ascByName("unreadCount")
             ) {
                 randomChannel(unreadCount = it)
             },
             sortArguments(
                 testName = "Sorting by unreadCount field reference in descending order",
-                querySort = QuerySort<Channel>().desc(Channel::unreadCount)
+                querySort = QuerySortByField.descByName("unreadCount")
             ) {
                 randomChannel(unreadCount = 9 - it)
             },
             sortArguments(
                 testName = "Sorting by unread_count field name in ascending order",
-                querySort = QuerySort<Channel>().asc("unread_count")
+                querySort = QuerySortByField.ascByName("unread_count")
             ) {
                 randomChannel(unreadCount = it)
             },
             sortArguments(
                 testName = "Sorting by unread_count field name in descending order",
-                querySort = QuerySort<Channel>().desc("unread_count")
+                querySort = QuerySortByField.descByName("unread_count")
             ) {
                 randomChannel(unreadCount = 9 - it)
             },
@@ -254,7 +253,7 @@ internal class QueryChannelsSortTest {
                         expectedList[2],
                         expectedList[5]
                     ),
-                    QuerySort<Channel>().asc(Channel::hasUnread),
+                    QuerySortByField.ascByName<Channel>("hasUnread"),
                     expectedList,
                 )
             },
@@ -271,7 +270,7 @@ internal class QueryChannelsSortTest {
                         expectedList[2],
                         expectedList[5]
                     ),
-                    QuerySort<Channel>().desc(Channel::hasUnread),
+                    QuerySortByField.descByName<Channel>("hasUnread"),
                     expectedList,
                 )
             },
@@ -288,7 +287,7 @@ internal class QueryChannelsSortTest {
                         expectedList[2],
                         expectedList[5]
                     ),
-                    QuerySort<Channel>().asc("has_unread"),
+                    QuerySortByField.ascByName<Channel>("has_unread"),
                     expectedList,
                 )
             },
@@ -305,7 +304,7 @@ internal class QueryChannelsSortTest {
                         expectedList[2],
                         expectedList[5]
                     ),
-                    QuerySort<Channel>().desc("has_unread"),
+                    QuerySortByField.descByName<Channel>("has_unread"),
                     expectedList,
                 )
             }
@@ -315,13 +314,13 @@ internal class QueryChannelsSortTest {
         fun nameSortArguments() = listOf(
             sortArguments(
                 testName = "Sorting by name extra data field in ascending order",
-                querySort = QuerySort<Channel>().asc("name")
+                querySort = QuerySortByField.ascByName("name"),
             ) {
                 randomChannel().apply { name = "$it" }
             },
             sortArguments(
                 testName = "Sorting by name extra data field in descending order",
-                querySort = QuerySort<Channel>().desc("name")
+                querySort = QuerySortByField.descByName("name"),
             ) {
                 randomChannel().apply { name = "${9 - it}" }
             }
@@ -333,7 +332,7 @@ internal class QueryChannelsSortTest {
                 Arguments.of(
                     "Sorting by unsupported field in ascending order",
                     expectedList,
-                    QuerySort<Channel>().asc("unsupported_field"),
+                    QuerySortByField.ascByName<Channel>("unsupported_field"),
                     expectedList,
                 )
             },
@@ -341,7 +340,7 @@ internal class QueryChannelsSortTest {
                 Arguments.of(
                     "Sorting by unsupported field in descending order",
                     expectedList,
-                    QuerySort<Channel>().desc("unsupported_field"),
+                    QuerySortByField.descByName<Channel>("unsupported_field"),
                     expectedList,
                 )
             },
@@ -351,9 +350,9 @@ internal class QueryChannelsSortTest {
         fun multiSortByFieldReferencesArguments() = listOf(
             sortArguments(
                 testName = "Sorting by unreadCount field reference in descending order and by memberCount field reference in ascending order",
-                querySort = QuerySort<Channel>()
-                    .desc(Channel::unreadCount)
-                    .asc(Channel::memberCount)
+                querySort = QuerySortByField
+                    .descByName<Channel>("unreadCount")
+                    .ascByName("memberCount")
             ) {
                 randomChannel(
                     memberCount = it,
@@ -366,9 +365,9 @@ internal class QueryChannelsSortTest {
         fun multiSortByFieldNamesArguments() = listOf(
             sortArguments(
                 testName = "Sorting by unread_count field name in descending order and by name extra data field in ascending order",
-                querySort = QuerySort<Channel>()
-                    .desc("unread_count")
-                    .asc("name")
+                querySort = QuerySortByField
+                    .descByName<Channel>("unreadCount")
+                    .ascByName("name")
             ) {
                 randomChannel().apply {
                     name = "$it"
@@ -379,7 +378,7 @@ internal class QueryChannelsSortTest {
 
         private fun sortArguments(
             testName: String,
-            querySort: QuerySort<Channel>,
+            querySort: QuerySortByField<Channel>,
             channelFactory: (Int) -> Channel,
         ): Arguments {
             return List(10, channelFactory).let { expectedList ->


### PR DESCRIPTION
closes #3894 

### 🎯 Goal

Remove QuerySort usages from tests

### 🧪 Testing

Run tests.


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
