### PR TITLE
[3984] mark channel as read when opening from push notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
-- Fixed marking the channel as read when opening it from a push notification. [#3985](https://github.com/GetStream/stream-chat-android/pull/3985)
+- Fixed marking the channel as read when opening it from a push notification. Previously the SDK would fail to make that call. [#3985](https://github.com/GetStream/stream-chat-android/pull/3985)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
-- Fixed marking the channel as read when opening it from a push notification. Previously the SDK would fail to make that call. [#3985](https://github.com/GetStream/stream-chat-android/pull/3985)
+- Fixed marking the channel as read when opening it from a push notification. Previously the SDK would fail to make the call. [#3985](https://github.com/GetStream/stream-chat-android/pull/3985)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 ## stream-chat-android-offline
 ### 🐞 Fixed
 - Fixed preview for channels when sending messages offline. [3933](https://github.com/GetStream/stream-chat-android/pull/3933)
+- Fixed marking the channel as read when opening it from a push notification. [#3985](https://github.com/GetStream/stream-chat-android/pull/3985)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -635,7 +635,6 @@ constructor(
         return channelApi.markRead(
             channelType = channelType,
             channelId = channelId,
-            connectionId = connectionId,
             request = MarkReadRequest(messageId),
         ).toUnitCall()
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
@@ -171,7 +171,6 @@ internal interface ChannelApi {
     fun markRead(
         @Path("type") channelType: String,
         @Path("id") channelId: String,
-        @Query(QueryParams.CONNECTION_ID) connectionId: String,
         @Body request: MarkReadRequest,
     ): RetrofitCall<CompletableResponse>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/state/ClientState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/state/ClientState.kt
@@ -52,16 +52,16 @@ public interface ClientState {
     public val connectionState: StateFlow<ConnectionState>
 
     /**
-     * If the user is online or not.
+     * If the WebSocket is connected.
      *
-     * @return True if the user is online otherwise False.
+     * @return True if the WebSocket is connected, otherwise false.
      */
     public val isOnline: Boolean
 
     /**
-     * If the user is offline or not.
+     * If the WebSocket is disconnected.
      *
-     * @return True if the user is offline otherwise False.
+     * @return True if the WebSocket is disconnected, otherwise false.
      */
     public val isOffline: Boolean
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelMarkReadHelper.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelMarkReadHelper.kt
@@ -87,7 +87,7 @@ internal class ChannelMarkReadHelper(
                 }
 
                 if (!clientState.isNetworkAvailable) {
-                    logger.i { "Cannot mark read because user is offline!" }
+                    logger.i { "Cannot mark as read because the network connection is unavailable." }
                     return false
                 }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelMarkReadHelper.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/utils/internal/ChannelMarkReadHelper.kt
@@ -86,7 +86,7 @@ internal class ChannelMarkReadHelper(
                     return false
                 }
 
-                if (!clientState.isOnline) {
+                if (!clientState.isNetworkAvailable) {
                     logger.i { "Cannot mark read because user is offline!" }
                     return false
                 }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/channel/ChannelMarkReadHelperTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/channel/ChannelMarkReadHelperTests.kt
@@ -214,7 +214,7 @@ internal class ChannelMarkReadHelperTests {
         }
 
         fun givenOnlineUser() = apply {
-            whenever(clientState.isOnline) doReturn true
+            whenever(clientState.isNetworkAvailable) doReturn true
         }
 
         fun get(): ChannelMarkReadHelper = ChannelMarkReadHelper(chatClient, logic, state, clientState)


### PR DESCRIPTION
### 🎯 Goal

closes #3984

### 🛠 Implementation details

- removed `connection_id` from `ChannelApi.mark read`
- switched from checking `clientState.isOnline` to `clientState.isNetworkAvailable` when marking channels as read

### 🧪 Testing

For all test scenarios, you should open the app on two different devices with the same user and check the same channel.

Test Scenario 1:

1. From device A enter a channel and send a message
2. From device B enter the same channel

Expectation: Channel should be marked as read on Device A

Test Scenario 1:

1. Put the app on device A to the background or kill it, preferably try both scenarios
2. From device B trigger a push notification by sending a message to a shared channel
3. Click on the push notification on device A
4. Go back to the channels screen and check if the channel was marked as read


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `release` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media0.giphy.com/media/DPH2d2WQsvTVEDVa2p/giphy.gif?cid=ecf05e474xb6wcx8umugpqf1c31ycdqq91g6le849hgiv2li&rid=giphy.gif&ct=g)
