### PR TITLE
Fix keyboard listener not cleared

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/input/MessageInputView.kt
@@ -82,6 +82,7 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import net.yslibrary.android.keyboardvisibilityevent.KeyboardVisibilityEvent
+import net.yslibrary.android.keyboardvisibilityevent.Unregistrar
 import java.io.File
 import kotlin.properties.Delegates
 
@@ -116,7 +117,7 @@ public class MessageInputView : ConstraintLayout {
      * Used to buffer typing updates in order to conserve API calls.
      */
     private var typingUpdatesBuffer: TypingUpdatesBuffer? = null
-    private var isKeyboardListenerRegistered: Boolean = false
+    private var keyboardListener: Unregistrar? = null
 
     private var maxMessageLength: Int = Integer.MAX_VALUE
 
@@ -437,6 +438,8 @@ public class MessageInputView : ConstraintLayout {
         hideSuggestionList()
         scope?.cancel()
         scope = null
+        keyboardListener?.unregister()
+        keyboardListener = null
         super.onDetachedFromWindow()
     }
 
@@ -829,8 +832,7 @@ public class MessageInputView : ConstraintLayout {
                     hideSuggestionList()
                 }
 
-                if (!isKeyboardListenerRegistered) {
-                    isKeyboardListenerRegistered = true
+                if (keyboardListener == null) {
                     registerKeyboardListener()
                 }
             }
@@ -870,7 +872,7 @@ public class MessageInputView : ConstraintLayout {
      */
     private fun registerKeyboardListener() {
         try {
-            KeyboardVisibilityEvent.setEventListener(activity) { isOpen: Boolean ->
+            keyboardListener = KeyboardVisibilityEvent.registerEventListener(activity) { isOpen: Boolean ->
                 if (!isOpen) {
                     binding.messageInputFieldView.clearMessageInputFocus()
                     hideSuggestionList()


### PR DESCRIPTION
### 🎯 Goal

When using `MessageInputView` in a Fragment, as soon as the input view gets focus, a listener is set. If the fragment gets dismissed
Issue: https://github.com/GetStream/stream-chat-android/issues/4498

### 🛠 Implementation details

Simply unregister the listener when the view is detached (it'll get reattached on the next focus event

### 🎨 UI Changes

None

### 🧪 Testing

- Add LeakCanary
- Add `MessageInputView` to a fragment
- Tap on the input view
- Dismiss the fragment
- 5s later, leak canary will report a leak on `main`, but shouldn't on this branch

### ☑️Contributor Checklist

#### General
- [X] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] ~~Assigned a person / code owner group (required)~~
- [ ] ~~Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)~~
- [ ] ~~PR targets the `develop` branch~~
- [X] PR is linked to the GitHub issue it resolves

