### PR TITLE
Add GitHub cache to download translations workflow

### DIFF
--- a/.github/workflows/localazy-download.yml
+++ b/.github/workflows/localazy-download.yml
@@ -17,6 +17,9 @@ jobs:
         with:
           read_key: ${{ secrets.LOCALAZY_READ_KEY }}
           write_key: ${{ secrets.LOCALAZY_WRITE_KEY }}
+      - uses: ./.github/actions/gradle-cache
+        with:
+          key-prefix: gradle-lint
       - name: Add license headers
         run: ./gradlew spotlessApply
       - name: Create Pull Request


### PR DESCRIPTION
### 🎯 Goal
Improve Download Translations Workflow performance by adding cache for our Gradle Dependencies
### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/iH1rdIKYvNhOu5Z8RY/giphy.gif)
