### PR TITLE
Fix empty placeholder blinking while loading channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
-- Return an error when invoking `ChatClient::disconnect` without a connected user. [#4494](https://github.com/GetStream/stream-chat-android/pull/4494)
 
 ### ✅ Added
 
@@ -24,7 +23,6 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-- Fixed `IllegalArgumentException` when uploading attachments fails. [#4487](https://github.com/GetStream/stream-chat-android/pull/4487)
 
 ### ⬆️ Improved
 
@@ -62,7 +60,6 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-- Added the `streamUiShowReactionsForUnsentMessages` attribute to `MessageListView` that allows to show/hide the edit reactions bubble for unsent messages on the options overlay. [#4449](https://github.com/GetStream/stream-chat-android/pull/4449)
 
 ### ⚠️ Changed
 
@@ -122,6 +119,28 @@
 ### ⚠️ Changed
 
 ### ❌ Removed
+
+# November 23th, 2022 - 5.11.8
+## stream-chat-android-client
+### ⬆️ Improved
+- Return an error when invoking `ChatClient::disconnect` without a connected user. [#4494](https://github.com/GetStream/stream-chat-android/pull/4494)
+
+## stream-chat-android-offline
+### 🐞 Fixed
+- Fixed `IllegalArgumentException` when uploading attachments fails. [#4487](https://github.com/GetStream/stream-chat-android/pull/4487)
+- Fixed returning `ChannelsStateData.OfflineNoResults` from `QueryChannelsState::channelsStateData` when API call is still in progress. [#4496](https://github.com/GetStream/stream-chat-android/pull/4496)
+- Fixed returning an empty map from `QueryChannelsState::channels` when API call is still in progress. [#4496](https://github.com/GetStream/stream-chat-android/pull/4496)
+
+## stream-chat-android-ui-components
+### ✅ Added
+- Added the `streamUiShowReactionsForUnsentMessages` attribute to `MessageListView` that allows to show/hide the edit reactions bubble for unsent messages on the options overlay. [#4449](https://github.com/GetStream/stream-chat-android/pull/4449)
+
+### 🐞 Fixed
+- Fixed empty placeholder blinking on `ChannelListView` when loading channels. [#4496](https://github.com/GetStream/stream-chat-android/pull/4496)
+
+## stream-chat-android-compose
+### 🐞 Fixed
+- Fixed empty placeholder blinking on `ChannelList` when loading channels. [#4496](https://github.com/GetStream/stream-chat-android/pull/4496)
 
 # November 18th, 2022 - 5.11.7
 ## stream-chat-android-client

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -7,7 +7,7 @@ object Configuration {
     const val minSdk = 21
     const val majorVersion = 5
     const val minorVersion = 11
-    const val patchVersion = 7
+    const val patchVersion = 8
     const val versionName = "$majorVersion.$minorVersion.$patchVersion"
     const val snapshotVersionName = "$majorVersion.$minorVersion.${patchVersion + 1}-SNAPSHOT"
     const val artifactGroup = "io.getstream"

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsLogic.kt
@@ -130,6 +130,8 @@ internal class QueryChannelsLogic(
 
         if (result.isSuccess) {
             updateOnlineChannels(request, result.data())
+        } else {
+            queryChannelsStateLogic?.initializeChannelsIfNeeded()
         }
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
@@ -57,7 +57,7 @@ internal class QueryChannelsStateLogic(
     /**
      * Get all the channels that were queried so far.
      */
-    internal fun getChannels(): Map<String, Channel> = mutableState.rawChannels
+    internal fun getChannels(): Map<String, Channel>? = mutableState.rawChannels
 
     /**
      * The the specs of the query.
@@ -135,7 +135,7 @@ internal class QueryChannelsStateLogic(
     internal fun addChannelsState(channels: List<Channel>) {
         mutableState.queryChannelsSpec.cids += channels.map { it.cid }
         val existingChannels = mutableState.rawChannels
-        mutableState.setChannels(existingChannels + channels.map { it.cid to it })
+        mutableState.setChannels((existingChannels ?: emptyMap()) + channels.map { it.cid to it })
         channels.forEach { channel ->
             logicRegistry.channelState(channel.type, channel.id).updateDataFromChannel(
                 channel,
@@ -150,9 +150,22 @@ internal class QueryChannelsStateLogic(
      */
     internal fun removeChannels(cidSet: Set<String>) {
         val existingChannels = mutableState.rawChannels
-
+        if (existingChannels == null) {
+            logger.w { "[removeChannels] rejected (existingChannels is null)" }
+            return
+        }
         mutableState.queryChannelsSpec.cids = mutableState.queryChannelsSpec.cids - cidSet
         mutableState.setChannels(existingChannels - cidSet)
+    }
+
+    /**
+     * Initializes [QueryChannelsMutableState.rawChannels] with an empty map if it wasn't initialized yet.
+     * This might happen when we don't have any channels in the offline storage and API request fails.
+     */
+    internal fun initializeChannelsIfNeeded() {
+        if (mutableState.rawChannels == null) {
+            mutableState.setChannels(emptyMap())
+        }
     }
 
     /**
@@ -162,7 +175,13 @@ internal class QueryChannelsStateLogic(
      * @param cidList The channels to refresh.
      */
     internal fun refreshChannels(cidList: Collection<String>) {
-        val newChannels = mutableState.rawChannels + mutableState.queryChannelsSpec.cids
+        val existingChannels = mutableState.rawChannels
+        if (existingChannels == null) {
+            logger.w { "[refreshChannels] rejected (existingChannels is null)" }
+            return
+        }
+
+        val newChannels = existingChannels + mutableState.queryChannelsSpec.cids
             .intersect(cidList.toSet())
             .map { cid -> cid.cidToTypeAndId() }
             .filter { (channelType, channelId) ->
@@ -190,6 +209,11 @@ internal class QueryChannelsStateLogic(
     internal fun refreshMembersStateForUser(newUser: User) {
         val userId = newUser.id
         val existingChannels = mutableState.rawChannels
+
+        if (existingChannels == null) {
+            logger.w { "[refreshMembersStateForUser] rejected (existingChannels is null)" }
+            return
+        }
 
         val affectedChannels = existingChannels
             .filter { (_, channel) -> channel.users().any { it.id == userId } }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/querychannels/internal/QueryChannelsMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/querychannels/internal/QueryChannelsMutableState.kt
@@ -47,7 +47,7 @@ internal class QueryChannelsMutableState(
 
     private val logger = StreamLog.getLogger("Chat:QueryChannelsState")
 
-    internal var rawChannels: Map<String, Channel>
+    internal var rawChannels: Map<String, Channel>?
         get() = _channels.value
         private set(value) {
             _channels.value = value
@@ -55,7 +55,17 @@ internal class QueryChannelsMutableState(
 
     // This is needed for queries
     internal val queryChannelsSpec: QueryChannelsSpec = QueryChannelsSpec(filter, sort)
-    private val _channels = MutableStateFlow<Map<String, Channel>>(emptyMap())
+
+    /**
+     * Property that exposes a map of raw channels.
+     * The channels are later sorted and enriched with latest users updates
+     * and exposed either as [channels] or [channelsStateData].
+     * The value is nullable in order to have a clear distinction between different channels state. When the value is:
+     * - null - the state should be either [ChannelsStateData.NoQueryActive] or [ChannelsStateData.Loading]
+     * - emptyMap() - the stat should be [ChannelsStateData.OfflineNoResults]
+     * - notEmptyMap() - the state should be [ChannelsStateData.Result]
+     */
+    private val _channels = MutableStateFlow<Map<String, Channel>?>(null)
     private val _loading = MutableStateFlow(false)
     private val _loadingMore = MutableStateFlow(false)
 
@@ -65,16 +75,16 @@ internal class QueryChannelsMutableState(
     private val _endOfChannels = MutableStateFlow(false)
     private val _sortedChannels: StateFlow<List<Channel>?> =
         _channels.combine(latestUsers) { channelMap, userMap ->
-            channelMap.values.updateUsers(userMap)
+            channelMap?.values?.updateUsers(userMap)
         }.map { channels ->
-            if (channels.isNotEmpty()) {
+            if (channels?.isNotEmpty() == true) {
                 logger.d {
                     val ids = channels.joinToString { channel -> channel.id }
                     "Sorting channels: $ids"
                 }
             }
 
-            channels.sortedWith(sort.comparator).also { sortedChannels ->
+            channels?.sortedWith(sort.comparator)?.also { sortedChannels ->
                 if (sortedChannels.isNotEmpty()) {
                     logger.d {
                         val ids = sortedChannels.joinToString { channel -> channel.id }


### PR DESCRIPTION
### 🎯 Goal

Fix the empty placeholder blinking while loading channels.

### 🛠 Implementation details

_Describe the implementation_

### 🧪 Testing
Test 3 different scenario:
1. Try to load channels when DB is empty
2. Try to load channels when DB is empty and there is no Internet connection
3. Try to load channels when DB is not empty and there is no Internet connection

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
