### PR TITLE
Loging unrecoverable error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### ⬆️ Improved
 - Offline data is clear after the user is disconnect by calling `ChatClient.disconnect(true)`. [#3917](https://github.com/GetStream/stream-chat-android/pull/3917)
+- Adding logs to understand more about unrecoverable errors in socket connection. [#3946](https://github.com/GetStream/stream-chat-android/pull/3946)
 
 ### ✅ Added
 - Added a check if `lastSyncedAt` is no later than 30 days when calling `ChatClient::getSyncHistory`. [#3934](https://github.com/GetStream/stream-chat-android/pull/3934)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/experimental/socket/ChatSocket.kt
@@ -268,6 +268,9 @@ internal open class ChatSocket constructor(
             ChatErrorCode.API_KEY_NOT_FOUND.code,
             ChatErrorCode.VALIDATION_ERROR.code,
             -> {
+                logger.d {
+                    "One unrecoverable error happened. Error: ${error.stringify()}. Error code: ${error.streamCode}"
+                }
                 disconnect(DisconnectCause.UnrecoverableError(error))
             }
             else -> {


### PR DESCRIPTION
### 🎯 Goal

Log when an unrecoverable error happens. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (1)](https://user-images.githubusercontent.com/10619102/180866230-846c5e96-4be7-4bf2-ba21-727336c8a21c.gif)
_Logs_
