### PR TITLE
[4680] Fix setting date separator handler not being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed image scaling when width is bigger than height. [#4659](https://github.com/GetStream/stream-chat-android/pull/4659)
+- Fixed date separator handlers not being applied when calling `MessageListViewModel.setDateSeparatorHandler()` and  `MessageListViewModel.()`. [#4681](https://github.com/GetStream/stream-chat-android/pull/4681)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListItemLiveData.kt
@@ -84,7 +84,7 @@ internal class MessageListItemLiveData(
     private val readsLd: LiveData<List<ChannelUserRead>>,
     private val typingLd: LiveData<List<User>>? = null,
     private val isThread: Boolean = false,
-    private val dateSeparatorHandler: MessageListViewModel.DateSeparatorHandler? = null,
+    private var dateSeparatorHandler: MessageListViewModel.DateSeparatorHandler? = null,
     private val deletedMessageVisibility: LiveData<DeletedMessageVisibility>,
     private val messageFooterVisibility: LiveData<MessageFooterVisibility>,
     private val messagePositionHandlerProvider: () -> MessageListViewModel.MessagePositionHandler,
@@ -436,5 +436,15 @@ internal class MessageListItemLiveData(
                 func(type, user)
             }
         }
+    }
+
+    /**
+     * Updates [MessageListItemLiveData.dateSeparatorHandler].
+     *
+     * @param dateSeparatorHandler The new date separator handler which will be assigned to
+     * [MessageListItemLiveData.dateSeparatorHandler].
+     */
+    internal fun updateDateSeparatorHandlers(dateSeparatorHandler: MessageListViewModel.DateSeparatorHandler?) {
+        this.dateSeparatorHandler = dateSeparatorHandler
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -730,6 +730,7 @@ public class MessageListViewModel(
      */
     public fun setDateSeparatorHandler(dateSeparatorHandler: DateSeparatorHandler?) {
         this.dateSeparatorHandler = dateSeparatorHandler
+        this.messageListData?.updateDateSeparatorHandlers(this.dateSeparatorHandler)
     }
 
     /**
@@ -740,6 +741,7 @@ public class MessageListViewModel(
      */
     public fun setThreadDateSeparatorHandler(threadDateSeparatorHandler: DateSeparatorHandler?) {
         this.threadDateSeparatorHandler = threadDateSeparatorHandler
+        this.threadListData?.updateDateSeparatorHandlers(this.dateSeparatorHandler)
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Closes #4680 

### 🛠 Implementation details

Implemented a method inside `MessageListItemLiveData` which updates the date separator handler.

### 🧪 Testing

<details>

<summary>Patch that logs separator handler calls</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(revision b71509124a73e34ff5e0d869ea44a7ed2a1abd5d)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt	(date 1676654206028)
@@ -17,6 +17,7 @@
 package io.getstream.chat.ui.sample.feature.chat
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -223,6 +224,7 @@
             )
             bindView(binding.messageListView, viewLifecycleOwner)
             setDateSeparatorHandler { previousMessage, message ->
+                Log.d("dateSeparator", "called")
                 if (previousMessage == null) {
                     true
                 } else {
@@ -230,6 +232,7 @@
                 }
             }
             setThreadDateSeparatorHandler { previousMessage, message ->
+                Log.d("threadDateSeparator", "called")
                 if (previousMessage == null) {
                     false
                 } else {
```

</details>

1. Apply the patch above
2. Enter a channel and scroll
3. Enter a thread and scroll
4. Filter logs for `dateSeparator` and `threadDateSeparator`. You should see these being logged.
5. Go to `v5` and apply the same patch
6. Repeat steps `2` and `3`. You should not see `dateSeparator` being logged, `threadDateSeparator` will still be logged however 


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the ~~`develop`~~ branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media1.giphy.com/media/114X7S7MjUV1FS/giphy.gif?cid=ecf05e47eqd5tp6qu4zq5gnqy5ifimtnho0kuxf7jp4agluv&rid=giphy.gif&ct=g)
