### PR TITLE
Fix parsing of giphy size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# September 30th, 2022 - 5.11.1
+## stream-chat-android-ui-common
+### 🐞 Fixed
+- Fixed giphy size parsing. [#4222](https://github.com/GetStream/stream-chat-android/pull/4222)
+
 # September 21th, 2022 - 5.11.0
 ## stream-chat-android-client
 ### ⬆️ Improved

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
@@ -71,10 +71,23 @@ public fun Attachment.giphyInfo(field: GiphyInfoType): GiphyInfo? {
     return giphyInfoMap?.let { map ->
         GiphyInfo(
             url = map["url"] ?: "",
-            width = map["width"]?.toInt() ?: Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP),
-            height = map["height"]?.toInt() ?: Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP)
+            width = getGiphySize(map, "width", Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP)),
+            height = getGiphySize(map, "height", Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP))
         )
     }
+}
+
+/**
+ * Returns specified size for the giphy.
+ *
+ * @param map Map containing giphy size.
+ * @param size The size we need.
+ * @param defaultValue Default value if the size can't be parsed.
+ *
+ * @return The requested giphy [size].
+ */
+private fun getGiphySize(map: Map<String, String>, size: String, defaultValue: Int): Int {
+    return if (!map[size].isNullOrBlank()) map[size]?.toInt() ?: defaultValue else defaultValue
 }
 
 /**


### PR DESCRIPTION
### 🎯 Goal

#4221 

### 🛠 Implementation details

Refactored how giphy size is parsed.

### 🧪 Testing

1. Login as Amit and open Giphy testing
2. The sizes of giphies should fit the giphy size
3. Apply the patch and repeat, giphys should be the default size

<details>
  <summary>Patch file to apply these changes for testing</summary>

```
Index: stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt	(revision 76bcc7989221863051f5095fd253fbff883cfaa0)
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt	(date 1664536342625)
@@ -69,10 +69,13 @@
         (extraData[ModelType.attach_giphy] as? Map<String, Any>?)?.get(field.value) as? Map<String, String>?
 
     return giphyInfoMap?.let { map ->
+        val mutableMap = map.toMutableMap()
+        mutableMap["width"] = ""
+        mutableMap["height"] = ""
         GiphyInfo(
             url = map["url"] ?: "",
-            width = getGiphySize(map, "width", Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP)),
-            height = getGiphySize(map, "height", Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP))
+            width = getGiphySize(mutableMap, "width", Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP)),
+            height = getGiphySize(mutableMap, "height", Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP))
         )
     }
 }

```

</details>

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy (3)](https://user-images.githubusercontent.com/38032787/193258041-88e2a641-36bc-4134-b74c-cc9231f1da0b.gif)
