### PR TITLE
[4305] Fix UI tests

### DIFF
--- a/stream-chat-android-ui-uitests/build.gradle
+++ b/stream-chat-android-ui-uitests/build.gradle
@@ -103,6 +103,7 @@ dependencies {
     androidTestImplementation Dependencies.composeUiTestManifest
     androidTestImplementation Dependencies.testParameterInjector
     androidTestImplementation Dependencies.okhttpMockWebserver
+    androidTestImplementation Dependencies.threeTenBp
 
     detektPlugins(Dependencies.detektFormatting)
 }

--- a/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/util/TestData.kt
+++ b/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/util/TestData.kt
@@ -124,28 +124,24 @@ object TestData {
     fun channel1() = Channel().apply {
         type = "messaging"
         id = "channel1"
-        cid = "messaging:channel1"
         unreadCount = 0
     }
 
     fun channel2() = Channel().apply {
         type = "messaging"
         id = "channel2"
-        cid = "messaging:channel2"
         unreadCount = 0
     }
 
     fun channel3() = Channel().apply {
         type = "messaging"
         id = "channel3"
-        cid = "messaging:channel3"
         unreadCount = 0
     }
 
     fun channel4() = Channel().apply {
         type = "messaging"
         id = "channel4"
-        cid = "messaging:channel4"
         unreadCount = 0
     }
 


### PR DESCRIPTION
### 🎯 Goal

https://github.com/GetStream/stream-chat-android/issues/4305

Fix compilation error in UI tests introduced after ThreeTenABP dependency was removed from the main source set. 

### 🧪 Testing

Execute `./gradlew stream-chat-android-ui-uitests:assembleDebugAndroidTest` and verify that the code compiles.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
