### PR TITLE
[4598] Enable Downloading Attachments Without Valid Name or Title Properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
-- Allowed downloading `Attachment`s with missing `title` and `name` properties by ensuring a fallback name is present. Please note that the properties should be populated, this is only guarding against edge cases. [#4599](https://github.com/GetStream/stream-chat-android/pull/4599)
+- Allowed downloading `Attachment`s with missing `title` and `name` properties by ensuring a fallback name is present. Please note that the properties should be populated, this is only used to guard against edge cases. [#4599](https://github.com/GetStream/stream-chat-android/pull/4599)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Allowed downloading `Attachment`s with missing `title` and `name` properties by ensuring a fallback name is present. Please note that the properties should be populated, this is only guarding against edge cases. [#4599](https://github.com/GetStream/stream-chat-android/pull/4599)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Attachment.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/Attachment.kt
@@ -43,7 +43,7 @@ import java.io.File
  * @param text The page description.
  * @param type The type of the attachment. e.g "file", "image, "audio".
  * @param image The image attachment.
- * @param fallback Alternative description in the case on an image attachment
+ * @param fallback Alternative description in the case of an image attachment
  * (img alt in HTML).
  * @param originalHeight The original height of the attachment.
  * Provided if the attachment is of type "image".

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -39,8 +39,8 @@ import io.getstream.chat.android.client.utils.map
 import io.getstream.chat.android.client.utils.toResultError
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
-import io.getstream.chat.android.offline.extensions.internal.getAttachmentFallbackName
 import io.getstream.chat.android.offline.extensions.internal.logic
+import io.getstream.chat.android.offline.extensions.internal.parseAttachmentNameFromUrl
 import io.getstream.chat.android.offline.extensions.internal.requestsAsState
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.plugin.state.channel.ChannelState
@@ -55,6 +55,9 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
 
 /**
  * [StateRegistry] instance that contains all state objects exposed in offline plugin.
@@ -199,7 +202,8 @@ public fun ChatClient.downloadAttachment(context: Context, attachment: Attachmen
             val logger = StreamLog.getLogger("Chat:DownloadAttachment")
             val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
             val url = attachment.assetUrl ?: attachment.imageUrl
-            val subPath = attachment.name ?: attachment.title ?: attachment.getAttachmentFallbackName() ?: "attachment"
+            val subPath = attachment.name ?: attachment.title ?: attachment.parseAttachmentNameFromUrl()
+            ?: createAttachmentFallbackName()
 
             logger.d { "Downloading attachment. Name: $subPath, Url: $url" }
 
@@ -331,3 +335,21 @@ private suspend fun ChatClient.loadMessageByIdInternal(
         Result(ChatError("Error while fetching messages from backend. Messages around id: $messageId"))
     }
 }
+
+/**
+ * Creates a fallback name for attachments without [Attachment.name] or [Attachment.title] properties.
+ * Fallback names are generated in the following manner: "attachment_2022-16-12_12-15-06".
+ */
+private fun createAttachmentFallbackName(): String {
+    val dateString = SimpleDateFormat(ATTACHMENT_FALLBACK_NAME_DATE_FORMAT, Locale.getDefault())
+        .format(Date())
+        .toString()
+
+    return "attachment_$dateString"
+}
+
+/**
+ * Date format pattern used for creating fallback names for attachments without [Attachment.name] or [Attachment.title]
+ * properties
+ */
+private const val ATTACHMENT_FALLBACK_NAME_DATE_FORMAT: String = "yyyy-MM-dd_HH-mm-ss"

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -39,6 +39,7 @@ import io.getstream.chat.android.client.utils.map
 import io.getstream.chat.android.client.utils.toResultError
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.offline.event.handler.chat.factory.ChatEventHandlerFactory
+import io.getstream.chat.android.offline.extensions.internal.getAttachmentFallbackName
 import io.getstream.chat.android.offline.extensions.internal.logic
 import io.getstream.chat.android.offline.extensions.internal.requestsAsState
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
@@ -198,7 +199,7 @@ public fun ChatClient.downloadAttachment(context: Context, attachment: Attachmen
             val logger = StreamLog.getLogger("Chat:DownloadAttachment")
             val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
             val url = attachment.assetUrl ?: attachment.imageUrl
-            val subPath = attachment.name ?: attachment.title
+            val subPath = attachment.name ?: attachment.title ?: attachment.getAttachmentFallbackName() ?: "attachment"
 
             logger.d { "Downloading attachment. Name: $subPath, Url: $url" }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/ChatClient.kt
@@ -203,7 +203,7 @@ public fun ChatClient.downloadAttachment(context: Context, attachment: Attachmen
             val downloadManager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
             val url = attachment.assetUrl ?: attachment.imageUrl
             val subPath = attachment.name ?: attachment.title ?: attachment.parseAttachmentNameFromUrl()
-            ?: createAttachmentFallbackName()
+                ?: createAttachmentFallbackName()
 
             logger.d { "Downloading attachment. Name: $subPath, Url: $url" }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
@@ -19,16 +19,16 @@ package io.getstream.chat.android.offline.extensions.internal
 import io.getstream.chat.android.client.models.Attachment
 
 /**
- * Uses a regex pattern to extract the file name from the attachment URL.
+ * Uses substrings to extract the file name from the attachment URL.
  *
  * Useful in situations where no attachment name or title has been provided and
  * we need a name in order to download the file to storage.
  */
 internal fun Attachment.getAttachmentFallbackName(): String? {
     val url = when (this.type) {
-        "image" -> this.imageUrl ?: this.thumbUrl ?: this.assetUrl
+        "image" -> this.imageUrl ?: this.assetUrl ?: this.thumbUrl
         else -> this.assetUrl ?: this.imageUrl ?: this.thumbUrl
     }
 
-    return url?.let { Regex("""[^/]+(?=\?)""").find(it)?.value }
+    return url?.substringAfterLast("/")?.substringBefore("?")
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
@@ -24,11 +24,15 @@ import io.getstream.chat.android.client.models.Attachment
  * Useful in situations where no attachment name or title has been provided and
  * we need a name in order to download the file to storage.
  */
-internal fun Attachment.getAttachmentFallbackName(): String? {
+internal fun Attachment.parseAttachmentNameFromUrl(): String? {
     val url = when (this.type) {
         "image" -> this.imageUrl ?: this.assetUrl ?: this.thumbUrl
         else -> this.assetUrl ?: this.imageUrl ?: this.thumbUrl
     }
 
-    return url?.substringAfterLast("/")?.substringBefore("?")
+    return url?.substringAfterLast(
+        delimiter = "/",
+        missingDelimiterValue = ""
+    )?.takeIf { it.isNotBlank() }
+        ?.substringBefore("?")
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
@@ -30,5 +30,5 @@ internal fun Attachment.getAttachmentFallbackName(): String? {
         else -> this.assetUrl ?: this.imageUrl ?: this.thumbUrl
     }
 
-    return url?.let { Regex("""[^\/]*(?=\?)""").find(it)?.value }
+    return url?.let { Regex("""[^/]+(?=\?)""").find(it)?.value }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
@@ -1,0 +1,18 @@
+package io.getstream.chat.android.offline.extensions.internal
+
+import io.getstream.chat.android.client.models.Attachment
+
+/**
+ * Uses a regex pattern to extract the file name from the attachment URL.
+ *
+ * Useful in situations where no attachment name or title has been provided and
+ * we need a name in order to download the file to storage.
+ */
+internal fun Attachment.getAttachmentFallbackName(): String? {
+    val url = when (this.type) {
+        "image" -> this.imageUrl ?: this.thumbUrl ?: this.assetUrl
+        else -> this.assetUrl ?: this.imageUrl ?: this.thumbUrl
+    }
+
+    return url?.let { Regex("""[^\/]*(?=\?)""").find(it)?.value }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/extensions/internal/Attachment.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.offline.extensions.internal
 
 import io.getstream.chat.android.client.models.Attachment


### PR DESCRIPTION
### 🎯 Goal

closes #4598 

### 🛠 Implementation details

Added an extension function which uses regex to find the file name from the URL in case it's missing.

Inside the channel `Giphy testing` there is an image of a pair of headphones that was sent from an iPhone device. The image does not have proper `Attachment.name` or `Attachment.title` properties.

Testing steps:

1. Open the image mentioned above in the gallery
2. Download it

Expected: Will silently fail on `v5`/ `develop` branches but will succeed downloading it here.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the ~~`develop`~~ `v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media1.giphy.com/media/MBCrWIdDS5RwvZqO6z/giphy.gif?cid=ecf05e47adqmsmtqrum653bifouq3lcm6ob5dq4vks68kb8a&rid=giphy.gif&ct=g)
