### PR TITLE
Clear all GlobalState values during disconnection

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/GlobalMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/GlobalMutableState.kt
@@ -78,12 +78,13 @@ public class GlobalMutableState private constructor(
     }
 
     override fun clearState() {
+        _user.value = null
         _totalUnreadCount.value = 0
         _channelUnreadCount.value = 0
-        _banned.value = false
-
         _mutedUsers.value = emptyList()
         _channelMutes.value = emptyList()
+        _banned.value = false
+        _typingChannels.value = emptyMap()
     }
 
     override fun setUser(user: User) {


### PR DESCRIPTION
### 🎯 Goal

Fix a bug when chat is not loaded when logging in after a logout.

### 🛠 Implementation details

We didn't call `connectUser` properly as `GlobalState::user` was not cleared during disconnection. 
Added clearing all `GlobalState` values during disconnection.

### 🧪 Testing

1. Sign in
2. Sign out
3. Sign in
4. Confirm everything works as expected


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)