### PR TITLE
Skip removed strings while uploading translations

### DIFF
--- a/localazy.json
+++ b/localazy.json
@@ -1,6 +1,7 @@
 {
   "upload": {
     "type": "android",
+    "deprecate": "project",
     "files": [
       {
         "pattern": "stream-chat-android-ui-common/src/main/res/values/strings*.xml",


### PR DESCRIPTION
### 🎯 Goal

Skip removed strings while uploading translations.

### 🛠 Implementation details

Removed strings will be marked as deprecated.
See more info [here](https://localazy.com/docs/cli/upload-reference#upload-configuration)

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves
