### PR TITLE
Update actions/setup-java to version 3.6.0

### DIFF
--- a/.github/workflows/apk-s3-distribute.yml
+++ b/.github/workflows/apk-s3-distribute.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -47,7 +47,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt 
           java-version: 11
@@ -67,7 +67,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -87,7 +87,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -40,7 +40,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -57,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -74,7 +74,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: release
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-record.yaml
+++ b/.github/workflows/snapshot-record.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11


### PR DESCRIPTION
### 🎯 Goal
Update `action/setup-java` gh-action to version 3.6.0 that replace some internal methods that are deprecated in the previous version.
Related PR: #4278
Fix: #4279

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/TJbEBUJMLEjDhah2cK/giphy-downsized.gif)
