### PR TITLE
[3963] Side effects for DistinctCalls run multiple times

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -507,6 +507,7 @@ public final class io/getstream/chat/android/client/api/models/PinnedMessagesPag
 
 public class io/getstream/chat/android/client/api/models/QueryChannelRequest : io/getstream/chat/android/client/api/models/ChannelRequest {
 	public fun <init> ()V
+	public fun equals (Ljava/lang/Object;)Z
 	public final fun filteringOlderMessages ()Z
 	public final fun getData ()Ljava/util/Map;
 	public final fun getMembers ()Ljava/util/Map;
@@ -515,6 +516,7 @@ public class io/getstream/chat/android/client/api/models/QueryChannelRequest : i
 	public fun getState ()Z
 	public fun getWatch ()Z
 	public final fun getWatchers ()Ljava/util/Map;
+	public fun hashCode ()I
 	public final fun isFilteringAroundIdMessages ()Z
 	public final fun isFilteringNewerMessages ()Z
 	public final fun membersLimit ()I

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -226,7 +226,7 @@ internal constructor(
     private val repositoryFactoryProvider: RepositoryFactory.Provider,
 ) {
     private val logger = StreamLog.getLogger("Chat:Client")
-    private val scope = scope + SharedCalls()
+    internal val scope = scope + SharedCalls()
     private val waitConnection = MutableSharedFlow<Result<ConnectionData>>()
     private val eventsObservable = ChatEventsObservable(socket, waitConnection, scope, chatSocketExperimental)
     private val lifecycleObserver = StreamLifecycleObserver(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -34,13 +34,29 @@ import io.getstream.chat.android.client.api.models.QueryChannelRequest
 import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QueryUsersRequest
 import io.getstream.chat.android.client.api.models.SendActionRequest
+import io.getstream.chat.android.client.api.models.identifier.DeleteMessageIdentifier
+import io.getstream.chat.android.client.api.models.identifier.DeleteReactionIdentifier
+import io.getstream.chat.android.client.api.models.identifier.GetRepliesIdentifier
+import io.getstream.chat.android.client.api.models.identifier.GetRepliesMoreIdentifier
+import io.getstream.chat.android.client.api.models.identifier.HideChannelIdentifier
+import io.getstream.chat.android.client.api.models.identifier.MarkAllReadIdentifier
+import io.getstream.chat.android.client.api.models.identifier.QueryChannelIdentifier
+import io.getstream.chat.android.client.api.models.identifier.QueryChannelsIdentifier
+import io.getstream.chat.android.client.api.models.identifier.QueryMembersIdentifier
+import io.getstream.chat.android.client.api.models.identifier.SendEventIdentifier
+import io.getstream.chat.android.client.api.models.identifier.SendGiphyIdentifier
+import io.getstream.chat.android.client.api.models.identifier.SendReactionIdentifier
+import io.getstream.chat.android.client.api.models.identifier.ShuffleGiphyIdentifier
+import io.getstream.chat.android.client.api.models.identifier.UpdateMessageIdentifier
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.CoroutineCall
+import io.getstream.chat.android.client.call.SharedCalls
 import io.getstream.chat.android.client.call.doOnResult
 import io.getstream.chat.android.client.call.doOnStart
 import io.getstream.chat.android.client.call.map
+import io.getstream.chat.android.client.call.share
 import io.getstream.chat.android.client.call.toUnitCall
 import io.getstream.chat.android.client.call.withPrecondition
 import io.getstream.chat.android.client.channel.ChannelClient
@@ -173,6 +189,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.plus
 import kotlinx.coroutines.withTimeoutOrNull
 import okhttp3.OkHttpClient
 import java.io.File
@@ -198,7 +215,7 @@ internal constructor(
     private val userCredentialStorage: UserCredentialStorage,
     private val userStateService: UserStateService = UserStateService(),
     private val tokenUtils: TokenUtils = TokenUtils,
-    internal val scope: CoroutineScope,
+    scope: CoroutineScope,
     internal val retryPolicy: RetryPolicy,
     private val initializationCoordinator: InitializationCoordinator = InitializationCoordinator.getOrCreate(),
     private val appSettingsManager: AppSettingManager,
@@ -209,6 +226,7 @@ internal constructor(
     private val repositoryFactoryProvider: RepositoryFactory.Provider,
 ) {
     private val logger = StreamLog.getLogger("Chat:Client")
+    private val scope = scope + SharedCalls()
     private val waitConnection = MutableSharedFlow<Result<ConnectionData>>()
     private val eventsObservable = ChatEventsObservable(socket, waitConnection, scope, chatSocketExperimental)
     private val lifecycleObserver = StreamLifecycleObserver(
@@ -653,12 +671,13 @@ internal constructor(
         sort: QuerySorter<Member>,
         members: List<Member> = emptyList(),
     ): Call<List<Member>> {
+        logger.d { "[queryMembers] cid: $channelType:$channelId, offset: $offset, limit: $limit" }
         val relevantPlugins = plugins.filterIsInstance<QueryMembersListener>().also(::logPlugins)
         val errorHandlers = errorHandlers.filterIsInstance<QueryMembersErrorHandler>()
         return api.queryMembers(channelType, channelId, offset, limit, filter, sort, members)
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onQueryMembersResult" }
+                    logger.v { "[queryMembers] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onQueryMembersResult(
                         result,
                         channelType,
@@ -669,9 +688,11 @@ internal constructor(
                         sort,
                         members
                     )
+                    logger.v { "[queryMembers] result: ${result.stringify { "Members(count=${it.size})" }}" }
                 }
             }
             .onQueryMembersError(errorHandlers, channelType, channelId, offset, limit, filter, sort, members)
+            .share(scope) { QueryMembersIdentifier(channelType, channelId, offset, limit, filter, sort, members) }
     }
 
     /**
@@ -803,7 +824,7 @@ internal constructor(
             .retry(scope = scope, retryPolicy = retryPolicy)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onDeleteReactionRequest" }
+                    logger.v { "[deleteReaction] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onDeleteReactionRequest(
                         cid = cid,
                         messageId = messageId,
@@ -814,7 +835,7 @@ internal constructor(
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onDeleteReactionResult" }
+                    logger.v { "[deleteReaction] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onDeleteReactionResult(
                         cid = cid,
                         messageId = messageId,
@@ -826,6 +847,7 @@ internal constructor(
             }
             .precondition(relevantPlugins) { onDeleteReactionPrecondition(currentUser) }
             .onMessageError(relevantErrorHandlers, cid, messageId)
+            .share(scope) { DeleteReactionIdentifier(messageId, reactionType, cid) }
     }
 
     /**
@@ -858,7 +880,7 @@ internal constructor(
             .doOnStart(scope) {
                 relevantPlugins
                     .forEach { plugin ->
-                        logger.d { "Applying ${plugin::class.qualifiedName}.onSendReactionRequest" }
+                        logger.v { "[sendReaction] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                         plugin.onSendReactionRequest(
                             cid = cid,
                             reaction = reaction,
@@ -869,7 +891,7 @@ internal constructor(
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onSendReactionResult" }
+                    logger.v { "[sendReaction] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onSendReactionResult(
                         cid = cid,
                         reaction = reaction,
@@ -881,6 +903,7 @@ internal constructor(
             }
             .onReactionError(relevantErrorHandlers, reaction, enforceUnique, currentUser!!)
             .precondition(relevantPlugins) { onSendReactionPrecondition(currentUser, reaction) }
+            .share(scope) { SendReactionIdentifier(reaction, enforceUnique, cid) }
     }
     //endregion
 
@@ -1269,22 +1292,24 @@ internal constructor(
 
     @CheckResult
     public fun getReplies(messageId: String, limit: Int): Call<List<Message>> {
+        logger.d { "[getReplies] messageId: $messageId, limit: $limit" }
         val relevantPlugins = plugins.filterIsInstance<ThreadQueryListener>().also(::logPlugins)
 
         return api.getReplies(messageId, limit)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onGetRepliesRequest" }
+                    logger.v { "[getReplies] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onGetRepliesRequest(messageId, limit)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onGetRepliesResult" }
+                    logger.v { "[getReplies] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onGetRepliesResult(result, messageId, limit)
                 }
             }
             .precondition(relevantPlugins) { onGetRepliesPrecondition(messageId, limit) }
+            .share(scope) { GetRepliesIdentifier(messageId, limit) }
     }
 
     @CheckResult
@@ -1293,22 +1318,24 @@ internal constructor(
         firstId: String,
         limit: Int,
     ): Call<List<Message>> {
+        logger.d { "[getRepliesMore] messageId: $messageId, firstId: $firstId, limit: $limit" }
         val relevantPlugins = plugins.filterIsInstance<ThreadQueryListener>().also(::logPlugins)
 
         return api.getRepliesMore(messageId, firstId, limit)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onGetRepliesMoreRequest" }
+                    logger.v { "[getRepliesMore] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onGetRepliesMoreRequest(messageId, firstId, limit)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onGetRepliesMoreResults" }
+                    logger.v { "[getRepliesMore] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onGetRepliesMoreResult(result, messageId, firstId, limit)
                 }
             }
             .precondition(relevantPlugins) { onGetRepliesMorePrecondition(messageId, firstId, limit) }
+            .share(scope) { GetRepliesMoreIdentifier(messageId, firstId, limit) }
     }
 
     @CheckResult
@@ -1335,10 +1362,11 @@ internal constructor(
             .retry(scope = scope, retryPolicy = retryPolicy)
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { listener ->
-                    logger.d { "Applying ${listener::class.qualifiedName}.onGiphySendResult" }
+                    logger.v { "[sendGiphy] #doOnResult; plugin: ${listener::class.qualifiedName}" }
                     listener.onGiphySendResult(cid = message.cid, result = result)
                 }
             }
+            .share(scope) { SendGiphyIdentifier(request) }
     }
 
     /**
@@ -1361,33 +1389,36 @@ internal constructor(
             .retry(scope = scope, retryPolicy = retryPolicy)
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { listener ->
-                    logger.d { "Applying ${listener::class.qualifiedName}.onShuffleGiphyResult" }
+                    logger.v { "[shuffleGiphy] #doOnResult; plugin: ${listener::class.qualifiedName}" }
                     listener.onShuffleGiphyResult(cid = message.cid, result = result)
                 }
             }
+            .share(scope) { ShuffleGiphyIdentifier(request) }
     }
 
     @CheckResult
     @JvmOverloads
     public fun deleteMessage(messageId: String, hard: Boolean = false): Call<Message> {
+        logger.d { "[deleteMessage] messageId: $messageId, hard: $hard" }
         val relevantPlugins = plugins.filterIsInstance<DeleteMessageListener>().also(::logPlugins)
 
         return api.deleteMessage(messageId, hard)
             .doOnStart(scope) {
                 relevantPlugins.forEach { listener ->
-                    logger.d { "Applying ${listener::class.qualifiedName}.onMessageDeleteRequest" }
+                    logger.v { "[deleteMessage] #doOnStart; plugin: ${listener::class.qualifiedName}" }
                     listener.onMessageDeleteRequest(messageId)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { listener ->
-                    logger.d { "Applying ${listener::class.qualifiedName}.onMessageDeleteResult" }
+                    logger.v { "[deleteMessage] #doOnResult; plugin: ${listener::class.qualifiedName}" }
                     listener.onMessageDeleteResult(messageId, result)
                 }
             }
             .precondition(relevantPlugins) {
                 onMessageDeletePrecondition(messageId)
             }
+            .share(scope) { DeleteMessageIdentifier(messageId, hard) }
     }
 
     @CheckResult
@@ -1429,7 +1460,7 @@ internal constructor(
                     .doOnResult(scope) { result ->
                         logger.i { "[sendMessage] result: ${result.stringify { it.toString() }}" }
                         relevantPlugins.forEach { listener ->
-                            logger.d { "Applying ${listener::class.qualifiedName}.onMessageSendResult" }
+                            logger.v { "[sendMessage] #doOnResult; plugin: ${listener::class.qualifiedName}" }
                             listener.onMessageSendResult(
                                 result,
                                 channelType,
@@ -1455,16 +1486,17 @@ internal constructor(
         return api.updateMessage(message)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onMessageEditRequest" }
+                    logger.v { "[updateMessage] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onMessageEditRequest(message)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onMessageEditResult" }
+                    logger.v { "[updateMessage] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onMessageEditResult(message, result)
                 }
             }
+            .share(scope) { UpdateMessageIdentifier(message) }
     }
 
     /**
@@ -1606,6 +1638,7 @@ internal constructor(
         channelId: String,
         request: QueryChannelRequest,
     ): Call<Channel> {
+        logger.d { "[queryChannel] cid: $channelType:$channelId" }
         val relevantPlugins = plugins.filterIsInstance<QueryChannelListener>().also(::logPlugins)
 
         return queryChannelInternal(channelType = channelType, channelId = channelId, request = request)
@@ -1621,6 +1654,8 @@ internal constructor(
                 }
             }.precondition(relevantPlugins) {
                 onQueryChannelPrecondition(channelType, channelId, request)
+            }.share(scope) {
+                QueryChannelIdentifier(channelType, channelId, request)
             }
     }
 
@@ -1637,6 +1672,7 @@ internal constructor(
      */
     @CheckResult
     public fun queryChannels(request: QueryChannelsRequest): Call<List<Channel>> {
+        logger.d { "[queryChannels] offset: ${request.offset}, limit: ${request.limit}" }
         val relevantPluginsLazy = { plugins.filterIsInstance<QueryChannelsListener>() }
         logPlugins(relevantPluginsLazy())
 
@@ -1652,6 +1688,8 @@ internal constructor(
             }
         }.precondition(relevantPluginsLazy()) {
             onQueryChannelsPrecondition(request)
+        }.share(scope) {
+            QueryChannelsIdentifier(request)
         }
     }
 
@@ -1691,21 +1729,23 @@ internal constructor(
         channelId: String,
         clearHistory: Boolean = false,
     ): Call<Unit> {
+        logger.d { "[hideChannel] cid: $channelType:$channelId, clearHistory: $clearHistory" }
         val relevantPlugins = plugins.filterIsInstance<HideChannelListener>().also(::logPlugins)
         return api.hideChannel(channelType, channelId, clearHistory)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onHideChannelRequest" }
+                    logger.v { "[hideChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onHideChannelRequest(channelType, channelId, clearHistory)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onHideChannelResult" }
+                    logger.v { "[hideChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onHideChannelResult(result, channelType, channelId, clearHistory)
                 }
             }
             .precondition(relevantPlugins) { onHideChannelPrecondition(channelType, channelId, clearHistory) }
+            .share(scope) { HideChannelIdentifier(channelType, channelId, clearHistory) }
     }
 
     /**
@@ -1884,10 +1924,11 @@ internal constructor(
         return api.markAllRead()
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onMarkAllReadRequest" }
+                    logger.v { "[markAllRead] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onMarkAllReadRequest()
                 }
             }
+            .share(scope) { MarkAllReadIdentifier() }
     }
 
     /**
@@ -1956,9 +1997,7 @@ internal constructor(
     @CheckResult
     public fun queryUsers(query: QueryUsersRequest): Call<List<User>> {
         val isConnectionRequired = query.presence
-        logger.d {
-            "[queryUsers]  request: $query, isConnectionRequired: $isConnectionRequired"
-        }
+        logger.d { "[queryUsers] isConnectionRequired: $isConnectionRequired, query: $query" }
 
         return callPostponeHelper.postponeCallIfNeeded(shouldPostpone = isConnectionRequired) {
             api.queryUsers(query)
@@ -2302,15 +2341,16 @@ internal constructor(
         val relevantErrorHandlers = errorHandlers.filterIsInstance<CreateChannelErrorHandler>()
         val currentUser = getCurrentUser()
 
+        val request = QueryChannelRequest().withData(extraData + mapOf(ModelFields.MEMBERS to memberIds))
         return queryChannelInternal(
             channelType = channelType,
             channelId = channelId,
-            request = QueryChannelRequest().withData(extraData + mapOf(ModelFields.MEMBERS to memberIds)),
+            request = request,
         )
             .retry(scope = scope, retryPolicy = retryPolicy)
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onCreateChannelRequest" }
+                    logger.v { "[createChannel] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onCreateChannelRequest(
                         channelType = channelType,
                         channelId = channelId,
@@ -2322,7 +2362,7 @@ internal constructor(
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onCreateChannelResult" }
+                    logger.v { "[createChannel] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onCreateChannelResult(
                         channelType = channelType,
                         channelId = channelId,
@@ -2345,6 +2385,7 @@ internal constructor(
                     memberIds = memberIds,
                 )
             }
+            .share(scope) { QueryChannelIdentifier(channelType, channelId, request) }
     }
 
     /**
@@ -2412,19 +2453,20 @@ internal constructor(
         )
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onTypingEventRequest" }
+                    logger.v { "[keystroke] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onTypingEventRequest(eventType, channelType, channelId, extraData, eventTime)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onTypingEventResult" }
+                    logger.v { "[keystroke] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onTypingEventResult(result, eventType, channelType, channelId, extraData, eventTime)
                 }
             }
             .precondition(relevantPlugins) {
                 this.onTypingEventPrecondition(eventType, channelType, channelId, extraData, eventTime)
             }
+            .share(scope) { SendEventIdentifier(eventType, channelType, channelId, parentId) }
     }
 
     /**
@@ -2453,19 +2495,20 @@ internal constructor(
         )
             .doOnStart(scope) {
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onTypingEventRequest" }
+                    logger.v { "[stopTyping] #doOnStart; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onTypingEventRequest(eventType, channelType, channelId, extraData, eventTime)
                 }
             }
             .doOnResult(scope) { result ->
                 relevantPlugins.forEach { plugin ->
-                    logger.d { "Applying ${plugin::class.qualifiedName}.onTypingEventResult" }
+                    logger.v { "[stopTyping] #doOnResult; plugin: ${plugin::class.qualifiedName}" }
                     plugin.onTypingEventResult(result, eventType, channelType, channelId, extraData, eventTime)
                 }
             }
             .precondition(relevantPlugins) {
                 this.onTypingEventPrecondition(eventType, channelType, channelId, extraData, eventTime)
             }
+            .share(scope) { SendEventIdentifier(eventType, channelType, channelId, parentId) }
     }
 
     private fun warmUp() {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelRequest.kt
@@ -149,6 +149,32 @@ public open class QueryChannelRequest : ChannelRequest<QueryChannelRequest> {
         }
     }
 
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is QueryChannelRequest) return false
+        if (state != other.state) return false
+        if (watch != other.watch) return false
+        if (presence != other.presence) return false
+        if (shouldRefresh != other.shouldRefresh) return false
+        if (messages != other.messages) return false
+        if (watchers != other.watchers) return false
+        if (members != other.members) return false
+        if (data != other.data) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = state.hashCode()
+        result = 31 * result + watch.hashCode()
+        result = 31 * result + presence.hashCode()
+        result = 31 * result + shouldRefresh.hashCode()
+        result = 31 * result + messages.hashCode()
+        result = 31 * result + watchers.hashCode()
+        result = 31 * result + members.hashCode()
+        result = 31 * result + data.hashCode()
+        return result
+    }
+
     private companion object {
         private const val KEY_LIMIT = "limit"
         private const val KEY_OFFSET = "offset"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.models.identifier
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.QueryChannelRequest
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.client.api.models.SendActionRequest
+import io.getstream.chat.android.client.api.models.querysort.QuerySorter
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.models.Reaction
+
+/**
+ * Identifier for a [ChatClient.queryChannel] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun QueryChannelIdentifier(
+    channelType: String,
+    channelId: String,
+    request: QueryChannelRequest,
+): String {
+    var result = channelType.hashCode()
+    result = 31 * result + channelId.hashCode()
+    result = 31 * result + request.hashCode()
+    return "QueryChannel($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.queryChannels] call.
+ */
+@Suppress("FunctionName")
+internal fun QueryChannelsIdentifier(
+    request: QueryChannelsRequest,
+): String {
+    return "QueryChannels(${request.hashCode()})"
+}
+
+/**
+ * Identifier for a [ChatClient.queryMembers] call.
+ */
+@Suppress("FunctionName", "MagicNumber", "LongParameterList")
+internal fun QueryMembersIdentifier(
+    channelType: String,
+    channelId: String,
+    offset: Int,
+    limit: Int,
+    filter: FilterObject,
+    sort: QuerySorter<Member>,
+    members: List<Member> = emptyList()
+): String {
+    var result = channelType.hashCode()
+    result = 31 * result + channelId.hashCode()
+    result = 31 * result + offset.hashCode()
+    result = 31 * result + limit.hashCode()
+    result = 31 * result + filter.hashCode()
+    result = 31 * result + sort.hashCode()
+    result = 31 * result + members.hashCode()
+    return "QueryMembers($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.deleteReaction] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun DeleteReactionIdentifier(
+    messageId: String,
+    reactionType: String,
+    cid: String?
+): String {
+    var result = messageId.hashCode()
+    result = 31 * result + reactionType.hashCode()
+    result = 31 * result + (cid?.hashCode() ?: 0)
+    return "DeleteReaction($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.sendReaction] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun SendReactionIdentifier(
+    reaction: Reaction,
+    enforceUnique: Boolean,
+    cid: String?
+): String {
+    var result = reaction.hashCode()
+    result = 31 * result + enforceUnique.hashCode()
+    result = 31 * result + cid.hashCode()
+    return "SendReaction($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.getReplies] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun GetRepliesIdentifier(
+    messageId: String,
+    limit: Int
+): String {
+    var result = messageId.hashCode()
+    result = 31 * result + limit.hashCode()
+    return "GetReplies($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.getRepliesMore] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun GetRepliesMoreIdentifier(
+    messageId: String,
+    firstId: String,
+    limit: Int
+): String {
+    var result = messageId.hashCode()
+    result = 31 * result + firstId.hashCode()
+    result = 31 * result + limit.hashCode()
+    return "GetRepliesMore($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.sendGiphy] call.
+ */
+@Suppress("FunctionName")
+internal fun SendGiphyIdentifier(
+    request: SendActionRequest
+): String {
+    return "SendGiphy(${request.hashCode()})"
+}
+
+/**
+ * Identifier for a [ChatClient.shuffleGiphy] call.
+ */
+@Suppress("FunctionName")
+internal fun ShuffleGiphyIdentifier(
+    request: SendActionRequest
+): String {
+    return "ShuffleGiphy(${request.hashCode()})"
+}
+
+/**
+ * Identifier for a [ChatClient.deleteMessage] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun DeleteMessageIdentifier(
+    messageId: String,
+    hard: Boolean
+): String {
+    var result = messageId.hashCode()
+    result = 31 * result + hard.hashCode()
+    return "DeleteMessage($result)"
+}
+
+/**
+ * Identifier for [ChatClient.keystroke] and [ChatClient.stopTyping] calls.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun SendEventIdentifier(
+    eventType: String,
+    channelType: String,
+    channelId: String,
+    parentId: String?
+): String {
+    var result = eventType.hashCode()
+    result = 31 * result + channelType.hashCode()
+    result = 31 * result + channelId.hashCode()
+    result = 31 * result + parentId.hashCode()
+    return "SendEvent($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.updateMessage] call.
+ */
+@Suppress("FunctionName")
+internal fun UpdateMessageIdentifier(
+    message: Message
+): String {
+    return "UpdateMessage(${message.hashCode()})"
+}
+
+/**
+ * Identifier for a [ChatClient.hideChannel] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun HideChannelIdentifier(
+    channelType: String,
+    channelId: String,
+    clearHistory: Boolean
+): String {
+    var result = channelType.hashCode()
+    result = 31 * result + channelId.hashCode()
+    result = 31 * result + clearHistory.hashCode()
+    return "HideChannel($result)"
+}
+
+/**
+ * Identifier for a [ChatClient.markAllRead] call.
+ */
+@Suppress("FunctionName", "FunctionOnlyReturningConstant")
+internal fun MarkAllReadIdentifier(): String {
+    return "MarkAllRead"
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
@@ -34,21 +34,24 @@ internal fun QueryChannelIdentifier(
     channelType: String,
     channelId: String,
     request: QueryChannelRequest,
-): String {
-    var result = channelType.hashCode()
+): Int {
+    var result = "QueryChannel".hashCode()
+    result = 31 * result + channelType.hashCode()
     result = 31 * result + channelId.hashCode()
     result = 31 * result + request.hashCode()
-    return "QueryChannel($result)"
+    return result
 }
 
 /**
  * Identifier for a [ChatClient.queryChannels] call.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionName", "MagicNumber")
 internal fun QueryChannelsIdentifier(
     request: QueryChannelsRequest,
-): String {
-    return "QueryChannels(${request.hashCode()})"
+): Int {
+    var result = "QueryChannels".hashCode()
+    result = 31 * result + request.hashCode()
+    return result
 }
 
 /**
@@ -63,15 +66,16 @@ internal fun QueryMembersIdentifier(
     filter: FilterObject,
     sort: QuerySorter<Member>,
     members: List<Member> = emptyList()
-): String {
-    var result = channelType.hashCode()
+): Int {
+    var result = "QueryMembers".hashCode()
+    result = 31 * result + channelType.hashCode()
     result = 31 * result + channelId.hashCode()
     result = 31 * result + offset.hashCode()
     result = 31 * result + limit.hashCode()
     result = 31 * result + filter.hashCode()
     result = 31 * result + sort.hashCode()
     result = 31 * result + members.hashCode()
-    return "QueryMembers($result)"
+    return result
 }
 
 /**
@@ -82,11 +86,12 @@ internal fun DeleteReactionIdentifier(
     messageId: String,
     reactionType: String,
     cid: String?
-): String {
-    var result = messageId.hashCode()
+): Int {
+    var result = "DeleteReaction".hashCode()
+    result = 31 * result + messageId.hashCode()
     result = 31 * result + reactionType.hashCode()
     result = 31 * result + (cid?.hashCode() ?: 0)
-    return "DeleteReaction($result)"
+    return result
 }
 
 /**
@@ -97,11 +102,12 @@ internal fun SendReactionIdentifier(
     reaction: Reaction,
     enforceUnique: Boolean,
     cid: String?
-): String {
-    var result = reaction.hashCode()
+): Int {
+    var result = "SendReaction".hashCode()
+    result = 31 * result + reaction.hashCode()
     result = 31 * result + enforceUnique.hashCode()
     result = 31 * result + cid.hashCode()
-    return "SendReaction($result)"
+    return result
 }
 
 /**
@@ -111,10 +117,11 @@ internal fun SendReactionIdentifier(
 internal fun GetRepliesIdentifier(
     messageId: String,
     limit: Int
-): String {
-    var result = messageId.hashCode()
+): Int {
+    var result = "GetReplies".hashCode()
+    result = 31 * result + messageId.hashCode()
     result = 31 * result + limit.hashCode()
-    return "GetReplies($result)"
+    return result
 }
 
 /**
@@ -125,31 +132,36 @@ internal fun GetRepliesMoreIdentifier(
     messageId: String,
     firstId: String,
     limit: Int
-): String {
-    var result = messageId.hashCode()
+): Int {
+    var result = "GetRepliesMore".hashCode()
+    result = 31 * result + messageId.hashCode()
     result = 31 * result + firstId.hashCode()
     result = 31 * result + limit.hashCode()
-    return "GetRepliesMore($result)"
+    return result
 }
 
 /**
  * Identifier for a [ChatClient.sendGiphy] call.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionName", "MagicNumber")
 internal fun SendGiphyIdentifier(
     request: SendActionRequest
-): String {
-    return "SendGiphy(${request.hashCode()})"
+): Int {
+    var result = "SendGiphy".hashCode()
+    result = 31 * result + request.hashCode()
+    return result
 }
 
 /**
  * Identifier for a [ChatClient.shuffleGiphy] call.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionName", "MagicNumber")
 internal fun ShuffleGiphyIdentifier(
     request: SendActionRequest
-): String {
-    return "ShuffleGiphy(${request.hashCode()})"
+): Int {
+    var result = "ShuffleGiphy".hashCode()
+    result = 31 * result + request.hashCode()
+    return result
 }
 
 /**
@@ -159,10 +171,11 @@ internal fun ShuffleGiphyIdentifier(
 internal fun DeleteMessageIdentifier(
     messageId: String,
     hard: Boolean
-): String {
-    var result = messageId.hashCode()
+): Int {
+    var result = "DeleteMessage".hashCode()
+    result = 31 * result + messageId.hashCode()
     result = 31 * result + hard.hashCode()
-    return "DeleteMessage($result)"
+    return result
 }
 
 /**
@@ -174,22 +187,25 @@ internal fun SendEventIdentifier(
     channelType: String,
     channelId: String,
     parentId: String?
-): String {
-    var result = eventType.hashCode()
+): Int {
+    var result = "SendEvent".hashCode()
+    result = 31 * result + eventType.hashCode()
     result = 31 * result + channelType.hashCode()
     result = 31 * result + channelId.hashCode()
     result = 31 * result + parentId.hashCode()
-    return "SendEvent($result)"
+    return result
 }
 
 /**
  * Identifier for a [ChatClient.updateMessage] call.
  */
-@Suppress("FunctionName")
+@Suppress("FunctionName", "MagicNumber")
 internal fun UpdateMessageIdentifier(
     message: Message
-): String {
-    return "UpdateMessage(${message.hashCode()})"
+): Int {
+    var result = "UpdateMessage".hashCode()
+    result = 31 * result + message.hashCode()
+    return result
 }
 
 /**
@@ -200,17 +216,18 @@ internal fun HideChannelIdentifier(
     channelType: String,
     channelId: String,
     clearHistory: Boolean
-): String {
-    var result = channelType.hashCode()
+): Int {
+    var result = "HideChannel".hashCode()
+    result = 31 * result + channelType.hashCode()
     result = 31 * result + channelId.hashCode()
     result = 31 * result + clearHistory.hashCode()
-    return "HideChannel($result)"
+    return result
 }
 
 /**
  * Identifier for a [ChatClient.markAllRead] call.
  */
 @Suppress("FunctionName", "FunctionOnlyReturningConstant")
-internal fun MarkAllReadIdentifier(): String {
-    return "MarkAllRead"
+internal fun MarkAllReadIdentifier(): Int {
+    return "MarkAllRead".hashCode()
 }

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -27,6 +27,9 @@ public final class io/getstream/chat/android/client/call/ReturnOnErrorCall : io/
 	public fun execute ()Lio/getstream/chat/android/client/utils/Result;
 }
 
+public final class io/getstream/chat/android/client/call/SharedCalls$Key : kotlin/coroutines/CoroutineContext$Key {
+}
+
 public class io/getstream/chat/android/client/errors/ChatError {
 	public fun <init> ()V
 	public fun <init> (Ljava/lang/String;Ljava/lang/Throwable;)V

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
@@ -152,7 +152,7 @@ public fun <T : Any> Call<T>.onErrorReturn(
 @InternalStreamChatApi
 public fun <T : Any> Call<T>.share(
     scope: CoroutineScope,
-    identifier: () -> String,
+    identifier: () -> Int,
 ): Call<T> {
     return SharedCall(this, identifier, scope)
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/Call.kt
@@ -137,13 +137,25 @@ public fun <T : Any> Call<T>.withPrecondition(
  * an error.
  *
  * @param scope Scope of coroutine in which to execute side effect function.
- * @param onError Function that returns data in the case of error.
+ * @param function Function that returns data in the case of error.
  */
 @InternalStreamChatApi
 public fun <T : Any> Call<T>.onErrorReturn(
     scope: CoroutineScope,
     function: suspend (originalError: ChatError) -> Result<T>,
 ): ReturnOnErrorCall<T> = ReturnOnErrorCall(this, scope, function)
+
+/**
+ * Shares the existing [Call] instance for the specified [identifier].
+ * If no existing call found the new [Call] instance will be provided.
+ */
+@InternalStreamChatApi
+public fun <T : Any> Call<T>.share(
+    scope: CoroutineScope,
+    identifier: () -> String,
+): Call<T> {
+    return SharedCall(this, identifier, scope)
+}
 
 @InternalStreamChatApi
 public fun Call<*>.toUnitCall(): Call<Unit> = map {}

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/DistinctCall.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/DistinctCall.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.call
 
 import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.concurrency.SynchronizedReference
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -34,7 +35,8 @@ import java.util.concurrent.atomic.AtomicReference
 /**
  * Reusable wrapper around [Call] which delivers a single result to all subscribers.
  */
-internal class DistinctCall<T : Any>(
+@InternalStreamChatApi
+public class DistinctCall<T : Any>(
     scope: CoroutineScope,
     private val callBuilder: () -> Call<T>,
     private val onFinished: () -> Unit,
@@ -44,7 +46,8 @@ internal class DistinctCall<T : Any>(
     private val deferred = SynchronizedReference<Deferred<Result<T>>>()
     private val delegateCall = AtomicReference<Call<T>>()
 
-    internal fun originCall(): Call<T> = callBuilder()
+    @InternalStreamChatApi
+    public fun originCall(): Call<T> = callBuilder()
 
     override fun execute(): Result<T> = runBlocking { await() }
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/SharedCalls.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/SharedCalls.kt
@@ -27,7 +27,7 @@ import kotlin.coroutines.CoroutineContext
 @Suppress("FunctionName", "UNCHECKED_CAST")
 internal fun <T : Any> SharedCall(
     origin: Call<T>,
-    originIdentifier: () -> String,
+    originIdentifier: () -> Int,
     scope: CoroutineScope,
 ): Call<T> {
     val sharedCalls = scope.coroutineContext[SharedCalls] ?: return origin
@@ -54,26 +54,26 @@ public class SharedCalls : CoroutineContext.Element {
     /**
      * A collection of uncompleted calls.
      */
-    private val calls = ConcurrentHashMap<String, Call<out Any>>()
+    private val calls = ConcurrentHashMap<Int, Call<out Any>>()
 
     /**
      * Provides a [Call] based of specified [identifier] if available.
      */
-    internal operator fun get(identifier: String): Call<out Any>? {
+    internal operator fun get(identifier: Int): Call<out Any>? {
         return calls[identifier]
     }
 
     /**
      * Puts a [Call] behind of specified [identifier].
      */
-    internal fun put(identifier: String, value: Call<out Any>) {
+    internal fun put(identifier: Int, value: Call<out Any>) {
         calls[identifier] = value
     }
 
     /**
      * Removes a [Call] based of specified [identifier].
      */
-    internal fun remove(identifier: String) {
+    internal fun remove(identifier: Int) {
         calls.remove(identifier)
     }
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/SharedCalls.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/call/SharedCalls.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.call
+
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Creates a shared [Call] instance.
+ */
+@Suppress("FunctionName", "UNCHECKED_CAST")
+internal fun <T : Any> SharedCall(
+    origin: Call<T>,
+    originIdentifier: () -> String,
+    scope: CoroutineScope,
+): Call<T> {
+    val sharedCalls = scope.coroutineContext[SharedCalls] ?: return origin
+    val identifier = originIdentifier()
+    return sharedCalls[identifier] as? Call<T>
+        ?: DistinctCall(scope, { origin }) {
+            sharedCalls.remove(identifier)
+        }.also {
+            sharedCalls.put(identifier, it)
+        }
+}
+
+/**
+ * The [CoroutineContext.Element] which holds ongoing calls until those get finished.
+ */
+@InternalStreamChatApi
+public class SharedCalls : CoroutineContext.Element {
+
+    /**
+     * A key of [SharedCalls] coroutine context element.
+     */
+    public override val key: CoroutineContext.Key<SharedCalls> = Key
+
+    /**
+     * A collection of uncompleted calls.
+     */
+    private val calls = ConcurrentHashMap<String, Call<out Any>>()
+
+    /**
+     * Provides a [Call] based of specified [identifier] if available.
+     */
+    internal operator fun get(identifier: String): Call<out Any>? {
+        return calls[identifier]
+    }
+
+    /**
+     * Puts a [Call] behind of specified [identifier].
+     */
+    internal fun put(identifier: String, value: Call<out Any>) {
+        calls[identifier] = value
+    }
+
+    /**
+     * Removes a [Call] based of specified [identifier].
+     */
+    internal fun remove(identifier: String) {
+        calls.remove(identifier)
+    }
+
+    public companion object Key : CoroutineContext.Key<SharedCalls>
+}

--- a/stream-chat-android-ui-components-sample/detekt-baseline.xml
+++ b/stream-chat-android-ui-components-sample/detekt-baseline.xml
@@ -5,7 +5,6 @@
     <ID>ComplexCondition:UserRepository.kt$UserRepository$apiKey != null &amp;&amp; id != null &amp;&amp; name != null &amp;&amp; token != null &amp;&amp; image != null</ID>
     <ID>ComplexMethod:ChatFragment.kt$ChatFragment$private fun initMessagesViewModel()</ID>
     <ID>ForbiddenComment:ChatInfoViewModel.kt$ChatInfoViewModel$// TODO: Handle error</ID>
-    <ID>ForbiddenComment:HomeFragmentViewModel.kt$HomeFragmentViewModel.State$// TODO: implement unread mentions count</ID>
     <ID>LongMethod:ChatFragment.kt$ChatFragment$private fun initMessagesViewModel()</ID>
     <ID>LongMethod:ComponentBrowserAvatarViewFragment.kt$ComponentBrowserAvatarViewFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>
     <ID>LongMethod:ComponentBrowserViewReactionsFragment.kt$ComponentBrowserViewReactionsFragment$override fun onViewCreated(view: View, savedInstanceState: Bundle?)</ID>


### PR DESCRIPTION
### 🎯 Goal

Make side effects for DistinctCalls run once.

### 🛠 Implementation details

A new operator named `share` has been introduced to reuse the same chain of the calls as long as the real request keeps running.

### 🧪 Testing

- Run sample app
- Open any channel 
- Make sure there is a single `doOnStart` and `doOnResult` presented in the logs even though the `queryChannel` is invoked multiple times

```
2022-08-18 19:29:49.657 5359-5359/io.getstream.chat.ui.sample.debug D/Chat:Client: (main:2) [queryChannel] cid: messaging:sample-app-channel-109
2022-08-18 19:29:49.661 5359-5470/io.getstream.chat.ui.sample.debug V/Chat:Client: (DefaultDispatcher-worker-13:119) [queryChannel] #doOnStart; plugin: io.getstream.chat.android.offline.plugin.internal.OfflinePlugin
2022-08-18 19:29:49.668 5359-5359/io.getstream.chat.ui.sample.debug D/Chat:Client: (main:2) [queryChannel] cid: messaging:sample-app-channel-109
2022-08-18 19:29:49.678 5359-5359/io.getstream.chat.ui.sample.debug D/Chat:Client: (main:2) [queryChannel] cid: messaging:sample-app-channel-109
2022-08-18 19:29:49.685 5359-5359/io.getstream.chat.ui.sample.debug D/Chat:Client: (main:2) [queryChannel] cid: messaging:sample-app-channel-109
2022-08-18 19:29:49.718 5359-5359/io.getstream.chat.ui.sample.debug D/Chat:Client: (main:2) [queryChannel] cid: messaging:sample-app-channel-109
2022-08-18 19:29:50.488 5359-5587/io.getstream.chat.ui.sample.debug V/Chat:Client: (DefaultDispatcher-worker-76:215) [queryChannel] #doOnResult; plugin: io.getstream.chat.android.offline.plugin.internal.OfflinePlugin

```


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
