### PR TITLE
Feature/error handling disconnect

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1218,8 +1218,15 @@ internal constructor(
     public fun disconnect(flushPersistence: Boolean): Call<Unit> =
         CoroutineCall(clientScope) {
             logger.d { "[disconnect] flushPersistence: $flushPersistence" }
-            disconnectSuspend(flushPersistence)
-            Result.success(Unit)
+            when (isUserSet()) {
+                true -> {
+                    disconnectSuspend(flushPersistence)
+                    Result.success(Unit)
+                }
+                false -> Result.error(
+                    ChatError("ChatClient can't be disconnected because user wasn't connected previously")
+                )
+            }
         }
 
     private suspend fun disconnectSuspend(flushPersistence: Boolean) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1207,6 +1207,8 @@ internal constructor(
 
     /**
      * Disconnect the current user, stop all observers and clear user data.
+     * This method should only be used whenever the user logout from the main app.
+     * If the user will continue using the Chat in the future, you shouldn't call this method.
      *
      * @param flushPersistence if true will clear user data.
      *


### PR DESCRIPTION
### 🎯 Goal
Return an error on the case `ChatClient::disconnect` is invoked without a connected user

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/l4pTju6aRosO0ZUOI/giphy.gif)
