### PR TITLE
[4082] Make EventHandlerSequential as a default one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,18 @@
 
 ### ❌ Removed
 
+## stream-chat-android-state
+### 🐞 Fixed
+
+### ⬆️ Improved
+
+### ✅ Added
+
+### ⚠️ Changed
+- `EventHandlerSequential` is now in use by default.
+
+### ❌ Removed
+
 ## stream-chat-android-offline
 ### 🐞 Fixed
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/configuration/StatePluginConfig.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/configuration/StatePluginConfig.kt
@@ -30,5 +30,5 @@ public data class StatePluginConfig @JvmOverloads constructor(
     public val backgroundSyncEnabled: Boolean = true,
     public val userPresence: Boolean = true,
     public val uploadAttachmentsNetworkType: UploadAttachmentsNetworkType = UploadAttachmentsNetworkType.NOT_ROAMING,
-    public val useSequentialEventHandler: Boolean = false,
+    public val useSequentialEventHandler: Boolean = true,
 )

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -55,7 +55,6 @@ import io.getstream.chat.android.offline.sync.internal.SyncHistoryManager
 import io.getstream.chat.android.offline.sync.internal.SyncManager
 import io.getstream.chat.android.offline.sync.messages.internal.OfflineSyncFirebaseMessagingHandler
 import io.getstream.chat.android.offline.utils.internal.ChannelMarkReadHelper
-import io.getstream.chat.android.state.BuildConfig
 import io.getstream.chat.android.state.plugin.configuration.StatePluginConfig
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.logging.StreamLog
@@ -270,7 +269,7 @@ public class StreamStatePluginFactory(
         sideEffect: suspend () -> Unit,
         syncedEvents: Flow<List<ChatEvent>>,
     ): EventHandler {
-        return when (BuildConfig.DEBUG || useSequentialEventHandler) {
+        return when (useSequentialEventHandler) {
             true -> EventHandlerSequential(
                 scope = scope,
                 currentUserId = user.id,


### PR DESCRIPTION
### 🎯 Goal

 Make EventHandlerSequential as a default one

### 🧪 Testing

- Run Sample app
- Login 
- Observe Logcat

You should see the following output:
```
D/Chat:EventHandlerSeq: (DefaultDispatcher-worker-1:186743) [handleBatchEvent] >>> id: 434514951
```


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
