### PR TITLE
Add possibility to customize chatEventHandler in compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added additional `chatEventHandlerFactory` parameter to `ChannelListViewModel` and `ChannelListViewModelFactory` that allows customizing `ChatEventHandler`. [#3997](https://github.com/GetStream/stream-chat-android/pull/3997)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1799,8 +1799,8 @@ public final class io/getstream/chat/android/compose/util/extensions/ChannelCapa
 
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;III)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deleteConversation (Lio/getstream/chat/android/client/models/Channel;)V
 	public final fun dismissChannelAction ()V
 	public final fun getActiveChannelAction ()Lio/getstream/chat/android/compose/state/channels/list/ChannelAction;
@@ -1824,8 +1824,8 @@ public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelL
 
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;III)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
@@ -37,6 +37,8 @@ import io.getstream.chat.android.compose.state.channels.list.Cancel
 import io.getstream.chat.android.compose.state.channels.list.ChannelAction
 import io.getstream.chat.android.compose.state.channels.list.ChannelItemState
 import io.getstream.chat.android.compose.state.channels.list.ChannelsState
+import io.getstream.chat.android.offline.event.handler.chat.ChatEventHandler
+import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
 import io.getstream.chat.android.offline.extensions.globalState
 import io.getstream.chat.android.offline.extensions.queryChannelsAsState
 import io.getstream.chat.android.offline.plugin.state.querychannels.ChannelsStateData
@@ -64,6 +66,7 @@ import kotlinx.coroutines.launch
  * @param channelLimit How many channels we fetch per page.
  * @param memberLimit How many members are fetched for each channel item when loading channels.
  * @param messageLimit How many messages are fetched for each channel item when loading channels.
+ * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
  */
 public class ChannelListViewModel(
     public val chatClient: ChatClient,
@@ -72,6 +75,7 @@ public class ChannelListViewModel(
     private val channelLimit: Int = DEFAULT_CHANNEL_LIMIT,
     private val memberLimit: Int = DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = DEFAULT_MESSAGE_LIMIT,
+    private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
 ) : ViewModel() {
 
     /**
@@ -193,6 +197,7 @@ public class ChannelListViewModel(
                 logger.d { "Querying channels as state" }
                 queryChannelsState = chatClient.queryChannelsAsState(
                     request = queryChannelsRequest,
+                    chatEventHandlerFactory = chatEventHandlerFactory,
                     coroutineScope = viewModelScope,
                 )
                 observeChannels(searchQuery = query)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -22,6 +22,8 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.offline.event.handler.chat.ChatEventHandler
+import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
 
 /**
  * Builds the factory that contains all the dependencies required for the Channels Screen.
@@ -33,6 +35,7 @@ import io.getstream.chat.android.client.models.Channel
  * @param channelLimit How many channels we fetch per page.
  * @param memberLimit How many members are fetched for each channel item when loading channels.
  * @param messageLimit How many messages are fetched for each channel item when loading channels.
+ * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
  */
 public class ChannelViewModelFactory(
     private val chatClient: ChatClient,
@@ -41,6 +44,7 @@ public class ChannelViewModelFactory(
     private val channelLimit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
+    private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(
@@ -51,7 +55,8 @@ public class ChannelViewModelFactory(
                 initialFilters = filters,
                 channelLimit = channelLimit,
                 messageLimit = messageLimit,
-                memberLimit = memberLimit
+                memberLimit = memberLimit,
+                chatEventHandlerFactory = chatEventHandlerFactory,
             )
         }
     )


### PR DESCRIPTION
closes #3981 
### 🎯 Goal

Add possibility to customize `ChatEventHandler` when using `ChannelListViewModel` in compose.

### 🛠 Implementation details

Added additional `chatEventHandler` parameter to `ChannelListViewModel` and `ChannelListViewModelFactory`

### 🧪 Testing

1. Apply the patch. It changes the default `ChatEventHandler` in a way that the channel will be removed from the list if new message arrives.
2. Build the app on device 1 and stay on `ChannelList`
3. Open the app on device 2 and send a message in some channel
4. Observer the channel disappears from the list on device 1

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt	(revision 3dcf74175d131f7e74dda4a123f831867c87ca1d)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt	(date 1659611448276)
@@ -49,6 +49,7 @@
 import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.TestChatEventHandlerFactory
 import io.getstream.chat.android.compose.state.channels.list.DeleteConversation
 import io.getstream.chat.android.compose.state.channels.list.LeaveGroup
 import io.getstream.chat.android.compose.state.channels.list.MuteChannel
@@ -109,7 +110,8 @@
             filters = filters,
             channelLimit = channelLimit,
             memberLimit = memberLimit,
-            messageLimit = messageLimit
+            messageLimit = messageLimit,
+            chatEventHandlerFactory = TestChatEventHandlerFactory(),
         )
     )
 
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/TestChatEventHandler.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/TestChatEventHandler.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/TestChatEventHandler.kt
new file mode 100644
--- /dev/null	(date 1659611444136)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/TestChatEventHandler.kt	(date 1659611444136)
@@ -0,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.events.CidEvent
+import io.getstream.chat.android.client.events.NewMessageEvent
+import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.offline.event.handler.chat.ChatEventHandler
+import io.getstream.chat.android.offline.event.handler.chat.DefaultChatEventHandler
+import io.getstream.chat.android.offline.event.handler.chat.EventHandlingResult
+import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
+import kotlinx.coroutines.flow.StateFlow
+
+public class TestChatEventHandlerFactory : ChatEventHandlerFactory() {
+    override fun chatEventHandler(channels: StateFlow<Map<String, Channel>?>): ChatEventHandler {
+        return TestChatEventHandler(channels)
+    }
+}
+
+public class TestChatEventHandler(channels: StateFlow<Map<String, Channel>?>) :
+    DefaultChatEventHandler(channels, ChatClient.instance().clientState) {
+
+    override fun handleCidEvent(event: CidEvent, filter: FilterObject, cachedChannel: Channel?): EventHandlingResult {
+        if (event is NewMessageEvent) {
+            return EventHandlingResult.Remove(event.cid)
+        }
+        return super.handleCidEvent(event, filter, cachedChannel)
+    }
+}

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

