### PR TITLE
[4224] Write to cache in buffered chunks

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
@@ -28,7 +28,6 @@ import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.utils.Result
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import java.io.File
-import java.io.FileOutputStream
 import java.io.IOException
 
 private const val DEFAULT_BITMAP_QUALITY = 90
@@ -218,10 +217,9 @@ public object StreamFileUtil {
                 if (response.isSuccess) {
                     // write the response to a file
                     response.data().byteStream().use { inputStream ->
-                        val fileOutputStream = FileOutputStream(file)
-
-                        inputStream.copyTo(fileOutputStream)
-                        fileOutputStream.close()
+                        file.outputStream().use { outputStream ->
+                            inputStream.copyTo(outputStream)
+                        }
                     }
 
                     Result(data = getUriForFile(context, file))

--- a/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/com/getstream/sdk/chat/StreamFileUtil.kt
@@ -30,7 +30,6 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
-import kotlin.Exception
 
 private const val DEFAULT_BITMAP_QUALITY = 90
 
@@ -218,10 +217,12 @@ public object StreamFileUtil {
 
                 if (response.isSuccess) {
                     // write the response to a file
-                    val byteArray = response.data().byteStream().readBytes()
-                    val fileOutputStream = FileOutputStream(file)
-                    fileOutputStream.write(byteArray)
-                    fileOutputStream.close()
+                    response.data().byteStream().use { inputStream ->
+                        val fileOutputStream = FileOutputStream(file)
+
+                        inputStream.copyTo(fileOutputStream)
+                        fileOutputStream.close()
+                    }
 
                     Result(data = getUriForFile(context, file))
                 } else {


### PR DESCRIPTION
### 🎯 Goal

Closes #4224 

### 🛠 Implementation details

Switched to using Kotlin's in built function for copying file streams.

### 🧪 Testing

Repeat the following steps on both dev and the current branch:

1. Launch the Compose app
2. Log in as `Jc`
3. Go to channel `Skinny Secret`
4. Scroll up until you find a video attachment with a message `87 MB video`
5. Open it in the gallery
6. Click on share

Expected result:  Should throw an OOM error on dev, work fine on the current branch.

Please note two things:

- If you are uploading  your own large files for testing do so using a `release` build. Our logging causes OOMs upon upload on `debug`. (unrelated to this PR)
- If you want to re test caching with the same file, you have to exit the activity. Clearing the cache is tied to the gallery's `onDestroy`, it it's not called you won't be re-downloading the file but pulling it from cache.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] ~~Changelog is updated with client-facing changes~~ (fixing unreleased code)
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works

### 🎉 GIF

![img](https://media0.giphy.com/media/532UBIVQ5vfz3CncQn/giphy.gif?cid=ecf05e47fnmg814sdswem2n8p773il7r64lwqucmeq0shb2o&rid=giphy.gif&ct=g)
