### PR TITLE
Minor optimization/fix

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
@@ -258,7 +258,7 @@ public fun MessageList(
 
     when {
         isLoading -> loadingContent()
-        !isLoading && messages.isNotEmpty() -> Messages(
+        messages.isNotEmpty() -> Messages(
             modifier = modifier,
             contentPadding = contentPadding,
             messagesState = currentState,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -548,8 +548,10 @@ public class MessageListViewModel(
      * @param threadMode Current thread mode.
      */
     private fun threadLoadMore(threadMode: MessageMode.MessageThread) {
-        threadMessagesState = threadMessagesState.copy(isLoadingMore = true)
-        if (threadMode.threadState != null) {
+        val threadState = threadMode.threadState
+        if (threadState != null && !threadState.endOfOlderMessages.value) {
+            threadMessagesState = threadMessagesState.copy(isLoadingMore = true)
+
             chatClient.getRepliesMore(
                 messageId = threadMode.parentMessage.id,
                 firstId = threadMode.threadState?.oldestInThread?.value?.id ?: threadMode.parentMessage.id,
@@ -1026,7 +1028,7 @@ public class MessageListViewModel(
     }
 
     /**
-     * Removes the shaddow ban for the given user inside
+     * Removes the shadow ban for the given user inside
      * this channel.
      *
      * @param userId The ID of the user for which the shadow


### PR DESCRIPTION
### 🎯 Goal

Just added checks to not trigger loading if there are no messages to load.

### 🧪 Testing

Test A)
1. Run Compose app on v5.
2. Open a new thread. (preferably with an image message as parent)
3. Attempt to scroll top/bottom. 

You should see a lot of requests in Logcat as well as the loading spinner freaking out.

Test B)
1. Run Compose on this branch.
2. Open a new thread. (preferably with an image message as parent)
3. Attempt to scroll top/bottom.

The scroll shouldn't trigger any unnecessary loads.

If you test it in a thread that has _many_ messages, it should work fine and load all the messages.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)

#### Code & documentation
- [ ] Changelog is updated with client-facing changes

### ☑️Reviewer Checklist
- [ ] Compose sample runs & works
- [ ] Bugs validated (bugfixes)
- [ ] Release notes and docs clearly describe changes