### PR TITLE
Fix HttpLoggingInterceptor crash

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2738,6 +2738,11 @@ public final class io/getstream/chat/android/client/models/ConnectionState : jav
 	public static fun values ()[Lio/getstream/chat/android/client/models/ConnectionState;
 }
 
+public final class io/getstream/chat/android/client/models/Constants {
+	public static final field INSTANCE Lio/getstream/chat/android/client/models/Constants;
+	public static final field MB_IN_BYTES J
+}
+
 public final class io/getstream/chat/android/client/models/ContentUtils {
 	public static final fun getInitials (Lio/getstream/chat/android/client/models/Channel;)Ljava/lang/String;
 	public static final fun getInitials (Lio/getstream/chat/android/client/models/User;)Ljava/lang/String;

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2738,11 +2738,6 @@ public final class io/getstream/chat/android/client/models/ConnectionState : jav
 	public static fun values ()[Lio/getstream/chat/android/client/models/ConnectionState;
 }
 
-public final class io/getstream/chat/android/client/models/Constants {
-	public static final field INSTANCE Lio/getstream/chat/android/client/models/Constants;
-	public static final field MB_IN_BYTES J
-}
-
 public final class io/getstream/chat/android/client/models/ContentUtils {
 	public static final fun getInitials (Lio/getstream/chat/android/client/models/Channel;)Ljava/lang/String;
 	public static final fun getInitials (Lio/getstream/chat/android/client/models/User;)Ljava/lang/String;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Constants.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Constants.kt
@@ -16,9 +16,12 @@
 
 package io.getstream.chat.android.client.models
 
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
 /**
  * Represents constants used across all SDKs.
  */
+@InternalStreamChatApi
 public object Constants {
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Constants.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Constants.kt
@@ -14,29 +14,20 @@
  * limitations under the License.
  */
 
-package com.getstream.sdk.chat.utils
-
-import io.getstream.chat.android.client.models.Constants
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
+package io.getstream.chat.android.client.models
 
 /**
- * Various constants regarding default attachment limits.
+ * Represents constants used across all SDKs.
  */
-@InternalStreamChatApi
-public object AttachmentConstants {
+public object Constants {
 
     /**
-     * Default max upload size in MB.
+     * Number of bytes in a megabyte.
      */
-    public const val MAX_UPLOAD_SIZE_IN_MB: Int = 100
+    public const val MB_IN_BYTES: Long = 1024 * 1024
 
     /**
-     * Default max upload size in bytes.
+     * Maximum request body length in bytes.
      */
-    public const val MAX_UPLOAD_FILE_SIZE: Long = Constants.MB_IN_BYTES * MAX_UPLOAD_SIZE_IN_MB
-
-    /**
-     * Default max number of attachments.
-     */
-    public const val MAX_ATTACHMENTS_COUNT: Int = 10
+    internal const val MAX_REQUEST_BODY_LENGTH = 1 * MB_IN_BYTES
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/internal/MessageInputFieldView.kt
@@ -33,6 +33,7 @@ import com.getstream.sdk.chat.utils.StorageHelper
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Attachment
 import io.getstream.chat.android.client.models.Command
+import io.getstream.chat.android.client.models.Constants
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
@@ -191,7 +192,7 @@ internal class MessageInputFieldView : FrameLayout {
      * in Stream's backend.
      */
     fun setAttachmentMaxFileMb(size: Int) {
-        attachmentMaxFileSize = size * AttachmentConstants.MB_IN_BYTES
+        attachmentMaxFileSize = size * Constants.MB_IN_BYTES
 
         selectedFileAttachmentAdapter.attachmentMaxFileSize = attachmentMaxFileSize
         selectedMediaAttachmentAdapter.attachmentMaxFileSize = attachmentMaxFileSize


### PR DESCRIPTION
### 🎯 Goal

Fix `HttpLoggingInterceptor` crash.

### 🛠 Implementation details

Added a limit for writing/reading from the buffer. Now we are not going to log request bodies of more than 1MB.

### 🧪 Testing

Send a big attachment (> 30MB).


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] All code we touched has new or updated KDocs
