### PR TITLE
Use Flipper only on Android API 23+

### DIFF
--- a/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
+++ b/stream-chat-android-ui-components-sample/src/debug/kotlin/io/getstream/chat/ui/sample/application/ApplicationConfigurator.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.ui.sample.application
 
 import android.app.Application
+import android.os.Build
 import com.facebook.flipper.android.AndroidFlipperClient
 import com.facebook.flipper.android.utils.FlipperUtils
 import com.facebook.flipper.plugins.databases.DatabasesFlipperPlugin
@@ -32,14 +33,16 @@ object ApplicationConfigurator {
     const val XIAOMI_APP_KEY = "5792005994340"
 
     fun configureApp(application: Application) {
-        SoLoader.init(application, false)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            SoLoader.init(application, false)
 
-        if (FlipperUtils.shouldEnableFlipper(application)) {
-            AndroidFlipperClient.getInstance(application).apply {
-                addPlugin(InspectorFlipperPlugin(application, DescriptorMapping.withDefaults()))
-                addPlugin(DatabasesFlipperPlugin(application))
-                addPlugin(networkFlipper)
-            }.start()
+            if (FlipperUtils.shouldEnableFlipper(application)) {
+                AndroidFlipperClient.getInstance(application).apply {
+                    addPlugin(InspectorFlipperPlugin(application, DescriptorMapping.withDefaults()))
+                    addPlugin(DatabasesFlipperPlugin(application))
+                    addPlugin(networkFlipper)
+                }.start()
+            }
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Only use Flipper on Android API 23+ because it is crashing on previous versions


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/IqcsXOImaOy8U/giphy.gif)
