### PR TITLE
Postpone calls that require active socket connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 - Added `ClientState::isNetworkAvailable` which gives you information about device's internet connection status.[#3880](https://github.com/GetStream/stream-chat-android/pull/3880)
 
 ### ⚠️ Changed
+- Queries that require active socket connection will be postponed until connection is established: [#3952](https://github.com/GetStream/stream-chat-android/pull/3952)
+  - `ChatClient::queryChannel` and `ChatClient::createChannel` will be postponed if [QueryChannelRequest.watch] or [QueryChannelRequest.presence] is enabled.
+  - `ChatClient::queryChannels` will be postponed if [QueryChannelsRequest.watch] or [QueryChannelsRequest.presence] is enabled.
+  - `ChatClient::queryUsers` will be postponed if [QueryUsersRequest.presence] is enabled.
+  - `ChatClient::stopWatching` always requires active socket connection.
+
 
 ### ❌ Removed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1518,15 +1518,26 @@ internal constructor(
      *
      * @param request The request's parameters combined into [QueryChannelsRequest] class.
      *
+     * @see [queryChannels]
+     *
      * @return Executable async [Call] responsible for querying channels.
      */
     @CheckResult
     @InternalStreamChatApi
     public fun queryChannelsInternal(request: QueryChannelsRequest): Call<List<Channel>> {
-        logger.d { "[queryChannelsInternal] request: $request" }
-        return callPostponeHelper.postponeCall { api.queryChannels(request) }
+        val isConnectionRequired = request.watch || request.presence
+        logger.d { "[queryChannelsInternal] request: $request, isConnectionRequired: $isConnectionRequired" }
+
+        return callPostponeHelper.postponeCallIfNeeded(shouldPostpone = isConnectionRequired) {
+            api.queryChannels(request)
+        }
     }
 
+    /**
+     * Runs [queryChannel] without applying side effects.
+     *
+     * @see [queryChannel]
+     */
     @CheckResult
     @InternalStreamChatApi
     public fun queryChannelInternal(
@@ -1534,14 +1545,23 @@ internal constructor(
         channelId: String,
         request: QueryChannelRequest,
     ): Call<Channel> {
-        logger.d { "[queryChannelInternal] cid: $channelType:$channelId, request: $request" }
-        return api.queryChannel(channelType, channelId, request)
+        val isConnectionRequired = request.watch || request.presence
+        logger.d {
+            "[queryChannelInternal] cid: $channelType:$channelId, request: $request, " +
+                "isConnectionRequired: $isConnectionRequired"
+        }
+
+        return callPostponeHelper.postponeCallIfNeeded(shouldPostpone = isConnectionRequired) {
+            api.queryChannel(channelType, channelId, request)
+        }
     }
 
     /**
      * Gets the channel from the server based on [channelType], [channelId] and parameters from [QueryChannelRequest].
-     * The call requires active socket connection and will be automatically postponed and retried until
-     * the connection is established or the maximum number of attempts is reached.
+     * The call requires active socket connection if [QueryChannelRequest.watch] or [QueryChannelRequest.presence] is
+     * enabled, and will be automatically postponed and retried until the connection is established or the maximum
+     * number of attempts is reached.
+     *
      * @see [CallPostponeHelper]
      *
      * @param request The request's parameters combined into [QueryChannelRequest] class.
@@ -1554,38 +1574,29 @@ internal constructor(
         channelId: String,
         request: QueryChannelRequest,
     ): Call<Channel> {
-        val isConnectionRequired = request.watch || request.presence
-        logger.d {
-            "[queryChannel] channelType: $channelType, channelId: $channelId, " +
-                "isConnectionRequired: $isConnectionRequired"
-        }
-
         val relevantPlugins = plugins.filterIsInstance<QueryChannelListener>().also(::logPlugins)
 
-        val callBuilder = { api.queryChannel(channelType, channelId, request) }
-        val queryChannelCall = when (isConnectionRequired) {
-            true -> callPostponeHelper.postponeCall(callBuilder)
-            else -> callBuilder.invoke()
-        }
-        return queryChannelCall.doOnStart(scope) {
-            relevantPlugins.forEach { plugin ->
-                logger.v { "[queryChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
-                plugin.onQueryChannelRequest(channelType, channelId, request)
+        return queryChannelInternal(channelType = channelType, channelId = channelId, request = request)
+            .doOnStart(scope) {
+                relevantPlugins.forEach { plugin ->
+                    logger.v { "[queryChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
+                    plugin.onQueryChannelRequest(channelType, channelId, request)
+                }
+            }.doOnResult(scope) { result ->
+                relevantPlugins.forEach { plugin ->
+                    logger.v { "[queryChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
+                    plugin.onQueryChannelResult(result, channelType, channelId, request)
+                }
+            }.precondition(relevantPlugins) {
+                onQueryChannelPrecondition(channelType, channelId, request)
             }
-        }.doOnResult(scope) { result ->
-            relevantPlugins.forEach { plugin ->
-                logger.v { "[queryChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
-                plugin.onQueryChannelResult(result, channelType, channelId, request)
-            }
-        }.precondition(relevantPlugins) {
-            onQueryChannelPrecondition(channelType, channelId, request)
-        }
     }
 
     /**
      * Gets the channels from the server based on parameters from [QueryChannelsRequest].
-     * The call requires active socket connection and will be automatically postponed and retried until
-     * the connection is established or the maximum number of attempts is reached.
+     * The call requires active socket connection if [QueryChannelsRequest.watch] or [QueryChannelsRequest.presence] is
+     * enabled, and will be automatically postponed and retried until the connection is established or
+     * the maximum number of attempts is reached.
      * @see [CallPostponeHelper]
      *
      * @param request The request's parameters combined into [QueryChannelsRequest] class.
@@ -1594,14 +1605,10 @@ internal constructor(
      */
     @CheckResult
     public fun queryChannels(request: QueryChannelsRequest): Call<List<Channel>> {
-        logger.d { "[queryChannels] request: $request" }
-
         val relevantPluginsLazy = { plugins.filterIsInstance<QueryChannelsListener>() }
         logPlugins(relevantPluginsLazy())
 
-        return callPostponeHelper.postponeCall {
-            api.queryChannels(request)
-        }.doOnStart(scope) {
+        return queryChannelsInternal(request = request).doOnStart(scope) {
             relevantPluginsLazy().forEach { listener ->
                 logger.v { "[queryChannels] #doOnStart; plugin: ${listener::class.qualifiedName}" }
                 listener.onQueryChannelsRequest(request)
@@ -1692,9 +1699,19 @@ internal constructor(
         )
     }
 
+    /**
+     * Stops watching the channel which means you won't receive more events for the channel.
+     * The call requires active socket connection and will be automatically postponed and
+     * retried until the connection is established.
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     *
+     * @return Executable async [Call] responsible for stop watching the channel.
+     */
     @CheckResult
     public fun stopWatching(channelType: String, channelId: String): Call<Unit> {
-        return api.stopWatching(channelType, channelId)
+        return callPostponeHelper.postponeCall { api.stopWatching(channelType, channelId) }
     }
 
     /**
@@ -1897,12 +1914,24 @@ internal constructor(
     /**
      * Query users matching [query] request.
      *
+     * The call requires active socket connection if [QueryUsersRequest.presence] is enabled, and will be
+     * automatically postponed and retried until the connection is established.
+     *
      * @param query [QueryUsersRequest] with query parameters like filters, sort to get matching users.
      *
      * @return [Call] with a list of [User].
      */
     @CheckResult
-    public fun queryUsers(query: QueryUsersRequest): Call<List<User>> = api.queryUsers(query)
+    public fun queryUsers(query: QueryUsersRequest): Call<List<User>> {
+        val isConnectionRequired = query.presence
+        logger.d {
+            "[queryUsers]  request: $query, isConnectionRequired: $isConnectionRequired"
+        }
+
+        return callPostponeHelper.postponeCallIfNeeded(shouldPostpone = isConnectionRequired) {
+            api.queryUsers(query)
+        }
+    }
 
     /**
      * Adds members to a given channel.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/helpers/CallPostponeHelper.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/helpers/CallPostponeHelper.kt
@@ -48,6 +48,22 @@ internal class CallPostponeHelper(
 ) {
 
     /**
+     * Postpones or immediately executes the call based on [shouldPostpone] parameter.
+     *
+     * @param shouldPostpone Whether the call should be postponed
+     * @param call A call to be run when the socket connection is established.
+     *
+     * @return Executable async [Call] responsible for querying channels
+     */
+    internal fun <T : Any> postponeCallIfNeeded(shouldPostpone: Boolean, call: () -> Call<T>): Call<T> {
+        return if (shouldPostpone) {
+            postponeCall(call)
+        } else {
+            call()
+        }
+    }
+
+    /**
      * Postpones call.
      *
      * @param call A call to be run when the socket connection is established.


### PR DESCRIPTION
closes #3896 

### 🎯 Goal

Postpone calls that require an active socket connection.

### 🛠 Implementation details
Added postponing the following calls:
  - `ChatClient::queryChannel` and `ChatClient::createChannel` if [QueryChannelRequest.watch] or [QueryChannelRequest.presence] is enabled
  - `ChatClient::queryChannels`  if [QueryChannelsRequest.watch] or [QueryChannelsRequest.presence] is enabled
  - `ChatClient::queryUsers`  if [QueryUsersRequest.presence] is enabled
  - `ChatClient::stopWatching` 

### 🧪 Testing

Smoke test the apps.


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
