### PR TITLE
Show the user avatar when a PN is received and it is using `MessagingStyleNotificationHandler`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Show rounded avatars on Push Notification when `MessagingStyleNotificationHandler` is used. [#4059](https://github.com/GetStream/stream-chat-android/pull/4059)
 
 ### ✅ Added
 


### PR DESCRIPTION
### 🎯 Goal
Show user avatar on push notifications when `MessagingStyleNotificationsHandler` is in use.
Fix #4053

### 🛠 Implementation details
Android Notification doesn't provide any native option to display remote images (eg: URLs), it only allows to use resources/files/Bitmap. 
To be able to show remote images we need to download them and store them into a file or a bitmap.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot from 2022-08-18 13-19-15](https://user-images.githubusercontent.com/4047514/185384012-35108943-e67f-4043-b2f8-5f807a5a5dc6.png) | ![Screenshot from 2022-08-18 13-16-16](https://user-images.githubusercontent.com/4047514/185384036-a056a390-6747-469a-af9f-3da9db84662d.png) |

### 🧪 Testing
To see avatar icons on MessagingStyles you need to use a device with Android Version 28+
Install the sample app, put it in the background, and send messages to this user from another device.
Notifications with the sender user avatar should be shown.


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/142BNtGkZkt5pC/giphy.gif)
