### PR TITLE
Fix returning error from worker when upload attachments fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed `IllegalArgumentException` when uploading attachments fails. [#4487](https://github.com/GetStream/stream-chat-android/pull/4487)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/message/attachments/internal/UploadAttachmentsAndroidWorker.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/message/attachments/internal/UploadAttachmentsAndroidWorker.kt
@@ -59,7 +59,8 @@ internal class UploadAttachmentsAndroidWorker(
                 Result.success()
             } else {
                 logger.i { "[doWork] Error while uploading attachments: ${result.error()}" }
-                Result.failure(Data.Builder().putAll(mapOf(ERROR_KEY to result)).build())
+                val message = result.error().message ?: "Error while uploading attachments"
+                Result.failure(Data.Builder().putAll(mapOf(ERROR_KEY to message)).build())
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Fix `IllegalArgumentException` when upload attachments worker fails.

### 🛠 Implementation details
We cannot pass `ChatError` to the `Data` object when creating `Result.failure` because valid value types are: Boolean, Integer, Long, Float, Double, String, and their array versions.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
