### PR TITLE
[4099] Remove usage of Kotlin's `getOrDefault()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Removed calls to Kotlin Collection's `getOrDefault()` inside `TypingEventPruner`. The function is not available below Android API 24 and was causing exceptions. [#4100](https://github.com/GetStream/stream-chat-android/pull/4100)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/TypingEventPruner.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/TypingEventPruner.kt
@@ -101,7 +101,7 @@ internal class TypingEventPruner(
         )
 
         // Cancel the self stopping event you are replacing if one exists
-        typingEvents.getOrDefault(userId, null)?.cancelJob()
+        typingEvents[userId]?.cancelJob()
 
         // Replace the old self stopping event and call
         // the updated typing events listener
@@ -116,7 +116,7 @@ internal class TypingEventPruner(
      * @param userId The ID of the user tied to the typing event.
      */
     private fun removeTypingEvent(userId: String) {
-        typingEvents.getOrDefault(userId, null)?.cancelJob()
+        typingEvents[userId]?.cancelJob()
 
         typingEvents.remove(userId)
         onUpdated(getRawTyping(), getTypingEvent())

--- a/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/util/FakeImageLoader.kt
+++ b/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/util/FakeImageLoader.kt
@@ -89,7 +89,7 @@ class FakeImageLoader(
 
         return ContextCompat.getDrawable(
             context,
-            userAvatars.getOrDefault(avatarUrl, R.drawable.avatar_user)
+            userAvatars[avatarUrl] ?: R.drawable.avatar_user
         )!!
     }
 


### PR DESCRIPTION
### 🎯 Goal

Closes #4099 

### 🛠 Implementation details

Replaced the implementation with a simple indexing and an elvis operator where necessary

### 🧪 Testing

This change affects the `TypingEventPruner` on API 23 and below. After the fix, we should re-test the functionality on both lower and higher APIs while paying special attention to API 

Please test using the testing regime from the original `TypingEventPruner` PR seen here: https://github.com/GetStream/stream-chat-android/pull/3637

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media2.giphy.com/media/S9crjCfQXC78ST61iv/giphy.gif?cid=ecf05e47jfhnyrdc2p6kdn5yf3baqm50rdqbbwjtmag51bys&rid=giphy.gif&ct=g)
