### PR TITLE
Exposed own/other message text color customization options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `ownMessageText` and `otherMessageText` to `StreamColors` to enable message text customization. [#4175](https://github.com/GetStream/stream-chat-android/pull/4175)
 
 ### ⚠️ Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,7 +74,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-- Added `ownMessageText` and `otherMessageText` to `StreamColors` to enable message text customization. [#4175](https://github.com/GetStream/stream-chat-android/pull/4175)
+- Added `ownMessageText` and `otherMessageText` to `StreamColors` to enable message text customization. If you have been using `StreamColors.textHighEmphasis` to customize the color of the message texts, we recommend switching to the new attributes instead. [#4175](https://github.com/GetStream/stream-chat-android/pull/4175)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1472,7 +1472,8 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamColors$Companion;
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
@@ -1486,6 +1487,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component19-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component20-0d7_KjU ()J
+	public final fun component21-0d7_KjU ()J
+	public final fun component22-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
 	public final fun component4-0d7_KjU ()J
 	public final fun component5-0d7_KjU ()J
@@ -1493,8 +1496,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component7-0d7_KjU ()J
 	public final fun component8-0d7_KjU ()J
 	public final fun component9-0d7_KjU ()J
-	public final fun copy-Cmkg8xs (JJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
-	public static synthetic fun copy-Cmkg8xs$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public final fun copy-0VcbP8k (JJJJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public static synthetic fun copy-0VcbP8k$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppBackground-0d7_KjU ()J
 	public final fun getBarsBackground-0d7_KjU ()J
@@ -1507,9 +1510,11 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun getInfoAccent-0d7_KjU ()J
 	public final fun getInputBackground-0d7_KjU ()J
 	public final fun getLinkBackground-0d7_KjU ()J
+	public final fun getOtherMessageText-0d7_KjU ()J
 	public final fun getOtherMessagesBackground-0d7_KjU ()J
 	public final fun getOverlay-0d7_KjU ()J
 	public final fun getOverlayDark-0d7_KjU ()J
+	public final fun getOwnMessageText-0d7_KjU ()J
 	public final fun getOwnMessagesBackground-0d7_KjU ()J
 	public final fun getPrimaryAccent-0d7_KjU ()J
 	public final fun getTextHighEmphasis-0d7_KjU ()J

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.getstream.sdk.chat.model.ModelType
+import com.getstream.sdk.chat.utils.extensions.isMine
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -81,7 +83,7 @@ public fun QuotedMessageText(
         "quotedMessageText is null. Cannot display invalid message title."
     }
 
-    val styledText = buildAnnotatedMessageText(quotedMessageText)
+    val styledText = buildAnnotatedMessageText(quotedMessageText, message.isMine(ChatClient.instance()))
 
     val horizontalPadding = ChatTheme.dimens.quotedMessageTextHorizontalPadding
     val verticalPadding = ChatTheme.dimens.quotedMessageTextVerticalPadding

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -45,6 +45,8 @@ import io.getstream.chat.android.compose.R
  * @param giphyMessageBackground Used as a background for the ephemeral giphy messages.
  * @param threadSeparatorGradientStart Used as a start color for vertical gradient background in a thread separator.
  * @param threadSeparatorGradientEnd Used as an end color for vertical gradient background in a thread separator.
+ * @param ownMessageText Used for message text color for the current user. [textHighEmphasis] by default.
+ * @param otherMessageText Used for message text color for other users. [textHighEmphasis] by default.
  */
 @Immutable
 public data class StreamColors(
@@ -68,6 +70,8 @@ public data class StreamColors(
     public val giphyMessageBackground: Color,
     public val threadSeparatorGradientStart: Color,
     public val threadSeparatorGradientEnd: Color,
+    public val ownMessageText: Color = textHighEmphasis,
+    public val otherMessageText: Color = textHighEmphasis
 ) {
 
     public companion object {
@@ -98,6 +102,8 @@ public data class StreamColors(
             giphyMessageBackground = colorResource(R.color.stream_compose_bars_background),
             threadSeparatorGradientStart = colorResource(R.color.stream_compose_input_background),
             threadSeparatorGradientEnd = colorResource(R.color.stream_compose_app_background),
+            ownMessageText = colorResource(R.color.stream_compose_text_high_emphasis),
+            otherMessageText = colorResource(R.color.stream_compose_text_high_emphasis)
         )
 
         /**
@@ -127,6 +133,8 @@ public data class StreamColors(
             giphyMessageBackground = colorResource(R.color.stream_compose_bars_background_dark),
             threadSeparatorGradientStart = colorResource(R.color.stream_compose_input_background_dark),
             threadSeparatorGradientEnd = colorResource(R.color.stream_compose_app_background_dark),
+            ownMessageText = colorResource(R.color.stream_compose_text_high_emphasis_dark),
+            otherMessageText = colorResource(R.color.stream_compose_text_high_emphasis_dark)
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -46,7 +46,7 @@ internal fun buildAnnotatedMessageText(message: Message): AnnotatedString {
  * if there are any links available.
  *
  * @param text The message text to style.
- * @param isOwnMessage Whether the message is the current users message or not.
+ * @param isOwnMessage Whether the message is the current user's message or not.
  *
  * @return The annotated String, with clickable links, if applicable.
  */

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.util.PatternsCompat
+import com.getstream.sdk.chat.utils.extensions.isMine
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
@@ -36,7 +38,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  */
 @Composable
 internal fun buildAnnotatedMessageText(message: Message): AnnotatedString {
-    return buildAnnotatedMessageText(message.text)
+    return buildAnnotatedMessageText(message.text, message.isMine(ChatClient.instance()))
 }
 
 /**
@@ -48,14 +50,14 @@ internal fun buildAnnotatedMessageText(message: Message): AnnotatedString {
  * @return The annotated String, with clickable links, if applicable.
  */
 @Composable
-internal fun buildAnnotatedMessageText(text: String): AnnotatedString {
+internal fun buildAnnotatedMessageText(text: String, isOwnMessage: Boolean): AnnotatedString {
     return buildAnnotatedString {
         // First we add the whole text to the [AnnotatedString] and style it as a regular text.
         append(text)
         addStyle(
             SpanStyle(
                 fontStyle = ChatTheme.typography.body.fontStyle,
-                color = ChatTheme.colors.textHighEmphasis
+                color = if (isOwnMessage) ChatTheme.colors.ownMessageText else ChatTheme.colors.otherMessageText
             ),
             start = 0,
             end = text.length

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -46,6 +46,7 @@ internal fun buildAnnotatedMessageText(message: Message): AnnotatedString {
  * if there are any links available.
  *
  * @param text The message text to style.
+ * @param isOwnMessage Whether the message is the current users message or not.
  *
  * @return The annotated String, with clickable links, if applicable.
  */


### PR DESCRIPTION
### 🎯 Goal

Expose way to custimize own/other message text color.

### 🛠 Implementation details

Added `ownMessageText` and `otherMessageText` to `StreamColors`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1663664532](https://user-images.githubusercontent.com/38032787/191216073-d40bd03a-1e4e-4e49-989e-5c234eb110df.png) | ![Screenshot_1663664329](https://user-images.githubusercontent.com/38032787/191216048-42543a78-2985-4c1b-b32e-a3b1b353594e.png) |

### 🧪 Testing

1. Build this branch and check the text colors
2. Apply the patch and build again, the message text colors should be red for current the user and blue for other users

<details>

<summary>Test patch</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision b175b1f5fb5d6561815f4740ee439ab9ef98347b)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1663664351512)
@@ -47,6 +47,7 @@
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.common.state.DeletedMessageVisibility
@@ -68,6 +69,7 @@
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.StreamColors
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
@@ -93,7 +95,10 @@
         val channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: return
 
         setContent {
-            ChatTheme(dateFormatter = ChatApp.dateFormatter) {
+            ChatTheme(dateFormatter = ChatApp.dateFormatter, colors = StreamColors.defaultColors().copy(
+                otherMessageText = Color.Blue,
+                ownMessageText = Color.Red
+            )) {
                 MessagesScreen(
                     channelId = channelId,
                     onBackPressed = { finish() },

```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (2)](https://user-images.githubusercontent.com/38032787/191216420-eb96e892-4e13-4375-98f3-1ce4c3160ae1.gif)
