### PR TITLE
Fix multi-bundle feature when using Firebase as Push Provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@
 
 ## stream-chat-android-pushprovider-firebase
 ### 🐞 Fixed
+- Fix multi-bundle feature when using Firebase as Push Provider. [#4341](https://github.com/GetStream/stream-chat-android/pull/4341)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/PushTokenUpdateHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/PushTokenUpdateHandler.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.notifications
 
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.core.content.edit
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.getNonNullString
 import io.getstream.chat.android.client.models.Device
@@ -34,12 +35,12 @@ internal class PushTokenUpdateHandler(context: Context) {
 
     private var userPushToken: UserPushToken
         set(value) {
-            prefs.edit()
-                .putString(KEY_USER_ID, value.userId)
-                .putString(KEY_TOKEN, value.token)
-                .putString(KEY_PUSH_PROVIDER, value.pushProvider)
-                .putString(KEY_PUSH_PROVIDER_NAME, value.providerName)
-                .apply()
+            prefs.edit(true) {
+                putString(KEY_USER_ID, value.userId)
+                putString(KEY_TOKEN, value.token)
+                putString(KEY_PUSH_PROVIDER, value.pushProvider)
+                putString(KEY_PUSH_PROVIDER_NAME, value.providerName)
+            }
         }
         get() {
             return UserPushToken(

--- a/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/ChatFirebaseMessagingService.kt
+++ b/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/ChatFirebaseMessagingService.kt
@@ -36,7 +36,7 @@ internal class ChatFirebaseMessagingService : FirebaseMessagingService() {
 
     override fun onNewToken(token: String) {
         try {
-            FirebaseMessagingDelegate.registerFirebaseToken(token, null)
+            FirebaseMessagingDelegate.registerFirebaseToken(token)
         } catch (exception: IllegalStateException) {
             logger.e(exception) { "[onFirebaseNewToken] error while registering Firebase Token" }
         }


### PR DESCRIPTION
### 🎯 Goal
When a new token come from FirebaseMessageService we were removing the `providerName` from the device, what could cause errors on our PN Logic.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![](https://media.giphy.com/media/3ohc10GA6j4XrLWzZK/giphy.gif)