### PR TITLE
Upgrade runners and gh actions

### DIFF
--- a/.github/actions/gradle-cache/action.yml
+++ b/.github/actions/gradle-cache/action.yml
@@ -7,7 +7,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3.0.11
       with:
         path: |
           ~/.gradle/caches

--- a/.github/workflows/apk-s3-distribute.yml
+++ b/.github/workflows/apk-s3-distribute.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build_ui_components_sample_app:
     name: Build and push to S3
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/apk-s3-distribute.yml
+++ b/.github/workflows/apk-s3-distribute.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and push to S3
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/apk-s3-distribute.yml
+++ b/.github/workflows/apk-s3-distribute.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/apk-s3-distribute.yml
+++ b/.github/workflows/apk-s3-distribute.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Assemble
         run: bash ./gradlew :stream-chat-android-ui-components-sample:assembleDemoRelease --stacktrace
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: stream-chat-android-ui-components-sample-release
           path: stream-chat-android-ui-components-sample/build/outputs/apk/demo/release/
@@ -60,7 +60,7 @@ jobs:
       - name: Assemble
         run: bash ./gradlew :stream-chat-android-compose-sample:assembleRelease --stacktrace
       - name: Upload APK
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: stream-chat-android-compose-sample-release
           path: stream-chat-android-compose-sample/build/outputs/apk/release/

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build_ui_components_sample_app:
     name: Build and Distribute UI Components Sample App
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -42,7 +42,7 @@ jobs:
 
   build_compose_sample_app:
     name: Build and Distribute Compose Sample App
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -12,7 +12,7 @@ jobs:
     name: Build and Distribute UI Components Sample App
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -44,7 +44,7 @@ jobs:
     name: Build and Distribute Compose Sample App
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/app-distribute.yml
+++ b/.github/workflows/app-distribute.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -46,7 +46,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -85,7 +85,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -47,7 +47,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt 
           java-version: 11
@@ -67,7 +67,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -87,7 +87,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -47,7 +47,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt 
           java-version: 11
@@ -67,7 +67,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -87,7 +87,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   debug_build:
     name: Debug build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
 
   release_build:
     name: Release build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -42,7 +42,7 @@ jobs:
 
   tests:
     name: Tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -62,7 +62,7 @@ jobs:
 
   size_check_xml:
     name: Size Check XML
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
           
   size_check_compose:
     name: Size Check Compose
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Unit tests
         run: ./scripts/ci-unit-tests.sh
       - name: Upload testDebugUnitTest results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         if: failure()
         with:
           name: testDebugUnitTest

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 0
       - name: Set up JDK 11

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/clean-detekt-baseline.yaml
+++ b/.github/workflows/clean-detekt-baseline.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   clean_detekt_baseline_files:
     name: Clean Detekt Baseline Files
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/clean-detekt-baseline.yaml
+++ b/.github/workflows/clean-detekt-baseline.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: develop
           token: ${{ secrets.STREAM_PUBLIC_BOT_TOKEN }}

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -10,7 +10,7 @@ jobs:
     name: Publish docusaurus docs
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push_docusaurus:
     name: Publish docusaurus docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/localazy-download.yml
+++ b/.github/workflows/localazy-download.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   localazy-download:
     name: Download strings from Localazy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/localazy-download.yml
+++ b/.github/workflows/localazy-download.yml
@@ -10,7 +10,7 @@ jobs:
     name: Download strings from Localazy
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v3.1.0
         with:
           ref: develop
       - uses: localazy/download@v1

--- a/.github/workflows/localazy-upload.yml
+++ b/.github/workflows/localazy-upload.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   localazy-upload:
     name: Upload strings to Localazy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v1
       - uses: localazy/upload@v1

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   noResponse:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -40,7 +40,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -57,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -74,7 +74,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -40,7 +40,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -57,7 +57,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -74,7 +74,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   lint:
     name: ktlint
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -35,7 +35,7 @@ jobs:
 
   api_check:
     name: API check
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -52,7 +52,7 @@ jobs:
 
   debug_build:
     name: Debug build
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2
@@ -69,7 +69,7 @@ jobs:
 
   test:
     name: Unit tests
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -55,7 +55,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Unit tests
         run: ./scripts/ci-unit-tests.sh
       - name: Upload testDebugUnitTest results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         if: failure()
         with:
           name: testDebugUnitTest

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/publish-hotfix.yml
+++ b/.github/workflows/publish-hotfix.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v2
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: Snapshot build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v2

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
       - name: Set up JDK 11
         uses: actions/setup-java@v3.5.1
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: release
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           ref: release
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Release build and publish
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: release
       - name: Set up JDK 11

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish_dokka:
     name: Dokka docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -29,7 +29,7 @@ jobs:
           publish_branch: gh-pages
   push_docusaurus:
     name: Publish docusaurus docs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: main
       - name: Set up JDK 11
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: main
       - name: Set up JDK 11

--- a/.github/workflows/release-docs.yaml
+++ b/.github/workflows/release-docs.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11
@@ -36,7 +36,7 @@ jobs:
         with:
           ref: main
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/release-post.yaml
+++ b/.github/workflows/release-post.yaml
@@ -13,7 +13,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps: 
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: main
       - name: Sync main
@@ -31,7 +31,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: release
       - name: Update changelog

--- a/.github/workflows/release-post.yaml
+++ b/.github/workflows/release-post.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   release_to_main:
     name: Sync main with release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps: 
       - name: Check out code
@@ -27,7 +27,7 @@ jobs:
           branch: main
   update_changelog:
     name: Update Changelog - Model
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Check out code

--- a/.github/workflows/release-start-test.yaml
+++ b/.github/workflows/release-start-test.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   start_release:
     name: Start Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: 'publish'
     steps:
       - name: Check out code

--- a/.github/workflows/release-start-test.yaml
+++ b/.github/workflows/release-start-test.yaml
@@ -19,7 +19,7 @@ jobs:
     environment: 'publish'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: release-test
       - name: Minor version bump

--- a/.github/workflows/release-start.yaml
+++ b/.github/workflows/release-start.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   start_release:
     name: Start Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: 'publish'
     steps:
       - name: Check out code

--- a/.github/workflows/release-start.yaml
+++ b/.github/workflows/release-start.yaml
@@ -19,7 +19,7 @@ jobs:
     environment: 'publish'
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v3.1.0
         with:
           ref: release
       - name: Minor version bump

--- a/.github/workflows/snapshot-record.yaml
+++ b/.github/workflows/snapshot-record.yaml
@@ -29,7 +29,7 @@ jobs:
           emulator-options: -no-snapshot-save -no-window -no-audio -no-boot-anim -gpu swiftshader_indirect -camera-back none -camera-front none
           script: ./gradlew stream-chat-android-ui-uitests:executeScreenshotTests -Precord -Pandroid.testInstrumentationRunnerArguments.filter=io.getstream.chat.android.uitests.util.SnapshotTestFilter
       - name: Upload screnshots
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: screenshots
           path: ${{ github.workspace }}/stream-chat-android-ui-uitests/screenshots/

--- a/.github/workflows/snapshot-record.yaml
+++ b/.github/workflows/snapshot-record.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           ref: develop
       - name: Set up JDK 11

--- a/.github/workflows/snapshot-record.yaml
+++ b/.github/workflows/snapshot-record.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-record.yaml
+++ b/.github/workflows/snapshot-record.yaml
@@ -12,7 +12,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.5.1
+        uses: actions/setup-java@v3.6.0
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -16,7 +16,7 @@ jobs:
         with:
           ref: develop
       - name: Set up JDK 11
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3.5.1
         with:
           distribution: adopt
           java-version: 11

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           script: ./gradlew stream-chat-android-ui-uitests:executeScreenshotTests -Pandroid.testInstrumentationRunnerArguments.filter=io.getstream.chat.android.uitests.util.SnapshotTestFilter
       - name: Upload screnshot results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3.1.0
         with:
           name: screenshots_reports
           path: ${{ github.workspace }}/stream-chat-android-ui-uitests/build/reports/*

--- a/.github/workflows/snapshot-tests.yaml
+++ b/.github/workflows/snapshot-tests.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
         with:
           ref: develop
       - name: Set up JDK 11


### PR DESCRIPTION
### 🎯 Goal
Update Ubuntu Runners Version to 22.04, previous one will be deprecated at the end of this year.
Actions has been upgraded as well to the last version to avoid some Warning Messages:
-. actions/cache@v3.0.11
-. actions/setup-java@v3.6.0
-. actions/checkout@v3.1.0
-. actions/upload-artifact@v3.1.0

This PR cherry-pick behavior from `develop` branch to our `v5` branch


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the ~`develop`~ `v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/TlK63EA6F1qRb7lll6M/giphy.gif)
