### PR TITLE
[ISSUE-4109] Using Repositories implementations instead of facade

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -37,14 +37,14 @@ import java.util.Date
 @InternalStreamChatApi
 @SuppressWarnings("LongParameterList")
 public class RepositoryFacade private constructor(
-    private val userRepository: UserRepository,
-    private val configsRepository: ChannelConfigRepository,
-    private val channelsRepository: ChannelRepository,
-    private val queryChannelsRepository: QueryChannelsRepository,
-    private val messageRepository: MessageRepository,
-    private val reactionsRepository: ReactionRepository,
-    private val syncStateRepository: SyncStateRepository,
-    private val attachmentRepository: AttachmentRepository,
+    public val userRepository: UserRepository,
+    public val configsRepository: ChannelConfigRepository,
+    public val channelsRepository: ChannelRepository,
+    public val queryChannelsRepository: QueryChannelsRepository,
+    public val messageRepository: MessageRepository,
+    public val reactionsRepository: ReactionRepository,
+    public val syncStateRepository: SyncStateRepository,
+    public val attachmentRepository: AttachmentRepository,
     private val scope: CoroutineScope,
     private val defaultConfig: Config,
 ) : UserRepository by userRepository,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -158,12 +158,13 @@ public class StreamOfflinePluginFactory(
         val sendMessageListener: SendMessageListener = getSendMessageListener(repositoryFacade, statePlugin)
         val shuffleGiphyListener: ShuffleGiphyListener = getShuffleGiphyListener(repositoryFacade, statePlugin)
         val queryMembersListener: QueryMembersListener = QueryMembersListenerDatabase(
-            repositoryFacade, repositoryFacade
+            userRepository = repositoryFacade.userRepository,
+            channelRepository = repositoryFacade.channelsRepository
         )
         val createChannelListener: CreateChannelListener = CreateChannelListenerImpl(
             clientState = clientState,
-            channelRepository = repositoryFacade,
-            userRepository = repositoryFacade
+            channelRepository = repositoryFacade.channelsRepository,
+            userRepository = repositoryFacade.userRepository
         )
 
         return OfflinePlugin(
@@ -213,8 +214,8 @@ public class StreamOfflinePluginFactory(
         statePlugin: StatePlugin
     ): EditMessageListenerComposite {
         val editMessageListenerDatabase = EditMessageListenerDatabase(
-            userRepository = repositoryFacade,
-            messageRepository = repositoryFacade,
+            userRepository = repositoryFacade.userRepository,
+            messageRepository = repositoryFacade.messageRepository,
             clientState = clientState
         )
 
@@ -226,8 +227,8 @@ public class StreamOfflinePluginFactory(
         statePlugin: StatePlugin
     ): HideChannelListener {
         val hideChannelListenerDatabase = HideChannelListenerDatabase(
-            channelRepository = repositoryFacade,
-            messageRepository = repositoryFacade
+            channelRepository = repositoryFacade.channelsRepository,
+            messageRepository = repositoryFacade.messageRepository
         )
 
         return HideChannelListenerComposite(
@@ -242,8 +243,8 @@ public class StreamOfflinePluginFactory(
     ): DeleteReactionListener {
         val deleteReactionListenerDatabase = DeleteReactionListenerDatabase(
             clientState = clientState,
-            reactionsRepository = repositoryFacade,
-            messageRepository = repositoryFacade
+            reactionsRepository = repositoryFacade.reactionsRepository,
+            messageRepository = repositoryFacade.messageRepository
         )
 
         return DeleteReactionListenerComposite(
@@ -258,9 +259,9 @@ public class StreamOfflinePluginFactory(
     ): SendReactionListener {
         val sendReactionListenerDatabase = SendReactionListenerDatabase(
             clientState = clientState,
-            messageRepository = repositoryFacade,
-            reactionsRepository = repositoryFacade,
-            userRepository = repositoryFacade
+            messageRepository = repositoryFacade.messageRepository,
+            reactionsRepository = repositoryFacade.reactionsRepository,
+            userRepository = repositoryFacade.userRepository
         )
 
         return SendReactionListenerComposite(
@@ -273,7 +274,10 @@ public class StreamOfflinePluginFactory(
         statePlugin: StatePlugin,
     ): SendMessageListener {
 
-        val sendMessageListenerDatabase = SendMessageListenerDatabase(repositoryFacade, repositoryFacade)
+        val sendMessageListenerDatabase = SendMessageListenerDatabase(
+            userRepository = repositoryFacade.userRepository,
+            messageRepository = repositoryFacade.messageRepository
+        )
         return SendMessageListenerComposite(listOf(statePlugin, sendMessageListenerDatabase))
     }
 
@@ -282,8 +286,8 @@ public class StreamOfflinePluginFactory(
         statePlugin: StatePlugin
     ): ShuffleGiphyListener {
         val shuffleGiphyListenerDatabase = ShuffleGiphyListenerDatabase(
-            userRepository = repositoryFacade,
-            messageRepository = repositoryFacade
+            userRepository = repositoryFacade.userRepository,
+            messageRepository = repositoryFacade.messageRepository
         )
 
         return ShuffleGiphyListenerComposite(
@@ -298,8 +302,8 @@ public class StreamOfflinePluginFactory(
     ): DeleteMessageListener {
         val deleteMessageListenerDatabase = DeleteMessageListenerDatabase(
             clientState = clientState,
-            messageRepository = repositoryFacade,
-            userRepository = repositoryFacade
+            messageRepository = repositoryFacade.messageRepository,
+            userRepository = repositoryFacade.userRepository
         )
 
         return DeleteMessageListenerComposite(

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -135,7 +135,11 @@ public class StreamStatePluginFactory(
         }
 
         val stateRegistry = StateRegistry.create(
-            scope.coroutineContext.job, scope, clientState.user, repositoryFacade, repositoryFacade.observeLatestUsers()
+            scope.coroutineContext.job,
+            scope,
+            clientState.user,
+            repositoryFacade.messageRepository,
+            repositoryFacade.observeLatestUsers()
         )
         val logic = LogicRegistry.create(
             stateRegistry = stateRegistry,


### PR DESCRIPTION
### 🎯 Goal

Using implementation of repositories instead of `RepositoryFacade`.

### 🧪 Testing

Test the persistence of the SDK

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- ~[ ] Changelog is updated with client-facing changes~
- ~[ ] New code is covered by unit tests~
- ~[ ] Comparison screenshots added for visual changes~
- ~[ ] Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (1)](https://user-images.githubusercontent.com/10619102/187999196-8dc7f053-fdda-42e3-9b6f-bb3623adee71.gif)
_A facade_
