### PR TITLE
[4437] Hide reactions for unsent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added the `streamUiShowReactionsForUnsentMessages` attribute to `MessageListView` that allows to show/hide the edit reactions bubble for unsent messages on the options overlay. [#4449](https://github.com/GetStream/stream-chat-android/pull/4449)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -3074,8 +3074,8 @@ public abstract interface class io/getstream/chat/android/ui/message/list/Messag
 
 public final class io/getstream/chat/android/ui/message/list/MessageListViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/list/MessageListViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)V
-	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIZ)V
+	public fun <init> (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIZ)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
 	public final fun component10 ()I
 	public final fun component11 ()Z
@@ -3119,13 +3119,14 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun component46 ()I
 	public final fun component47 ()I
 	public final fun component48 ()I
+	public final fun component49 ()Z
 	public final fun component5 ()Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;
 	public final fun component6 ()Z
 	public final fun component7 ()I
 	public final fun component8 ()I
 	public final fun component9 ()Z
-	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIII)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIZ)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/message/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/message/list/MessageListItemStyle;Lio/getstream/chat/android/ui/message/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/message/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIIZIZIZZZZZLio/getstream/chat/android/ui/common/style/TextStyle;Lio/getstream/chat/android/ui/common/style/TextStyle;IILio/getstream/chat/android/ui/common/style/TextStyle;ILio/getstream/chat/android/ui/common/style/TextStyle;IIIIIIZIIIZIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getBlockEnabled ()Z
@@ -3167,6 +3168,7 @@ public final class io/getstream/chat/android/ui/message/list/MessageListViewStyl
 	public final fun getScrollButtonBottomMargin ()I
 	public final fun getScrollButtonEndMargin ()I
 	public final fun getScrollButtonViewStyle ()Lio/getstream/chat/android/ui/message/list/ScrollButtonViewStyle;
+	public final fun getShowReactionsForUnsentMessages ()Z
 	public final fun getThreadMessagesStart ()I
 	public final fun getThreadReplyIcon ()I
 	public final fun getThreadsEnabled ()Z

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListViewStyle.kt
@@ -89,6 +89,7 @@ import io.getstream.chat.android.ui.message.list.internal.ScrollButtonView
  * @property optionsOverlayEditReactionsMargin Defines the margin between the selected message and the edit reactions bubble on the options overlay.
  * @property optionsOverlayUserReactionsMargin Defines the margin between the selected message and the user reaction list on the options overlay.
  * @property optionsOverlayMessageOptionsMargin Defines the margin between the selected message and the message option list on the options overlay.
+ * @property showReactionsForUnsentMessages If we need to show the edit reactions bubble for unsent messages on the options overlay.
  */
 public data class MessageListViewStyle
 @Deprecated(
@@ -146,6 +147,7 @@ constructor(
     public val optionsOverlayEditReactionsMargin: Int,
     public val optionsOverlayUserReactionsMargin: Int,
     public val optionsOverlayMessageOptionsMargin: Int,
+    public val showReactionsForUnsentMessages: Boolean,
 ) {
 
     /**
@@ -237,6 +239,7 @@ constructor(
         optionsOverlayEditReactionsMargin: Int,
         optionsOverlayUserReactionsMargin: Int,
         optionsOverlayMessageOptionsMargin: Int,
+        showReactionsForUnsentMessages: Boolean,
     ) : this(
         scrollButtonViewStyle = scrollButtonViewStyle,
         scrollButtonBehaviour = scrollButtonBehaviour,
@@ -285,7 +288,8 @@ constructor(
         disableScrollWhenShowingDialog = disableScrollWhenShowingDialog,
         optionsOverlayEditReactionsMargin = optionsOverlayEditReactionsMargin,
         optionsOverlayUserReactionsMargin = optionsOverlayUserReactionsMargin,
-        optionsOverlayMessageOptionsMargin = optionsOverlayMessageOptionsMargin
+        optionsOverlayMessageOptionsMargin = optionsOverlayMessageOptionsMargin,
+        showReactionsForUnsentMessages = showReactionsForUnsentMessages,
     )
 
     public companion object {
@@ -604,6 +608,11 @@ constructor(
                         DEFAULT_MESSAGE_OPTIONS_MARGIN
                     )
 
+                val showReactionsForUnsentMessages = attributes.getBoolean(
+                    R.styleable.MessageListView_streamUiShowReactionsForUnsentMessages,
+                    false
+                )
+
                 return MessageListViewStyle(
                     scrollButtonViewStyle = scrollButtonViewStyle,
                     scrollButtonBehaviour = scrollButtonBehaviour,
@@ -653,6 +662,7 @@ constructor(
                     optionsOverlayEditReactionsMargin = optionsOverlayEditReactionsMargin,
                     optionsOverlayUserReactionsMargin = optionsOverlayUserReactionsMargin,
                     optionsOverlayMessageOptionsMargin = optionsOverlayMessageOptionsMargin,
+                    showReactionsForUnsentMessages = showReactionsForUnsentMessages,
                 ).let(TransformStyle.messageListStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/options/message/MessageOptionsDialogFragment.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.models.Reaction
 import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.utils.SyncStatus
 import io.getstream.chat.android.common.state.MessageAction
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.ui.ChatUI
@@ -216,7 +217,9 @@ public class MessageOptionsDialogFragment : FullScreenDialogFragment() {
     private fun setupEditReactionsView() {
         with(binding.editReactionsView) {
             applyStyle(style.itemStyle.editReactionsViewStyle)
-            if (style.reactionsEnabled) {
+
+            val isMessageSynced = message.syncStatus == SyncStatus.COMPLETED
+            if (style.reactionsEnabled && (isMessageSynced || style.showReactionsForUnsentMessages)) {
                 setMessage(message, messageItem.isMine)
                 setReactionClickListener {
                     reactionClickListener?.onReactionClick(message, it)

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -517,5 +517,8 @@
         <attr name="streamUiOptionsOverlayUserReactionsMargin" format="dimension|reference" />
         <!-- The margin between the selected message and the message option list on the options overlay. -->
         <attr name="streamUiOptionsOverlayMessageOptionsMargin" format="dimension|reference" />
+
+        <!-- Show the edit reactions bubble for unsent messages on the options overlay. -->
+        <attr name="streamUiShowReactionsForUnsentMessages" format="boolean" />
     </declare-styleable>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -458,6 +458,7 @@
 
         <!-- Options overly dialog -->
         <item name="streamUiOptionsOverlayDimColor">@color/stream_ui_literal_transparent</item>
+        <item name="streamUiShowReactionsForUnsentMessages">false</item>
 
         <!-- Giphy view holder -->
         <item name="streamUiGiphyCardBackgroundColor">@color/stream_ui_white</item>
@@ -584,7 +585,7 @@
     </style>
 
     <style name="StreamUi.ChannelListHeader.Avatar" parent="StreamUi.BaseAvatar">
-        <!--Style properties for Avatar inside of ChanneListHeaderView Item-->
+        <!--Style properties for Avatar inside of ChannelListHeaderView Item-->
         <item name="android:layout_width">@dimen/stream_ui_avatar_size_medium</item>
         <item name="android:layout_height">@dimen/stream_ui_avatar_size_medium</item>
         <item name="streamUiAvatarTextSize">@dimen/stream_ui_avatar_text_size_medium</item>


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/stream-chat-android/issues/4437

Hide reactions by default for messages that haven't been synced.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![photo_2022-11-18 13 57 54](https://user-images.githubusercontent.com/9600921/202689968-8a60b99a-a289-4bea-911b-e0c7574ce472.jpeg) | ![photo_2022-11-18 13 57 56](https://user-images.githubusercontent.com/9600921/202689961-af675a7d-433e-42ab-abd5-8fe85a43aaa8.jpeg) |
| ![photo_2022-11-18 14 02 40](https://user-images.githubusercontent.com/9600921/202690836-d532fe54-271e-4101-9fa1-0f95f35f947f.jpeg) | ![photo_2022-11-18 14 02 38](https://user-images.githubusercontent.com/9600921/202690841-ffe9d179-ae3d-4acb-9a60-629bff0aa8bb.jpeg) |

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
