### PR TITLE
[3967] Deprecate `DefaultTypingUpdatesBuffer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 ### ⚠️ Changed
 - Deprecated `LegacyDateFormatter`, `PorterImageView` and `PorterShapeImageView` classes as they are unused. [3923](https://github.com/GetStream/stream-chat-android/pull/3923)
+- Deprecated `DefaultTypingUpdatesBuffer`. Should you wish to create your own implementation of a typing buffer, you can create a custom implementation of `TypingUpdatesBuffer`. [#3968](https://github.com/GetStream/stream-chat-android/pull/3968)
 
 ### ❌ Removed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `DefaultTypingUpdatesBuffer` | 2022.08.02 <br/>5.7.0 | 2022.08.16 ⌛ | 2022.08.30 ⌛ | This implementation of `TypingUpdatesBuffer` has been deprecated and will be removed. Should you wish to user your own typing updates buffer, you should create a custom implementation of `TypingUpdatesBuffer`. |
 | `ChannelListView.showLoadingMore()` | 2022.08.02 <br/>5.6.0 | 2022.09.06 ⌛ | 2022.10.04 ⌛ | Insert the loading item before passing the list to the adapter. |
 | `ChannelListView.hideLoadingMore()` | 2022.08.02 <br/>5.6.0 | 2022.09.06 ⌛ | 2022.10.04 ⌛ | Insert the loading item before passing the list to the adapter. |
 | `RowScope.DefaultComposerInputContent` | 2022.08.02 <br/>5.6.0 | 2022.09.06 ⌛ | 2022.10.04 ⌛ | Use `MessageInput` instead. |

--- a/docusaurus/docs/Android/03-ui/04-message-components/04-message-input.mdx
+++ b/docusaurus/docs/Android/03-ui/04-message-components/04-message-input.mdx
@@ -53,25 +53,16 @@ messageInputView.setOnSendButtonClickListener {
 }
 ```
 
-If you want to listen to typing updates, you can set your own instance of [`DefaultTypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt) on the `MessageInputView`.
-The buffer is designed to save valuable API calls by not firing an event on each keystroke, but intelligently time them based on an interval. Additionally, it automatically tracks typing inactivity after the last keystroke and sends a stop typing event after a set period of time.
+Typing updates should be sent sparingly as a way of saving valuable API calls. Luckily, we offer such behavior out of the box by using our [`DefaultTypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt) in order to intelligently make start and stop typing API calls.
+
+If you want to implement your own buffering mechanism you can pass in an implementation of the [`TypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer.kt) interface instead:
 
 ```kotlin
 messageInputView.setTypingUpdatesBuffer(
-    DefaultTypingUpdatesBuffer(
-        onTypingStarted = {
-            // Make a keystroke API call
-            // Implement your custom action
-        },
-        onTypingStopped = {
-            // Make a typing stopped API call
-            // Implement your custom action
-        }
-    )
+    // Your custom implementation of TypingUpdatesBuffer
 )
 ```
 
-If you want to implement your own buffering mechanism you can pass in an implementation of the [`TypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer.kt) interface instead.
 
 You can show a custom error when the maximum message length is exceeded:
 

--- a/docusaurus/docs/Android/04-compose/05-message-components/04-message-composer.mdx
+++ b/docusaurus/docs/Android/04-compose/05-message-components/04-message-composer.mdx
@@ -108,25 +108,13 @@ To customize these actions, simply pass in a lambda function for each when build
 Typing updates should be sent sparingly as a way of saving valuable API calls. Luckily, we offer such behavior out of the box.
 `MessageComposerViewModel` contains `MessageComposerController`, which in turn uses [`DefaultTypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt) in order to intelligently make start and stop typing API calls.
 
-Should you wish to customize the behavior, you can set your own `DefaultTypingUpdatesBuffer` like so:
+If you want to implement your own buffering mechanism you can pass in an implementation of the [`TypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer.kt) interface instead:
 
 ```kotlin
 composerViewModel.setTypingUpdatesBuffer(
-    DefaultTypingUpdatesBuffer(
-        onTypingStarted = {
-            // Make a keystroke API call
-            // Implement your custom action
-        },
-        onTypingStopped = {
-            // Make a typing stopped API call
-            // Implement your custom action
-        }
-    )
+    // Your custom implementation of TypingUpdatesBuffer
 )
 ```
-
-If you want to implement your own buffering mechanism you can pass in an implementation of the [`TypingUpdatesBuffer`](https://github.com/GetStream/stream-chat-android/blob/main/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer.kt) interface instead.
-
 
 ## Customization
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/MessageComposer.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/MessageComposer.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
-import com.getstream.sdk.chat.utils.typing.DefaultTypingUpdatesBuffer
 import io.getstream.chat.android.compose.ui.components.composer.MessageInput
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -146,18 +145,12 @@ private object HandlingTypingUpdatesSnippet {
         override fun onCreate(savedInstanceState: Bundle?, persistentState: PersistableBundle?) {
             super.onCreate(savedInstanceState, persistentState)
 
+            // This needs to be commented out or the docs module build will fail
+            /*
             composerViewModel.setTypingUpdatesBuffer(
-                DefaultTypingUpdatesBuffer(
-                    onTypingStarted = {
-                        // Make a keystroke API call
-                        // Implement your custom action
-                    },
-                    onTypingStopped = {
-                        // Make a typing stopped API call
-                        // Implement your custom action
-                    }
-                )
+                // Your custom implementation of TypingUpdatesBuffer
             )
+            */
         }
     }
 }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageInput.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageInput.kt
@@ -7,7 +7,6 @@ import android.view.ViewGroup
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
-import com.getstream.sdk.chat.utils.typing.DefaultTypingUpdatesBuffer
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Message
@@ -52,18 +51,11 @@ private class MessageInputViewSnippets : Fragment() {
         messageInputView.setOnSendButtonClickListener {
             // Handle send button click
         }
+        // This needs to be commented out or the docs module build will fail
+        /*
         messageInputView.setTypingUpdatesBuffer(
-            DefaultTypingUpdatesBuffer(
-                onTypingStarted = {
-                    // Make a keystroke API call
-                    // Implement your custom action
-                },
-                onTypingStopped = {
-                    // Make a typing stopped API call
-                    // Implement your custom action
-                }
-            )
-        )
+            // Your custom implementation of TypingUpdatesBuffer
+        )*/
         messageInputView.setMaxMessageLengthHandler { messageText, messageLength, maxMessageLength, maxMessageLengthExceeded ->
             if (maxMessageLengthExceeded) {
                 // Show custom max-length error

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -187,6 +187,13 @@ public class com/getstream/sdk/chat/utils/roundedImageView/PorterShapeImageView 
 	public fun setShape (Landroid/content/Context;Landroid/graphics/drawable/Drawable;)V
 }
 
+public final class com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer : com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer {
+	public fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
+	public synthetic fun <init> (Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun clear ()V
+	public fun onKeystroke ()V
+}
+
 public abstract interface class com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer {
 	public abstract fun clear ()V
 	public abstract fun onKeystroke ()V

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -187,12 +187,6 @@ public class com/getstream/sdk/chat/utils/roundedImageView/PorterShapeImageView 
 	public fun setShape (Landroid/content/Context;Landroid/graphics/drawable/Drawable;)V
 }
 
-public final class com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer : com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer {
-	public fun <init> (Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;)V
-	public fun clear ()V
-	public fun onKeystroke ()V
-}
-
 public abstract interface class com/getstream/sdk/chat/utils/typing/TypingUpdatesBuffer {
 	public abstract fun clear ()V
 	public abstract fun onKeystroke ()V

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt
@@ -17,6 +17,7 @@
 package com.getstream.sdk.chat.utils.typing
 
 import com.getstream.sdk.chat.utils.typing.DefaultTypingUpdatesBuffer.Companion.DEFAULT_SEND_TYPING_UPDATES_INTERVAL
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -35,21 +36,18 @@ import kotlinx.coroutines.launch
  *
  * You should call [clear] before an instance of this class is removed.
  *
+ * @param coroutineScope The coroutine scope used for running the timer and sending updates.
  * @param onTypingStarted Signals that a typing event should be sent.
  * Usually used to make an API call using [io.getstream.chat.android.client.ChatClient.keystroke]
  * @param onTypingStopped Signals that a stop typing event should be sent.
  * Usually used to make an API call using [io.getstream.chat.android.client.ChatClient.stopTyping]
  */
+@InternalStreamChatApi
 public class DefaultTypingUpdatesBuffer(
+    private val coroutineScope: CoroutineScope = CoroutineScope(DispatcherProvider.IO),
     private val onTypingStarted: () -> Unit,
     private val onTypingStopped: () -> Unit,
 ) : TypingUpdatesBuffer {
-
-    /**
-     * The coroutine scope used for running the timer and
-     * sending updates.
-     */
-    private val coroutineScope: CoroutineScope = CoroutineScope(DispatcherProvider.IO)
 
     /**
      * Holds the currently running job.

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/utils/typing/DefaultTypingUpdatesBuffer.kt
@@ -17,7 +17,6 @@
 package com.getstream.sdk.chat.utils.typing
 
 import com.getstream.sdk.chat.utils.typing.DefaultTypingUpdatesBuffer.Companion.DEFAULT_SEND_TYPING_UPDATES_INTERVAL
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -42,7 +41,12 @@ import kotlinx.coroutines.launch
  * @param onTypingStopped Signals that a stop typing event should be sent.
  * Usually used to make an API call using [io.getstream.chat.android.client.ChatClient.stopTyping]
  */
-@InternalStreamChatApi
+@Deprecated(
+    message = "This class has been deprecated and will be removed." +
+        "Should you wish to implement your own buffer, you can create " +
+        "a custom implementation of `TypingUpdatesBuffer`.",
+    level = DeprecationLevel.WARNING
+)
 public class DefaultTypingUpdatesBuffer(
     private val coroutineScope: CoroutineScope = CoroutineScope(DispatcherProvider.IO),
     private val onTypingStarted: () -> Unit,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -98,7 +98,8 @@ public class MessageComposerController(
      */
     public var typingUpdatesBuffer: TypingUpdatesBuffer = DefaultTypingUpdatesBuffer(
         onTypingStarted = ::sendKeystrokeEvent,
-        onTypingStopped = ::sendStopTypingEvent
+        onTypingStopped = ::sendStopTypingEvent,
+        coroutineScope = scope
     )
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/MessageInputViewModel.kt
@@ -125,7 +125,8 @@ public class MessageInputViewModel @JvmOverloads constructor(
      */
     public var typingUpdatesBuffer: TypingUpdatesBuffer = DefaultTypingUpdatesBuffer(
         onTypingStarted = ::keystroke,
-        onTypingStopped = ::stopTyping
+        onTypingStopped = ::stopTyping,
+        coroutineScope = viewModelScope
     )
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Closes #3967

### 🛠 Implementation details

- Move `CoroutineScope` to the constructor
- Update the documentation
- Start the deprecation process

### 🧪 Testing

#### Docs:

**Please run a docusaurus build and check the documentation changes**

#### Code:

Although the actual changes to the code were very slight and there is no real change in behavior expected, if you want to be thorough you can do the following on both apps.

Pre testing scenario:

1. Launch the app on two devices with two different users logged in
2. Enter the same channel

Test scenario 1:

1. On user device A start typing
2. Observe on User B that the typing update has appeared and should disappear ~3 seconds since the last keystroke on device B

Test scenario 2: 

1. Repeat the same but exist channel mid typing (the typing updates should stop)

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media4.giphy.com/media/T8Dhl1KPyzRqU/giphy.gif?cid=ecf05e474sa9rnp9pfnilt5gbpx5jtz60bndy14ol70xwht8&rid=giphy.gif&ct=g)
