### PR TITLE
[ISSUE-3710] Thread query listener impl separation

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerFull.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerFull.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.offline.plugin.listener.internal
 
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.extensions.internal.users
 import io.getstream.chat.android.client.models.Message
@@ -36,7 +35,7 @@ import io.getstream.logging.StreamLog
  * @param logic [LogicRegistry] Optional class to handle state updates
  * @param messageRepository [MessageRepository] Optional to handle database updates related to messages
  * @param userRepository [UserRepository]  Optional to handle database updates related to user
- * @param chatClient [ChatClient]
+ * @param getRemoteMessage Returns a remote message from backend side.
  */
 internal class ThreadQueryListenerFull(
     private val logic: LogicRegistry?,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/thread/internal/ThreadLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/thread/internal/ThreadLogic.kt
@@ -16,8 +16,6 @@
 
 package io.getstream.chat.android.offline.plugin.logic.channel.thread.internal
 
-import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.events.HasMessage
 import io.getstream.chat.android.client.events.MessageDeletedEvent
 import io.getstream.chat.android.client.events.MessageUpdatedEvent
@@ -29,98 +27,26 @@ import io.getstream.chat.android.client.events.ReactionUpdateEvent
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
-import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.client.utils.onSuccessSuspend
 import io.getstream.chat.android.offline.plugin.state.channel.thread.internal.ThreadMutableState
-import io.getstream.logging.StreamLog
 
 /** Logic class for thread state management. Implements [ThreadQueryListener] as listener for LLC requests. */
 internal class ThreadLogic(
     private val repos: RepositoryFacade,
-    private val client: ChatClient,
     private val threadStateLogic: ThreadStateLogic,
-) : ThreadQueryListener {
+) {
 
     private val mutableState: ThreadMutableState = threadStateLogic.writeThreadState()
-    private val logger = StreamLog.getLogger("Chat:ThreadLogic")
 
-    /** Runs side effect when a result is obtained. */
-    private suspend fun onResult(result: Result<List<Message>>, limit: Int) {
-        if (result.isSuccess) {
-            val newMessages = result.data()
-            upsertMessages(newMessages)
-            mutableState.setEndOfOlderMessages(newMessages.size < limit)
-            mutableState.setOldestInThread(
-                newMessages.sortedBy { it.createdAt }
-                    .firstOrNull()
-                    ?: mutableState.oldestInThread.value
-            )
-        }
-        result.onSuccessSuspend {
-            repos.insertMessages(it)
-        }
+    fun isLoadingOlderMessages(): Boolean = mutableState.loadingOlderMessages.value
+
+    fun isLoadingMessages(): Boolean = mutableState.loading.value
+
+    internal fun setLoading(isLoading: Boolean) {
+        mutableState.setLoading(isLoading)
     }
 
-    override suspend fun onGetRepliesPrecondition(messageId: String, limit: Int): Result<Unit> {
-        return if (mutableState.loading.value) {
-            val errorMsg = "already loading messages for this thread, ignoring the load requests."
-            logger.i { errorMsg }
-            Result(ChatError(errorMsg))
-        } else {
-            Result.success(Unit)
-        }
-    }
-
-    override suspend fun onGetRepliesRequest(messageId: String, limit: Int) {
-        mutableState.setLoading(true)
-        val messages = repos.selectMessagesForThread(messageId, limit)
-        val parentMessage = messages.firstOrNull { it.id == messageId }
-        if (parentMessage != null) {
-            upsertMessages(messages)
-            Result.success(Unit)
-        } else {
-            val result = client.getMessage(messageId).await()
-            if (result.isSuccess) {
-                upsertMessage(result.data())
-                repos.insertMessage(result.data())
-                Result.success(Unit)
-            } else {
-                Result(result.error())
-            }
-        }
-    }
-
-    override suspend fun onGetRepliesResult(result: Result<List<Message>>, messageId: String, limit: Int) {
-        mutableState.setLoading(false)
-        onResult(result, limit)
-    }
-
-    override suspend fun onGetRepliesMorePrecondition(messageId: String, firstId: String, limit: Int): Result<Unit> {
-        return if (mutableState.loadingOlderMessages.value) {
-            val errorMsg = "already loading messages for this thread, ignoring the load more requests."
-            logger.i { errorMsg }
-            Result(ChatError(errorMsg))
-        } else {
-            Result.success(Unit)
-        }
-    }
-
-    override suspend fun onGetRepliesMoreRequest(
-        messageId: String,
-        firstId: String,
-        limit: Int
-    ) {
-        mutableState.setLoadingOlderMessages(true)
-    }
-
-    override suspend fun onGetRepliesMoreResult(
-        result: Result<List<Message>>,
-        messageId: String,
-        firstId: String,
-        limit: Int
-    ) {
-        mutableState.setLoadingOlderMessages(false)
-        onResult(result, limit)
+    internal fun setLoadingOlderMessages(isLoading: Boolean) {
+        mutableState.setLoadingOlderMessages(isLoading)
     }
 
     /**
@@ -165,6 +91,18 @@ internal class ThreadLogic(
         threadStateLogic.removeLocalMessage(message)
     }
 
+    internal fun setEndOfOlderMessages(isEnd: Boolean) {
+        mutableState.setEndOfOlderMessages(isEnd)
+    }
+
+    internal fun updateOldestMessageInThread(messages: List<Message>) {
+        mutableState.setOldestInThread(
+            messages.sortedBy { it.createdAt }
+                .firstOrNull()
+                ?: mutableState.oldestInThread.value
+        )
+    }
+
     internal fun handleEvents(events: List<HasMessage>) {
         for (event in events) {
             handleEvent(event)
@@ -183,7 +121,8 @@ internal class ThreadLogic(
             is NotificationMessageNewEvent,
             is ReactionNewEvent,
             is ReactionUpdateEvent,
-            is ReactionDeletedEvent -> {
+            is ReactionDeletedEvent,
+            -> {
                 upsertMessage(event.message)
             }
             else -> Unit

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -142,11 +142,7 @@ internal class LogicRegistry internal constructor(
         return threads.getOrPut(messageId) {
             val mutableState = stateRegistry.thread(messageId).toMutableState()
             val stateLogic = ThreadStateLogicImpl(mutableState)
-            ThreadLogic(
-                repos,
-                client,
-                stateLogic
-            )
+            ThreadLogic(repos, stateLogic)
         }
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -223,7 +223,7 @@ public class StreamStatePluginFactory(
             activeUser = user,
             queryChannelsListener = QueryChannelsListenerImpl(logic),
             queryChannelListener = QueryChannelListenerImpl(logic),
-            threadQueryListener = ThreadQueryListenerImpl(logic),
+            threadQueryListener = ThreadQueryListenerImpl(logic, repositoryFacade, chatClient),
             channelMarkReadListener = ChannelMarkReadListenerState(channelMarkReadHelper),
             editMessageListener = EditMessageListenerImpl(logic, clientState),
             hideChannelListener = HideChannelListenerImpl(logic, repositoryFacade),

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -45,7 +45,7 @@ import io.getstream.chat.android.offline.plugin.listener.internal.SendGiphyListe
 import io.getstream.chat.android.offline.plugin.listener.internal.SendMessageListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.SendReactionListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.ShuffleGiphyListenerState
-import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerImpl
+import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerFull
 import io.getstream.chat.android.offline.plugin.listener.internal.TypingEventListenerState
 import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
@@ -223,7 +223,7 @@ public class StreamStatePluginFactory(
             activeUser = user,
             queryChannelsListener = QueryChannelsListenerImpl(logic),
             queryChannelListener = QueryChannelListenerImpl(logic),
-            threadQueryListener = ThreadQueryListenerImpl(logic, repositoryFacade, chatClient),
+            threadQueryListener = ThreadQueryListenerFull(logic, repositoryFacade, repositoryFacade, chatClient),
             channelMarkReadListener = ChannelMarkReadListenerState(channelMarkReadHelper),
             editMessageListener = EditMessageListenerImpl(logic, clientState),
             hideChannelListener = HideChannelListenerImpl(logic, repositoryFacade),

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -20,11 +20,13 @@ import android.content.Context
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.interceptor.message.PrepareMessageLogicFactory
+import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
 import io.getstream.chat.android.client.setup.InitializationCoordinator
+import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.errorhandler.factory.internal.OfflineErrorHandlerFactoriesProvider
@@ -219,11 +221,15 @@ public class StreamStatePluginFactory(
             }
         }
 
+        val getMessageFun: suspend (String) -> Result<Message> = { messageId: String ->
+            chatClient.getMessage(messageId).await()
+        }
+
         return StatePlugin(
             activeUser = user,
             queryChannelsListener = QueryChannelsListenerImpl(logic),
             queryChannelListener = QueryChannelListenerImpl(logic),
-            threadQueryListener = ThreadQueryListenerFull(logic, repositoryFacade, repositoryFacade, chatClient),
+            threadQueryListener = ThreadQueryListenerFull(logic, repositoryFacade, repositoryFacade, getMessageFun),
             channelMarkReadListener = ChannelMarkReadListenerState(channelMarkReadHelper),
             editMessageListener = EditMessageListenerImpl(logic, clientState),
             hideChannelListener = HideChannelListenerImpl(logic, repositoryFacade),


### PR DESCRIPTION
### 🎯 Goal

Prepare ThreadQueryListenerImpl to handle both state and/or persistence accordingly with how users configure the SDK.

### 🛠 Implementation details

- `ThreadLogic` is no longer the implementation of `ThreadQueryListener`. There's already a specific class for that which is `ThreadQueryListenerImpl` (or `ThreadQueryListenerFull`) now.  `ThreadLogic` should only handle the logic of threads instead of also being a lister of ChatClient requests. This way each class becomes more specialized. 

- `ThreadQueryListenerFull` handles both state and persistence, but its properties are optional.

I don't believe this class should be separated into database and state completely because the code uses persistence to update the state if the information lives only inside the database at the moment the listener is called. Separating it would cause more requests to API, because the state won't be aware that information can be fetched from persistence. 

As a solution, the properties that handle each case are now optional and the class adapts itself to the configuration of the SDK. If no persistence is provided by the user, this class only interacts with the state and updates it with the data that comes from the API. If only the database is provided, the state is not propagated and only the database receives updates. If none of the dependencies is provided, this class doesn't do anything and becomes a NOOP listener. 

### 🧪 Testing

Check the threads inside the channels.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~. There's no client facing changes
- [ ] New code is covered by unit tests. **Let's discuss the approach first**.
- ~[ ] Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (7)](https://user-images.githubusercontent.com/10619102/184234091-d67a0414-ec13-405f-92b4-a09eb6f0b4db.gif)
_I didn't find a good giphy for this pr..._
