### PR TITLE
Fix updating channel list after receiving new message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,10 +36,12 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
+- Fixed adding a channel to `ChannelListView` when receiving `NewMessageEvent` and channel is not present in the list yet. [#3975](https://github.com/GetStream/stream-chat-android/pull/3975)
 
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added calling watch channel after receiving `NotificationMessageNew` event. [#3975](https://github.com/GetStream/stream-chat-android/pull/3975)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -21,6 +21,7 @@ public abstract class io/getstream/chat/android/offline/event/handler/chat/BaseC
 	public fun handleCidEvent (Lio/getstream/chat/android/client/events/CidEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleMemberAddedEvent (Lio/getstream/chat/android/client/events/MemberAddedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleMemberRemovedEvent (Lio/getstream/chat/android/client/events/MemberRemovedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
+	public fun handleNewMessageEvent (Lio/getstream/chat/android/client/events/NewMessageEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public abstract fun handleNotificationAddedToChannelEvent (Lio/getstream/chat/android/client/events/NotificationAddedToChannelEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleNotificationMessageNewEvent (Lio/getstream/chat/android/client/events/NotificationMessageNewEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleNotificationRemovedFromChannelEvent (Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
@@ -30,14 +31,14 @@ public abstract interface class io/getstream/chat/android/offline/event/handler/
 	public abstract fun handleChatEvent (Lio/getstream/chat/android/client/events/ChatEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 }
 
-public final class io/getstream/chat/android/offline/event/handler/chat/DefaultChatEventHandler : io/getstream/chat/android/offline/event/handler/chat/BaseChatEventHandler {
+public class io/getstream/chat/android/offline/event/handler/chat/DefaultChatEventHandler : io/getstream/chat/android/offline/event/handler/chat/BaseChatEventHandler {
 	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;)V
 	public fun handleChannelUpdatedByUserEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedByUserEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleChannelUpdatedEvent (Lio/getstream/chat/android/client/events/ChannelUpdatedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleMemberAddedEvent (Lio/getstream/chat/android/client/events/MemberAddedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleMemberRemovedEvent (Lio/getstream/chat/android/client/events/MemberRemovedEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
+	public fun handleNewMessageEvent (Lio/getstream/chat/android/client/events/NewMessageEvent;Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleNotificationAddedToChannelEvent (Lio/getstream/chat/android/client/events/NotificationAddedToChannelEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
-	public fun handleNotificationMessageNewEvent (Lio/getstream/chat/android/client/events/NotificationMessageNewEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 	public fun handleNotificationRemovedFromChannelEvent (Lio/getstream/chat/android/client/events/NotificationRemovedFromChannelEvent;Lio/getstream/chat/android/client/api/models/FilterObject;)Lio/getstream/chat/android/offline/event/handler/chat/EventHandlingResult;
 }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/chat/ChatEventHandler.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/chat/ChatEventHandler.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.client.events.CidEvent
 import io.getstream.chat.android.client.events.HasChannel
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
+import io.getstream.chat.android.client.events.NewMessageEvent
 import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
 import io.getstream.chat.android.client.events.NotificationChannelDeletedEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
@@ -128,10 +129,30 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
         filter: FilterObject,
     ): EventHandlingResult = EventHandlingResult.WatchAndAdd(event.cid)
 
-    /** Handles [NotificationMessageNewEvent] event. It runs in background. */
+    /**
+     * Handles [NotificationMessageNewEvent] event.
+     * By default returns [EventHandlingResult.WatchAndAdd].
+     *
+     * @param event [NotificationMessageNewEvent] to handle.
+     * @param filter [FilterObject] for query channels collection.
+     */
     public open fun handleNotificationMessageNewEvent(
         event: NotificationMessageNewEvent,
         filter: FilterObject,
+    ): EventHandlingResult = EventHandlingResult.WatchAndAdd(event.cid)
+
+    /**
+     * Handles [NewMessageEvent] event.
+     * By default returns [EventHandlingResult.Skip].
+     *
+     * @param event [NewMessageEvent] to handle.
+     * @param filter [FilterObject] for query channels collection.
+     * @param cachedChannel optional [Channel] object cached.
+     */
+    public open fun handleNewMessageEvent(
+        event: NewMessageEvent,
+        filter: FilterObject,
+        cachedChannel: Channel?,
     ): EventHandlingResult = EventHandlingResult.Skip
 
     /** Handles [NotificationRemovedFromChannelEvent] event. It runs in background. */
@@ -159,6 +180,7 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
         cachedChannel: Channel?,
     ): EventHandlingResult {
         return when (event) {
+            is NewMessageEvent -> handleNewMessageEvent(event, filter, cachedChannel)
             is ChannelHiddenEvent -> EventHandlingResult.Remove(event.cid)
             is ChannelVisibleEvent -> handleChannelVisibleEvent(event, filter)
             is MemberRemovedEvent -> handleMemberRemovedEvent(event, filter, cachedChannel)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/chat/DefaultChatEventHandler.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/chat/DefaultChatEventHandler.kt
@@ -21,8 +21,8 @@ import io.getstream.chat.android.client.events.ChannelUpdatedByUserEvent
 import io.getstream.chat.android.client.events.ChannelUpdatedEvent
 import io.getstream.chat.android.client.events.MemberAddedEvent
 import io.getstream.chat.android.client.events.MemberRemovedEvent
+import io.getstream.chat.android.client.events.NewMessageEvent
 import io.getstream.chat.android.client.events.NotificationAddedToChannelEvent
-import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
 import io.getstream.chat.android.client.models.Channel
 import kotlinx.coroutines.flow.StateFlow
@@ -33,7 +33,7 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * @param channels The list of visible channels.
  */
-public class DefaultChatEventHandler(
+public open class DefaultChatEventHandler(
     private val channels: StateFlow<List<Channel>?>,
 ) : BaseChatEventHandler() {
 
@@ -74,15 +74,17 @@ public class DefaultChatEventHandler(
     ): EventHandlingResult = EventHandlingResult.Skip
 
     /**
-     * Handles [NotificationMessageNewEvent]. It adds the channel, if it is absent.
+     * Handles [NewMessageEvent]. It adds the channel if it is absent and but the channel was already cached.
      *
-     * @param event Instance of [NotificationMessageNewEvent] that is being handled.
+     * @param event Instance of [NewMessageEvent] that is being handled.
      * @param filter [FilterObject] which is used to define an outcome.
+     * @param cachedChannel optional [Channel] object cached.
      */
-    override fun handleNotificationMessageNewEvent(
-        event: NotificationMessageNewEvent,
+    override fun handleNewMessageEvent(
+        event: NewMessageEvent,
         filter: FilterObject,
-    ): EventHandlingResult = addIfChannelIsAbsent(channels, event.channel)
+        cachedChannel: Channel?
+    ): EventHandlingResult = addIfChannelIsAbsent(channels, cachedChannel)
 
     /**
      * Handles [MemberRemovedEvent]. It removes the channel if it's present in the list.

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
@@ -97,23 +97,7 @@ internal class DefaultChatEventHandlerTest {
     }
 
     @Test
-    fun `Given the channel is not present When received NotificationMessageNewEvent Should add the channel`() {
-        val cid = randomString()
-        val channel = randomChannel(cid = cid)
-        val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyList()))
-
-        val event = randomNotificationMessageNewEvent(cid, channel)
-
-        val result = eventHandler.handleNotificationMessageNewEvent(
-            event,
-            Filters.neutral()
-        )
-
-        result `should be equal to` EventHandlingResult.Add(channel)
-    }
-
-    @Test
-    fun `Given the channel is not present When received NotificationMessageNewEvent Should skip the event`() {
+    fun `Given the channel is not present When received NotificationMessageNewEvent Should watch and add a channel`() {
         val cid = randomString()
         val channel = randomChannel(cid = cid)
         val eventHandler = DefaultChatEventHandler(MutableStateFlow(listOf(channel)))
@@ -125,7 +109,7 @@ internal class DefaultChatEventHandlerTest {
             Filters.neutral()
         )
 
-        result `should be equal to` EventHandlingResult.Skip
+        result `should be equal to` EventHandlingResult.WatchAndAdd(cid)
     }
 
     @Test


### PR DESCRIPTION
closes #3973 
### 🎯 Goal
Fixed updating channel list after receiving new message-related events.

### 🛠 Implementation details
1. Added handling `NewMessageEvent` in `ChatEventHandler`. It solves the issue when the user watches a hidden channel but the channel is not added to the channel list yet
2. Added calling `watch` after receiving `NotificationMessageNewEvent`
3. Made `DefaultChatEventHandler` open so it's easy to customize the default behavior
4. Added #3974 as a follow-up

### 🧪 Testing
1. Apply the patch. You will need 2 devices with Compose application
2. On device 1 sign in as Rafal and go to the available channel
3. On device 2 sign in as Jaewoong, stay on `ChannelList` and click avatar (channel will be hidden)
4. Send a message from device 1 and confirm the channel on device 2 is now visible

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(revision 9ca1895d55c2d4f9e609d16f72029297cb308085)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(date 1659364401000)
@@ -48,9 +48,9 @@
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.compose.sample.ChatApp
-import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
 import io.getstream.chat.android.compose.state.channels.list.ChannelItemState
@@ -71,7 +71,7 @@
         ChannelViewModelFactory(
             ChatClient.instance(),
             QuerySortByField.descByName("last_updated"),
-            null
+            Filters.eq("cid", "messaging:1be58003-bd92-4840-8088-16c333c39373")
         )
     }
 
@@ -90,6 +90,7 @@
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 ChannelsScreen(
+                    filters = Filters.eq("cid", "messaging:1be58003-bd92-4840-8088-16c333c39373"),
                     title = stringResource(id = R.string.app_name),
                     isShowingHeader = true,
                     isShowingSearch = true,
@@ -97,8 +98,7 @@
                     onBackPressed = ::finish,
                     onHeaderAvatarClick = {
                         listViewModel.viewModelScope.launch {
-                            ChatHelper.disconnectUser()
-                            openUserLogin()
+                            ChatClient.instance().hideChannel(channelType = "messaging", channelId = "1be58003-bd92-4840-8088-16c333c39373").await()
                         }
                     }
                 )

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
