### PR TITLE
Fix image scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed image scaling when width is bigger than height. [#4659](https://github.com/GetStream/stream-chat-android/pull/4659)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
@@ -21,6 +21,7 @@ import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.View
 import android.view.ViewGroup
+import android.widget.ImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
@@ -109,7 +110,13 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
             if (imageWidth != null && imageHeight != null) {
                 val ratio = (imageWidth / imageHeight).toString()
                 this.setDimensionRatio(imageAttachmentView.id, ratio)
+                imageAttachmentView.binding.imageView.scaleType = if (imageWidth > imageHeight) {
+                    ImageView.ScaleType.FIT_XY
+                } else {
+                    ImageView.ScaleType.CENTER_CROP
+                }
             } else {
+                imageAttachmentView.binding.imageView.scaleType = ImageView.ScaleType.CENTER_CROP
                 constrainHeight(imageAttachmentView.id, LayoutParams.WRAP_CONTENT)
             }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
@@ -137,7 +137,6 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
             imageAttachmentView.binding.imageView.scaleType = ImageView.ScaleType.CENTER_CROP
         }
 
-
         imageAttachmentView.showAttachment(first)
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/adapter/view/internal/ImageAttachmentsGroupView.kt
@@ -97,6 +97,8 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
 
         val imageWidth = first.originalWidth?.toFloat()
         val imageHeight = first.originalHeight?.toFloat()
+        // Beware, floating point division by 0f results in NaN,
+        // division by 0 using types such as Int would result in an exception.
         val imageAspectRatio = (imageWidth ?: 0f) / (imageHeight ?: 0f)
 
         ConstraintSet().apply {
@@ -139,6 +141,8 @@ internal class ImageAttachmentsGroupView : ConstraintLayout {
         imageHeight: Float?,
         imageAttachmentView: ImageAttachmentView,
     ) {
+        // Beware, floating point division by 0f results in NaN,
+        // division by 0 using types such as Int would result in an exception.
         val imageAspectRatio = (imageWidth ?: 0f) / (imageHeight ?: 0f)
         when {
             imageWidth == null || imageHeight == null ->


### PR DESCRIPTION
### 🎯 Goal

Closes #4657

### 🛠 Implementation details

Apply `fitXY` scaling if the image height on the screen is smaller than the max container height. Otherwise `centerCrop` so scaling is not broken.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_20230207_122025_Chat Sample Android](https://user-images.githubusercontent.com/38032787/217231394-9215a6f2-1dcc-47c6-9797-efc7e5d9de41.jpg) | ![Screenshot_20230207_121935_Chat Sample Android](https://user-images.githubusercontent.com/38032787/217231416-1dd5b69f-f06b-4058-a9b2-ae8f8fb804ef.jpg) |

### 🧪 Testing

| Test image 1 | Test image 2 | Test image 3 |
| --- | --- | --- |
| ![Screenshot 2023-02-06 at 12 13 19](https://user-images.githubusercontent.com/38032787/217230613-0b283618-6bf1-4609-9659-87e1d18f9fbd.png) | ![216983320-179eec7b-aa7b-4e0e-9043-cbd83d0413b6](https://user-images.githubusercontent.com/38032787/217230615-40e02b4b-e1c5-4c82-8fb7-88cd822ca396.png) | ![Screenshot 2023-02-08 at 10 14 14](https://user-images.githubusercontent.com/38032787/217505816-a5837e23-afc4-4cc8-9d35-bd566afff465.png) |

1. Run v5 
2. Rry sending or opening channels with images above, the scale will not be correct
3. Run this branch and repeat step 2, the scale should be ok

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![giphy (1)](https://user-images.githubusercontent.com/38032787/217230551-eca4bf4f-317c-4529-b387-bf54c3bfb399.gif)