### PR TITLE
[3961] Fix crash when attaching photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed a crash when passing content URIs without duration metadata to the `StorageHelper::.getAttachmentsFromUriList` method. [4002](https://github.com/GetStream/stream-chat-android/pull/4002)
 
 ### ⬆️ Improved
 
@@ -63,6 +64,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fixed a crash when passing content URIs without duration metadata to the `StorageHelperWrapper::.getAttachmentsFromUris` method. [4002](https://github.com/GetStream/stream-chat-android/pull/4002)
 
 ### ⬆️ Improved
 


### PR DESCRIPTION
### 🎯 Goal

Closes #3961

Fix the crash happening when processing a list of content URIs with `StorageHelper::.getAttachmentsFromUriList` and submitting the prepared attachments to `MessageInputView` (or `MessageComposerView`).

```
android.database.sqlite.SQLiteException: no such column: duration (code 1 SQLITE_ERROR): , while compiling: SELECT _id, _display_name, mime_type, _size, duration FROM images WHERE (_id=?)
        at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:179)
        at android.database.DatabaseUtils.readExceptionFromParcel(DatabaseUtils.java:135)
        at android.content.ContentProviderProxy.query(ContentProviderNative.java:418)
        at android.content.ContentResolver.query(ContentResolver.java:802)
        at android.content.ContentResolver.query(ContentResolver.java:752)
        at android.content.ContentResolver.query(ContentResolver.java:710)
```

### 🛠 Implementation details

Removed the duration column from the content resolver query.

### 🧪 Testing

Use Pixel 2 API 28 emulator, and check both `MessageInputView` and `MessageComposerView`.

**Scenario 0:**
1. Don't apply any patches
2. Run the `UI-Components` sample app
3. Open a channel
4. Click on the attachment button
5. Ensure that you are able to submit attachments from all 3 tabs (image, file, camera)

**Scenario 1:**
1. Apply the patch below with a custom attachment picker library returning content URIs
2. Run the `UI-Components` sample app
3. Open a channel click on the attachment button
4. Attach a photo and ensure that the app doesn't crash when the message is sent

<details>

<summary>Custom image picker library returning content URI</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision 9042beee17c2e04ac5671a43805d1c35552c1074)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1659921628509)
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.ui.sample.feature.chat
 
+import android.app.Activity.RESULT_OK
+import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -26,10 +29,14 @@
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.getstream.sdk.chat.utils.StorageHelper
 import com.getstream.sdk.chat.utils.extensions.getCreatedAtOrThrow
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
+import droidninja.filepicker.FilePickerBuilder
+import droidninja.filepicker.FilePickerConst
 import io.getstream.chat.android.client.errors.ChatNetworkError
+import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Flag
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
@@ -46,6 +53,7 @@
 import io.getstream.chat.android.livedata.utils.EventObserver
 import io.getstream.chat.android.ui.message.composer.viewmodel.MessageComposerViewModel
 import io.getstream.chat.android.ui.message.composer.viewmodel.bindView
+import io.getstream.chat.android.ui.message.input.attachment.AttachmentSource
 import io.getstream.chat.android.ui.message.input.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
@@ -169,6 +177,9 @@
             }
             binding.messageListView.setMessageEditHandler(::postMessageToEdit)
         }
+        binding.messageInputView.setAttachmentButtonClickListener {
+            FilePickerBuilder.instance.pickPhoto(this)
+        }
     }
 
     private fun initMessageComposerViewModel() {
@@ -207,6 +218,40 @@
                 }
             }
         }
+
+        binding.messageComposerView.attachmentsButtonClickListener = {
+            FilePickerBuilder.instance.pickPhoto(this)
+        }
+    }
+
+    @OptIn(InternalStreamChatApi::class)
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        super.onActivityResult(requestCode, resultCode, data)
+        if (requestCode == FilePickerConst.REQUEST_CODE_PHOTO && resultCode == RESULT_OK && data != null) {
+            val uriList = data.getParcelableArrayListExtra<Uri>(FilePickerConst.KEY_SELECTED_MEDIA) ?: emptyList()
+            val attachments = StorageHelper().getAttachmentsFromUriList(requireContext(), uriList)
+
+            if (ToggleService.isEnabled(ToggleService.TOGGLE_KEY_MESSAGE_COMPOSER)) {
+                messageComposerViewModel.addSelectedAttachments(
+                    attachments.map {
+                        val fileFromUri = StorageHelper().getCachedFileFromUri(requireContext(), it)
+                        Attachment(
+                            upload = fileFromUri,
+                            type = it.type,
+                            name = it.title ?: fileFromUri.name ?: "",
+                            fileSize = it.size.toInt(),
+                            mimeType = it.mimeType,
+                            title = it.title,
+                        )
+                    }
+                )
+            } else {
+                binding.messageInputView.submitAttachments(
+                    attachments = attachments,
+                    attachmentSource = AttachmentSource.MEDIA
+                )
+            }
+        }
     }
 
     private fun initMessagesViewModel() {
Index: build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/build.gradle b/build.gradle
--- a/build.gradle	(revision 9042beee17c2e04ac5671a43805d1c35552c1074)
+++ b/build.gradle	(date 1659906149129)
@@ -64,6 +64,7 @@
 
 allprojects {
     repositories {
+        jcenter()
         google()
         mavenCentral()
         maven {
Index: stream-chat-android-ui-components-sample/build.gradle
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/build.gradle b/stream-chat-android-ui-components-sample/build.gradle
--- a/stream-chat-android-ui-components-sample/build.gradle	(revision 9042beee17c2e04ac5671a43805d1c35552c1074)
+++ b/stream-chat-android-ui-components-sample/build.gradle	(date 1659906149164)
@@ -143,6 +143,9 @@
     implementation project(":stream-chat-android-pushprovider-xiaomi")
     implementation files('../libraries/external/MiPush_SDK_Client_5_0_6-G_3rd.aar')
 
+    implementation 'com.droidninja:filepicker:2.2.5'
+    implementation 'com.github.bumptech.glide:glide:4.13.2'
+
     implementation Dependencies.androidxActivityKtx
     implementation Dependencies.androidxAppCompat
     implementation Dependencies.androidxCoreKtx

```

</details>

**Scenario 2:**
1. Apply the patch below with `ActivityResultContracts.TakePicture` contract that returns a content URI
2. Run the `UI-Components` sample app
3. Open a channel and click on the attachment button
4. Take a photo and ensure that the app doesn't crash when the message is sent

<details>
  <summary>Take picture intent with content URI</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision 9042beee17c2e04ac5671a43805d1c35552c1074)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1659944672439)
@@ -16,20 +16,27 @@
 
 package io.getstream.chat.ui.sample.feature.chat
 
+import android.content.ContentValues
+import android.net.Uri
 import android.os.Bundle
+import android.provider.MediaStore
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.activity.OnBackPressedCallback
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.view.isVisible
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.getstream.sdk.chat.utils.StorageHelper
 import com.getstream.sdk.chat.utils.extensions.getCreatedAtOrThrow
 import com.getstream.sdk.chat.viewmodel.MessageInputViewModel
 import com.getstream.sdk.chat.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.client.errors.ChatNetworkError
+import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Flag
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.utils.Result
@@ -46,6 +53,7 @@
 import io.getstream.chat.android.livedata.utils.EventObserver
 import io.getstream.chat.android.ui.message.composer.viewmodel.MessageComposerViewModel
 import io.getstream.chat.android.ui.message.composer.viewmodel.bindView
+import io.getstream.chat.android.ui.message.input.attachment.AttachmentSource
 import io.getstream.chat.android.ui.message.input.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.header.viewmodel.MessageListHeaderViewModel
 import io.getstream.chat.android.ui.message.list.header.viewmodel.bindView
@@ -70,6 +78,9 @@
     private val messageComposerViewModel: MessageComposerViewModel by viewModels { factory }
     private val chatViewModel: ChatViewModel by viewModels { chatViewModelFactory }
 
+    private var activityResultLauncher: ActivityResultLauncher<Uri>? = null
+    private var photoUri: Uri? = null
+
     private var _binding: FragmentChatBinding? = null
     private val binding get() = _binding!!
 
@@ -99,6 +110,33 @@
         } else {
             initMessageInputViewModel()
         }
+
+        activityResultLauncher = activity?.activityResultRegistry
+            ?.register("capture_media_request_key", ActivityResultContracts.TakePicture()) { success: Boolean ->
+                val attachments = StorageHelper().getAttachmentsFromUriList(requireContext(), listOf(photoUri!!))
+
+                if (ToggleService.isEnabled(ToggleService.TOGGLE_KEY_MESSAGE_COMPOSER)) {
+                    messageComposerViewModel.addSelectedAttachments(
+                        attachments.map {
+
+                            val fileFromUri = StorageHelper().getCachedFileFromUri(requireContext(), it)
+                            Attachment(
+                                upload = fileFromUri,
+                                type = it.type,
+                                name = it.title ?: fileFromUri.name ?: "",
+                                fileSize = it.size.toInt(),
+                                mimeType = it.mimeType,
+                                title = it.title,
+                            )
+                        }
+                    )
+                } else {
+                    binding.messageInputView.submitAttachments(
+                        attachments = attachments,
+                        attachmentSource = AttachmentSource.MEDIA
+                    )
+                }
+            }
     }
 
     override fun onResume() {
@@ -169,6 +207,10 @@
             }
             binding.messageListView.setMessageEditHandler(::postMessageToEdit)
         }
+        binding.messageInputView.setAttachmentButtonClickListener {
+            photoUri = createImageFile()
+            activityResultLauncher?.launch(photoUri)
+        }
     }
 
     private fun initMessageComposerViewModel() {
@@ -207,6 +249,22 @@
                 }
             }
         }
+
+        binding.messageComposerView.attachmentsButtonClickListener = {
+            photoUri = createImageFile()
+            activityResultLauncher?.launch(photoUri)
+        }
+    }
+
+    private fun createImageFile(): Uri? {
+        val imageFileName = "JPEG_" + System.currentTimeMillis() + ".jpg"
+        val resolver = requireContext().contentResolver
+        val contentValues = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, imageFileName)
+            put(MediaStore.MediaColumns.MIME_TYPE, "image/jpeg")
+        }
+
+        return resolver.insert(MediaStore.Images.Media.EXTERNAL_CONTENT_URI, contentValues)
     }
 
     private fun initMessagesViewModel() {

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
