### PR TITLE
[ISSUE-4625] Fix for message gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed message gaps in message list view when using offline support. [#4626](https://github.com/GetStream/stream-chat-android/pull/4626)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2078,6 +2078,7 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessage (Lio/getstream/chat/android/models/Message;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessages (Ljava/util/List;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun selectLastMessageForChannel (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessageBySyncState (Lio/getstream/chat/android/models/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessageIdsBySyncState (Lio/getstream/chat/android/models/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -114,9 +114,14 @@ public interface MessageRepository {
     public suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message>
 
     /**
+     * Gets the last message of a channel
+     *
+     * @param cid String. Identifier of a [Channel]
+     */
+    public suspend fun selectLastMessageForChannel(cid: String): Message?
+
+    /**
      * Clear messages of this repository.
      */
     public suspend fun clear()
-
-    public suspend fun selectLastMessageForChannel(cid: String): Message?
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -118,5 +118,5 @@ public interface MessageRepository {
      */
     public suspend fun clear()
 
-    public suspend fun getLastMessageForChannel(cid: String): Message?
+    public suspend fun selectLastMessageForChannel(cid: String): Message?
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -117,4 +117,6 @@ public interface MessageRepository {
      * Clear messages of this repository.
      */
     public suspend fun clear()
+
+    public suspend fun getLastMessageForChannel(cid: String): Message?
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -190,7 +190,7 @@ public class RepositoryFacade private constructor(
                 configsRepository = factory.createChannelConfigRepository(),
                 channelsRepository = factory.createChannelRepository(
                     getUser,
-                    messageRepository::getLastMessageForChannel
+                    messageRepository::selectLastMessageForChannel
                 ),
                 queryChannelsRepository = factory.createQueryChannelsRepository(),
                 messageRepository = messageRepository,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -184,12 +184,14 @@ public class RepositoryFacade private constructor(
             }
 
             val messageRepository = factory.createMessageRepository(getUser)
-            val getMessage: suspend (messageId: String) -> Message? = messageRepository::selectMessage
 
             return RepositoryFacade(
                 userRepository = userRepository,
                 configsRepository = factory.createChannelConfigRepository(),
-                channelsRepository = factory.createChannelRepository(getUser, getMessage),
+                channelsRepository = factory.createChannelRepository(
+                    getUser,
+                    messageRepository::getLastMessageForChannel
+                ),
                 queryChannelsRepository = factory.createQueryChannelsRepository(),
                 messageRepository = messageRepository,
                 reactionsRepository = factory.createReactionRepository(getUser),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
@@ -46,11 +46,11 @@ public interface RepositoryFactory {
      * Creates [ChannelRepository]
      *
      * @param getUser function that provides userId.
-     * @param getMessage function that provides messageId.
+     * @param getLastMessage function that provides messageId.
      */
     public fun createChannelRepository(
         getUser: suspend (userId: String) -> User,
-        getMessage: suspend (messageId: String) -> Message?,
+        getLastMessageForChannel: suspend (String) -> Message?,
     ): ChannelRepository
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -37,6 +37,8 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun selectMessageIdsBySyncState(syncStatus: SyncStatus): List<String> = emptyList()
     override suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message> = emptyList()
     override suspend fun clear() { /* No-Op */ }
+    override suspend fun getLastMessageForChannel(cid: String): Message? = null
+
     override suspend fun selectMessagesForChannel(
         cid: String,
         pagination: AnyChannelPaginationRequest?,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -37,7 +37,7 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun selectMessageIdsBySyncState(syncStatus: SyncStatus): List<String> = emptyList()
     override suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message> = emptyList()
     override suspend fun clear() { /* No-Op */ }
-    override suspend fun getLastMessageForChannel(cid: String): Message? = null
+    override suspend fun selectLastMessageForChannel(cid: String): Message? = null
 
     override suspend fun selectMessagesForChannel(
         cid: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
@@ -48,7 +48,7 @@ internal object NoOpRepositoryFactory : RepositoryFactory {
 
     override fun createChannelRepository(
         getUser: suspend (userId: String) -> User,
-        getLastMessageForChannel: suspend (String) -> Message?,
+        getLastMessageForChannel: suspend (cid: String) -> Message?,
     ): ChannelRepository = NoOpChannelRepository
 
     object Provider : RepositoryFactory.Provider {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
@@ -48,7 +48,7 @@ internal object NoOpRepositoryFactory : RepositoryFactory {
 
     override fun createChannelRepository(
         getUser: suspend (userId: String) -> User,
-        getMessage: suspend (messageId: String) -> Message?,
+        getLastMessageForChannel: suspend (String) -> Message?,
     ): ChannelRepository = NoOpChannelRepository
 
     object Provider : RepositoryFactory.Provider {

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -95,6 +95,7 @@ public final class io/getstream/chat/android/offline/repository/domain/message/i
 	public fun selectBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectChunked (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectIdsBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun selectLastMessageForChannel (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectWaitForAttachments (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun updateMessageInnerEntity (Lio/getstream/chat/android/offline/repository/domain/message/internal/MessageInnerEntity;)V
 	public fun upsertMessageInnerEntities (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntityUtils.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntityUtils.kt
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.offline.repository.domain.channel
-
-import io.getstream.chat.android.offline.repository.domain.channel.internal.ChannelEntity
+package io.getstream.chat.android.offline.repository.domain.channel.internal
 
 /**
  * Composes a short version of [ChannelEntity.toString] with the last message information only.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntityUtils.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntityUtils.kt
@@ -20,5 +20,5 @@ package io.getstream.chat.android.offline.repository.domain.channel.internal
  * Composes a short version of [ChannelEntity.toString] with the last message information only.
  */
 internal fun ChannelEntity.lastMessageInfo(): String {
-    return "ChannelEntity(lastMessageId: $lastMessageId, lastMessageAt: $lastMessageAt, cid: $cid)"
+    return "ChannelEntity(lastMessageAt: $lastMessageAt, cid: $cid)"
 }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
@@ -65,7 +65,7 @@ internal fun Channel.toEntity(): ChannelEntity {
 
 internal suspend fun ChannelEntity.toModel(
     getUser: suspend (userId: String) -> User,
-    getMessage: suspend (messageId: String) -> Message?,
+    getLastMessageForChannel: suspend (String) -> Message?,
 ): Channel = Channel(
     cooldown = cooldown,
     type = type,
@@ -83,7 +83,7 @@ internal suspend fun ChannelEntity.toModel(
     hiddenMessagesBefore = hideMessagesBefore,
     members = members.values.map { it.toModel(getUser) },
     memberCount = memberCount,
-    messages = listOfNotNull(lastMessageId?.let { getMessage(it) }),
+    messages = listOfNotNull(getLastMessageForChannel(cid)),
     read = reads.values.map { it.toModel(getUser) },
     createdBy = getUser(createdByUserId),
     watchers = watcherIds.map { getUser(it) },

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
@@ -65,7 +65,7 @@ internal fun Channel.toEntity(): ChannelEntity {
 
 internal suspend fun ChannelEntity.toModel(
     getUser: suspend (userId: String) -> User,
-    getLastMessageForChannel: suspend (String) -> Message?,
+    getLastMessageForChannel: suspend (cid: String) -> Message?,
 ): Channel = Channel(
     cooldown = cooldown,
     type = type,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
@@ -35,7 +35,7 @@ import java.util.Date
 internal class DatabaseChannelRepository(
     private val channelDao: ChannelDao,
     private val getUser: suspend (userId: String) -> User,
-    private val getLastMessageForChannel: suspend (String) -> Message?,
+    private val getLastMessageForChannel: suspend (cid: String) -> Message?,
     cacheSize: Int = 100,
 ) : ChannelRepository {
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -171,7 +171,7 @@ internal class DatabaseMessageRepository(
     }
 
     override suspend fun selectLastMessageForChannel(cid: String): Message? {
-        return messageDao.selectLastMessageForChannel(cid).firstOrNull()?.toModel(getUser, ::selectMessage)
+        return messageDao.selectLastMessageForChannel(cid)?.toModel(getUser, ::selectMessage)
     }
 
     private suspend fun selectMessagesEntitiesForChannel(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -170,7 +170,7 @@ internal class DatabaseMessageRepository(
         messageDao.deleteAll()
     }
 
-    override suspend fun getLastMessageForChannel(cid: String): Message? {
+    override suspend fun selectLastMessageForChannel(cid: String): Message? {
         return messageDao.selectLastMessageForChannel(cid).firstOrNull()?.toModel(getUser, ::selectMessage)
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -171,7 +171,7 @@ internal class DatabaseMessageRepository(
     }
 
     override suspend fun getLastMessageForChannel(cid: String): Message? {
-        return  messageDao.selectLastMessageForChannel(cid).firstOrNull()?.toModel(getUser, ::selectMessage)
+        return messageDao.selectLastMessageForChannel(cid).firstOrNull()?.toModel(getUser, ::selectMessage)
     }
 
     private suspend fun selectMessagesEntitiesForChannel(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -170,6 +170,10 @@ internal class DatabaseMessageRepository(
         messageDao.deleteAll()
     }
 
+    override suspend fun getLastMessageForChannel(cid: String): Message? {
+        return  messageDao.selectLastMessageForChannel(cid).firstOrNull()?.toModel(getUser, ::selectMessage)
+    }
+
     private suspend fun selectMessagesEntitiesForChannel(
         cid: String,
         pagination: AnyChannelPaginationRequest?,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -228,7 +228,7 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END DESC LIMIT 1"
     )
-    suspend fun selectLastMessageForChannel(cid: String): List<MessageEntity>
+    suspend fun selectLastMessageForChannel(cid: String): MessageEntity?
 
     private companion object {
         private const val SQLITE_MAX_VARIABLE_NUMBER: Int = 999

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -220,6 +220,16 @@ internal interface MessageDao {
     @Query("DELETE FROM $MESSAGE_ENTITY_TABLE_NAME")
     suspend fun deleteAll()
 
+    @Query(
+        "SELECT * from $MESSAGE_ENTITY_TABLE_NAME " +
+            "WHERE cid = :cid " +
+            "ORDER BY CASE WHEN createdAt " +
+            "IS NULL THEN createdLocallyAt " +
+            "ELSE createdAt " +
+            "END DESC LIMIT 1"
+    )
+    suspend fun selectLastMessageForChannel(cid: String): List<MessageEntity>
+
     private companion object {
         private const val SQLITE_MAX_VARIABLE_NUMBER: Int = 999
         private const val NO_LIMIT: Int = -1

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
@@ -69,7 +69,7 @@ internal class DatabaseRepositoryFactory(
 
     override fun createChannelRepository(
         getUser: suspend (userId: String) -> User,
-        getLastMessageForChannel: suspend (String) -> Message?,
+        getLastMessageForChannel: suspend (cid: String) -> Message?,
     ): ChannelRepository {
         val databaseChannelRepository = repositoriesCache[ChannelRepository::class.java] as? DatabaseChannelRepository?
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
@@ -69,12 +69,12 @@ internal class DatabaseRepositoryFactory(
 
     override fun createChannelRepository(
         getUser: suspend (userId: String) -> User,
-        getMessage: suspend (messageId: String) -> Message?,
+        getLastMessageForChannel: suspend (String) -> Message?,
     ): ChannelRepository {
         val databaseChannelRepository = repositoriesCache[ChannelRepository::class.java] as? DatabaseChannelRepository?
 
         return databaseChannelRepository ?: run {
-            DatabaseChannelRepository(database.channelStateDao(), getUser, getMessage, DEFAULT_CACHE_SIZE)
+            DatabaseChannelRepository(database.channelStateDao(), getUser, getLastMessageForChannel, DEFAULT_CACHE_SIZE)
                 .also { repository ->
                     repositoriesCache[ChannelRepository::class.java] = repository
                 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
@@ -58,8 +58,7 @@ internal class ChannelRepositoryImplTest {
 
         verify(channelDao).insert(
             argThat { channelEntity ->
-                channelEntity.lastMessageAt == lastMessage.createdAt &&
-                    channelEntity.lastMessageId == lastMessage.id
+                channelEntity.lastMessageAt == lastMessage.createdAt
             }
         )
     }
@@ -77,8 +76,7 @@ internal class ChannelRepositoryImplTest {
 
         verify(channelDao).insert(
             argThat { channelEntity ->
-                channelEntity.lastMessageAt == after &&
-                    channelEntity.lastMessageId == newLastMessage.id
+                channelEntity.lastMessageAt == after
             }
         )
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -260,6 +260,10 @@ internal class MockMessageRepository : MessageRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun selectLastMessageForChannel(cid: String): Message? {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun clear() {
         messages.clear()
     }


### PR DESCRIPTION
### 🎯 Goal

Fix message gaps.

### 🛠 Implementation details

Refactoring feature to get last message of channel from DB. Now the SDK always request the last message by using only the database, instead keeping `lastMessageId` only to get the last message.

This provents the possibility to get an outdated last messages, caused by a delayed write of `lastMessageId`, now you always get the last message available in the database, if a write of the database in due, that won't affect this functionality. 

The problem of having the wrong last message causes gaps in the pagination of messages, because when the online request finishes, the 2 messages are added in the channel creating a gap in the messages. Check the video for a visual example of that. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/10619102/212930083-a3d23301-2b73-43f8-8f0e-3bfdb02391b9.mov" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/10619102/212930071-c1242f12-e41f-4bb9-8eaf-ae81eb6066ff.mov" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Check many times that the last message of each channel is the correct one and check that no gaps happens in pagination for new messages.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/212928439-644fdc20-9caa-42b7-827d-9f172b196c19.gif)

