### PR TITLE
[4297] V5 Make attachment equality comparisons based on shortened links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed an edge case in which deleting an attachment using the attachment gallery would not delete it given the message was freshly uploaded.  [4349](https://github.com/GetStream/stream-chat-android/pull/4349)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -565,7 +565,7 @@ public class MessageListViewModel(
                 ).enqueue(
                     onError = { chatError ->
                         val errorMessage = chatError.message ?: chatError.cause?.message
-                            ?: "Unable to shadow ban the user"
+                        ?: "Unable to shadow ban the user"
                         logger.e { errorMessage }
 
                         _errorEvents.postValue(EventWrapper(ErrorEvent.BlockUserError(chatError)))
@@ -638,22 +638,43 @@ public class MessageListViewModel(
                 ).enqueue { result ->
                     if (result.isSuccess) {
                         val message = result.data()
+
                         message.attachments.removeAll { attachment ->
-                            if (attachmentToBeDeleted.assetUrl != null) {
-                                attachment.assetUrl == attachmentToBeDeleted.assetUrl
-                            } else {
-                                attachment.imageUrl == attachmentToBeDeleted.imageUrl
+                            val imageUrl = attachmentToBeDeleted.imageUrl
+                            val assetUrl = attachmentToBeDeleted.assetUrl
+
+                            when {
+                                assetUrl != null -> {
+                                    attachment.assetUrl?.substringBefore("?") ==
+                                        assetUrl.substringBefore("?")
+                                }
+                                imageUrl != null -> {
+                                    attachment.imageUrl?.substringBefore("?") ==
+                                        imageUrl.substringBefore("?")
+                                }
+                                else -> false
                             }
                         }
 
-                        chatClient.updateMessage(message).enqueue(
-                            onError = { chatError ->
-                                logger.e {
-                                    "Could not edit message to remove its attachments: ${chatError.message}. " +
-                                        "Cause: ${chatError.cause?.message}"
+                        if (message.text.isBlank() && message.attachments.isEmpty()) {
+                            chatClient.deleteMessage(messageId = event.messageId).enqueue(
+                                onError = { chatError ->
+                                    logger.e {
+                                        "Could not remove the attachment and delete the remaining blank message" +
+                                            ": ${chatError.message}. Cause: ${chatError.cause?.message}"
+                                    }
                                 }
-                            }
-                        )
+                            )
+                        } else {
+                            chatClient.updateMessage(message).enqueue(
+                                onError = { chatError ->
+                                    logger.e {
+                                        "Could not edit message to remove its attachments: ${chatError.message}. " +
+                                            "Cause: ${chatError.cause?.message}"
+                                    }
+                                }
+                            )
+                        }
                     } else {
                         logger.e { "Could not load message: ${result.error()}" }
                     }

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -565,7 +565,7 @@ public class MessageListViewModel(
                 ).enqueue(
                     onError = { chatError ->
                         val errorMessage = chatError.message ?: chatError.cause?.message
-                        ?: "Unable to shadow ban the user"
+                            ?: "Unable to shadow ban the user"
                         logger.e { errorMessage }
 
                         _errorEvents.postValue(EventWrapper(ErrorEvent.BlockUserError(chatError)))


### PR DESCRIPTION
### 🎯 Goal

Closes #4297 

### 🛠 Implementation details

Instead of comparing the full attachment link which might differ depending on when it was loaded, fallback to comparing a shortened URL

This PR technically touches upon the compose SDK as well since they share the new `MessageListController` , however the Compose SDK uses internal logic inside `MediaGalleryPreviewViewModel.deleteCurrentMediaAttachment()` so it will not be affected in the compose sample app.

### 🧪 Testing

**Note**: It is important to always test freshly uploaded attachments, they must always be the latest message without navigating away from the message list in any way.

#### Previous behavior

1. Checkout `develop`
2. Launch the UI Components sample app
3. Send a message with multiple image and/or video attachments
4. Open an attachment in the gallery.
5. Delete an attachment via the gallery

**Result:** The attachment was not deleted

#### Deleting attachments

1. Checkout `develop`
2. Launch the UI Components sample app
3. Send a message with multiple image and/or video attachments
4. Open an attachment in the gallery.
5. Delete an attachment via the gallery

**Result:** The attachment is deleted

#### Deleting all attachments

1. Checkout `develop`
2. Launch the UI Components sample app
3. Send a message with multiple image and/or video attachments
4. Open an attachment in the gallery.
5. Delete all attachments inside the message

You should repeat this test in the following fashion

1. With a blank message (Result: Message is deleted when the last remaining attachment has been deleted)
2. With a message containing a text (Result: All attachments are removed, message remains)
3. With a message containing a hyperlink (Result: All attachments are removed, message remains and is transformed into a link attachment)


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes (the changelog has been updated in the `v5` version of this PR: https://github.com/GetStream/stream-chat-android/pull/4349)
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media4.giphy.com/media/kouVntpG4ypyAK9fBz/giphy.gif?cid=ecf05e47fpb5uihwpdysqevi2ndme20gzhgo63w2vvwmruhd&rid=giphy.gif&ct=g)
