### PR TITLE
Synchronize ChatClient initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,11 @@
 
 ### ❌ Removed
 
+# November 16th, 2022 - 5.11.6
+## stream-chat-android-client
+### 🐞 Fixed
+- Fixed the race condition when connecting the user just after receiving a push notification when the application is killed. [#4429](https://github.com/GetStream/stream-chat-android/pull/4429)
+
 # November 15th, 2022 - 5.11.5
 ## stream-chat-android-client
 ### 🐞 Fixed

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -7,7 +7,7 @@ object Configuration {
     const val minSdk = 21
     const val majorVersion = 5
     const val minorVersion = 11
-    const val patchVersion = 5
+    const val patchVersion = 6
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -502,6 +502,7 @@ internal constructor(
         }
     }
 
+    @Synchronized
     private fun initializeClientWithUser(
         user: User,
         tokenProvider: CacheableTokenProvider,
@@ -518,6 +519,7 @@ internal constructor(
         tokenManager.setTokenProvider(tokenProvider)
         appSettingsManager.loadAppSettings()
         warmUp()
+        logger.i { "[initializeClientWithUser] user.id: '${user.id}'completed" }
     }
 
     private fun createRepositoryFactory(user: User): RepositoryFactory =

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -256,7 +256,7 @@ internal constructor(
      * The user's id for which the client is initialized.
      * Used in [initializeClientWithUser] to prevent recreating objects like repository, plugins, etc.
      */
-    private val currentUserId = AtomicReference<String?>(null)
+    private val initializedUserId = AtomicReference<String?>(null)
 
     /**
      * Launches a new coroutine in the [UserScope] without blocking the current thread
@@ -519,10 +519,10 @@ internal constructor(
         val clientJobCount = clientScope.coroutineContext[Job]?.children?.count() ?: -1
         val userJobCount = userScope.coroutineContext[Job]?.children?.count() ?: -1
         logger.v { "[initializeClientWithUser] clientJobCount: $clientJobCount, userJobCount: $userJobCount" }
-        if (currentUserId.get() != user.id) {
+        if (initializedUserId.get() != user.id) {
             _repositoryFacade = createRepositoryFacade(userScope, createRepositoryFactory(user))
             plugins = pluginFactories.map { it.get(user) }
-            currentUserId.set(user.id)
+            initializedUserId.set(user.id)
         } else {
             logger.i {
                 "[initializeClientWithUser] initializing client with the same user id." +
@@ -1218,7 +1218,7 @@ internal constructor(
 
     private suspend fun disconnectSuspend(flushPersistence: Boolean) {
         val userId = clientState.user.value?.id
-        currentUserId.set(null)
+        initializedUserId.set(null)
         logger.d { "[disconnectSuspend] userId: '$userId', flushPersistence: $flushPersistence" }
         userScope.coroutineContext.cancelChildren()
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -811,6 +811,7 @@ internal class MoshiChatApi @Suppress("LongParameterList") constructor(
 
         val isConnectionRequired = query.watch || query.presence
         return if (connectionId.isBlank() && isConnectionRequired) {
+            logger.i { "[queryChannels] postponing because an active connection is required" }
             postponeCall(lazyQueryChannelsCall)
         } else {
             lazyQueryChannelsCall()
@@ -847,6 +848,7 @@ internal class MoshiChatApi @Suppress("LongParameterList") constructor(
 
         val isConnectionRequired = query.watch || query.presence
         return if (connectionId.isBlank() && isConnectionRequired) {
+            logger.i { "[queryChannel] postponing because an active connection is required" }
             postponeCall(lazyQueryChannelCall)
         } else {
             lazyQueryChannelCall()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/plugin/factory/StreamOfflinePluginFactory.kt
@@ -78,6 +78,7 @@ public class StreamOfflinePluginFactory(
 ) : PluginFactory, RepositoryFactory.Provider {
 
     private val logger = StreamLog.getLogger("Chat:OfflinePluginFactory")
+    @Volatile
     private var cachedOfflinePluginInstance: OfflinePlugin? = null
     private val exceptionHandler = CoroutineExceptionHandler { context, throwable ->
         StreamLog.e("StreamOfflinePlugin", throwable) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -278,5 +278,12 @@ internal class LogicRegistry internal constructor(
             "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
                 "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
         }
+
+        /**
+         * Clears cached [LogicRegistry] instance.
+         */
+        internal fun clear() {
+            instance = null
+        }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
@@ -198,5 +198,12 @@ public class StateRegistry private constructor(
             "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
                 "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
         }
+
+        /**
+         * Clears cached [StateRegistry] instance.
+         */
+        internal fun clear() {
+            instance = null
+        }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -77,6 +77,7 @@ public class StreamStatePluginFactory(
     private val appContext: Context,
 ) : PluginFactory {
 
+    @Volatile
     private var cachedStatePluginInstance: StatePlugin? = null
 
     private val logger = StreamLog.getLogger("Chat:StatePluginFactory")
@@ -297,5 +298,7 @@ public class StreamStatePluginFactory(
 
     private fun clearCachedInstance() {
         cachedStatePluginInstance = null
+        StateRegistry.clear()
+        LogicRegistry.clear()
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Synchronize `ChatClient` initialization.

### 🛠 Implementation details

Fixed the race condition when connecting the user just after receiving the push notification when the application is killed. In both scenarios, we are calling `initializeClientWithUser` from different threads which might result in rebuilding things like plugins.

### 🧪 Testing

1. Apply the patch below and filter logs by `initializeClientWithUser`
2. On device1 sign in as Marton and kill the app
3. From device2 send a message to a channel in which Marton is a member
4. Receive a push notification on device1 and observe the logs. You should see two `initializeClientWithUser` synchronized invocation (there is a log at the beginning and end of the method)

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/FirebaseMessagingDelegate.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/FirebaseMessagingDelegate.kt b/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/FirebaseMessagingDelegate.kt
--- a/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/FirebaseMessagingDelegate.kt	(revision 3914ce1dd98df2e7af1dcc0336cc1123fe92fc94)
+++ b/stream-chat-android-pushprovider-firebase/src/main/java/io/getstream/chat/android/pushprovider/firebase/FirebaseMessagingDelegate.kt	(date 1668588609659)
@@ -21,6 +21,9 @@
 import io.getstream.chat.android.client.models.Device
 import io.getstream.chat.android.client.models.PushMessage
 import io.getstream.chat.android.client.models.PushProvider
+import io.getstream.chat.android.client.models.User
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
 
 /**
  * Helper class for delegating Firebase push messages to the Stream Chat SDK.
@@ -45,7 +48,10 @@
         if (!remoteMessage.isValid()) {
             return false
         }
-
+        GlobalScope.launch {
+            val user = User(id = "marton", name = "Márton Braun", image = "https://ca.slack-edge.com/T02RM6X6B-U018YPHEW7L-26ab96fd1ed3-128")
+            ChatClient.instance().connectUser(user, "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydG9uIn0.22wjzwYCNdaG5FLVeTD49NqVA11UJpEwrNRjZxZrcK8").await()
+        }
         ChatClient.handlePushMessage(remoteMessage.toPushMessage())
         return true
     }

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
