### PR TITLE
Update channels list after receiving new message event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### ⬆️ Improved
 - Improved updating channels after receiving `NotificationMessageNew` event. [#3991](https://github.com/GetStream/stream-chat-android/pull/3991)
+- Improved updating channels after receiving `NewMessageEvent`. The channel will be added to the list if the message is not a system message. [#3999](https://github.com/GetStream/stream-chat-android/pull/3999)
 
 ### ✅ Added
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/querychannels/DefaultChatEventHandlerTest.kt
@@ -22,6 +22,8 @@ import io.getstream.chat.android.client.test.randomChannel
 import io.getstream.chat.android.client.test.randomMember
 import io.getstream.chat.android.client.test.randomMemberAddedEvent
 import io.getstream.chat.android.client.test.randomMemberRemovedEvent
+import io.getstream.chat.android.client.test.randomMessage
+import io.getstream.chat.android.client.test.randomNewMessageEvent
 import io.getstream.chat.android.client.test.randomNotificationAddedToChannelEvent
 import io.getstream.chat.android.client.test.randomNotificationMessageNewEvent
 import io.getstream.chat.android.client.test.randomNotificationRemovedFromChannelEvent
@@ -185,6 +187,42 @@ internal class DefaultChatEventHandlerTest {
         val event = randomNotificationRemovedFromChannelEvent()
 
         val result = eventHandler.handleChatEvent(event = event, filter = Filters.neutral(), cachedChannel = null)
+
+        result `should be equal to` EventHandlingResult.Skip
+    }
+
+    @Test
+    fun `Given the channel is not present When received NewMessageEvent with not system message Should add the channel`() {
+        val channel = randomChannel()
+        val clientState = mock<ClientState>()
+        val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyMap()), clientState)
+        val event = randomNewMessageEvent(cid = channel.cid, message = randomMessage(type = "regular"))
+
+        val result = eventHandler.handleChatEvent(event = event, filter = Filters.neutral(), cachedChannel = channel)
+
+        result `should be equal to` EventHandlingResult.Add(channel)
+    }
+
+    @Test
+    fun `Given the channel is not present When received NewMessageEvent with system message Should skip the update`() {
+        val channel = randomChannel()
+        val clientState = mock<ClientState>()
+        val eventHandler = DefaultChatEventHandler(MutableStateFlow(emptyMap()), clientState)
+        val event = randomNewMessageEvent(cid = channel.cid, message = randomMessage(type = "system"))
+
+        val result = eventHandler.handleChatEvent(event = event, filter = Filters.neutral(), cachedChannel = channel)
+
+        result `should be equal to` EventHandlingResult.Skip
+    }
+
+    @Test
+    fun `Given the channel is present When received NewMessageEvent with not system message Should skip the update`() {
+        val channel = randomChannel()
+        val clientState = mock<ClientState>()
+        val eventHandler = DefaultChatEventHandler(MutableStateFlow(mapOf(channel.cid to channel)), clientState)
+        val event = randomNewMessageEvent(cid = channel.cid, message = randomMessage(type = "regular"))
+
+        val result = eventHandler.handleChatEvent(event = event, filter = Filters.neutral(), cachedChannel = channel)
 
         result `should be equal to` EventHandlingResult.Skip
     }


### PR DESCRIPTION
closes #3973 
### 🎯 Goal

Fix updating channels list after receiving new message event.

### 🛠 Implementation details
Add handling `NewMessageEvent` in `DefaultChatEventHandler` if the message is not a system message.
We should skip `system` messages for now in order to properly handle the remove member use case, as removed member can still receive a message with information that they just left the channel.

### 🧪 Testing
Test 2 scenarios:
1. Apply the patch. You will need 2 devices with Compose application
2. On device 1 sign in as Rafal and go to the available channel
3. On device 2 sign in as Jaewoong, stay on `ChannelList` and click avatar (channel will be hidden)
4. Send a message from device 1 and confirm the channel on device 2 is now visible

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(revision 1b21519ac9a2c229764ac2eb88bb8970098104cf)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(date 1659690458784)
@@ -48,9 +48,9 @@
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.compose.sample.ChatApp
-import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
 import io.getstream.chat.android.compose.state.channels.list.ChannelItemState
@@ -71,7 +71,7 @@
         ChannelViewModelFactory(
             ChatClient.instance(),
             QuerySortByField.descByName("last_updated"),
-            null
+            Filters.eq("cid", "messaging:1be58003-bd92-4840-8088-16c333c39373")
         )
     }
 
@@ -90,6 +90,7 @@
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 ChannelsScreen(
+                    filters = Filters.eq("cid", "messaging:1be58003-bd92-4840-8088-16c333c39373"),
                     title = stringResource(id = R.string.app_name),
                     isShowingHeader = true,
                     isShowingSearch = true,
@@ -97,8 +98,7 @@
                     onBackPressed = ::finish,
                     onHeaderAvatarClick = {
                         listViewModel.viewModelScope.launch {
-                            ChatHelper.disconnectUser()
-                            openUserLogin()
+                            ChatClient.instance().hideChannel(channelType = "messaging", channelId = "1be58003-bd92-4840-8088-16c333c39373").await()
                         }
                     }
                 )

```

</details>

**Scenario 2**
1. Use XML sample application and leave the channel
2. Make sure the channel is not visible in the list


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [x] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
