### PR TITLE
Task/4238 improve message options dialog customization

### DIFF
--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -1,22 +1,19 @@
 name: ReleaseDocs
 
 on:
-  workflow_dispatch:
-  workflow_run:
-    workflows: ["Publish"]
-    types:
-      - completed
+  push:
+    branches:
+      - main
 
 jobs:
   publish_dokka:
     name: Dokka docs
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: release
+          ref: main
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
@@ -33,12 +30,11 @@ jobs:
   push_docusaurus:
     name: Publish docusaurus docs
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
         uses: actions/checkout@v3
         with:
-          ref: release
+          ref: main
       - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# September 30th, 2022 - 5.11.1
+## stream-chat-android-ui-common
+### 🐞 Fixed
+- Fixed giphy size parsing. [#4222](https://github.com/GetStream/stream-chat-android/pull/4222)
+
 # September 21th, 2022 - 5.11.0
 ## stream-chat-android-client
 ### ⬆️ Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # UNRELEASED CHANGELOG
 ## stream-chat-android-ui-components
+### ✅ Added
+- Added `*MarginTop`, `*MarginBottom`, `*MarginStart` and `*MarginEnd` respectively, for each major piece of the MessageOptionsDialogFragment UI. [#4240](https://github.com/GetStream/stream-chat-android/pull/4240)
+- You can now override each of the margins for the `EditReactionsView`, `MessageOptionsView` and `UserReactionsView`. [#4240](https://github.com/GetStream/stream-chat-android/pull/4240)
+
 ### 🐞 Fixed
 - Fixed displaying messages with failed image attachments. [#4234](https://github.com/GetStream/stream-chat-android/pull/4234)
+
+### ⚠️ Changed
+- Changed the way `MessageOptionsDialogFragment` margins are exposed for specific Views. Instead of just one vertical margin, we now expose all four directions for each major piece of the dialog. [#4240](https://github.com/GetStream/stream-chat-android/pull/4240)
+- Because of this, there were three refactor/rename changes for the parameters you might have to update, if you're overriding the margins. [#4240](https://github.com/GetStream/stream-chat-android/pull/4240)
 
 # September 30th, 2022 - 5.11.1
 ## stream-chat-android-ui-common

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -7,7 +7,7 @@ object Configuration {
     const val minSdk = 21
     const val majorVersion = 5
     const val minorVersion = 11
-    const val patchVersion = 0
+    const val patchVersion = 1
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/utils/GiphyInfoType.kt
@@ -71,10 +71,23 @@ public fun Attachment.giphyInfo(field: GiphyInfoType): GiphyInfo? {
     return giphyInfoMap?.let { map ->
         GiphyInfo(
             url = map["url"] ?: "",
-            width = map["width"]?.toInt() ?: Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP),
-            height = map["height"]?.toInt() ?: Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP)
+            width = getGiphySize(map, "width", Utils.dpToPx(GIPHY_INFO_DEFAULT_WIDTH_DP)),
+            height = getGiphySize(map, "height", Utils.dpToPx(GIPHY_INFO_DEFAULT_HEIGHT_DP))
         )
     }
+}
+
+/**
+ * Returns specified size for the giphy.
+ *
+ * @param map Map containing giphy size.
+ * @param size The size we need.
+ * @param defaultValue Default value if the size can't be parsed.
+ *
+ * @return The requested giphy [size].
+ */
+private fun getGiphySize(map: Map<String, String>, size: String, defaultValue: Int): Int {
+    return if (!map[size].isNullOrBlank()) map[size]?.toInt() ?: defaultValue else defaultValue
 }
 
 /**

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -3053,8 +3053,8 @@ public abstract interface class io/getstream/chat/android/ui/message/list/Messag
 
 public final class io/getstream/chat/android/ui/message/list/MessageListViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/list/MessageListViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)V
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIIIIIIIII)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIIIIIIIII)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public final fun component10 ()I
 	public final fun component11 ()Z
@@ -3098,13 +3098,22 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun component46 ()I
 	public final fun component47 ()I
 	public final fun component48 ()I
+	public final fun component49 ()I
 	public final fun component5 ()Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;
+	public final fun component50 ()I
+	public final fun component51 ()I
+	public final fun component52 ()I
+	public final fun component53 ()I
+	public final fun component54 ()I
+	public final fun component55 ()I
+	public final fun component56 ()I
+	public final fun component57 ()I
 	public final fun component6 ()Z
 	public final fun component7 ()I
 	public final fun component8 ()I
 	public final fun component9 ()Z
-	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIIIIIIIII)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIIIIIIIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getBlockEnabled ()Z
@@ -3131,9 +3140,18 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun getMuteEnabled ()Z
 	public final fun getMuteIcon ()I
 	public final fun getOptionsOverlayDimColor ()I
-	public final fun getOptionsOverlayEditReactionsMargin ()I
-	public final fun getOptionsOverlayMessageOptionsMargin ()I
-	public final fun getOptionsOverlayUserReactionsMargin ()I
+	public final fun getOptionsOverlayEditReactionsMarginBottom ()I
+	public final fun getOptionsOverlayEditReactionsMarginEnd ()I
+	public final fun getOptionsOverlayEditReactionsMarginStart ()I
+	public final fun getOptionsOverlayEditReactionsMarginTop ()I
+	public final fun getOptionsOverlayMessageOptionsMarginBottom ()I
+	public final fun getOptionsOverlayMessageOptionsMarginEnd ()I
+	public final fun getOptionsOverlayMessageOptionsMarginStart ()I
+	public final fun getOptionsOverlayMessageOptionsMarginTop ()I
+	public final fun getOptionsOverlayUserReactionsMarginBottom ()I
+	public final fun getOptionsOverlayUserReactionsMarginEnd ()I
+	public final fun getOptionsOverlayUserReactionsMarginStart ()I
+	public final fun getOptionsOverlayUserReactionsMarginTop ()I
 	public final fun getPinIcon ()I
 	public final fun getPinMessageEnabled ()Z
 	public final fun getReactionsEnabled ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -86,9 +86,18 @@ import io.getstream.chat.android.ui.message.list.internal.ScrollButtonView
  * @property scrollButtonBottomMargin Defines the bottom margin of the scroll button.
  * @property scrollButtonEndMargin Defines the end margin of the scroll button.
  * @property disableScrollWhenShowingDialog Enables/disables scroll while a dialog is shown over the message list.
- * @property optionsOverlayEditReactionsMargin Defines the margin between the selected message and the edit reactions bubble on the options overlay.
- * @property optionsOverlayUserReactionsMargin Defines the margin between the selected message and the user reaction list on the options overlay.
- * @property optionsOverlayMessageOptionsMargin Defines the margin between the selected message and the message option list on the options overlay.
+ * @property optionsOverlayEditReactionsMarginBottom Defines the margin between the selected message and the edit reactions bubble on the options overlay.
+ * @property optionsOverlayEditReactionsMarginTop Defines the top margin between the edit reactions bubble on the options overlay and the parent.
+ * @property optionsOverlayEditReactionsMarginStart Defines the start margin between the edit reactions bubble on the options overlay and the parent.
+ * @property optionsOverlayEditReactionsMarginEnd Defines the end margin between the edit reactions bubble on the options overlay and the parent.
+ * @property optionsOverlayUserReactionsMarginTop Defines the margin between the selected message and the user reaction list on the options overlay.
+ * @property optionsOverlayUserReactionsMarginBottom Defines the bottom margin between the user reaction list on the options overlay and the parent.
+ * @property optionsOverlayUserReactionsMarginStart Defines the start margin between the user reaction list on the options overlay and the parent.
+ * @property optionsOverlayUserReactionsMarginEnd Defines the end margin between the user reaction list on the options overlay and the parent.
+ * @property optionsOverlayMessageOptionsMarginTop Defines the margin between the selected message and the message option list on the options overlay.
+ * @property optionsOverlayMessageOptionsMarginBottom Defines the bottom margin between the message option list on the options overlay and the user reactions view.
+ * @property optionsOverlayMessageOptionsMarginStart Defines the start margin between the message option list on the options overlay and the parent.
+ * @property optionsOverlayMessageOptionsMarginEnd Defines the end margin between the message option list on the options overlay and the parent.
  */
 public data class MessageListViewStyle
 @Deprecated(
@@ -143,9 +152,18 @@ constructor(
     public val scrollButtonBottomMargin: Int,
     public val scrollButtonEndMargin: Int,
     public val disableScrollWhenShowingDialog: Boolean,
-    public val optionsOverlayEditReactionsMargin: Int,
-    public val optionsOverlayUserReactionsMargin: Int,
-    public val optionsOverlayMessageOptionsMargin: Int,
+    public val optionsOverlayEditReactionsMarginBottom: Int,
+    public val optionsOverlayEditReactionsMarginTop: Int,
+    public val optionsOverlayEditReactionsMarginStart: Int,
+    public val optionsOverlayEditReactionsMarginEnd: Int,
+    public val optionsOverlayUserReactionsMarginTop: Int,
+    public val optionsOverlayUserReactionsMarginBottom: Int,
+    public val optionsOverlayUserReactionsMarginStart: Int,
+    public val optionsOverlayUserReactionsMarginEnd: Int,
+    public val optionsOverlayMessageOptionsMarginTop: Int,
+    public val optionsOverlayMessageOptionsMarginBottom: Int,
+    public val optionsOverlayMessageOptionsMarginStart: Int,
+    public val optionsOverlayMessageOptionsMarginEnd: Int,
 ) {
 
     /**
@@ -234,9 +252,18 @@ constructor(
         scrollButtonBottomMargin: Int,
         scrollButtonEndMargin: Int,
         disableScrollWhenShowingDialog: Boolean,
-        optionsOverlayEditReactionsMargin: Int,
-        optionsOverlayUserReactionsMargin: Int,
-        optionsOverlayMessageOptionsMargin: Int,
+        optionsOverlayEditReactionsMarginBottom: Int,
+        optionsOverlayEditReactionsMarginTop: Int,
+        optionsOverlayEditReactionsMarginStart: Int,
+        optionsOverlayEditReactionsMarginEnd: Int,
+        optionsOverlayUserReactionsMarginTop: Int,
+        optionsOverlayUserReactionsMarginBottom: Int,
+        optionsOverlayUserReactionsMarginStart: Int,
+        optionsOverlayUserReactionsMarginEnd: Int,
+        optionsOverlayMessageOptionsMarginTop: Int,
+        optionsOverlayMessageOptionsMarginBottom: Int,
+        optionsOverlayMessageOptionsMarginStart: Int,
+        optionsOverlayMessageOptionsMarginEnd: Int,
     ) : this(
         scrollButtonViewStyle = scrollButtonViewStyle,
         scrollButtonBehaviour = scrollButtonBehaviour,
@@ -283,9 +310,18 @@ constructor(
         scrollButtonBottomMargin = scrollButtonBottomMargin,
         scrollButtonEndMargin = scrollButtonEndMargin,
         disableScrollWhenShowingDialog = disableScrollWhenShowingDialog,
-        optionsOverlayEditReactionsMargin = optionsOverlayEditReactionsMargin,
-        optionsOverlayUserReactionsMargin = optionsOverlayUserReactionsMargin,
-        optionsOverlayMessageOptionsMargin = optionsOverlayMessageOptionsMargin
+        optionsOverlayEditReactionsMarginBottom = optionsOverlayEditReactionsMarginBottom,
+        optionsOverlayEditReactionsMarginTop = optionsOverlayEditReactionsMarginTop,
+        optionsOverlayEditReactionsMarginStart = optionsOverlayEditReactionsMarginStart,
+        optionsOverlayEditReactionsMarginEnd = optionsOverlayEditReactionsMarginEnd,
+        optionsOverlayUserReactionsMarginTop = optionsOverlayUserReactionsMarginTop,
+        optionsOverlayMessageOptionsMarginTop = optionsOverlayMessageOptionsMarginTop,
+        optionsOverlayMessageOptionsMarginBottom = optionsOverlayMessageOptionsMarginBottom,
+        optionsOverlayMessageOptionsMarginStart = optionsOverlayMessageOptionsMarginStart,
+        optionsOverlayMessageOptionsMarginEnd = optionsOverlayMessageOptionsMarginEnd,
+        optionsOverlayUserReactionsMarginBottom = optionsOverlayUserReactionsMarginBottom,
+        optionsOverlayUserReactionsMarginEnd = optionsOverlayUserReactionsMarginEnd,
+        optionsOverlayUserReactionsMarginStart = optionsOverlayUserReactionsMarginStart
     )
 
     public companion object {
@@ -294,9 +330,21 @@ constructor(
         private val DEFAULT_SCROLL_BUTTON_MARGIN = 6.dpToPx()
         private val DEFAULT_SCROLL_BUTTON_INTERNAL_MARGIN = 2.dpToPx()
         private val DEFAULT_SCROLL_BUTTON_BADGE_ELEVATION = DEFAULT_SCROLL_BUTTON_ELEVATION
-        private val DEFAULT_EDIT_REACTIONS_MARGIN = 0.dpToPx()
-        private val DEFAULT_USER_REACTIONS_MARGIN = 8.dpToPx()
-        private val DEFAULT_MESSAGE_OPTIONS_MARGIN = 24.dpToPx()
+
+        private val DEFAULT_EDIT_REACTIONS_MARGIN_BOTTOM = 0.dpToPx()
+        private val DEFAULT_EDIT_REACTIONS_MARGIN_TOP = 0.dpToPx()
+        private val DEFAULT_EDIT_REACTIONS_MARGIN_START = 8.dpToPx()
+        private val DEFAULT_EDIT_REACTIONS_MARGIN_END = 8.dpToPx()
+
+        private val DEFAULT_USER_REACTIONS_MARGIN_TOP = 8.dpToPx()
+        private val DEFAULT_USER_REACTIONS_MARGIN_BOTTOM = 0.dpToPx()
+        private val DEFAULT_USER_REACTIONS_MARGIN_START = 8.dpToPx()
+        private val DEFAULT_USER_REACTIONS_MARGIN_END = 8.dpToPx()
+
+        private val DEFAULT_MESSAGE_OPTIONS_MARGIN_TOP = 24.dpToPx()
+        private val DEFAULT_MESSAGE_OPTIONS_MARGIN_BOTTOM = 0.dpToPx()
+        private val DEFAULT_MESSAGE_OPTIONS_MARGIN_START = 50.dpToPx()
+        private val DEFAULT_MESSAGE_OPTIONS_MARGIN_END = 8.dpToPx()
 
         /**
          * Creates an [MessageListViewStyle] instance with the default values.
@@ -586,22 +634,76 @@ constructor(
                     true
                 )
 
-                val optionsOverlayEditReactionsMargin =
+                val optionsOverlayEditReactionsMarginBottom =
                     attributes.getDimensionPixelSize(
-                        R.styleable.MessageListView_streamUiOptionsOverlayEditReactionsMargin,
-                        DEFAULT_EDIT_REACTIONS_MARGIN
+                        R.styleable.MessageListView_streamUiOptionsOverlayEditReactionsMarginBottom,
+                        DEFAULT_EDIT_REACTIONS_MARGIN_BOTTOM
                     )
 
-                val optionsOverlayUserReactionsMargin =
+                val optionsOverlayEditReactionsMarginTop =
                     attributes.getDimensionPixelSize(
-                        R.styleable.MessageListView_streamUiOptionsOverlayUserReactionsMargin,
-                        DEFAULT_USER_REACTIONS_MARGIN
+                        R.styleable.MessageListView_streamUiOptionsOverlayEditReactionsMarginTop,
+                        DEFAULT_EDIT_REACTIONS_MARGIN_TOP
                     )
 
-                val optionsOverlayMessageOptionsMargin =
+                val optionsOverlayEditReactionsMarginStart =
                     attributes.getDimensionPixelSize(
-                        R.styleable.MessageListView_streamUiOptionsOverlayMessageOptionsMargin,
-                        DEFAULT_MESSAGE_OPTIONS_MARGIN
+                        R.styleable.MessageListView_streamUiOptionsOverlayEditReactionsMarginStart,
+                        DEFAULT_EDIT_REACTIONS_MARGIN_START
+                    )
+
+                val optionsOverlayEditReactionsMarginEnd =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayEditReactionsMarginEnd,
+                        DEFAULT_EDIT_REACTIONS_MARGIN_END
+                    )
+
+                val optionsOverlayUserReactionsMarginTop =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayUserReactionsMarginTop,
+                        DEFAULT_USER_REACTIONS_MARGIN_TOP
+                    )
+
+                val optionsOverlayUserReactionsMarginBottom =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayUserReactionsMarginBottom,
+                        DEFAULT_USER_REACTIONS_MARGIN_BOTTOM
+                    )
+
+                val optionsOverlayUserReactionsMarginStart =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayUserReactionsMarginStart,
+                        DEFAULT_USER_REACTIONS_MARGIN_START
+                    )
+
+                val optionsOverlayUserReactionsMarginEnd =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayUserReactionsMarginEnd,
+                        DEFAULT_USER_REACTIONS_MARGIN_END
+                    )
+
+                val optionsOverlayMessageOptionsMarginTop =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayMessageOptionsMarginTop,
+                        DEFAULT_MESSAGE_OPTIONS_MARGIN_TOP
+                    )
+
+                val optionsOverlayMessageOptionsMarginBottom =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayMessageOptionsMarginBottom,
+                        DEFAULT_MESSAGE_OPTIONS_MARGIN_BOTTOM
+                    )
+
+                val optionsOverlayMessageOptionsMarginStart =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayMessageOptionsMarginStart,
+                        DEFAULT_MESSAGE_OPTIONS_MARGIN_START
+                    )
+
+                val optionsOverlayMessageOptionsMarginEnd =
+                    attributes.getDimensionPixelSize(
+                        R.styleable.MessageListView_streamUiOptionsOverlayMessageOptionsMarginEnd,
+                        DEFAULT_MESSAGE_OPTIONS_MARGIN_END
                     )
 
                 return MessageListViewStyle(
@@ -650,9 +752,18 @@ constructor(
                     threadMessagesStart = threadMessagesStart,
                     messageOptionsUserReactionAlignment = messageOptionsUserReactionAlignment,
                     disableScrollWhenShowingDialog = disableScrollWhenShowingDialog,
-                    optionsOverlayEditReactionsMargin = optionsOverlayEditReactionsMargin,
-                    optionsOverlayUserReactionsMargin = optionsOverlayUserReactionsMargin,
-                    optionsOverlayMessageOptionsMargin = optionsOverlayMessageOptionsMargin,
+                    optionsOverlayEditReactionsMarginBottom = optionsOverlayEditReactionsMarginBottom,
+                    optionsOverlayEditReactionsMarginTop = optionsOverlayEditReactionsMarginTop,
+                    optionsOverlayEditReactionsMarginStart = optionsOverlayEditReactionsMarginStart,
+                    optionsOverlayEditReactionsMarginEnd = optionsOverlayEditReactionsMarginEnd,
+                    optionsOverlayUserReactionsMarginTop = optionsOverlayUserReactionsMarginTop,
+                    optionsOverlayUserReactionsMarginBottom = optionsOverlayUserReactionsMarginBottom,
+                    optionsOverlayUserReactionsMarginStart = optionsOverlayUserReactionsMarginStart,
+                    optionsOverlayUserReactionsMarginEnd = optionsOverlayUserReactionsMarginEnd,
+                    optionsOverlayMessageOptionsMarginTop = optionsOverlayMessageOptionsMarginTop,
+                    optionsOverlayMessageOptionsMarginBottom = optionsOverlayMessageOptionsMarginBottom,
+                    optionsOverlayMessageOptionsMarginStart = optionsOverlayMessageOptionsMarginStart,
+                    optionsOverlayMessageOptionsMarginEnd = optionsOverlayMessageOptionsMarginEnd,
                 ).let(TransformStyle.messageListStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
@@ -27,7 +27,7 @@ import android.widget.FrameLayout
 import android.widget.LinearLayout
 import androidx.core.view.isVisible
 import androidx.core.view.updateLayoutParams
-import androidx.core.view.updateMargins
+import androidx.core.view.updateMarginsRelative
 import com.getstream.sdk.chat.adapter.MessageListItem
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
@@ -233,7 +233,12 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             }
 
             val params = (layoutParams as ViewGroup.MarginLayoutParams)
-            params.updateMargins(bottom = style.optionsOverlayEditReactionsMargin)
+            params.updateMarginsRelative(
+                bottom = style.optionsOverlayEditReactionsMarginBottom,
+                top = style.optionsOverlayEditReactionsMarginTop,
+                start = style.optionsOverlayEditReactionsMarginStart,
+                end = style.optionsOverlayEditReactionsMarginEnd
+            )
         }
     }
 
@@ -272,7 +277,12 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             }
 
             val params = (layoutParams as ViewGroup.MarginLayoutParams)
-            params.updateMargins(top = style.optionsOverlayUserReactionsMargin)
+            params.updateMarginsRelative(
+                top = style.optionsOverlayUserReactionsMarginTop,
+                bottom = style.optionsOverlayUserReactionsMarginBottom,
+                start = style.optionsOverlayUserReactionsMarginStart,
+                end = style.optionsOverlayUserReactionsMarginEnd
+            )
         }
     }
 
@@ -300,7 +310,12 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
             }
 
             val params = (layoutParams as ViewGroup.MarginLayoutParams)
-            params.updateMargins(top = style.optionsOverlayMessageOptionsMargin)
+            params.updateMarginsRelative(
+                top = style.optionsOverlayMessageOptionsMarginTop,
+                bottom = style.optionsOverlayMessageOptionsMarginBottom,
+                start = style.optionsOverlayMessageOptionsMarginStart,
+                end = style.optionsOverlayMessageOptionsMarginEnd
+            )
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_message_options.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_message_options.xml
@@ -34,7 +34,8 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginHorizontal="@dimen/stream_ui_spacing_small"
+            android:layout_marginStart="@dimen/stream_ui_spacing_small"
+            android:layout_marginEnd="@dimen/stream_ui_spacing_small"
             />
 
         <io.getstream.chat.android.ui.common.internal.TouchInterceptingFrameLayout
@@ -59,7 +60,8 @@
             android:id="@+id/userReactionsView"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginHorizontal="@dimen/stream_ui_spacing_small"
+            android:layout_marginStart="@dimen/stream_ui_spacing_small"
+            android:layout_marginEnd="@dimen/stream_ui_spacing_small"
             android:layout_marginTop="@dimen/stream_ui_spacing_small"
             android:visibility="gone"
             />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -406,7 +406,7 @@
             <flag name="italic" value="2" />
         </attr>
 
-        <!-- Options overly dialog -->
+        <!-- Options overlay dialog -->
         <attr name="streamUiOptionsOverlayDimColor" format="color" />
 
         <!-- Giphy view holder -->
@@ -512,10 +512,26 @@
         <attr name="streamUiDisableScrollWhenShowingDialog" format="boolean" />
 
         <!-- The margin between the selected message and the edit reactions bubble on the options overlay. -->
-        <attr name="streamUiOptionsOverlayEditReactionsMargin" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayEditReactionsMarginBottom" format="dimension|reference" />
+        <!-- The margin between the edit reactions bubble on the options overlay and the parent. -->
+        <attr name="streamUiOptionsOverlayEditReactionsMarginTop" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayEditReactionsMarginStart" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayEditReactionsMarginEnd" format="dimension|reference" />
+
         <!-- The margin between the selected message and the user reaction list on the options overlay. -->
-        <attr name="streamUiOptionsOverlayUserReactionsMargin" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayUserReactionsMarginTop" format="dimension|reference" />
+        <!-- The margin between the message option list and the user reaction list on the options overlay. -->
+        <attr name="streamUiOptionsOverlayUserReactionsMarginBottom" format="dimension|reference" />
+        <!-- The margin between the user reaction list on the options overlay and the parent. -->
+        <attr name="streamUiOptionsOverlayUserReactionsMarginStart" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayUserReactionsMarginEnd" format="dimension|reference" />
+
         <!-- The margin between the selected message and the message option list on the options overlay. -->
-        <attr name="streamUiOptionsOverlayMessageOptionsMargin" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayMessageOptionsMarginTop" format="dimension|reference" />
+        <!-- The margin between the message option list on the options overlay and the parent. -->
+        <attr name="streamUiOptionsOverlayMessageOptionsMarginBottom" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayMessageOptionsMarginStart" format="dimension|reference" />
+        <attr name="streamUiOptionsOverlayMessageOptionsMarginEnd" format="dimension|reference" />
+
     </declare-styleable>
 </resources>


### PR DESCRIPTION
### 🎯 Goal

It's not possible to customize our View margins in the MessageOptionsDialog, but we have customers who need this API. Fixes #4238.

### 🛠 Implementation details

Added all four sets of margins rather than just one that was exposed. Renamed the existing to proper names rather than 

### 🎨 UI Changes

These Before/After should be the same - no changes in the design, we've only changed the internal API and what we expose.

| Before | After |
| --- | --- |
| ![before](https://user-images.githubusercontent.com/17215808/194039120-42277b7f-4aba-4b8b-a711-27dbdc6e93dc.png) | ![after](https://user-images.githubusercontent.com/17215808/194039143-4f12a31c-0292-4e81-a763-c80d1c7f51bc.png) |

Customizing the options can be seen here:

| No margins | Large margins |
| --- | --- |
| ![margins2](https://user-images.githubusercontent.com/17215808/194039376-18665792-53ea-4173-af7e-9f7501deb0d1.png) | ![largemargin](https://user-images.githubusercontent.com/17215808/194040425-83f1d129-3644-4823-b698-3ca54b73bba0.png) |


### 🧪 Testing

There are a few patches here. We also tested with 7 (2 new hardcoded) reactions, to expand the reactions view and stress test the anchoring.

Apply the first patch to completely remove all possible margins from these views (except from inherent anchoring).

<details>

<summary>Removing all margins</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt	(date 1664964217724)
@@ -62,7 +62,7 @@
     }
 
     private var bubbleHeight: Int = 0
-    private var reactionsColumns: Int = 5
+    private var reactionsColumns: Int = 7
 
     public fun setMessage(message: Message, isMyMessage: Boolean) {
         this.isMyMessage = isMyMessage
@@ -110,7 +110,7 @@
         this.reactionsViewStyle = editReactionsViewStyle
         this.bubbleDrawer = EditReactionsBubbleDrawer(reactionsViewStyle)
 
-        reactionsColumns = minOf(ChatUI.supportedReactions.reactions.size, editReactionsViewStyle.reactionsColumn)
+        reactionsColumns = 7 // minOf(ChatUI.supportedReactions.reactions.size, editReactionsViewStyle.reactionsColumn)
         setPadding(
             reactionsViewStyle.horizontalPadding,
             reactionsViewStyle.verticalPadding,
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1664962843814)
@@ -42,6 +42,18 @@
         app:streamUiFlagMessageConfirmationEnabled="true"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="true"
+        app:streamUiOptionsOverlayEditReactionsMarginTop="0dp"
+        app:streamUiOptionsOverlayEditReactionsMarginBottom="0dp"
+        app:streamUiOptionsOverlayEditReactionsMarginStart="0dp"
+        app:streamUiOptionsOverlayEditReactionsMarginEnd="0dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginTop="0dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginBottom="0dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginStart="0dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginEnd="0dp"
+        app:streamUiOptionsOverlayUserReactionsMarginTop="0dp"
+        app:streamUiOptionsOverlayUserReactionsMarginBottom="0dp"
+        app:streamUiOptionsOverlayUserReactionsMarginStart="0dp"
+        app:streamUiOptionsOverlayUserReactionsMarginEnd="0dp"
         />
 
     <FrameLayout
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt	(date 1664963669554)
@@ -47,6 +47,8 @@
         THUMBS_DOWN to thumbsDownDrawable(context),
         LOL to lolDrawable(context),
         WUT to wutDrawable(context),
+        "WUT2" to wutDrawable(context),
+        "WUT3" to wutDrawable(context),
     ),
 ) {
     public val types: List<String> = reactions.keys.toList()

```

</details>

For the second patch, we're testing increasing margins to a large value to push the UI more.

<details>

<summary>Adding large margins</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/reactions/edit/internal/EditReactionsView.kt	(date 1664964217724)
@@ -62,7 +62,7 @@
     }
 
     private var bubbleHeight: Int = 0
-    private var reactionsColumns: Int = 5
+    private var reactionsColumns: Int = 7
 
     public fun setMessage(message: Message, isMyMessage: Boolean) {
         this.isMyMessage = isMyMessage
@@ -110,7 +110,7 @@
         this.reactionsViewStyle = editReactionsViewStyle
         this.bubbleDrawer = EditReactionsBubbleDrawer(reactionsViewStyle)
 
-        reactionsColumns = minOf(ChatUI.supportedReactions.reactions.size, editReactionsViewStyle.reactionsColumn)
+        reactionsColumns = 7 // minOf(ChatUI.supportedReactions.reactions.size, editReactionsViewStyle.reactionsColumn)
         setPadding(
             reactionsViewStyle.horizontalPadding,
             reactionsViewStyle.verticalPadding,
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1664962843814)
@@ -42,6 +42,18 @@
         app:streamUiFlagMessageConfirmationEnabled="true"
         app:streamUiMuteUserEnabled="false"
         app:streamUiPinMessageEnabled="true"
+        app:streamUiOptionsOverlayEditReactionsMarginTop="32dp"
+        app:streamUiOptionsOverlayEditReactionsMarginBottom="32dp"
+        app:streamUiOptionsOverlayEditReactionsMarginStart="32dp"
+        app:streamUiOptionsOverlayEditReactionsMarginEnd="32dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginTop="32dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginBottom="32dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginStart="32dp"
+        app:streamUiOptionsOverlayMessageOptionsMarginEnd="32dp"
+        app:streamUiOptionsOverlayUserReactionsMarginTop="32dp"
+        app:streamUiOptionsOverlayUserReactionsMarginBottom="32dp"
+        app:streamUiOptionsOverlayUserReactionsMarginStart="32dp"
+        app:streamUiOptionsOverlayUserReactionsMarginEnd="32dp"
         />
 
     <FrameLayout
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt	(revision 4ba99ac13cac41a0b125e431d612b095cea08a93)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/SupportedReactions.kt	(date 1664963669554)
@@ -47,6 +47,8 @@
         THUMBS_DOWN to thumbsDownDrawable(context),
         LOL to lolDrawable(context),
         WUT to wutDrawable(context),
+        "WUT2" to wutDrawable(context),
+        "WUT3" to wutDrawable(context),
     ),
 ) {
     public val types: List<String> = reactions.keys.toList()

```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch (pushing to v5, will cherry pick from it)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs