### PR TITLE
[4231] Fix displaying image attachments that have failed to send V5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED CHANGELOG
+## stream-chat-android-ui-components
+### 🐞 Fixed
+- Fixed displaying messages with failed image attachments. [#4234](https://github.com/GetStream/stream-chat-android/pull/4234)
+
 # September 30th, 2022 - 5.11.1
 ## stream-chat-android-ui-common
 ### 🐞 Fixed

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentView.kt
@@ -96,14 +96,14 @@ internal class ImageAttachmentView : ConstraintLayout {
      * images the message contains in case they don't all fit in the preview.
      */
     fun showAttachment(attachment: Attachment, andMoreCount: Int = NO_MORE_COUNT) {
-        val url = attachment.imagePreviewUrl ?: attachment.titleLink ?: attachment.ogUrl ?: return
+        val url = attachment.imagePreviewUrl ?: attachment.titleLink ?: attachment.ogUrl ?: attachment.upload ?: return
         val showMore = {
             if (andMoreCount > NO_MORE_COUNT) {
                 showMoreCount(andMoreCount)
             }
         }
 
-        showImageByUrl(url) {
+        showImage(url) {
             showMore()
         }
 
@@ -124,7 +124,7 @@ internal class ImageAttachmentView : ConstraintLayout {
     /**
      * Loads the images.
      */
-    private fun showImageByUrl(imageUrl: String, onCompleteCallback: () -> Unit) {
+    private fun showImage(imageUrl: Any, onCompleteCallback: () -> Unit) {
         binding.imageView.load(
             data = imageUrl,
             placeholderDrawable = style.placeholderIcon,


### PR DESCRIPTION
### 🎯 Goal

closes #4231

### 🛠 Implementation details

Added a fallback to `Attachment.upload`

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1664884140](https://user-images.githubusercontent.com/37080097/193820155-729573f7-712b-4431-aa5a-cd18fb437040.png) | ![Screenshot_1664884104](https://user-images.githubusercontent.com/37080097/193820264-c79be0d5-ed39-4f96-b640-9471d578a065.png) |

### 🧪 Testing

1. Open the XML app
2. Go to a channel
3. Send an image and kill the internet mid send

Result: You should see a failed message that will be correctly displayed.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Checked the V6 version here https://github.com/GetStream/stream-chat-android/pull/4232

### 🎉 GIF

![gif](https://media1.giphy.com/media/8vQSQ3cNXuDGo/giphy.gif?cid=ecf05e47ocjbsa35mv3xe3sx7kx42lzaszr8lj3f4hekektr&rid=giphy.gif&ct=g)
