### PR TITLE
[4037] fix query channels request not being fire on app launch

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -270,11 +270,11 @@ internal constructor(
                 is ConnectedEvent -> {
                     val user = event.me
                     val connectionId = event.connectionId
+                    api.setConnection(user.id, connectionId)
                     if (ToggleService.isSocketExperimental().not()) {
                         socketStateService.onConnected(connectionId)
                         lifecycleObserver.observe()
                     }
-                    api.setConnection(user.id, connectionId)
                     notifications.onSetUser()
 
                     clientState.toMutableState()?.run {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -119,8 +119,9 @@ constructor(
     private val coroutineScope: CoroutineScope,
 ) : ChatApi {
 
-    val logger = StreamLog.getLogger("Chat:MoshiChatApi")
+    private val logger = StreamLog.getLogger("Chat:MoshiChatApi")
 
+    @Volatile
     private var userId: String = ""
         get() {
             if (field == "") {
@@ -128,6 +129,8 @@ constructor(
             }
             return field
         }
+
+    @Volatile
     private var connectionId: String = ""
         get() {
             if (field == "") {
@@ -137,6 +140,7 @@ constructor(
         }
 
     override fun setConnection(userId: String, connectionId: String) {
+        logger.d { "[setConnection] userId: '$userId', connectionId: '$connectionId'" }
         this.userId = userId
         this.connectionId = connectionId
     }
@@ -808,8 +812,10 @@ constructor(
     }
 
     override fun queryChannels(query: QueryChannelsRequest): Call<List<Channel>> {
-        if (connectionId.isEmpty()) return noConnectionIdError()
-
+        if (connectionId.isEmpty()) {
+            logger.w { "[queryChannels] rejected (no connectionId)" }
+            return noConnectionIdError()
+        }
         val request = io.getstream.chat.android.client.api2.model.requests.QueryChannelsRequest(
             filter_conditions = query.filter.toMap(),
             offset = query.offset,


### PR DESCRIPTION
### 🎯 Goal

Let `QueryChannelsRequest` be fired on app launch

### 🧪 Testing

1) Launch Sample app. 
2) Login as any user.
3) Kill the app
4) Launch again
5) Repeat steps 3 & 4 until unread counts are not presented

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
