### PR TITLE
Close StreamWebSocket on case a Disconnected Event happens

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/experimental/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/experimental/ChatSocket.kt
@@ -122,18 +122,21 @@ internal class ChatSocket private constructor(
                     is State.Disconnected -> {
                         when (state) {
                             is State.Disconnected.DisconnectedByRequest -> {
+                                streamWebSocket?.close()
                                 healthMonitor.stop()
                                 coroutineScope.launch { disposeObservers() }
-                                streamWebSocket?.close()
                             }
                             is State.Disconnected.NetworkDisconnected -> {
+                                streamWebSocket?.close()
                                 healthMonitor.stop()
                             }
                             is State.Disconnected.Stopped -> {
+                                streamWebSocket?.close()
                                 healthMonitor.stop()
                                 disposeNetworkStateObserver()
                             }
                             is State.Disconnected.DisconnectedPermanently -> {
+                                streamWebSocket?.close()
                                 healthMonitor.stop()
                                 coroutineScope.launch { disposeObservers() }
                             }
@@ -141,6 +144,7 @@ internal class ChatSocket private constructor(
                                 healthMonitor.onDisconnected()
                             }
                             is State.Disconnected.WebSocketEventLost -> {
+                                streamWebSocket?.close()
                                 connectionConf?.let { chatSocketStateService.onReconnect(it) }
                             }
                         }


### PR DESCRIPTION
### 🎯 Goal
After the app went to the background the WebSocket wasn't properly closed, and some events could arrive through it. It is not a good approach because while the socket is connected the backend doesn't send any Push Notification. 

Now, whenever we know the SDK is not in a state that could receive WS Event, we close the connection to be sure they are not accepted.

### 🧪 Testing
Use any of our Sample Apps, after login, move de app to the background and with another device send some messages to your users. Messages should appear as a Notifications

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/arldiHgOAWyIw/giphy.gif)
