### PR TITLE
Publish docs whenever a new commit arrive to `main`

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -1,22 +1,19 @@
 name: ReleaseDocs
 
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Publish"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   publish_dokka:
     name: Dokka docs
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: release
+          ref: main
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -33,12 +30,11 @@ jobs:
   push_docusaurus:
     name: Publish docusaurus docs
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: release
+          ref: main
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:


### PR DESCRIPTION
### 🎯 Goal
Publish docs whenever a new commit arrive to `main`

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the ~`develop`~ `main` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/wpgYasZ0tBrP4lCgS3/giphy-downsized-large.gif)
