### PR TITLE
Remove incrementing unread count if the message is already in state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 
 ## stream-chat-android-state
 ### 🐞 Fixed
+- Fixed incrementing unread count if the message is already in the state. [#4135](https://github.com/GetStream/stream-chat-android/pull/4135)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogicImpl.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogicImpl.kt
@@ -107,12 +107,12 @@ internal class ChannelStateLogicImpl(
             val unreadCount: Int = readState.unreadMessages
             val lastMessageSeenDate = readState.lastMessageSeenDate
 
-            val shouldIncrementUnreadCount =
-                message.shouldIncrementUnreadCount(
-                    currentUserId = currentUserId,
-                    lastMessageAtDate = lastMessageSeenDate,
-                    isChannelMuted = globalMutableState.isChannelMutedForCurrentUser(mutableState.cid)
-                )
+            val isMessageAlreadyInState = mutableState.rawMessages.containsKey(message.id)
+            val shouldIncrementUnreadCount = !isMessageAlreadyInState && message.shouldIncrementUnreadCount(
+                currentUserId = currentUserId,
+                lastMessageAtDate = lastMessageSeenDate,
+                isChannelMuted = globalMutableState.isChannelMutedForCurrentUser(mutableState.cid)
+            )
 
             if (shouldIncrementUnreadCount) {
                 StreamLog.d(TAG) {


### PR DESCRIPTION
### 🎯 Goal

Fix unread count when processing duplicate events.

### 🛠 Implementation details

Remove incrementing unread count if the message is already in the state.

### 🧪 Testing

Make sure unread count is stable after restoring the app from the background.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

