### PR TITLE
Fix reply action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### 🐞 Fixed
 - Rename of field for optional multi bundle push provider. Now projects with multiple push providers will correct correctly. [#4008](https://github.com/GetStream/stream-chat-android/pull/4008)
 - Fixed blinking unread count indicator. [#4030](https://github.com/GetStream/stream-chat-android/pull/4030)
+- Fixed push notification reply action. [#4046](https://github.com/GetStream/stream-chat-android/pull/4046)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/receivers/NotificationMessageReceiver.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/receivers/NotificationMessageReceiver.kt
@@ -25,8 +25,10 @@ import androidx.core.app.NotificationCompat
 import androidx.core.app.RemoteInput
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.R
+import io.getstream.chat.android.client.extensions.internal.toCid
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
+import io.getstream.logging.StreamLog
 
 internal class NotificationMessageReceiver : BroadcastReceiver() {
 
@@ -130,6 +132,8 @@ internal class NotificationMessageReceiver : BroadcastReceiver() {
             }
     }
 
+    private val logger = StreamLog.getLogger("NotificationMessageReceiver")
+
     override fun onReceive(context: Context, intent: Intent) {
         val channelType = intent.getStringExtra(KEY_CHANNEL_TYPE) ?: return
         val channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: return
@@ -155,7 +159,12 @@ internal class NotificationMessageReceiver : BroadcastReceiver() {
     }
 
     private fun markAsRead(messageId: String, channelId: String, channelType: String) {
-        if (!ChatClient.isInitialized) return
+        if (!ChatClient.isInitialized) {
+            logger.d {
+                "[markAsRead] ChatClient is not initialized, returning."
+            }
+            return
+        }
 
         ChatClient.instance().markMessageRead(channelType, channelId, messageId).enqueue()
     }
@@ -165,16 +174,19 @@ internal class NotificationMessageReceiver : BroadcastReceiver() {
         type: String,
         messageChars: CharSequence,
     ) {
-        if (!ChatClient.isInitialized) return
-
-        val currentUser = ChatClient.instance().getCurrentUser() ?: return
+        if (!ChatClient.isInitialized) {
+            logger.d {
+                "[replyText] ChatClient is not initialized, returning."
+            }
+            return
+        }
 
         ChatClient.instance().sendMessage(
             channelType = type,
             channelId = channelId,
             message = Message().apply {
                 text = messageChars.toString()
-                user = currentUser
+                cid = (type to channelId).toCid()
             }
         ).enqueue()
     }


### PR DESCRIPTION
### 🎯 Goal

Fix reply action.

### 🛠 Implementation details

There is no need to set `message.user` when sending a message. Moreover,  `ChatClient.user` always will be null as the user is not set before connecting the socket.

### 🧪 Testing

1. Receive push notification
2. Use reply action and make sure the message is sent

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
