### PR TITLE
[V5 ISSUE-4245] Alignment for reaction with custom view holders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed displaying messages with failed image attachments. [#4234](https://github.com/GetStream/stream-chat-android/pull/4234)
-- Fixes problem when alligning reactions ballon for custom ViewHolders in message options dialog. [#4246](https://github.com/GetStream/stream-chat-android/pull/4246)
+- Fixes problem when alligning reactions ballon for custom ViewHolders in message options dialog. [#4248](https://github.com/GetStream/stream-chat-android/pull/4248)
 
 ### ⬆️ Improved
 - Improved asking for `WRITE_EXTERNAL_STORAGE` permission. The permission won't be requested starting from Android Q unless legacy external storage is requested. [#4219](https://github.com/GetStream/stream-chat-android/pull/4219)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed displaying messages with failed image attachments. [#4234](https://github.com/GetStream/stream-chat-android/pull/4234)
+- Fixes problem when alligning reactions ballon for custom ViewHolders in message options dialog. [#4246](https://github.com/GetStream/stream-chat-android/pull/4246)
 
 ### ⬆️ Improved
 - Improved asking for `WRITE_EXTERNAL_STORAGE` permission. The permission won't be requested starting from Android Q unless legacy external storage is requested. [#4219](https://github.com/GetStream/stream-chat-android/pull/4219)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -3233,6 +3233,7 @@ public abstract class io/getstream/chat/android/ui/message/list/adapter/BaseMess
 	public abstract fun bindData (Lcom/getstream/sdk/chat/adapter/MessageListItem;Lio/getstream/chat/android/ui/message/list/adapter/MessageListItemPayloadDiff;)V
 	protected final fun getContext ()Landroid/content/Context;
 	protected final fun getData ()Lcom/getstream/sdk/chat/adapter/MessageListItem;
+	public fun messageContainerView ()Landroid/view/View;
 	public fun onAttachedToWindow ()V
 	public fun onDetachedFromWindow ()V
 	public fun unbind ()V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/BaseMessageItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/BaseMessageItemViewHolder.kt
@@ -38,6 +38,10 @@ public abstract class BaseMessageItemViewHolder<T : MessageListItem>(
 
     private var highlightAnimation: ValueAnimator? = null
 
+    public open fun messageContainerView(): View? {
+        return null
+    }
+
     /**
      * Workaround to allow a downcast of the MessageListItem to T.
      */

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/CustomAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/CustomAttachmentsViewHolder.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
@@ -67,6 +68,8 @@ internal class CustomAttachmentsViewHolder(
         initializeListeners()
         setLinkMovementMethod()
     }
+
+    override fun messageContainerView(): View = binding.messageContainer
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         super.bindData(data, diff)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/FileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/FileAttachmentsViewHolder.kt
@@ -71,6 +71,8 @@ internal class FileAttachmentsViewHolder(
         binding.fileAttachmentsView.setPadding(4.dpToPx())
     }
 
+    override fun messageContainerView(): View = binding.messageContainer
+
     /**
      * Binds the data to the view.
      */

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyAttachmentViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/GiphyAttachmentViewHolder.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
@@ -59,6 +60,8 @@ internal class GiphyAttachmentViewHolder(
     init {
         initializeListeners()
     }
+
+    override fun messageContainerView(): View = binding.messageContainer
 
     /**
      * Initializes listeners that enable handling clicks on various

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/ImageAttachmentViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/ImageAttachmentViewHolder.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.isVisible
@@ -64,6 +65,8 @@ internal class ImageAttachmentViewHolder(
         initializeListeners()
         setLinkMovementMethod()
     }
+
+    override fun messageContainerView(): View = binding.messageContainer
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         super.bindData(data, diff)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/LinkAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/LinkAttachmentsViewHolder.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.updateLayoutParams
@@ -62,6 +63,8 @@ internal class LinkAttachmentsViewHolder(
         initializeListeners()
         setLinkMovementMethod()
     }
+
+    override fun messageContainerView(): View = binding.messageContainer
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         super.bindData(data, diff)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/viewholder/internal/MessagePlainTextViewHolder.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.message.list.adapter.viewholder.internal
 
+import android.view.View
 import android.view.ViewGroup
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.view.updateLayoutParams
@@ -69,6 +70,8 @@ internal class MessagePlainTextViewHolder(
             }
         }
     }
+
+    override fun messageContainerView(): View = binding.messageContainer
 
     override fun bindData(data: MessageListItem.MessageItem, diff: MessageListItemPayloadDiff?) {
         super.bindData(data, diff)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
@@ -49,12 +49,6 @@ import io.getstream.chat.android.ui.message.list.adapter.internal.MessageListIte
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.attachment.AttachmentFactoryManager
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.decorator.internal.Decorator
 import io.getstream.chat.android.ui.message.list.adapter.viewholder.decorator.internal.DecoratorProvider
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.CustomAttachmentsViewHolder
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.FileAttachmentsViewHolder
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.GiphyAttachmentViewHolder
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.ImageAttachmentViewHolder
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.LinkAttachmentsViewHolder
-import io.getstream.chat.android.ui.message.list.adapter.viewholder.internal.MessagePlainTextViewHolder
 import io.getstream.chat.android.ui.message.list.background.MessageBackgroundFactory
 import io.getstream.chat.android.ui.message.list.background.MessageBackgroundFactoryImpl
 import io.getstream.chat.android.ui.message.list.options.message.internal.MessageOptionsDecoratorProvider
@@ -311,15 +305,7 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         val reactionsWidth = requireContext().getDimension(R.dimen.stream_ui_edit_reactions_total_width)
         val reactionsOffset = requireContext().getDimension(R.dimen.stream_ui_edit_reactions_horizontal_offset)
 
-        when (val viewHolder = viewHolder) {
-            is MessagePlainTextViewHolder -> viewHolder.binding.messageContainer
-            is CustomAttachmentsViewHolder -> viewHolder.binding.messageContainer
-            is LinkAttachmentsViewHolder -> viewHolder.binding.messageContainer
-            is FileAttachmentsViewHolder -> viewHolder.binding.messageContainer
-            is GiphyAttachmentViewHolder -> viewHolder.binding.messageContainer
-            is ImageAttachmentViewHolder -> viewHolder.binding.messageContainer
-            else -> null
-        }?.addOnLayoutChangeListener { _, left, _, right, _, _, _, _, _ ->
+        viewHolder.messageContainerView()?.addOnLayoutChangeListener { _, left, _, right, _, _, _, _, _ ->
             with(binding) {
                 val maxTranslation = messageContainer.width / 2 - reactionsWidth / 2
                 editReactionsView.translationX = if (messageItem.isMine) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
@@ -305,16 +305,17 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         val reactionsWidth = requireContext().getDimension(R.dimen.stream_ui_edit_reactions_total_width)
         val reactionsOffset = requireContext().getDimension(R.dimen.stream_ui_edit_reactions_horizontal_offset)
 
-        viewHolder.messageContainerView()?.addOnLayoutChangeListener { _, left, _, right, _, _, _, _, _ ->
-            with(binding) {
-                val maxTranslation = messageContainer.width / 2 - reactionsWidth / 2
-                editReactionsView.translationX = if (messageItem.isMine) {
-                    left - messageContainer.width / 2 - reactionsOffset
-                } else {
-                    right - messageContainer.width / 2 + reactionsOffset
-                }.coerceIn(-maxTranslation, maxTranslation).toFloat()
+        viewHolder.messageContainerView()
+            ?.addOnLayoutChangeListener { _, left, _, right, _, _, _, _, _ ->
+                with(binding) {
+                    val maxTranslation = messageContainer.width / 2 - reactionsWidth / 2
+                    editReactionsView.translationX = if (messageItem.isMine) {
+                        left - messageContainer.width / 2 - reactionsOffset
+                    } else {
+                        right - messageContainer.width / 2 + reactionsOffset
+                    }.coerceIn(-maxTranslation, maxTranslation).toFloat()
+                }
             }
-        }
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Align reactions ballon in message options dialog even when using a custom view holder for the messages.

### 🛠 Implementation details

Now implementations of `BaseMessageItemViewHolder` can provide the message container. 

### 🎨 UI Changes

| Before (with custom ViewHolder) | After (with custom ViewHolder)|
| --- | --- |
| ![Screenshot_20221005-180745](https://user-images.githubusercontent.com/10619102/194165204-14001e53-8758-4f2f-a836-174a706644a5.png) | ![Screenshot_20221005-180822](https://user-images.githubusercontent.com/10619102/194165221-4d0d7201-43f5-491f-b7b9-49308d543a3b.png) |
| ![Screenshot_20221005-180750](https://user-images.githubusercontent.com/10619102/194165213-4c272d2f-fa7d-41ac-9a28-f8173f222ea9.png)  | ![Screenshot_20221005-180827](https://user-images.githubusercontent.com/10619102/194165229-89cca389-7bbb-4ea4-9e58-646ce2969a7e.png) |

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
index 006c18ef4d..869637d349 100644
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
@@ -312,7 +312,6 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
         val reactionsOffset = requireContext().getDimension(R.dimen.stream_ui_edit_reactions_horizontal_offset)

         when (val viewHolder = viewHolder) {
-            is MessagePlainTextViewHolder -> viewHolder.binding.messageContainer
             is CustomAttachmentsViewHolder -> viewHolder.binding.messageContainer
             is LinkAttachmentsViewHolder -> viewHolder.binding.messageContainer
             is FileAttachmentsViewHolder -> viewHolder.binding.messageContainer
(END)
```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/194169141-d33d3d0f-29d6-44d6-95ae-2876623228d4.gif)

