### PR TITLE
[4395] `V5` Don't show link attachments in the attachment galleries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Fixed an edge case in which deleting an attachment using the attachment gallery would not delete it given the message was freshly uploaded.  [4349](https://github.com/GetStream/stream-chat-android/pull/4349)
+- Fixed an edge case in which deleting an attachment using the attachment gallery would not delete it given the message was freshly uploaded.  [#4349](https://github.com/GetStream/stream-chat-android/pull/4349)
+- When a user uploads image attachments in a message that contains links, the link attachments are no longer displayed inside the attachment gallery along with the image attachments. [#4399](https://github.com/GetStream/stream-chat-android/pull/4399)
 
 ### ⬆️ Improved
 
@@ -70,6 +71,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- When a user uploads image attachments in a message that contains links, the link attachments are no longer displayed inside the attachment gallery along with the image attachments. [#4399](https://github.com/GetStream/stream-chat-android/pull/4399)
 
 ### ✅ Added
 

--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -9,6 +9,7 @@
     <ID>ComplexMethod:MessageOptions.kt$@Composable public fun defaultMessageOptionsState( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, ): List&lt;MessageOptionItemState></ID>
     <ID>ForbiddenComment:MessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
     <ID>ForbiddenComment:QuotedMessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
+    <ID>LargeClass:ImagePreviewActivity.kt$ImagePreviewActivity : AppCompatActivity</ID>
     <ID>LongMethod:GiphyMessageContent.kt$@Composable public fun GiphyMessageContent( message: Message, modifier: Modifier = Modifier, onGiphyActionClick: (GiphyAction) -> Unit = {}, )</ID>
     <ID>LongMethod:GroupAvatar.kt$@Composable public fun GroupAvatar( users: List&lt;User>, modifier: Modifier = Modifier, shape: Shape = ChatTheme.shapes.avatar, textStyle: TextStyle = ChatTheme.typography.captionBold, onClick: (() -> Unit)? = null, )</ID>
     <ID>LongMethod:ImageAttachmentContent.kt$@OptIn(ExperimentalFoundationApi::class) @Composable public fun ImageAttachmentContent( attachmentState: AttachmentState, modifier: Modifier = Modifier, )</ID>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -145,6 +145,7 @@ import io.getstream.chat.android.ui.message.list.options.message.MessageOptionIt
 import io.getstream.chat.android.ui.message.list.options.message.MessageOptionItemsFactory
 import io.getstream.chat.android.ui.message.list.options.message.MessageOptionsDialogFragment
 import io.getstream.chat.android.ui.utils.extensions.isCurrentUserBanned
+import io.getstream.chat.android.uiutils.extension.hasLink
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -486,7 +487,10 @@ public class MessageListView : ConstraintLayout {
                 val destination = when {
                     message.attachments.all(Attachment::isImage) -> {
                         val filteredAttachments = message.attachments
-                            .filter { it.type == ModelType.attach_image && !it.imagePreviewUrl.isNullOrEmpty() }
+                            .filter {
+                                it.type == ModelType.attach_image && !it.imagePreviewUrl.isNullOrEmpty() &&
+                                    !it.hasLink()
+                            }
                         val attachmentGalleryItems = filteredAttachments.map {
                             AttachmentGalleryItem(
                                 attachment = it,


### PR DESCRIPTION
### 🎯 Goal

Implements #4395 

### 🛠 Implementation details

Filtered out attachments link attachments in both XML and Compose SDKs

### 🧪 Testing

Please repeat the test procedure on both apps:

#### Test Scheme:

1. Launch the app
2. Open a channel
3. Send a message that contains multiple media attachments (image and/or video) 
4. Open the message in the gallery
5. Exert all options such as reply, show in chat, save and delete
6. Exhaust delete until the last attachment is deleted

Repeat step 3 with the following variations:

- Message contains no text (should delete the message with the last attachment deleted)
- Message contains text (should not delete the message with the last attachment deleted)
- Message contains link (should not display the link attachment in the gallery and should not delete the message with the last attachment deleted)

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media1.giphy.com/media/NVBR6cLvUjV9C/giphy.gif?cid=ecf05e4783p0kgryzuyxyokxpjcedzo7q5vtq8vmerlons4c&rid=giphy.gif&ct=g)
