### PR TITLE
[4446] Correct mentions of uplaod file size limit from 20 MB to 100 MB

### DIFF
--- a/docusaurus/docs/Android/02-client/03-messages.mdx
+++ b/docusaurus/docs/Android/02-client/03-messages.mdx
@@ -100,7 +100,7 @@ channelClient.deleteMessage("message-id").enqueue { result ->
 
 The `channel.sendImage` and `channel.sendFile` methods make it easy to upload files.
 
-This functionality defaults to using the Stream CDN. If you would like, you can easily change the logic to upload to your own CDN of choice. The maximum file size is 20mb for the Stream Chat CDN.
+This functionality defaults to using the Stream CDN. If you would like, you can easily change the logic to upload to your own CDN of choice. The maximum file size is 100 MB for the Stream Chat CDN.
 
 ### Uploading an Image
 

--- a/docusaurus/docs/Android/02-client/06-guides/02-sending-custom-attachments.mdx
+++ b/docusaurus/docs/Android/02-client/06-guides/02-sending-custom-attachments.mdx
@@ -121,4 +121,4 @@ attachment.setUpload(new File("audio-file.mp3"));
 1. Again, a custom `type` allows you to identify your custom attachments to render them in the Message List.
 2. The file in the `upload` property will be uploaded automatically before the message is sent. The URL where it's available from will be placed in the `url` property of the `Attachment`.
    
-By default, files are uploaded to Stream's CDN, which has a 20 MB size limit. However, you can also [use your own CDN for files](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin#using-your-own-cdn).
+By default, files are uploaded to Stream's CDN, which has a 100 MB size limit. However, you can also [use your own CDN for files](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin#using-your-own-cdn).

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -821,7 +821,7 @@ internal constructor(
      * Uploads a file for the given channel. Progress can be accessed via [callback].
      *
      * The Stream CDN imposes the following restrictions on file uploads:
-     * - The maximum file size is 20 MB
+     * - The maximum file size is 100 MB
      *
      * @param channelType The channel type. ie messaging.
      * @param channelId The channel id. ie 123.
@@ -849,7 +849,7 @@ internal constructor(
      * Uploads an image for the given channel. Progress can be accessed via [callback].
      *
      * The Stream CDN imposes the following restrictions on image uploads:
-     * - The maximum image size is 20 MB
+     * - The maximum image size is 100 MB
      * - Supported MIME types are listed in [StreamCdnImageMimeTypes.SUPPORTED_IMAGE_MIME_TYPES]
      *
      * @param channelType The channel type. ie messaging.
@@ -2793,7 +2793,7 @@ internal constructor(
          * to upload files and images.
          *
          * The default implementation uses Stream's own CDN to store these files,
-         * which has a 20 MB upload size limit.
+         * which has a 100 MB upload size limit.
          *
          * For more info, see
          * [the File Uploads documentation](https://getstream.io/chat/docs/android/file_uploads/?language=kotlin).

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -414,7 +414,7 @@ public class ChannelClient internal constructor(
      * Uploads a file for the given channel. Progress can be accessed via [callback].
      *
      * The Stream CDN imposes the following restrictions on file uploads:
-     * - The maximum file size is 20 MB
+     * - The maximum file size is 100 MB
      *
      * @param file The file that needs to be uploaded.
      * @param callback The callback to track progress.
@@ -435,7 +435,7 @@ public class ChannelClient internal constructor(
      * Uploads an image for the given channel. Progress can be accessed via [callback].
      *
      * The Stream CDN imposes the following restrictions on image uploads:
-     * - The maximum image size is 20 MB
+     * - The maximum image size is 100 MB
      * - Supported MIME types are listed in [StreamCdnImageMimeTypes.SUPPORTED_IMAGE_MIME_TYPES]
      *
      * @param file The image file that needs to be uploaded.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit
  * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
  * @param messageLimit The limit when loading messages.
  * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
- * @param maxAttachmentSize The maximum file size of each attachment in bytes. By default, 20mb for Stream CDN.
+ * @param maxAttachmentSize The maximum file size of each attachment in bytes. By default, 100 MB for Stream CDN.
  * @param showDateSeparators If we should show date separator items in the list.
  * @param showSystemMessages If we should show system message items in the list.
  * @param deletedMessageVisibility The behavior of deleted messages in the list and if they're visible or not.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/common/composer/MessageComposerController.kt
@@ -69,7 +69,7 @@ import java.util.regex.Pattern
  * @param channelId The ID of the channel we're chatting in.
  * @param chatClient The client used to communicate to the API.
  * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
- * @param maxAttachmentSize Tne maximum file size of each attachment in bytes. By default, 20mb for Stream CDN.
+ * @param maxAttachmentSize Tne maximum file size of each attachment in bytes. By default, 100 MB for Stream CDN.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
 @InternalStreamChatApi

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputViewStyle.kt
@@ -58,8 +58,8 @@ import io.getstream.chat.android.ui.message.input.attachment.AttachmentSelection
  * @property backgroundColor Background color of MessageInputView.
  * @property editTextBackgroundDrawable Background color of message input box inside MessageInputView.
  * @property customCursorDrawable Custom cursor of message input box inside MessageInputView.
- * @property attachmentMaxFileSize The max attachment size. Be aware that currently the back end of Stream allow 20MB as
- * the max size, use this only if you use your own backend.
+ * @property attachmentMaxFileSize The max attachment size. Limited to 100 MB by Stream's CDN. Use your own CDN if you
+ * need to upload larger files.
  * @property dividerBackground The background of the divider in the top of MessageInputView.
  * @property attachmentSelectionDialogStyle Style for attachment selection dialog.
  * @property commandInputCancelIcon Icon for cancel button. Default value is [R.drawable.stream_ui_ic_clear].


### PR DESCRIPTION
### 🎯 Goal

Closes #4446 

### 🛠 Implementation details

Search for all references to the previous 20 MB file limit and change them to 100 MB

Search phrases included:

- 20MB
- 20 MB
- MB
- 20
- Mega
- Megabyte
- Twenty

### 🧪 Testing

Test A:

Launch Docusaurus and check that the updated pages render correctly and that the correct text is updated

Test B: 

Only kdocs were changed and no code but you can run the sample apps for good measure

</details>


### ☑️Contributor Checklist

#### General
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the ~~`develop`~~ branch (targeting `main` for a quicker release due to reports of users getting confused which limit is true)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media3.giphy.com/media/42HK08uOXRzC20y9RW/giphy.gif?cid=ecf05e47lag1hb781wdiic02het3u6gandwiif3ulk8vmz6c&rid=giphy.gif&ct=g)
