### PR TITLE
Removing duplicated counts

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -108,7 +108,7 @@ internal class ChannelStateLogic(
                     currentUserId = currentUserId,
                     lastMessageAtDate = lastMessageSeenDate,
                     isChannelMuted = globalMutableState.isChannelMutedForCurrentUser(mutableState.cid)
-                )
+                ) && !mutableState.containsMessageWithId(message.id)
 
             if (shouldIncrementUnreadCount) {
                 StreamLog.d(TAG) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/internal/ChannelMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/channel/internal/ChannelMutableState.kt
@@ -446,6 +446,10 @@ internal class ChannelMutableState(
         _messages.value = messages.associateBy(Message::id)
     }
 
+    fun containsMessageWithId(messageId: String): Boolean {
+        return _messages.value.containsKey(messageId)
+    }
+
     private companion object {
         private const val OFFSET_EVENT_TIME = 5L
     }


### PR DESCRIPTION
### 🎯 Goal

Very simple solution to remove the possibility to count messages that were already upserted.

### 🧪 Testing


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
