### PR TITLE
Task/improve compose screen components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,10 +69,14 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Improved the way the [ChannelsScreen](https://getstream.io/chat/docs/sdk/android/compose/channel-components/channels-screen/) is built. [#4183](https://github.com/GetStream/stream-chat-android/pull/4183)
+- Improved the way the [MessagesScreen](https://getstream.io/chat/docs/sdk/android/compose/message-components/messages-screen/) is built. [#4183](https://github.com/GetStream/stream-chat-android/pull/4183)
 
 ### ✅ Added
 
 ### ⚠️ Changed
+- Changed the way ChannelsScreen and MessagesScreen components are built. Instead of exposing a ton of parameters for customization, we now expose a ViewModelFactory that accepts them. [#4183](https://github.com/GetStream/stream-chat-android/pull/4183)
+- Using this new approach you can reuse and connect to ViewModels from the outside, if you want to power custom behavior. Make sure to check out our documentation regarding these components. [#4183](https://github.com/GetStream/stream-chat-android/pull/4183)
 
 ### ❌ Removed
 

--- a/docusaurus/docs/Android/04-compose/04-channel-components/01-channels-screen.mdx
+++ b/docusaurus/docs/Android/04-compose/04-channel-components/01-channels-screen.mdx
@@ -98,26 +98,59 @@ When it comes to UI and behavior customization in the `ChannelsScreen` signature
 
 ```kotlin
 fun ChannelsScreen(
-    filters: FilterObject? = null,
-    querySort: QuerySort<Channel> = QuerySort.desc("last_updated"),
+    viewModelFactory: ChannelViewModelFactory = ChannelViewModelFactory(
+      ... // params
+    ),
     title: String = "Stream Chat",
     isShowingHeader: Boolean = true,
     isShowingSearch: Boolean = true,
-    channelLimit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
-    memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
-    messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     ... // Action handlers
 )
 ```
 
-* `filters`: These filters are applied to the channel query, meaning you can customize what data to show in the list. By default they are null which signals us to use default messaging channel filters.
-* `querySort`: Like with filters, these are applied to the list data and affect its sorting order.
+* `viewModelFactory`: The factory that you build yourself, if you want access to `ViewModels` for custom behavior. This lets you control not just the way the `ViewModel`s are built, but also their lifecycle, as you can share them between components. You can also customize its parameters to affect the behavior of the screen.
 * `title`: The title of the `ChannelListHeader`.
 * `isShowingHeader`: Flag that affects if we show the `ChannelListHeader`. `true` by default.
 * `isShowingSearch`: Flag that affects if we show the `SearchInput`. `false` by default.
-* `channelLimit` The limit of channels queried per page.
-* `memberLimit` The limit of members requested per channel.
-* `messageLimit` The limit of messages requested per channel item.
+
+## Overriding the ViewModels
+
+In case you want to control the logic when using the `ChannelsScreen`, you can do so by providing a `ChannelViewModelFactory` that you use to build the respective ViewModels yourself.
+
+Here's an example:
+
+```kotlin
+class ChannelsActivity : BaseConnectedActivity() {
+
+    // 1
+    private val factory by lazy {
+        ChannelViewModelFactory(
+            chatClient = ChatClient.instance(),
+            querySort = QuerySortByField.descByName("last_updated"),
+            filters = null
+        )
+    }
+
+    // 2
+    private val listViewModel: ChannelListViewModel by viewModels { factory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            ChannelsScreen(
+                viewModelFactory = factory // 3
+            )
+        }
+    }
+```
+
+There are a few steps here that allow you to override and control the ViewModels:
+1. You create the `ChannelViewModelFactory` yourself, which lets you describe the data and configuration used to build the `ViewModel`s.
+2. You lazily create an instance of the `ChannelListViewModel`. This means that you'll either build the `ViewModel` first and then pass it to the Compose component, or your Compose component will create the `ViewModel` and you'll get access to it here.
+3. You pass in the factory to the `ChannelsScreen`, which allows this connection to happen.
+
+The `ViewModel`s should be the same and you should easily be able to react to things like item clicks, changes in the state and more.
 
 :::note
 Even though `ChannelsScreen` offers limited customization, you can still achieve a unique look and feel by modifying `ChatTheme` parameters.

--- a/docusaurus/docs/Android/04-compose/05-message-components/01-messages-screen.mdx
+++ b/docusaurus/docs/Android/04-compose/05-message-components/01-messages-screen.mdx
@@ -13,7 +13,7 @@ The `MessagesScreen` component is the second screen component in the SDK, out of
 
 ## Usage
 
-The benefit of a screen component solution is easy integration. All you need to do to integrate `MessagesScreen` in your app is to call it within `setContent()` in your `Activity` or `Fragment` and pass in your `channelId`:
+The benefit of a screen component solution is easy integration. All you need to do to integrate `MessagesScreen` in your app is to call it within `setContent()` in your `Activity` or `Fragment` and pass in the `MessagesViewModelFactory` with your `channelId`:
 
 ```kotlin
 override fun onCreate(savedInstanceState: Bundle?) {
@@ -23,7 +23,12 @@ override fun onCreate(savedInstanceState: Bundle?) {
 
     setContent {
         ChatTheme {
-            MessagesScreen(channelId = channelId)
+            MessagesScreen(
+                viewModelFactory = MessagesViewModelFactory(
+                    context = this,
+                    channelId = channelId
+                )
+            )
         }
     }
 }
@@ -70,30 +75,65 @@ Given that the `MessagesScreen` is a screen level solution, it offers limited cu
 ```kotlin
 @Composable
 fun MessagesScreen(
-    messageLimit: Int = 30,
+    viewModelFactory: MessagesViewModelFactory,
     showHeader: Boolean = true,
-    enforceUniqueReactions: Boolean = true,
-    showDateSeparators: Boolean = true,
-    showSystemMessages: Boolean = true,
-    deletedMessageVisibility: DeletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
-    messageFooterVisibility: MessageFooterVisibility = MessageFooterVisibility.WithTimeDifference(),
     ... // action handlers and state
 )
 ```
 
-* `messageLimit`: The number of messages per query.
+* `viewModelFactory`: The factory that you build yourself. This lets you control not just the way the `ViewModel`s are built, but also their lifecycle, as you can share them between components. This requires of you to provide a `channelId` in order to power the screen and show data, but it also allows you to customize the behavior of the screen through various parameters.
 * `showHeader`: Controls whether the messages header is shown or not.
-* `enforceUniqueReactions`: Controls whether the user can leave multiple reactions to a message.
-* `showDateSeparators`: Controls if we show date separator items.
-* `showSystemMessages`: Controls if we show system message items.
-* `deletedMessageVisibility`: Controls the visibility of deleted messages. By default, all deleted messages are visible in the "deleted" state.
-* `messageFooterVisibility`: Controls the visibility of the message footer. By default, determined by a time difference.
 
 If you set `showHeader` to `false` you'll get the following UI:
 
 ![MessagesScreen without the MessageListHeader](../../assets/compose_custom_messages_screen_component.png)
 
 As you can see, the header is removed from the screen, rendering only the list and the composer.
+
+## Overriding the ViewModels
+
+In case you want to control the logic when using the `MessagesScreen`, you can do so by providing a `MessagesViewModelFactory` that you use to build the respective ViewModels yourself.
+
+Here's an example:
+
+```kotlin
+class MessagesActivity : BaseConnectedActivity() {
+
+    // 1
+    private val factory by lazy {
+        MessagesViewModelFactory(
+            context = this,
+            channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: "",
+            deletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
+        )
+    }
+
+    // 2
+    private val listViewModel by viewModels<MessageListViewModel>(factoryProducer = { factory })
+
+    private val attachmentsPickerViewModel by viewModels<AttachmentsPickerViewModel>(factoryProducer = { factory })
+    private val composerViewModel by viewModels<MessageComposerViewModel>(factoryProducer = { factory })
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            ChatTheme(dateFormatter = ChatApp.dateFormatter) {
+                MessagesScreen( // 3
+                    viewModelFactory = factory,
+                    onBackPressed = { finish() },
+                )
+            }
+        }
+    }
+```
+
+There are a few steps here that allow you to override and control the ViewModels:
+1. You create the `MessagesViewModelFactory` yourself, which lets you describe the data and configuration used to build the `ViewModel`s.
+2. You lazily create an instance of the required `ViewModel`s. This means that you'll either build the `ViewModel` first and then pass it to the Compose component, or your Compose component will create the `ViewModel` and you'll get access to it here.
+3. You pass in the factory to the `MessagesScreen`, which allows this connection to happen.
+
+The `ViewModel`s should be the same and you should easily be able to react to things like item clicks, changes in the state and more.
 
 :::note
 Even though `MessagesScreen` offers limited customization, you can still achieve a unique look and feel by modifying `ChatTheme` parameters.

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
@@ -90,6 +90,7 @@ class ChannelsActivity : BaseConnectedActivity() {
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 ChannelsScreen(
+                    viewModelFactory = factory,
                     title = stringResource(id = R.string.app_name),
                     isShowingHeader = true,
                     isShowingSearch = true,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -78,7 +78,7 @@ class MessagesActivity : BaseConnectedActivity() {
     private val factory by lazy {
         MessagesViewModelFactory(
             context = this,
-            channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: "",
+            channelId = requireNotNull(intent.getStringExtra(KEY_CHANNEL_ID)),
             deletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
         )
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -90,13 +90,14 @@ class MessagesActivity : BaseConnectedActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        val channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: return
 
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 MessagesScreen(
-                    channelId = channelId,
-                    onBackPressed = { finish() },
+                    viewModelFactory = factory,
+                    onBackPressed = {
+                        finish()
+                    },
                     onHeaderActionClick = {}
                 )
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -711,7 +711,7 @@ public final class io/getstream/chat/android/compose/ui/attachments/preview/hand
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/ChannelsScreenKt {
-	public static final fun ChannelsScreen (Lio/getstream/chat/android/client/api/models/FilterObject;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Ljava/lang/String;ZZIIILkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+	public static final fun ChannelsScreen (Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Ljava/lang/String;ZZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/header/ChannelListHeaderKt {
@@ -1304,7 +1304,7 @@ public final class io/getstream/chat/android/compose/ui/components/userreactions
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/MessagesScreenKt {
-	public static final fun MessagesScreen (Ljava/lang/String;IZZZZLio/getstream/chat/android/common/state/DeletedMessageVisibility;Lio/getstream/chat/android/common/state/MessageFooterVisibility;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessagesScreen (Lio/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory;ZLkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPickerKt {
@@ -1874,6 +1874,7 @@ public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelL
 
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
+	public fun <init> ()V
 	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;)V
 	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/api/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/FilterObject;IIILio/getstream/chat/android/offline/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
@@ -43,10 +43,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.api.models.FilterObject
-import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
-import io.getstream.chat.android.client.api.models.querysort.QuerySorter
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.channels.list.DeleteConversation
@@ -67,16 +63,12 @@ import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFact
  * Default root Channel screen component, that provides the necessary ViewModel.
  *
  * It can be used without most parameters for default behavior, that can be tweaked if necessary.
- *
- * @param filters Default filters for channels. By passing in `null` to the ViewModel, we show messaging channels
- * where the current user is a member.
- * @param querySort Default query sort for channels.
+ * @param viewModelFactory The factory used to build the ViewModels and power the behavior.
+ * You can use the default implementation by not passing in an instance yourself, or you
+ * can customize the behavior using its parameters.
  * @param title Header title.
  * @param isShowingHeader If we show the header or hide it.
  * @param isShowingSearch If we show the search input or hide it.
- * @param channelLimit The limit of channels queried per page.
- * @param memberLimit The limit of members requested per channel.
- * @param messageLimit The limit of messages requested per channel item.
  * @param onHeaderActionClick Handler for the default header action.
  * @param onHeaderAvatarClick Handle for when the user clicks on the header avatar.
  * @param onItemClick Handler for Channel item clicks.
@@ -87,14 +79,10 @@ import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFact
 @Composable
 @Suppress("LongMethod")
 public fun ChannelsScreen(
-    filters: FilterObject? = null,
-    querySort: QuerySorter<Channel> = QuerySortByField.descByName("last_updated"),
+    viewModelFactory: ChannelViewModelFactory = ChannelViewModelFactory(),
     title: String = "Stream Chat",
     isShowingHeader: Boolean = true,
     isShowingSearch: Boolean = false,
-    channelLimit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
-    memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
-    messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     onHeaderActionClick: () -> Unit = {},
     onHeaderAvatarClick: () -> Unit = {},
     onItemClick: (Channel) -> Unit = {},
@@ -103,14 +91,7 @@ public fun ChannelsScreen(
 ) {
     val listViewModel: ChannelListViewModel = viewModel(
         ChannelListViewModel::class.java,
-        factory = ChannelViewModelFactory(
-            chatClient = ChatClient.instance(),
-            querySort = querySort,
-            filters = filters,
-            channelLimit = channelLimit,
-            memberLimit = memberLimit,
-            messageLimit = messageLimit
-        )
+        factory = viewModelFactory
     )
 
     val selectedChannel by listViewModel.selectedChannel
@@ -141,7 +122,6 @@ public fun ChannelsScreen(
                     )
                 }
             }
-
         ) {
             Column(
                 modifier = Modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -16,8 +16,6 @@
 
 package io.getstream.chat.android.compose.ui.messages
 
-import android.content.ClipboardManager
-import android.content.Context
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -47,7 +45,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -57,10 +54,8 @@ import io.getstream.chat.android.common.model.DeleteMessage
 import io.getstream.chat.android.common.model.EditMessage
 import io.getstream.chat.android.common.model.SendAnyway
 import io.getstream.chat.android.common.state.Delete
-import io.getstream.chat.android.common.state.DeletedMessageVisibility
 import io.getstream.chat.android.common.state.Edit
 import io.getstream.chat.android.common.state.Flag
-import io.getstream.chat.android.common.state.MessageFooterVisibility
 import io.getstream.chat.android.common.state.MessageMode
 import io.getstream.chat.android.common.state.Reply
 import io.getstream.chat.android.common.state.Resend
@@ -88,57 +83,34 @@ import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerVie
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 
 /**
  * Default root Messages screen component, that provides the necessary ViewModels and
  * connects all the data handling operations, as well as some basic actions, like back pressed handling.
  *
  * Because this screen can be shown only if there is an active/selected Channel, the user must provide
- * a [channelId] in order to load up all the data. Otherwise, we can't show the UI.
+ * a [viewModelFactory] that contains the channel ID, in order to load up all the data. Otherwise, we can't show the UI.
  *
- * @param channelId The ID of the opened/active Channel.
- * @param messageLimit The limit of messages per query.
+ * @param viewModelFactory The factory used to build ViewModels and power the behavior.
+ * You can customize the behavior of the list through its parameters. For default behavior,
+ * simply create an instance and pass in just the channel ID and the context.
  * @param showHeader If we're showing the header or not.
- * @param enforceUniqueReactions If we need to enforce unique reactions or not.
- * @param showDateSeparators If we should show date separators or not.
- * @param showSystemMessages If we should show system messages or not.
- * @param deletedMessageVisibility The behavior of deleted messages in the list and if they're visible or not.
- * @param messageFooterVisibility The behavior of message footers in the list and their visibility.
  * @param onBackPressed Handler for when the user taps on the Back button and/or the system
  * back button.
  * @param onHeaderActionClick Handler for when the user taps on the header action.
  */
 @Suppress("LongMethod")
-@OptIn(ExperimentalCoroutinesApi::class)
 @Composable
 public fun MessagesScreen(
-    channelId: String,
-    messageLimit: Int = MessageListViewModel.DefaultMessageLimit,
+    viewModelFactory: MessagesViewModelFactory,
     showHeader: Boolean = true,
-    enforceUniqueReactions: Boolean = true,
-    showDateSeparators: Boolean = true,
-    showSystemMessages: Boolean = true,
-    deletedMessageVisibility: DeletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
-    messageFooterVisibility: MessageFooterVisibility = MessageFooterVisibility.WithTimeDifference(),
     onBackPressed: () -> Unit = {},
     onHeaderActionClick: (channel: Channel) -> Unit = {},
 ) {
-    val factory = buildViewModelFactory(
-        context = LocalContext.current,
-        channelId = channelId,
-        enforceUniqueReactions = enforceUniqueReactions,
-        messageLimit = messageLimit,
-        showSystemMessages = showSystemMessages,
-        showDateSeparators = showDateSeparators,
-        deletedMessageVisibility = deletedMessageVisibility,
-        messageFooterVisibility = messageFooterVisibility
-    )
-
-    val listViewModel = viewModel(MessageListViewModel::class.java, factory = factory)
-    val composerViewModel = viewModel(MessageComposerViewModel::class.java, factory = factory)
+    val listViewModel = viewModel(MessageListViewModel::class.java, factory = viewModelFactory)
+    val composerViewModel = viewModel(MessageComposerViewModel::class.java, factory = viewModelFactory)
     val attachmentsPickerViewModel =
-        viewModel(AttachmentsPickerViewModel::class.java, factory = factory)
+        viewModel(AttachmentsPickerViewModel::class.java, factory = viewModelFactory)
 
     val backAction = {
         val isInThread = listViewModel.isInThread
@@ -556,39 +528,4 @@ private fun MessageDialogs(listViewModel: MessageListViewModel) {
             onDismiss = { listViewModel.dismissMessageAction(flagAction) }
         )
     }
-}
-
-/**
- * Builds the [MessagesViewModelFactory] required to run the Conversation/Messages screen.
- *
- * @param context Used to build the [ClipboardManager].
- * @param channelId The current channel ID, to load the messages from.
- * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
- * @param messageLimit The limit when loading messages.
- * @param showDateSeparators If we should show date separators or not.
- * @param showSystemMessages If we should show system messages or not. * @param deletedMessageVisibility The behavior of deleted messages in the list.
- * @param deletedMessageVisibility The behavior of deleted messages in the list and if they're visible or not.
- * @param messageFooterVisibility The behavior of message footers in the list and their visibility.
- */
-@ExperimentalCoroutinesApi
-private fun buildViewModelFactory(
-    context: Context,
-    channelId: String,
-    enforceUniqueReactions: Boolean,
-    messageLimit: Int,
-    showDateSeparators: Boolean,
-    showSystemMessages: Boolean,
-    deletedMessageVisibility: DeletedMessageVisibility,
-    messageFooterVisibility: MessageFooterVisibility,
-): MessagesViewModelFactory {
-    return MessagesViewModelFactory(
-        context = context,
-        channelId = channelId,
-        enforceUniqueReactions = enforceUniqueReactions,
-        messageLimit = messageLimit,
-        showDateSeparators = showDateSeparators,
-        showSystemMessages = showSystemMessages,
-        deletedMessageVisibility = deletedMessageVisibility,
-        messageFooterVisibility = messageFooterVisibility
-    )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -20,7 +20,9 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.models.FilterObject
+import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.api.models.querysort.QuerySorter
+import io.getstream.chat.android.client.events.ChatEventHandler
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
 
@@ -37,9 +39,9 @@ import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHan
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
  */
 public class ChannelViewModelFactory(
-    private val chatClient: ChatClient,
-    private val querySort: QuerySorter<Channel>,
-    private val filters: FilterObject?,
+    private val chatClient: ChatClient = ChatClient.instance(),
+    private val querySort: QuerySorter<Channel> = QuerySortByField.descByName("last_updated"),
+    private val filters: FilterObject? = null,
     private val channelLimit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/channels/ChannelsScreen.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/channels/ChannelsScreen.kt
@@ -10,6 +10,7 @@ import io.getstream.chat.android.client.api.models.querysort.QuerySortByField
 import io.getstream.chat.android.client.models.Filters
 import io.getstream.chat.android.compose.ui.channels.ChannelsScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFactory
 
 /**
  * [Usage](https://getstream.io/chat/docs/sdk/android/compose/channel-components/channels-screen/#usage)
@@ -76,17 +77,19 @@ private object ChannelsScreenCustomizationSnippet {
             setContent {
                 ChatTheme {
                     ChannelsScreen(
-                        filters = Filters.and(
-                            Filters.eq("type", "messaging"),
-                            Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: ""))
+                        viewModelFactory = ChannelViewModelFactory(
+                            filters = Filters.and(
+                                Filters.eq("type", "messaging"),
+                                Filters.`in`("members", listOf(ChatClient.instance().getCurrentUser()?.id ?: ""))
+                            ),
+                            querySort = QuerySortByField.descByName("last_updated"),
+                            channelLimit = 30,
+                            memberLimit = 30,
+                            messageLimit = 1
                         ),
-                        querySort = QuerySortByField.descByName("last_updated"),
                         title = "Stream Chat",
                         isShowingHeader = true,
-                        isShowingSearch = true,
-                        channelLimit = 30,
-                        memberLimit = 30,
-                        messageLimit = 1
+                        isShowingSearch = true
                     )
                 }
             }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamShapes
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
 /**
  * [Usage](https://getstream.io/chat/docs/sdk/android/compose/general-customization/chat-theme/#usage)
@@ -25,8 +26,11 @@ private object ChatThemeUsageSnippet {
             setContent {
                 ChatTheme {
                     MessagesScreen(
-                        channelId = "messaging:123",
-                        messageLimit = 30,
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = "messaging:123",
+                            messageLimit = 30
+                        ),
                         onBackPressed = { finish() },
                         onHeaderActionClick = {}
                     )
@@ -58,8 +62,10 @@ private object ChatThemeCustomizationSnippet {
                     )
                 ) {
                     MessagesScreen(
-                        channelId = "messaging:123",
-                        messageLimit = 30,
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = "messaging:123",
+                        ),
                         onBackPressed = { finish() },
                         onHeaderActionClick = {}
                     )

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/guides/ProvidingCustomReactions.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/guides/ProvidingCustomReactions.kt
@@ -13,6 +13,7 @@ import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.ReactionIcon
 import io.getstream.chat.android.compose.ui.util.ReactionIconFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 import io.getstream.chat.docs.R
 
 /**
@@ -30,7 +31,10 @@ private object ProvidingCustomReactionsSnippet {
                 // Provide a factory with custom reactions
                 ChatTheme(reactionIconFactory = CustomReactionIconFactory()) {
                     MessagesScreen(
-                        channelId = channelId,
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = channelId,
+                        ),
                         onBackPressed = { finish() },
                         onHeaderActionClick = {}
                     )

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/MessagesScreen.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/MessagesScreen.kt
@@ -7,6 +7,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
 /**
  * [Usage](https://getstream.io/chat/docs/sdk/android/compose/message-components/messages-screen/#usage)
@@ -22,7 +23,12 @@ private object MessagesScreenUsageSnippet {
 
             setContent {
                 ChatTheme {
-                    MessagesScreen(channelId = channelId)
+                    MessagesScreen(
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = channelId
+                        )
+                    )
                 }
             }
         }
@@ -44,7 +50,10 @@ private object MessagesScreenHandlingActionsSnippet {
             setContent {
                 ChatTheme {
                     MessagesScreen(
-                        channelId = channelId,
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = channelId
+                        ),
                         onBackPressed = { finish() }, // Navigation handler
                         onHeaderActionClick = { channel ->
                             // Show channel info
@@ -71,12 +80,15 @@ private object MessagesScreenCustomizationSnippet {
             setContent {
                 ChatTheme {
                     MessagesScreen(
-                        channelId = channelId,
-                        messageLimit = 30,
+                        viewModelFactory = MessagesViewModelFactory(
+                            context = this,
+                            channelId = channelId,
+                            messageLimit = 30,
+                            enforceUniqueReactions = true,
+                            showDateSeparators = true,
+                            showSystemMessages = true
+                        ),
                         showHeader = true,
-                        enforceUniqueReactions = true,
-                        showDateSeparators = true,
-                        showSystemMessages = true,
                     )
                 }
             }

--- a/stream-chat-android-ui-uitests/src/main/java/io/getstream/chat/android/uitests/app/compose/ComposeMessagesActivity.kt
+++ b/stream-chat-android-ui-uitests/src/main/java/io/getstream/chat/android/uitests/app/compose/ComposeMessagesActivity.kt
@@ -23,6 +23,7 @@ import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.android.compose.ui.messages.MessagesScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 
 /**
  * An Activity that represents a message list screen. Relies on the components
@@ -37,7 +38,10 @@ class ComposeMessagesActivity : AppCompatActivity() {
         setContent {
             ChatTheme {
                 MessagesScreen(
-                    channelId = channelId,
+                    viewModelFactory = MessagesViewModelFactory(
+                        context = this,
+                        channelId = channelId
+                    ),
                     onBackPressed = ::finish,
                 )
             }


### PR DESCRIPTION
### 🎯 Goal

It was confusing to use Screen components and their respective ViewModels(or factories) and expect results in both to be the same. This could and couldn't be true because the Screen component created its own ViewModels and factories, and the way the user could create their own could be different.

Additionally, it was tedious to send customization params for behavior through the local viewModelFactory and the screen component, because you could customize something in one place but not in another.

This way, we're "forcing" users to pass in ViewModelFactories and as such, the ViewModels used outside the components and inside should always be the same (as they're cached in the factory/provider). Additionally, you only customize the behavior params (like message limits and similar) in one place (the factory), so the screen components have fewer parameters, are easier and cleaner to use.

Finally, our documentation is up to date and shows how to override ViewModels and use the same ones in both the inner components and the outside world.

### 🛠 Implementation details

Made the ViewModelFactories mandatory params of screen components, but also set up default values for their constructors, so it's much easier to create and pass them in.

Outlined important parameters for both the Messages and Channels screens.

Updated all the docs and examples.

### 🎨 UI Changes

N/A - there shouldn't be any changes in the UI or behavior. 

### 🧪 Testing

To test this, apply the following patch and search the Logcat console for `ViewModelAddress`:

```
ViewModelAddress: ChannelListViewModel@e86d6c8
ViewModelAddress: ChannelListViewModel@e86d6c8
ViewModelAddress: ChannelListViewModel@e86d6c8
ViewModelAddress: MessageListViewModel@5eb7a75
ViewModelAddress: AttachmentsPickerViewModel@10fa0a
ViewModelAddress: MessageComposerViewModel@f90a898
ViewModelAddress: MessageListViewModel@5eb7a75
ViewModelAddress: AttachmentsPickerViewModel@10fa0a
ViewModelAddress: MessageComposerViewModel@f90a898
```

Note how the addresses of the VMs are the same in both the activity and the compose component.

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt	(revision 5cc3a84a4a39a26ff8e1ee6ea478c3c72344c585)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt	(date 1663761764814)
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.channels
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -94,6 +95,8 @@
         factory = viewModelFactory
     )
 
+    Log.d("ViewModelAddress", "Channels: $listViewModel")
+
     val selectedChannel by listViewModel.selectedChannel
     val user by listViewModel.user.collectAsState()
     val connectionState by listViewModel.connectionState.collectAsState()
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt	(revision 5cc3a84a4a39a26ff8e1ee6ea478c3c72344c585)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt	(date 1663761764822)
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.messages
 
+import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
@@ -112,6 +113,10 @@
     val attachmentsPickerViewModel =
         viewModel(AttachmentsPickerViewModel::class.java, factory = viewModelFactory)
 
+    Log.d("ViewModelAddress", "Messages (List): $listViewModel")
+    Log.d("ViewModelAddress", "Messages (List): $attachmentsPickerViewModel")
+    Log.d("ViewModelAddress", "Messages (List): $composerViewModel")
+
     val backAction = {
         val isInThread = listViewModel.isInThread
         val isShowingOverlay = listViewModel.isShowingOverlay
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 5cc3a84a4a39a26ff8e1ee6ea478c3c72344c585)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1663761764809)
@@ -19,6 +19,7 @@
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -91,6 +92,10 @@
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
+        Log.d("ViewModelAddress", "Messages (List): $listViewModel")
+        Log.d("ViewModelAddress", "Messages (List): $attachmentsPickerViewModel")
+        Log.d("ViewModelAddress", "Messages (List): $composerViewModel")
+
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 MessagesScreen(
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(revision 5cc3a84a4a39a26ff8e1ee6ea478c3c72344c585)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(date 1663761764818)
@@ -19,6 +19,7 @@
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -87,6 +88,7 @@
          * You can use the default [ChannelsScreen] component that sets everything up for you,
          * or build a custom component yourself, like [MyCustomUi].
          */
+        Log.d("ViewModelAddress", "Channels: $listViewModel")
         setContent {
             ChatTheme(dateFormatter = ChatApp.dateFormatter) {
                 ChannelsScreen(
```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
