### PR TITLE
[4066] Fix image attachments without dimensions not loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,35 +1,7 @@
 # August 22nd, 2022 - 5.8.1
-## Common changes for all artifacts
-### ⚠️ Changed
-
-## stream-chat-android-client
-### 🐞 Fixed
-
-### ✅ Added
-
-## stream-chat-android-offline
-### ⬆️ Improved
-
-### ✅ Added
-
-### ⚠️ Changed
-
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed loading of image attachments with null values of `Attachment.originalWidth` and `Attachment.originalHeight`. A bug was introduced in the previous release that made these image attachments not load as their container height would remain set to 0. [#4067](https://github.com/GetStream/stream-chat-android/pull/4067)
-
-### ✅ Added
-
-### ⚠️ Changed
-
-## stream-chat-android-compose
-### 🐞 Fixed
-
-### ⬆️ Improved
-
-### ✅ Added
-
-### ⚠️ Changed
 
 # August 16th, 2022 - 5.8.0
 ## Common changes for all artifacts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+# August 22nd, 2022 - 5.8.1
+## Common changes for all artifacts
+### ⚠️ Changed
+
+## stream-chat-android-client
+### 🐞 Fixed
+
+### ✅ Added
+
+## stream-chat-android-offline
+### ⬆️ Improved
+
+### ✅ Added
+
+### ⚠️ Changed
+
+## stream-chat-android-ui-components
+### 🐞 Fixed
+- Fixed loading of image attachments with null values of `Attachment.originalWidth` and `Attachment.originalHeight`. A bug was introduced in the previous release that made these image attachments not load as their container height would remain set to 0. [#4067](https://github.com/GetStream/stream-chat-android/pull/4067)
+
+### ✅ Added
+
+### ⚠️ Changed
+
+## stream-chat-android-compose
+### 🐞 Fixed
+
+### ⬆️ Improved
+
+### ✅ Added
+
+### ⚠️ Changed
+
 # August 16th, 2022 - 5.8.0
 ## Common changes for all artifacts
 ### ⚠️ Changed

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -6,7 +6,7 @@ object Configuration {
     const val minSdk = 21
     const val majorVersion = 5
     const val minorVersion = 8
-    const val patchVersion = 0
+    const val patchVersion = 1
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
@@ -24,7 +24,6 @@ import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
-import androidx.core.view.updateLayoutParams
 import com.getstream.sdk.chat.adapter.MessageListItem
 import com.getstream.sdk.chat.model.ModelType
 import com.getstream.sdk.chat.utils.extensions.constrainViewToParentBySide
@@ -96,6 +95,7 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
         state = State.OneView(imageAttachmentView)
         ConstraintSet().apply {
             constrainMaxHeight(imageAttachmentView.id, maxImageAttachmentHeight)
+            constrainWidth(imageAttachmentView.id, ViewGroup.LayoutParams.MATCH_PARENT)
             constrainViewToParentBySide(imageAttachmentView, ConstraintSet.LEFT)
             constrainViewToParentBySide(imageAttachmentView, ConstraintSet.RIGHT)
             constrainViewToParentBySide(imageAttachmentView, ConstraintSet.TOP)
@@ -109,16 +109,11 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
             if (imageWidth != null && imageHeight != null) {
                 val ratio = (imageWidth / imageHeight).toString()
                 this.setDimensionRatio(imageAttachmentView.id, ratio)
+            } else {
+                constrainHeight(imageAttachmentView.id, LayoutParams.WRAP_CONTENT)
             }
 
             applyTo(this@ImageAttachmentsGroupView)
-        }
-
-        // Setting the dimen ratio above makes it narrow the width
-        // of the container, this way we force the width to match the parent
-        // and clip the height if needed.
-        imageAttachmentView.updateLayoutParams {
-            this.width = ViewGroup.LayoutParams.MATCH_PARENT
         }
 
         imageAttachmentView.showAttachment(first)


### PR DESCRIPTION
### 🎯 Goal

Closes #4066 

### 🛠 Implementation details

Added and else branch wrapping the image attachment View height in case the attachment does not have fixed dimensions

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| ![fixed_height_before](https://user-images.githubusercontent.com/37080097/185897974-4f02af09-387c-4a48-abe8-0e6078315e65.png) | ![fixed_height_after](https://user-images.githubusercontent.com/37080097/185898015-10fec92e-3fa8-4fa8-897e-09166d159297.png) |

### 🧪 Testing

<details>

<summary>Patch that logs image dimensions</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt	(revision 9c63ff241ad911e34e92240c6fb85f5d11075a58)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt	(date 1661163785295)
@@ -19,6 +19,7 @@
 import android.content.Context
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -89,6 +90,7 @@
     }
 
     private fun showOne(first: Attachment) {
+        Log.d("ImageDimens", "originalWidth: ${first.originalWidth} x originalHeight: ${first.originalHeight}")
         removeAllViews()
         val imageAttachmentView = createImageAttachmentView()
         addView(imageAttachmentView)
```

</details>

Pre testing: Apply the patch above and regex Logcat for `ImageDimens`. Make **clean installs** for all test scenarios.

Test Scenario A: Making sure this PR fixes the issue and loads images without `Attachment.originalWidth` and `Attachment.originalHeight`

1. Log in as Amit
2. Go to the channel `Same People`
3. Scroll up until you find images without fixed dimensions (you will see `ImageDimens: originalWidth: null x originalHeight: null` in the log)
4. Confirm that it is loading successfully
5. Compare with `Develop` (should not load successfully there)

Test Scenario B: Making sure that fixed height images load correctly as well

1. Log in as Amit
2. Go to the channel `Fixed image sizes test channel`
3. Scroll faster to load the images. 
4. Verify that the container size prior to loading is the same as the size after loading (no jumping should occur)

Test Scenario C: Making sure that new uploads work well

1. Upload an image to any channel
2. It should load and be previewed normally

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `main` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media0.giphy.com/media/3ohA2ZD9EkeK2AyfdK/giphy.gif?cid=ecf05e47mk6nxg5vin3880my0rwwsss096pblrnm0339g50s&rid=giphy.gif&ct=g)
