### PR TITLE
[ISSUE-4166] Separating ThreadQueryListenerFull

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ### ⚠️ Changed
 - Separated `QueryChannelListenerState` into state and databased focused classes. [#4188](https://github.com/GetStream/stream-chat-android/pull/4188)
-- Separated `ThreadQueryListener` into state and databased focused classes. [4208](https://github.com/GetStream/stream-chat-android/pull/4208)
+- Separated `ThreadQueryListener` into state and databased focused classes. [#4208](https://github.com/GetStream/stream-chat-android/pull/4208)
 - Rename of `QueryChannelsListenerImpl` to `QueryChannelsListenerState` [#4170](https://github.com/GetStream/stream-chat-android/pull/4170)
 
 ### ❌ Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 
 ### ⚠️ Changed
 - Separated `QueryChannelListenerState` into state and databased focused classes. [#4188](https://github.com/GetStream/stream-chat-android/pull/4188)
-- Separated `ThreadQueryListener` into state and databased focused classes. [#4208](https://github.com/GetStream/stream-chat-android/pull/4208)
+- Separated `ThreadQueryListener` into state and databased focused classes. [4208](https://github.com/GetStream/stream-chat-android/pull/4208)
 - Rename of `QueryChannelsListenerImpl` to `QueryChannelsListenerState` [#4170](https://github.com/GetStream/stream-chat-android/pull/4170)
 
 ### ❌ Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 
 ### ⚠️ Changed
 - Separated `QueryChannelListenerState` into state and databased focused classes. [#4188](https://github.com/GetStream/stream-chat-android/pull/4188)
+- Separated `ThreadQueryListener` into state and databased focused classes. [#4208](https://github.com/GetStream/stream-chat-android/pull/4208)
 - Rename of `QueryChannelsListenerImpl` to `QueryChannelsListenerState` [#4170](https://github.com/GetStream/stream-chat-android/pull/4170)
 
 ### ❌ Removed

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ include (
 
 buildCache {
 	local {
-		enabled = false
+		enabled = !System.getenv().containsKey("CI")
 		removeUnusedEntriesAfterDays = 7
 	}
 	Properties localProperties = new Properties()

--- a/settings.gradle
+++ b/settings.gradle
@@ -30,7 +30,7 @@ include (
 
 buildCache {
 	local {
-		enabled = !System.getenv().containsKey("CI")
+		enabled = false
 		removeUnusedEntriesAfterDays = 7
 	}
 	Properties localProperties = new Properties()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
 import io.getstream.chat.android.client.plugin.listeners.SendMessageListener
 import io.getstream.chat.android.client.plugin.listeners.SendReactionListener
 import io.getstream.chat.android.client.plugin.listeners.ShuffleGiphyListener
+import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.setup.InitializationCoordinator
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -56,6 +57,8 @@ import io.getstream.chat.android.offline.plugin.listener.internal.SendReactionLi
 import io.getstream.chat.android.offline.plugin.listener.internal.SendReactionListenerDatabase
 import io.getstream.chat.android.offline.plugin.listener.internal.ShuffleGiphyListenerComposite
 import io.getstream.chat.android.offline.plugin.listener.internal.ShuffleGiphyListenerDatabase
+import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerComposite
+import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerDatabase
 import io.getstream.chat.android.offline.repository.database.internal.ChatDatabase
 import io.getstream.chat.android.offline.repository.factory.internal.DatabaseRepositoryFactory
 import io.getstream.chat.android.state.plugin.configuration.StatePluginConfig
@@ -151,6 +154,8 @@ public class StreamOfflinePluginFactory(
 
         val queryChannelListener = getQueryChannelListener(repositoryFacade, statePlugin)
 
+        val threadQueryListener = getThreadQueryListener(repositoryFacade, statePlugin)
+
         val editMessageListener = getEditMessageListener(clientState, repositoryFacade, statePlugin)
         val hideChannelListener: HideChannelListener = getHideChannelListener(repositoryFacade, statePlugin)
         val deleteReactionListener: DeleteReactionListener = getDeleteReactionListener(
@@ -175,7 +180,7 @@ public class StreamOfflinePluginFactory(
             activeUser = user,
             queryChannelsListener = statePlugin,
             queryChannelListener = queryChannelListener,
-            threadQueryListener = statePlugin,
+            threadQueryListener = threadQueryListener,
             channelMarkReadListener = statePlugin,
             editMessageListener = editMessageListener,
             hideChannelListener = hideChannelListener,
@@ -219,6 +224,15 @@ public class StreamOfflinePluginFactory(
         val queryChannelListenerDatabase = QueryChannelListenerDatabase(repositoryFacade)
 
         return QueryChannelListenerComposite(listOf(statePlugin, queryChannelListenerDatabase))
+    }
+
+    private fun getThreadQueryListener(
+        repositoryFacade: RepositoryFacade,
+        statePlugin: StatePlugin,
+    ): ThreadQueryListener {
+        val queryChannelListenerDatabase = ThreadQueryListenerDatabase(repositoryFacade, repositoryFacade)
+
+        return ThreadQueryListenerComposite(listOf(queryChannelListenerDatabase, statePlugin))
     }
 
     private fun getEditMessageListener(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerComposite.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerComposite.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.offline.plugin.listener.internal
+
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
+import io.getstream.chat.android.client.utils.Result
+
+internal class ThreadQueryListenerComposite(
+    private val threadQueryListenerList: List<ThreadQueryListener>,
+) : ThreadQueryListener {
+    override suspend fun onGetRepliesRequest(messageId: String, limit: Int) {
+        threadQueryListenerList.forEach { threadQueryListener ->
+            threadQueryListener.onGetRepliesRequest(messageId, limit)
+        }
+    }
+
+    override suspend fun onGetRepliesResult(result: Result<List<Message>>, messageId: String, limit: Int) {
+        threadQueryListenerList.forEach { threadQueryListener ->
+            threadQueryListener.onGetRepliesResult(result, messageId, limit)
+        }
+    }
+
+    override suspend fun onGetRepliesMoreRequest(messageId: String, firstId: String, limit: Int) {
+        threadQueryListenerList.forEach { threadQueryListener ->
+            threadQueryListener.onGetRepliesMoreRequest(messageId, firstId, limit)
+        }
+    }
+
+    override suspend fun onGetRepliesMoreResult(
+        result: Result<List<Message>>,
+        messageId: String,
+        firstId: String,
+        limit: Int,
+    ) {
+        threadQueryListenerList.forEach { threadQueryListener ->
+            threadQueryListener.onGetRepliesMoreResult(result, messageId, firstId, limit)
+        }
+    }
+
+    override suspend fun onGetRepliesPrecondition(messageId: String, limit: Int): Result<Unit> {
+        return threadQueryListenerList.map { threadQueryListener ->
+            threadQueryListener.onGetRepliesPrecondition(messageId, limit)
+        }.foldResults()
+    }
+
+    override suspend fun onGetRepliesMorePrecondition(messageId: String, firstId: String, limit: Int): Result<Unit> {
+        return threadQueryListenerList.map { threadQueryListener ->
+            threadQueryListener.onGetRepliesMorePrecondition(messageId, firstId, limit)
+        }.foldResults()
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabase.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.offline.plugin.listener.internal
+
+import io.getstream.chat.android.client.extensions.internal.users
+import io.getstream.chat.android.client.models.Message
+import io.getstream.chat.android.client.persistance.repository.MessageRepository
+import io.getstream.chat.android.client.persistance.repository.UserRepository
+import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
+import io.getstream.chat.android.client.utils.Result
+
+/**
+ * ThreadQueryListenerFull handles both state and database. It uses, if available, the database
+ * to update, if available, the state.
+ *
+ * @param messageRepository [MessageRepository] Optional to handle database updates related to messages
+ * @param userRepository [UserRepository]  Optional to handle database updates related to user
+ */
+internal class ThreadQueryListenerDatabase(
+    private val messageRepository: MessageRepository?,
+    private val userRepository: UserRepository?,
+) : ThreadQueryListener {
+
+    override suspend fun onGetRepliesRequest(messageId: String, limit: Int) {
+        // Nothing to do.
+    }
+
+    override suspend fun onGetRepliesResult(result: Result<List<Message>>, messageId: String, limit: Int) {
+        onResult(result)
+    }
+
+    override suspend fun onGetRepliesMoreRequest(messageId: String, firstId: String, limit: Int) {
+        // Nothing to do.
+    }
+
+    override suspend fun onGetRepliesMoreResult(
+        result: Result<List<Message>>,
+        messageId: String,
+        firstId: String,
+        limit: Int,
+    ) {
+        onResult(result)
+    }
+
+    private suspend fun onResult(result: Result<List<Message>>) {
+        if (result.isSuccess) {
+            val messages = result.data()
+
+            userRepository?.insertUsers(messages.flatMap(Message::users))
+            messageRepository?.insertMessages(messages)
+        }
+    }
+}

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabase.kt
@@ -24,15 +24,15 @@ import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.utils.Result
 
 /**
- * ThreadQueryListenerFull handles both state and database. It uses, if available, the database
- * to update, if available, the state.
+ * ThreadQueryListenerFull handles database read and updates. It updates the database once the requests for backend
+ * is complete.
  *
  * @param messageRepository [MessageRepository] Optional to handle database updates related to messages
  * @param userRepository [UserRepository]  Optional to handle database updates related to user
  */
 internal class ThreadQueryListenerDatabase(
-    private val messageRepository: MessageRepository?,
-    private val userRepository: UserRepository?,
+    private val messageRepository: MessageRepository,
+    private val userRepository: UserRepository,
 ) : ThreadQueryListener {
 
     override suspend fun onGetRepliesRequest(messageId: String, limit: Int) {
@@ -60,8 +60,8 @@ internal class ThreadQueryListenerDatabase(
         if (result.isSuccess) {
             val messages = result.data()
 
-            userRepository?.insertUsers(messages.flatMap(Message::users))
-            messageRepository?.insertMessages(messages)
+            userRepository.insertUsers(messages.flatMap(Message::users))
+            messageRepository.insertMessages(messages)
         }
     }
 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabaseTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.offline.plugin.listener.internal
 
 import io.getstream.chat.android.client.errors.ChatError

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerDatabaseTest.kt
@@ -1,0 +1,49 @@
+package io.getstream.chat.android.offline.plugin.listener.internal
+
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.persistance.repository.MessageRepository
+import io.getstream.chat.android.client.persistance.repository.UserRepository
+import io.getstream.chat.android.client.test.randomMessage
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.test.randomInt
+import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ThreadQueryListenerDatabaseTest {
+
+    private val messageRepository: MessageRepository = mock()
+    private val userRepository: UserRepository = mock()
+
+    private val threadQueryListenerDatabase: ThreadQueryListenerDatabase = ThreadQueryListenerDatabase(
+        messageRepository, userRepository
+    )
+
+    @Test
+    fun `given the response is successful, database should be updated`() = runTest {
+        val message = randomMessage()
+        val messageList = listOf(message)
+
+        threadQueryListenerDatabase.onGetRepliesResult(Result.success(messageList), randomString(), randomInt())
+
+        verify(userRepository).insertUsers(any())
+        verify(messageRepository).insertMessages(messageList, false)
+    }
+
+    @Test
+    fun `given the response is failure, database should NOT be updated`() = runTest {
+        val message = randomMessage()
+        val messageList = listOf(message)
+
+        threadQueryListenerDatabase.onGetRepliesResult(Result.error(ChatError()), randomString(), randomInt())
+
+        verify(userRepository, never()).insertUsers(any())
+        verify(messageRepository, never()).insertMessages(messageList, false)
+    }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerState.kt
@@ -17,13 +17,10 @@
 package io.getstream.chat.android.offline.plugin.listener.internal
 
 import io.getstream.chat.android.client.errors.ChatError
-import io.getstream.chat.android.client.extensions.internal.users
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
-import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.utils.Result
-import io.getstream.chat.android.client.utils.onSuccessSuspend
 import io.getstream.chat.android.offline.plugin.logic.channel.thread.internal.ThreadLogic
 import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.logging.StreamLog
@@ -34,22 +31,18 @@ import io.getstream.logging.StreamLog
  *
  * @param logic [LogicRegistry] Optional class to handle state updates
  * @param messageRepository [MessageRepository] Optional to handle database updates related to messages
- * @param userRepository [UserRepository]  Optional to handle database updates related to user
- * @param getRemoteMessage Returns a remote message from backend side.
  */
-internal class ThreadQueryListenerFull(
-    private val logic: LogicRegistry?,
-    private val messageRepository: MessageRepository?,
-    private val userRepository: UserRepository?,
-    private val getRemoteMessage: suspend (messageId: String) -> Result<Message>
+internal class ThreadQueryListenerState(
+    private val logic: LogicRegistry,
+    private val messageRepository: MessageRepository,
 ) : ThreadQueryListener {
 
     private val logger = StreamLog.getLogger("Chat:ThreadQueryListener")
 
     override suspend fun onGetRepliesPrecondition(messageId: String, limit: Int): Result<Unit> {
-        val loadingMoreMessage = logic?.thread(messageId)?.isLoadingMessages()
+        val loadingMoreMessage = logic.thread(messageId).isLoadingMessages()
 
-        return if (loadingMoreMessage == true) {
+        return if (loadingMoreMessage) {
             val errorMsg = "already loading messages for this thread, ignoring the load requests."
             logger.i { errorMsg }
             Result(ChatError(errorMsg))
@@ -59,35 +52,27 @@ internal class ThreadQueryListenerFull(
     }
 
     override suspend fun onGetRepliesRequest(messageId: String, limit: Int) {
-        val threadLogic = logic?.thread(messageId)
+        val threadLogic = logic.thread(messageId)
 
-        threadLogic?.setLoading(true)
-        val messages = messageRepository?.selectMessagesForThread(messageId, limit)
-        val parentMessage = threadLogic?.getMessage(messageId) ?: messages?.firstOrNull { it.id == messageId }
+        threadLogic.setLoading(true)
+        val messages = messageRepository.selectMessagesForThread(messageId, limit)
+        val parentMessage = threadLogic.getMessage(messageId) ?: messages.firstOrNull { it.id == messageId }
 
-        if (parentMessage != null && messages?.isNotEmpty() == true) {
-            threadLogic?.upsertMessages(messages)
-        } else {
-            val result = getRemoteMessage(messageId)
-            if (result.isSuccess) {
-                val message = result.data()
-                threadLogic?.upsertMessage(result.data())
-                userRepository?.insertUsers(message.users())
-                messageRepository?.insertMessage(message)
-            }
+        if (parentMessage != null && messages.isNotEmpty()) {
+            threadLogic.upsertMessages(messages)
         }
     }
 
     override suspend fun onGetRepliesResult(result: Result<List<Message>>, messageId: String, limit: Int) {
-        val threadLogic = logic?.thread(messageId)
-        threadLogic?.setLoading(false)
+        val threadLogic = logic.thread(messageId)
+        threadLogic.setLoading(false)
         onResult(threadLogic, result, limit)
     }
 
     override suspend fun onGetRepliesMorePrecondition(messageId: String, firstId: String, limit: Int): Result<Unit> {
-        val loadingMoreMessage = logic?.thread(messageId)?.isLoadingOlderMessages()
+        val loadingMoreMessage = logic.thread(messageId).isLoadingOlderMessages()
 
-        return if (loadingMoreMessage == true) {
+        return if (loadingMoreMessage) {
             val errorMsg = "already loading messages for this thread, ignoring the load more requests."
             logger.i { errorMsg }
             Result(ChatError(errorMsg))
@@ -97,7 +82,7 @@ internal class ThreadQueryListenerFull(
     }
 
     override suspend fun onGetRepliesMoreRequest(messageId: String, firstId: String, limit: Int) {
-        logic?.thread(messageId)?.setLoadingOlderMessages(true)
+        logic.thread(messageId).setLoadingOlderMessages(true)
     }
 
     override suspend fun onGetRepliesMoreResult(
@@ -106,13 +91,13 @@ internal class ThreadQueryListenerFull(
         firstId: String,
         limit: Int,
     ) {
-        val threadLogic = logic?.thread(messageId)
+        val threadLogic = logic.thread(messageId)
 
-        threadLogic?.setLoadingOlderMessages(false)
+        threadLogic.setLoadingOlderMessages(false)
         onResult(threadLogic, result, limit)
     }
 
-    private suspend fun onResult(threadLogic: ThreadLogic?, result: Result<List<Message>>, limit: Int) {
+    private fun onResult(threadLogic: ThreadLogic?, result: Result<List<Message>>, limit: Int) {
         if (result.isSuccess) {
             val newMessages = result.data()
             threadLogic?.run {
@@ -120,11 +105,6 @@ internal class ThreadQueryListenerFull(
                 setEndOfOlderMessages(newMessages.size < limit)
                 updateOldestMessageInThread(newMessages)
             }
-        }
-
-        result.onSuccessSuspend { messages ->
-            userRepository?.insertUsers(messages.flatMap(Message::users))
-            messageRepository?.insertMessages(messages)
         }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerState.kt
@@ -26,8 +26,8 @@ import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.logging.StreamLog
 
 /**
- * ThreadQueryListenerFull handles both state and database. It uses, if available, the database
- * to update, if available, the state.
+ * ThreadQueryListenerState handles both state in the SDK. It uses, if available, the database
+ * to update the state.
  *
  * @param logic [LogicRegistry] Optional class to handle state updates
  * @param messageRepository [MessageRepository] Optional to handle database updates related to messages

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -20,13 +20,11 @@ import android.content.Context
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.events.ChatEvent
 import io.getstream.chat.android.client.interceptor.message.PrepareMessageLogicFactory
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
 import io.getstream.chat.android.client.setup.InitializationCoordinator
-import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.errorhandler.factory.internal.OfflineErrorHandlerFactoriesProvider
@@ -45,7 +43,7 @@ import io.getstream.chat.android.offline.plugin.listener.internal.SendGiphyListe
 import io.getstream.chat.android.offline.plugin.listener.internal.SendMessageListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.SendReactionListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.ShuffleGiphyListenerState
-import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerFull
+import io.getstream.chat.android.offline.plugin.listener.internal.ThreadQueryListenerState
 import io.getstream.chat.android.offline.plugin.listener.internal.TypingEventListenerState
 import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
@@ -218,15 +216,11 @@ public class StreamStatePluginFactory(
             }
         }
 
-        val getMessageFun: suspend (String) -> Result<Message> = { messageId: String ->
-            chatClient.getMessage(messageId).await()
-        }
-
         return StatePlugin(
             activeUser = user,
             queryChannelListener = QueryChannelListenerState(logic),
             queryChannelsListener = QueryChannelsListenerState(logic),
-            threadQueryListener = ThreadQueryListenerFull(logic, repositoryFacade, repositoryFacade, getMessageFun),
+            threadQueryListener = ThreadQueryListenerState(logic, repositoryFacade),
             channelMarkReadListener = ChannelMarkReadListenerState(channelMarkReadHelper),
             editMessageListener = EditMessageListenerState(logic, clientState),
             hideChannelListener = HideChannelListenerState(logic),

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerStateTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.offline.plugin.listener.internal
 
 import io.getstream.chat.android.client.errors.ChatError

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/ThreadQueryListenerStateTest.kt
@@ -1,0 +1,123 @@
+package io.getstream.chat.android.offline.plugin.listener.internal
+
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.persistance.repository.MessageRepository
+import io.getstream.chat.android.client.test.randomMessage
+import io.getstream.chat.android.client.utils.Result
+import io.getstream.chat.android.offline.plugin.logic.channel.thread.internal.ThreadLogic
+import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
+import io.getstream.chat.android.test.randomInt
+import io.getstream.chat.android.test.randomString
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class ThreadQueryListenerStateTest {
+
+    private val message = randomMessage()
+    private val messageList = listOf(message, randomMessage(), randomMessage())
+
+    private val threadLogic: ThreadLogic = mock()
+
+    private val logic: LogicRegistry = mock {
+        on(it.thread(message.id)) doReturn threadLogic
+    }
+    private val messageRepository: MessageRepository = mock {
+        onBlocking { it.selectMessagesForThread(any(), any()) } doReturn messageList
+    }
+
+    private val threadQueryListenerState = ThreadQueryListenerState(logic, messageRepository)
+
+    @Test
+    fun `given a request is already running, new requests are not allowed`() = runTest {
+        whenever(threadLogic.isLoadingMessages()) doReturn true
+
+        val result = threadQueryListenerState.onGetRepliesPrecondition(message.id, randomInt())
+
+        result.isError `should be` true
+    }
+
+    @Test
+    fun `given a request is not running, new requests are allowed`() = runTest {
+        whenever(threadLogic.isLoadingMessages()) doReturn false
+
+        val result = threadQueryListenerState.onGetRepliesPrecondition(message.id, randomInt())
+
+        result.isSuccess `should be` true
+    }
+
+    @Test
+    fun `given a request is already running for more replies, new requests are not allowed`() = runTest {
+        whenever(threadLogic.isLoadingOlderMessages()) doReturn true
+
+        val result = threadQueryListenerState.onGetRepliesMorePrecondition(message.id, randomString(), randomInt())
+
+        result.isError `should be` true
+    }
+
+    @Test
+    fun `given a request is not running for more replies, new requests are allowed`() = runTest {
+        whenever(threadLogic.isLoadingOlderMessages()) doReturn false
+
+        val result = threadQueryListenerState.onGetRepliesMorePrecondition(message.id, randomString(), randomInt())
+
+        result.isSuccess `should be` true
+    }
+
+    @Test
+    fun `given a request for replies is made, the SDK should be notified that it is running`() = runTest {
+        threadQueryListenerState.onGetRepliesRequest(message.id, randomInt())
+
+        verify(threadLogic).setLoading(true)
+    }
+
+    @Test
+    fun `given a request for replies is made for more messages, the SDK should be notified that it is running`() =
+        runTest {
+            threadQueryListenerState.onGetRepliesMoreRequest(message.id, randomString(), randomInt())
+
+            verify(threadLogic).setLoadingOlderMessages(true)
+        }
+
+    @Test
+    fun `given the database returns values messages are upserted in the SDK`() = runTest {
+        whenever(messageRepository.selectMessagesForThread(eq(message.id), any())) doReturn messageList
+        whenever(threadLogic.getMessage(message.id)) doReturn message
+
+        threadQueryListenerState.onGetRepliesRequest(message.id, randomInt())
+
+        verify(threadLogic).upsertMessages(messageList)
+    }
+
+    @Test
+    fun `given response it successful, the state should be updated in the SDK`() = runTest {
+        threadQueryListenerState.onGetRepliesResult(Result.success(messageList), message.id, 30)
+
+        verify(threadLogic).run {
+            setLoading(false)
+            upsertMessages(messageList)
+            setEndOfOlderMessages(false)
+        }
+    }
+
+    @Test
+    fun `given response it failure, the state should NOT be updated in the SDK`() = runTest {
+        threadQueryListenerState.onGetRepliesResult(Result.error(ChatError()), message.id, 30)
+
+        verify(threadLogic).setLoading(false)
+
+        verify(threadLogic, never()).run {
+            upsertMessages(messageList)
+            setEndOfOlderMessages(false)
+        }
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Separate ThreadQueryListener into database and state.

### 🛠 Implementation details

In comments


### 🧪 Testing

Test threads in the sample app. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- ~[ ] Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy (1)](https://user-images.githubusercontent.com/10619102/191351988-4534406a-fd05-4a91-8861-2fd851c6dffa.gif)
_No, man, it is Thread not Threat, jesus..._
