### PR TITLE
[4326] Fix text color in quoted messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-- Added `ownMessageQuotedBackground`, `otherMessageQuotedBackground`, `ownMessageQuotedText` and `otherMessageQuotedText` options to `StreamColors`, to make it possible to customize the appearance of quoted message via `ChatTheme`. [#4335](https://github.com/GetStream/stream-chat-android/pull/4335)
+- Added `ownMessageQuotedBackground`, `otherMessageQuotedBackground`, `ownMessageQuotedText` and `otherMessageQuotedText` options to `StreamColors`, to make it possible to customize the appearance of quoted messages via `ChatTheme`. [#4335](https://github.com/GetStream/stream-chat-android/pull/4335)
 
 ### ⚠️ Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `ownMessageQuotedBackground`, `otherMessageQuotedBackground`, `ownMessageQuotedText` and `otherMessageQuotedText` options to `StreamColors`, to make it possible to customize the appearance of quoted message via `ChatTheme`. [#4335](https://github.com/GetStream/stream-chat-android/pull/4335)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1044,10 +1044,8 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Comp
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$QuotedMessageContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$QuotedMessageContentKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$QuotedMessageKt {
@@ -1111,7 +1109,7 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Quot
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/QuotedMessageTextKt {
-	public static final fun QuotedMessageText (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;ILandroidx/compose/runtime/Composer;II)V
+	public static final fun QuotedMessageText (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/client/models/Message;ILandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ThreadParticipantsKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1053,12 +1053,10 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Comp
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$QuotedMessageKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$QuotedMessageKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function3;
-	public static field lambda-2 Lkotlin/jvm/functions/Function4;
-	public static field lambda-3 Lkotlin/jvm/functions/Function3;
+	public static field lambda-2 Lkotlin/jvm/functions/Function3;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-3$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContentKt {
@@ -1104,12 +1102,12 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Owne
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContentKt {
-	public static final fun QuotedMessageContent (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun QuotedMessageContent (Lio/getstream/chat/android/client/models/Message;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/QuotedMessageKt {
-	public static final fun DefaultQuotedMessageCenterContent (Landroidx/compose/foundation/layout/RowScope;Lio/getstream/chat/android/client/models/Message;Landroidx/compose/runtime/Composer;I)V
-	public static final fun QuotedMessage (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun DefaultQuotedMessageCenterContent (Landroidx/compose/foundation/layout/RowScope;Lio/getstream/chat/android/client/models/Message;Lio/getstream/chat/android/client/models/Message;Landroidx/compose/runtime/Composer;II)V
+	public static final fun QuotedMessage (Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/client/models/Message;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/QuotedMessageTextKt {
@@ -1472,8 +1470,8 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamColors$Companion;
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
@@ -1489,6 +1487,10 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component20-0d7_KjU ()J
 	public final fun component21-0d7_KjU ()J
 	public final fun component22-0d7_KjU ()J
+	public final fun component23-0d7_KjU ()J
+	public final fun component24-0d7_KjU ()J
+	public final fun component25-0d7_KjU ()J
+	public final fun component26-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
 	public final fun component4-0d7_KjU ()J
 	public final fun component5-0d7_KjU ()J
@@ -1496,8 +1498,8 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component7-0d7_KjU ()J
 	public final fun component8-0d7_KjU ()J
 	public final fun component9-0d7_KjU ()J
-	public final fun copy-0VcbP8k (JJJJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
-	public static synthetic fun copy-0VcbP8k$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public final fun copy-CRp9MJE (JJJJJJJJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public static synthetic fun copy-CRp9MJE$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJJJJJJJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAppBackground-0d7_KjU ()J
 	public final fun getBarsBackground-0d7_KjU ()J
@@ -1510,10 +1512,14 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun getInfoAccent-0d7_KjU ()J
 	public final fun getInputBackground-0d7_KjU ()J
 	public final fun getLinkBackground-0d7_KjU ()J
+	public final fun getOtherMessageQuotedBackground-0d7_KjU ()J
+	public final fun getOtherMessageQuotedText-0d7_KjU ()J
 	public final fun getOtherMessageText-0d7_KjU ()J
 	public final fun getOtherMessagesBackground-0d7_KjU ()J
 	public final fun getOverlay-0d7_KjU ()J
 	public final fun getOverlayDark-0d7_KjU ()J
+	public final fun getOwnMessageQuotedBackground-0d7_KjU ()J
+	public final fun getOwnMessageQuotedText-0d7_KjU ()J
 	public final fun getOwnMessageText-0d7_KjU ()J
 	public final fun getOwnMessagesBackground-0d7_KjU ()J
 	public final fun getPrimaryAccent-0d7_KjU ()J

--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -37,6 +37,7 @@
     <ID>MaxLineLength:MessageOptions.kt$title = if (selectedMessage.pinned) R.string.stream_compose_unpin_message else R.string.stream_compose_pin_message</ID>
     <ID>MaxLineLength:MessagesScreen.kt$*</ID>
     <ID>MaxLineLength:MessagesViewModelFactory.kt$MessagesViewModelFactory$private val dateSeparatorThresholdMillis: Long = TimeUnit.HOURS.toMillis(MessageListViewModel.DateSeparatorDefaultHourThreshold)</ID>
+    <ID>MaxLineLength:StreamColors.kt$StreamColors$*</ID>
     <ID>ReturnCount:MessageListViewModel.kt$MessageListViewModel$public fun updateLastSeenMessage(message: Message)</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -86,6 +86,7 @@ public fun MessageInput(
                     QuotedMessage(
                         modifier = Modifier.padding(horizontal = 4.dp),
                         message = activeAction.message,
+                        replyMessage = null,
                         onLongItemClick = {},
                         onQuotedMessageClick = {}
                     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.getstream.sdk.chat.utils.extensions.isMine
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.buildAnnotatedMessageText
@@ -61,7 +63,12 @@ public fun MessageText(
 ) {
     val context = LocalContext.current
 
-    val styledText = buildAnnotatedMessageText(message)
+    val textColor = if (message.isMine(ChatClient.instance())) {
+        ChatTheme.colors.ownMessageText
+    } else {
+        ChatTheme.colors.otherMessageText
+    }
+    val styledText = buildAnnotatedMessageText(message.text, textColor)
     val annotations = styledText.getStringAnnotations(0, styledText.lastIndex)
 
     // TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
@@ -37,7 +37,8 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 /**
  * Wraps the quoted message into a component that shows only the sender avatar, text and single attachment preview.
  *
- * @param message Message to show.
+ * @param message The quoted message to show.
+ * @param replyMessage The message that contains the reply.
  * @param onLongItemClick Handler when the item is long clicked.
  * @param onQuotedMessageClick Handler for quoted message click action.
  * @param modifier Modifier for styling.
@@ -55,8 +56,14 @@ public fun QuotedMessage(
     onLongItemClick: (Message) -> Unit,
     onQuotedMessageClick: (Message) -> Unit,
     modifier: Modifier = Modifier,
+    replyMessage: Message? = null,
     leadingContent: @Composable (Message) -> Unit = { DefaultQuotedMessageLeadingContent(message = it) },
-    centerContent: @Composable RowScope.(Message) -> Unit = { DefaultQuotedMessageCenterContent(it) },
+    centerContent: @Composable RowScope.(Message) -> Unit = {
+        DefaultQuotedMessageCenterContent(
+            message = it,
+            replyMessage = replyMessage,
+        )
+    },
     trailingContent: @Composable (Message) -> Unit = { DefaultQuotedMessageTrailingContent(message = it) },
 ) {
     Row(
@@ -126,13 +133,16 @@ internal fun DefaultQuotedMessageTrailingContent(message: Message) {
  * Represents the default content shown in the center of the quoted message wrapped inside a message bubble.
  *
  * @param message The quoted message.
+ * @param replyMessage The message that contains the reply.
  */
 @Composable
 public fun RowScope.DefaultQuotedMessageCenterContent(
     message: Message,
+    replyMessage: Message? = null,
 ) {
     QuotedMessageContent(
         message = message,
+        replyMessage = replyMessage,
         modifier = Modifier.weight(1f, fill = false)
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
@@ -38,10 +38,10 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
  * Wraps the quoted message into a component that shows only the sender avatar, text and single attachment preview.
  *
  * @param message The quoted message to show.
- * @param replyMessage The message that contains the reply.
  * @param onLongItemClick Handler when the item is long clicked.
  * @param onQuotedMessageClick Handler for quoted message click action.
  * @param modifier Modifier for styling.
+ * @param replyMessage The message that contains the reply.
  * @param leadingContent The content shown at the start of the quoted message. By default we provide
  * [DefaultQuotedMessageLeadingContent] which shows the sender avatar in case the sender is not the current user.
  * @param centerContent The content shown at the center of the quoted message. By default we provide

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.getstream.sdk.chat.utils.extensions.isMine
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.ui.attachments.content.QuotedMessageAttachmentContent
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -27,8 +28,9 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 /**
  * Represents the default quoted message content that shows an attachment preview, if available, and the message text.
  *
- * @param message The message to show.
+ * @param message The quoted message to show.
  * @param modifier Modifier for styling.
+ * @param replyMessage The message that contains the reply.
  * @param attachmentContent The content for the attachment preview, if available.
  * @param textContent The content for the text preview, or the attachment name or type.
  */
@@ -36,16 +38,27 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 public fun QuotedMessageContent(
     message: Message,
     modifier: Modifier = Modifier,
+    replyMessage: Message? = null,
     attachmentContent: @Composable (Message) -> Unit = { DefaultQuotedMessageAttachmentContent(it) },
     textContent: @Composable (Message) -> Unit = { DefaultQuotedMessageTextContent(it) },
 ) {
-    val isMyMessage = message.isMine()
+    val messageBubbleShape = if (message.isMine(ChatClient.instance())) {
+        ChatTheme.shapes.myMessageBubble
+    } else {
+        ChatTheme.shapes.otherMessageBubble
+    }
 
-    val messageBubbleShape = if (isMyMessage) ChatTheme.shapes.myMessageBubble else ChatTheme.shapes.otherMessageBubble
+    // The quoted section color depends on the author of the reply (outer message).
+    val messageBubbleColor = if (replyMessage?.isMine(ChatClient.instance()) != false) {
+        ChatTheme.colors.ownMessageQuotedBackground
+    } else {
+        ChatTheme.colors.otherMessageQuotedBackground
+    }
 
     MessageBubble(
         modifier = modifier,
-        shape = messageBubbleShape, color = ChatTheme.colors.barsBackground,
+        shape = messageBubbleShape,
+        color = messageBubbleColor,
         content = {
             Row {
                 attachmentContent(message)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
@@ -40,7 +40,12 @@ public fun QuotedMessageContent(
     modifier: Modifier = Modifier,
     replyMessage: Message? = null,
     attachmentContent: @Composable (Message) -> Unit = { DefaultQuotedMessageAttachmentContent(it) },
-    textContent: @Composable (Message) -> Unit = { DefaultQuotedMessageTextContent(it, replyMessage) },
+    textContent: @Composable (Message) -> Unit = {
+        DefaultQuotedMessageTextContent(
+            message = it,
+            replyMessage = replyMessage,
+        )
+    },
 ) {
     val messageBubbleShape = if (message.isMine(ChatClient.instance())) {
         ChatTheme.shapes.myMessageBubble
@@ -48,7 +53,7 @@ public fun QuotedMessageContent(
         ChatTheme.shapes.otherMessageBubble
     }
 
-    // The quoted section color depends on the author of the reply (outer message).
+    // The quoted section color depends on the author of the reply.
     val messageBubbleColor = if (replyMessage?.isMine(ChatClient.instance()) != false) {
         ChatTheme.colors.ownMessageQuotedBackground
     } else {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
@@ -40,7 +40,7 @@ public fun QuotedMessageContent(
     modifier: Modifier = Modifier,
     replyMessage: Message? = null,
     attachmentContent: @Composable (Message) -> Unit = { DefaultQuotedMessageAttachmentContent(it) },
-    textContent: @Composable (Message) -> Unit = { DefaultQuotedMessageTextContent(it) },
+    textContent: @Composable (Message) -> Unit = { DefaultQuotedMessageTextContent(it, replyMessage) },
 ) {
     val messageBubbleShape = if (message.isMine(ChatClient.instance())) {
         ChatTheme.shapes.myMessageBubble
@@ -92,10 +92,15 @@ internal fun DefaultQuotedMessageAttachmentContent(message: Message) {
  * By default we show the message text if there is any or show the previewed attachment name.
  *
  * @param message The quoted message.
+ * @param replyMessage The message that contains the reply.
  */
 @Composable
-internal fun DefaultQuotedMessageTextContent(message: Message) {
+internal fun DefaultQuotedMessageTextContent(
+    message: Message,
+    replyMessage: Message? = null,
+) {
     QuotedMessageText(
-        message = message
+        message = message,
+        replyMessage = replyMessage,
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -39,12 +39,14 @@ import io.getstream.chat.android.uiutils.extension.isFile
  *
  * @param message Message to show.
  * @param modifier Modifier for styling.
+ * @param replyMessage The message that contains the reply.
  * @param quoteMaxLines Max number of lines quoted text can have.
  */
 @Composable
 public fun QuotedMessageText(
     message: Message,
     modifier: Modifier = Modifier,
+    replyMessage: Message? = null,
     quoteMaxLines: Int = DefaultQuoteMaxLines,
 ) {
     val attachment = message.attachments.firstOrNull()
@@ -83,7 +85,7 @@ public fun QuotedMessageText(
         "quotedMessageText is null. Cannot display invalid message title."
     }
 
-    val textColor = if (message.isMine(ChatClient.instance())) {
+    val textColor = if (replyMessage?.isMine(ChatClient.instance()) != false) {
         ChatTheme.colors.ownMessageQuotedText
     } else {
         ChatTheme.colors.otherMessageQuotedText

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -83,7 +83,12 @@ public fun QuotedMessageText(
         "quotedMessageText is null. Cannot display invalid message title."
     }
 
-    val styledText = buildAnnotatedMessageText(quotedMessageText, message.isMine(ChatClient.instance()))
+    val textColor = if (message.isMine(ChatClient.instance())) {
+        ChatTheme.colors.ownMessageQuotedText
+    } else {
+        ChatTheme.colors.otherMessageQuotedText
+    }
+    val styledText = buildAnnotatedMessageText(quotedMessageText, textColor)
 
     val horizontalPadding = ChatTheme.dimens.quotedMessageTextHorizontalPadding
     val verticalPadding = ChatTheme.dimens.quotedMessageTextVerticalPadding

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -563,8 +563,9 @@ internal fun DefaultMessageTextContent(
     Column {
         if (quotedMessage != null) {
             QuotedMessage(
-                modifier = Modifier.padding(2.dp),
+                modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp),
                 message = quotedMessage,
+                replyMessage = message,
                 onLongItemClick = { onLongItemClick(message) },
                 onQuotedMessageClick = onQuotedMessageClick
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -47,7 +47,7 @@ import io.getstream.chat.android.compose.R
  * @param threadSeparatorGradientEnd Used as an end color for vertical gradient background in a thread separator.
  * @param ownMessageText Used for message text color for the current user. [textHighEmphasis] by default.
  * @param otherMessageText Used for message text color for other users. [textHighEmphasis] by default.
- * @param ownMessageQuotedBackground Used as a quoted section background color for the messages sent by the current user.
+ * @param ownMessageQuotedBackground Changes the background color of the quoted message contained in a reply sent by the current user.
  * @param otherMessageQuotedBackground Used as a quoted section background color for the messages sent by other users.
  * @param ownMessageQuotedText Used as a quoted section text color for the messages sent by the current user. [textHighEmphasis] by default.
  * @param otherMessageQuotedText Used as a quoted section text color for the messages sent by other users. [textHighEmphasis] by default.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -47,6 +47,10 @@ import io.getstream.chat.android.compose.R
  * @param threadSeparatorGradientEnd Used as an end color for vertical gradient background in a thread separator.
  * @param ownMessageText Used for message text color for the current user. [textHighEmphasis] by default.
  * @param otherMessageText Used for message text color for other users. [textHighEmphasis] by default.
+ * @param ownMessageQuotedBackground Used as a quoted section background color for the messages sent by the current user.
+ * @param otherMessageQuotedBackground Used as a quoted section background color for the messages sent by other users.
+ * @param ownMessageQuotedText Used as a quoted section text color for the messages sent by the current user. [textHighEmphasis] by default.
+ * @param otherMessageQuotedText Used as a quoted section text color for the messages sent by other users. [textHighEmphasis] by default.
  */
 @Immutable
 public data class StreamColors(
@@ -71,7 +75,11 @@ public data class StreamColors(
     public val threadSeparatorGradientStart: Color,
     public val threadSeparatorGradientEnd: Color,
     public val ownMessageText: Color = textHighEmphasis,
-    public val otherMessageText: Color = textHighEmphasis
+    public val otherMessageText: Color = textHighEmphasis,
+    public val ownMessageQuotedBackground: Color = otherMessagesBackground,
+    public val otherMessageQuotedBackground: Color = ownMessagesBackground,
+    public val ownMessageQuotedText: Color = textHighEmphasis,
+    public val otherMessageQuotedText: Color = textHighEmphasis,
 ) {
 
     public companion object {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -48,9 +48,9 @@ import io.getstream.chat.android.compose.R
  * @param ownMessageText Used for message text color for the current user. [textHighEmphasis] by default.
  * @param otherMessageText Used for message text color for other users. [textHighEmphasis] by default.
  * @param ownMessageQuotedBackground Changes the background color of the quoted message contained in a reply sent by the current user.
- * @param otherMessageQuotedBackground Used as a quoted section background color for the messages sent by other users.
- * @param ownMessageQuotedText Used as a quoted section text color for the messages sent by the current user. [textHighEmphasis] by default.
- * @param otherMessageQuotedText Used as a quoted section text color for the messages sent by other users. [textHighEmphasis] by default.
+ * @param otherMessageQuotedBackground Changes the background color of the quoted message contained in a reply sent by other users.
+ * @param ownMessageQuotedText Changes the text color of the quoted message contained in a reply sent by the current user. [textHighEmphasis] by default.
+ * @param otherMessageQuotedText Changes the text color of the quoted message contained in a reply sent by other users. [textHighEmphasis] by default.
  */
 @Immutable
 public data class StreamColors(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -18,47 +18,32 @@ package io.getstream.chat.android.compose.ui.util
 
 import android.annotation.SuppressLint
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.util.PatternsCompat
-import com.getstream.sdk.chat.utils.extensions.isMine
-import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
-
-/**
- * Takes the given message and builds an annotated message text that shows links and allows for clicks,
- * if there are any links available.
- *
- * @param message The message to extract the text from and style.
- *
- * @return The annotated String, with clickable links, if applicable.
- */
-@Composable
-internal fun buildAnnotatedMessageText(message: Message): AnnotatedString {
-    return buildAnnotatedMessageText(message.text, message.isMine(ChatClient.instance()))
-}
 
 /**
  * Takes the given message text and builds an annotated message text that shows links and allows for clicks,
  * if there are any links available.
  *
  * @param text The message text to style.
- * @param isOwnMessage Whether the message is the current user's message or not.
+ * @param color The color of the message text.
  *
  * @return The annotated String, with clickable links, if applicable.
  */
 @Composable
-internal fun buildAnnotatedMessageText(text: String, isOwnMessage: Boolean): AnnotatedString {
+internal fun buildAnnotatedMessageText(text: String, color: Color): AnnotatedString {
     return buildAnnotatedString {
         // First we add the whole text to the [AnnotatedString] and style it as a regular text.
         append(text)
         addStyle(
             SpanStyle(
                 fontStyle = ChatTheme.typography.body.fontStyle,
-                color = if (isOwnMessage) ChatTheme.colors.ownMessageText else ChatTheme.colors.otherMessageText
+                color = color,
             ),
             start = 0,
             end = text.length

--- a/stream-chat-android-ui-components/detekt-baseline.xml
+++ b/stream-chat-android-ui-components/detekt-baseline.xml
@@ -161,8 +161,6 @@
     <ID>MaxLineLength:SuggestionListController.kt$SuggestionListController$suggestionListControllerListener?.onSuggestionListUiVisibilityChanged(suggestionListUi.isSuggestionListVisible())</ID>
     <ID>MaxLineLength:SuggestionListViewStyle.kt$SuggestionListViewStyle$*</ID>
     <ID>MaxLineLength:SwipeViewHolder.kt$SwipeViewHolder$* If the swipe view is swiped of not. When true, swipe view is completely swiped, when false it is in the default state</ID>
-    <ID>MaxLineLength:TransformStyle.kt$TransformStyle$public var attachmentGalleryOptionsStyleTransformer: StyleTransformer&lt;AttachmentGalleryOptionsViewStyle> = noopTransformer()</ID>
-    <ID>MaxLineLength:TransformStyle.kt$TransformStyle$public var defaultQuotedAttachmentViewStyleTransformer: StyleTransformer&lt;DefaultQuotedAttachmentViewStyle> = noopTransformer()</ID>
     <ID>MaxLineLength:TypingIndicatorViewStyle.kt$TypingIndicatorViewStyle$*</ID>
     <ID>MaxLineLength:ViewReactionsBubbleDrawer.kt$ViewReactionsBubbleDrawer$"You need to specify either bubbleBorderColorTheirs and bubbleBorderWidthTheirs to draw a border for another user reaction bubble"</ID>
     <ID>NestedBlockDepth:MessageListHeaderView.kt$MessageListHeaderView$private fun renderSubtitleState()</ID>


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/stream-chat-android/issues/4326

### 🛠 Implementation details

Added some options to `StreamColors`, to make it possible to customize the appearance of quoted messages.

- `StreamColors.ownMessageQuotedBackground`
- `StreamColors.otherMessageQuotedBackground`
- `StreamColors.ownMessageQuotedText`
- `StreamColors.otherMessageQuotedText`

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2022-11-01 16 27 11](https://user-images.githubusercontent.com/9600921/199244368-693d99e0-cc41-4b5c-8bab-bf18da6298ae.jpeg) | ![photo_2022-11-01 16 27 08](https://user-images.githubusercontent.com/9600921/199244380-ae058f28-6cf6-4c71-8240-c3cf9d1db894.jpeg) |
| ![photo_2022-11-01 16 30 39](https://user-images.githubusercontent.com/9600921/199245109-31b245e7-42ae-4722-b2bd-4ad637a690fc.jpeg)| ![photo_2022-11-01 16 30 40](https://user-images.githubusercontent.com/9600921/199245100-42eb7abc-eee2-4b3c-8e76-4c9d68038729.jpeg) |

### 🧪 Testing

Apply the patch below with the modified colors:

```kotlin
StreamColors.defaultColors().copy(
     ownMessageQuotedBackground = Color.Green,
     otherMessageQuotedBackground = Color.Red,
     ownMessageQuotedText = Color.Blue,
     otherMessageQuotedText = Color.Yellow,
)
```

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 816b0920e7e76a1015437c3f7df528aafd18492d)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1667310092529)
@@ -47,6 +47,7 @@
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.common.state.DeletedMessageVisibility
@@ -68,6 +69,7 @@
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.StreamColors
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
@@ -93,7 +95,15 @@
         val channelId = intent.getStringExtra(KEY_CHANNEL_ID) ?: return
 
         setContent {
-            ChatTheme(dateFormatter = ChatApp.dateFormatter) {
+            ChatTheme(
+                dateFormatter = ChatApp.dateFormatter,
+                colors  =  StreamColors.defaultColors().copy(
+                    ownMessageQuotedBackground = Color.Green,
+                    otherMessageQuotedBackground = Color.Red,
+                    ownMessageQuotedText = Color.Blue,
+                    otherMessageQuotedText = Color.Yellow,
+                ),
+            ) {
                 MessagesScreen(
                     channelId = channelId,
                     onBackPressed = { finish() },

```

</details>

And verify that the result looks like that:

![photo_2022-11-01 16 44 18](https://user-images.githubusercontent.com/9600921/199248001-7e2e8538-40f0-4687-ad6d-faf36ba136a4.jpeg)

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
