### PR TITLE
[53] Link guides to the guides app in the main repo

### DIFF
--- a/docusaurus/docs/Android/02-client/06-guides/04-handling-user-connection.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/04-handling-user-connection.mdx
@@ -49,7 +49,7 @@ ChatClient.instance().disconnect(flushPersistence = false).enqueue { result ->
 ```
 
 Note that the `disconnect` method has an additional parameter that allows you to clear the database when using offline storage.
-For more information about working with offline mode see [Offline Support](../02-client/06-guides/06-offline-support.mdx)
+For more information about working with offline mode see [Offline Support](../../02-client/06-guides/06-offline-support.mdx)
 
 ## Switching the User
 

--- a/docusaurus/docs/Android/03-ui/06-guides/08-adding-custom-attachments-message-input.mdx
+++ b/docusaurus/docs/Android/03-ui/06-guides/08-adding-custom-attachments-message-input.mdx
@@ -13,7 +13,7 @@ This involves the following steps:
 :::note
 In this guide, we'll show only the main points concerning custom attachments. Smaller parts will be omitted for the sake of being concise.
 
-You can find the full code from this guide on [GitHub](https://github.com/GetStream/Android-Samples/tree/main/custom-attachments-message-input).
+You can find the full code from this guide on [GitHub](https://github.com/GetStream/stream-chat-android/tree/main/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/uicomponents/customattachments/input). To check the final result, clone the repository and run the `stream-chat-android-ui-guides` module.
 :::
 
 ## Sending Date Attachments

--- a/docusaurus/docs/Android/03-ui/06-guides/09-adding-custom-attachments-message-composer.mdx
+++ b/docusaurus/docs/Android/03-ui/06-guides/09-adding-custom-attachments-message-composer.mdx
@@ -17,7 +17,7 @@ This involves the following steps:
 :::note
 In this guide, we'll show only the main points concerning custom attachments. Smaller parts will be omitted for the sake of being concise.
 
-You can find the full code from this guide on [GitHub](https://github.com/GetStream/Android-Samples/tree/main/custom-attachments-message-composer).
+You can find the full code from this guide on [GitHub](https://github.com/GetStream/stream-chat-android/tree/main/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/uicomponents/customattachments/composer). To check the final result, clone the repository and run the `stream-chat-android-ui-guides` module.
 :::
 
 ## Sending Date Attachments

--- a/docusaurus/docs/Android/04-compose/07-guides/01-adding-custom-attachments.mdx
+++ b/docusaurus/docs/Android/04-compose/07-guides/01-adding-custom-attachments.mdx
@@ -13,7 +13,7 @@ This involves doing the following steps:
 :::note
 In this guide, we'll show only the main points concerning custom attachments and their factories. Smaller parts will be omitted for the sake of being concise.
 
-You can find the full code from this guide on [GitHub](https://github.com/GetStream/Android-Samples/tree/main/compose-custom-attachments).
+You can find the full code from this guide on [GitHub](https://github.com/GetStream/stream-chat-android/tree/main/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customattachments). To check the final result, clone the repository and run the `stream-chat-android-ui-guides` module.
 :::
 
 ## Sending Date Attachments


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/android-internal-board/issues/53

Remove the links to the guides from the Android-Samples repo as they will be removed:
- https://github.com/GetStream/Android-Samples/tree/main/compose-custom-attachments
- https://github.com/GetStream/Android-Samples/tree/main/custom-attachments-message-composer
- https://github.com/GetStream/Android-Samples/tree/main/custom-attachments-message-input

### 🛠 Implementation details

Linked the guides to the guides catalog app from the main repo (`stream-chat-android-ui-guides`). 

### 🧪 Testing

1. Run the docs by executing `npx stream-chat-docusaurus -i -s`
2. Ensure that the updated content is displayed correctly

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
