### PR TITLE
[ISSUE-4063] QueryMembersListenerImpl separation

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
@@ -1,0 +1,69 @@
+package io.getstream.chat.android.offline.plugin.listener.internal
+
+import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.models.Filters
+import io.getstream.chat.android.client.models.Member
+import io.getstream.chat.android.client.persistance.repository.ChannelRepository
+import io.getstream.chat.android.client.persistance.repository.UserRepository
+import io.getstream.chat.android.client.test.randomMember
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.test.randomCID
+import io.getstream.chat.android.test.randomInt
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class QueryMembersListenerDatabaseTest {
+
+    private val userRepository: UserRepository = mock()
+    private val channelRepository: ChannelRepository = mock()
+    private val queryMembersListenerDatabase = QueryMembersListenerDatabase(userRepository, channelRepository)
+
+    @Test
+    fun `when query members is successful database should be updated`() = runTest {
+        val memberList = randomMember().let(::listOf)
+        val cid = randomCID()
+        val (type, id) = cid.cidToTypeAndId()
+
+        queryMembersListenerDatabase.onQueryMembersResult(
+            result = Result.success(memberList),
+            channelType = type,
+            channelId = id,
+            offset = randomInt(),
+            limit = randomInt(),
+            filter = Filters.neutral(),
+            sort = QuerySortByField.descByName("name"),
+            members = memberList,
+        )
+
+        verify(userRepository).insertUsers(memberList.map(Member::user))
+        verify(channelRepository).updateMembersForChannel(cid, memberList)
+    }
+
+    @Test
+    fun `when query members fails database should not be updated`() = runTest {
+        val memberList = randomMember().let(::listOf)
+        val cid = randomCID()
+        val (type, id) = cid.cidToTypeAndId()
+
+        queryMembersListenerDatabase.onQueryMembersResult(
+            result = Result.error(ChatError()),
+            channelType = type,
+            channelId = id,
+            offset = randomInt(),
+            limit = randomInt(),
+            filter = Filters.neutral(),
+            sort = QuerySortByField.descByName("name"),
+            members = memberList,
+        )
+
+        verifyNoInteractions(userRepository, channelRepository)
+    }
+}

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
@@ -1,6 +1,21 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.offline.plugin.listener.internal
 
-import io.getstream.chat.android.client.api.models.FilterObject
 import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.errors.ChatError
 import io.getstream.chat.android.client.extensions.cidToTypeAndId

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/QueryMembersListenerDatabaseTest.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 
@@ -49,6 +50,8 @@ internal class QueryMembersListenerDatabaseTest {
 
     @Test
     fun `when query members fails database should not be updated`() = runTest {
+        reset(userRepository, channelRepository)
+
         val memberList = randomMember().let(::listOf)
         val cid = randomCID()
         val (type, id) = cid.cidToTypeAndId()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -42,7 +42,6 @@ import io.getstream.chat.android.offline.plugin.listener.internal.HideChannelLis
 import io.getstream.chat.android.offline.plugin.listener.internal.MarkAllReadListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.QueryChannelListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.QueryChannelsListenerImpl
-import io.getstream.chat.android.offline.plugin.listener.internal.QueryMembersListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.SendGiphyListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.SendMessageListenerImpl
 import io.getstream.chat.android.offline.plugin.listener.internal.SendReactionListenerState
@@ -240,7 +239,6 @@ public class StreamStatePluginFactory(
             sendMessageListener = SendMessageListenerImpl(logic, repositoryFacade),
             sendGiphyListener = SendGiphyListenerState(logic),
             shuffleGiphyListener = ShuffleGiphyListenerState(logic),
-            queryMembersListener = QueryMembersListenerImpl(repositoryFacade),
             typingEventListener = TypingEventListenerState(stateRegistry),
             provideDependency = createDependencyProvider(syncManager, eventHandler)
         )

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -27,7 +27,6 @@ import io.getstream.chat.android.client.plugin.listeners.HideChannelListener
 import io.getstream.chat.android.client.plugin.listeners.MarkAllReadListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelsListener
-import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
 import io.getstream.chat.android.client.plugin.listeners.SendGiphyListener
 import io.getstream.chat.android.client.plugin.listeners.SendMessageListener
 import io.getstream.chat.android.client.plugin.listeners.SendReactionListener
@@ -54,7 +53,6 @@ import kotlin.reflect.KClass
  * @param sendGiphyListener [SendGiphyListener]
  * @param shuffleGiphyListener [ShuffleGiphyListener]
  * @param sendMessageListener [SendMessageListener]
- * @param queryMembersListener [QueryMembersListener]
  * @param typingEventListener [TypingEventListener]
  * @param activeUser User associated with [StatePlugin] instance.
  */
@@ -75,7 +73,6 @@ public class StatePlugin(
     private val sendGiphyListener: SendGiphyListener,
     private val shuffleGiphyListener: ShuffleGiphyListener,
     private val sendMessageListener: SendMessageListener,
-    private val queryMembersListener: QueryMembersListener,
     private val typingEventListener: TypingEventListener,
     private val provideDependency: (KClass<*>) -> Any? = { null },
 ) : StateAwarePlugin,
@@ -93,7 +90,6 @@ public class StatePlugin(
     SendGiphyListener by sendGiphyListener,
     ShuffleGiphyListener by shuffleGiphyListener,
     SendMessageListener by sendMessageListener,
-    QueryMembersListener by queryMembersListener,
     TypingEventListener by typingEventListener {
 
     override val name: String = MODULE_NAME


### PR DESCRIPTION
### 🎯 Goal

Renaming QueryMembersListenerImpl to QueryMembersListenerDatabase because it only deals with persistence.

### 🛠 Implementation details

Class rename and adding unit tests

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
