### PR TITLE
Moving CreateChannelListenerImpl to offline module

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.client.setup.InitializationCoordinator
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.plugin.configuration.Config
 import io.getstream.chat.android.offline.plugin.internal.OfflinePlugin
+import io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl
 import io.getstream.chat.android.offline.repository.database.internal.ChatDatabase
 import io.getstream.chat.android.offline.repository.factory.internal.DatabaseRepositoryFactory
 import io.getstream.chat.android.state.plugin.configuration.StatePluginConfig
@@ -97,6 +98,14 @@ public class StreamOfflinePluginFactory(
             clearCachedInstance()
         }
 
+        val chatClient = ChatClient.instance()
+
+        val createChannelListener = CreateChannelListenerImpl(
+            clientState = chatClient.clientState,
+            channelRepository = chatClient.repositoryFacade,
+            userRepository = chatClient.repositoryFacade
+        )
+
         return OfflinePlugin(
             queryChannelsListener = statePlugin,
             queryChannelListener = statePlugin,
@@ -113,7 +122,7 @@ public class StreamOfflinePluginFactory(
             shuffleGiphyListener = statePlugin,
             queryMembersListener = statePlugin,
             typingEventListener = statePlugin,
-            createChannelListener = statePlugin,
+            createChannelListener = createChannelListener,
             activeUser = user
         ).also { offlinePlugin -> cachedOfflinePluginInstance = offlinePlugin }
     }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/CreateChannelTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/CreateChannelTests.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.offline.channel
+package io.getstream.chat.android.offline.plugin.listener.internal
 
 import io.getstream.chat.android.client.errors.ChatNetworkError
 import io.getstream.chat.android.client.models.Channel
@@ -26,7 +26,6 @@ import io.getstream.chat.android.client.test.randomMember
 import io.getstream.chat.android.client.test.randomUser
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.client.utils.SyncStatus
-import io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
@@ -285,9 +284,10 @@ internal class CreateChannelTests {
             repositoryFacade = repos
         }
 
-        fun get(): io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl {
-            return io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl(
+        fun get(): CreateChannelListenerImpl {
+            return CreateChannelListenerImpl(
                 clientState,
+                repositoryFacade,
                 repositoryFacade
             )
         }

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -332,6 +332,9 @@ public class io/getstream/chat/android/offline/utils/Event {
 	public final fun peekContent ()Ljava/lang/Object;
 }
 
+public final class io/getstream/chat/android/offline/utils/internal/ChannelUtilsKt {
+}
+
 public final class io/getstream/chat/android/state/BuildConfig {
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelUtils.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.offline.utils.internal
 
 import io.getstream.chat.android.client.setup.state.ClientState
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.offline.plugin.state.global.internal.GlobalMutableState
 
 /**
@@ -42,7 +43,8 @@ internal fun isChannelMutedForCurrentUser(cid: String, clientState: ClientState)
  *
  * @return [channelId] if not blank or new, member-based id.
  */
-internal fun generateChannelIdIfNeeded(channelId: String, memberIds: List<String>): String {
+@InternalStreamChatApi
+public fun generateChannelIdIfNeeded(channelId: String, memberIds: List<String>): String {
     return channelId.ifBlank {
         memberIds.joinToString(prefix = "!members-")
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -34,7 +34,6 @@ import io.getstream.chat.android.offline.event.handler.internal.EventHandlerSequ
 import io.getstream.chat.android.offline.interceptor.internal.DefaultInterceptor
 import io.getstream.chat.android.offline.interceptor.internal.SendMessageInterceptorImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.ChannelMarkReadListenerImpl
-import io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.DeleteMessageListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.DeleteReactionListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.EditMessageListenerImpl
@@ -237,7 +236,6 @@ public class StreamStatePluginFactory(
             shuffleGiphyListener = ShuffleGiphyListenerImpl(logic),
             queryMembersListener = QueryMembersListenerImpl(repositoryFacade),
             typingEventListener = TypingEventListenerImpl(stateRegistry),
-            createChannelListener = CreateChannelListenerImpl(clientState, repositoryFacade),
             activeUser = user
         )
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -19,7 +19,6 @@ package io.getstream.chat.android.state.plugin.internal
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
-import io.getstream.chat.android.client.plugin.listeners.CreateChannelListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteMessageListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteReactionListener
 import io.getstream.chat.android.client.plugin.listeners.EditMessageListener
@@ -55,10 +54,10 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
  * @param sendMessageListener [SendMessageListener]
  * @param queryMembersListener [QueryMembersListener]
  * @param typingEventListener [TypingEventListener]
- * @param createChannelListener [CreateChannelListener]
  * @param activeUser User associated with [StatePlugin] instance.
  */
 @InternalStreamChatApi
+@Suppress("LongParameterList")
 public class StatePlugin(
     private val queryChannelsListener: QueryChannelsListener,
     private val queryChannelListener: QueryChannelListener,
@@ -75,7 +74,6 @@ public class StatePlugin(
     private val sendMessageListener: SendMessageListener,
     private val queryMembersListener: QueryMembersListener,
     private val typingEventListener: TypingEventListener,
-    private val createChannelListener: CreateChannelListener,
     internal val activeUser: User,
 ) : Plugin,
     QueryChannelsListener by queryChannelsListener,
@@ -92,8 +90,7 @@ public class StatePlugin(
     ShuffleGiphyListener by shuffleGiphyListener,
     SendMessageListener by sendMessageListener,
     QueryMembersListener by queryMembersListener,
-    TypingEventListener by typingEventListener,
-    CreateChannelListener by createChannelListener {
+    TypingEventListener by typingEventListener {
 
     override val name: String = MODULE_NAME
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/channel/CreateChannelTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/channel/CreateChannelTests.kt
@@ -285,8 +285,11 @@ internal class CreateChannelTests {
             repositoryFacade = repos
         }
 
-        fun get(): CreateChannelListenerImpl {
-            return CreateChannelListenerImpl(clientState, repositoryFacade)
+        fun get(): io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl {
+            return io.getstream.chat.android.offline.plugin.listener.internal.CreateChannelListenerImpl(
+                clientState,
+                repositoryFacade
+            )
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Move `CreateChannelListenerImpl` to OfflinePlugin module. There's no need to separate this class into state and persistence because this is already just persistence. 

### 🧪 Testing

Create channels and check the persistence of it. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~ 
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/180854724-cc5bfb43-acf4-4be1-b5f5-44a281a91a27.gif)
_Change the channel_
