### PR TITLE
[ISSUE-3866] Making ClientMutableState internal interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Removed `Channel::cid` from constructor. It's now an immutable property calculated based on `type` and `id`. [#4322](https://github.com/GetStream/stream-chat-android/pull/4322)
 
 ### ❌ Removed
+- ClientMutableState is now an internal interface, intead of a public interface. [#4374](https://github.com/GetStream/stream-chat-android/pull/4374)
 
 ## stream-chat-android-offline
 ### 🐞 Fixed

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/state/ClientMutableState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/setup/state/ClientMutableState.kt
@@ -18,31 +18,29 @@ package io.getstream.chat.android.client.setup.state
 
 import io.getstream.chat.android.client.models.ConnectionState
 import io.getstream.chat.android.client.models.InitializationState
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 /**
  * Mutable version of [ClientState]. The class makes possible to change state of the SDK. Should only be used
  * internally by the SDK.
  */
-@InternalStreamChatApi
-public interface ClientMutableState : ClientState {
+internal interface ClientMutableState : ClientState {
 
     /**
      * Sets the [ConnectionState]
      *
      * @param connectionState [ConnectionState]
      */
-    public fun setConnectionState(connectionState: ConnectionState)
+    fun setConnectionState(connectionState: ConnectionState)
 
     /**
      * Sets initialized
      *
      * @param state [InitializationState]
      */
-    public fun setInitializationState(state: InitializationState)
+    fun setInitializationState(state: InitializationState)
 
     /**
      * Clears the state of [ClientMutableState].
      */
-    public override fun clearState()
+    override fun clearState()
 }


### PR DESCRIPTION
### 🎯 Goal

Making `ClientMutableState` as an internal interface.

### 🧪 Testing

Ci checks are enough in this case.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [ ] ~Affected documentation updated (KDocs, docusaurus, tutorial)~

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
