### PR TITLE
[4698] Port the new `v5` download permission handling into the `v6` `…

### DIFF
--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -9,10 +9,8 @@
     <ID>ComplexCondition:Messages.kt$!startOfMessages &amp;&amp; index == 0 &amp;&amp; messages.isNotEmpty() &amp;&amp; lazyListState.isScrollInProgress</ID>
     <ID>ComplexMethod:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$@Composable private fun ImagePreviewContent( attachment: Attachment, pagerState: PagerState, page: Int, )</ID>
     <ID>ComplexMethod:MessageOptions.kt$@Composable public fun defaultMessageOptionsState( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, ): List&lt;MessageOptionItemState></ID>
-    <ID>ForbiddenComment:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$// TODO: Marin</ID>
     <ID>ForbiddenComment:MessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
     <ID>ForbiddenComment:QuotedMessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
-    <ID>ImportOrdering:io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent.kt:19</ID>
     <ID>LargeClass:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity : AppCompatActivity</ID>
     <ID>LongMethod:GiphyMessageContent.kt$@Composable public fun GiphyMessageContent( message: Message, modifier: Modifier = Modifier, onGiphyActionClick: (GiphyAction) -> Unit = {}, )</ID>
     <ID>LongMethod:GroupAvatar.kt$@Composable public fun GroupAvatar( users: List&lt;User>, modifier: Modifier = Modifier, shape: Shape = ChatTheme.shapes.avatar, textStyle: TextStyle = ChatTheme.typography.captionBold, onClick: (() -> Unit)? = null, )</ID>
@@ -23,6 +21,7 @@
     <ID>LongMethod:MessageItem.kt$@Composable internal fun RegularMessageContent( messageItem: MessageItemState, modifier: Modifier = Modifier, onLongItemClick: (Message) -> Unit = {}, onGiphyActionClick: (GiphyAction) -> Unit = {}, onQuotedMessageClick: (Message) -> Unit = {}, onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {}, )</ID>
     <ID>LongMethod:MessageOptions.kt$@Composable public fun defaultMessageOptionsState( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, ): List&lt;MessageOptionItemState></ID>
     <ID>LongMethod:StreamTypography.kt$StreamTypography.Companion$public fun defaultTypography(fontFamily: FontFamily? = null): StreamTypography</ID>
+    <ID>LongParameterList:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$( context: Context, mediaGalleryPreviewAction: MediaGalleryPreviewAction, currentPage: Int, attachments: List&lt;Attachment>, writePermissionState: PermissionState, downloadPayload: MutableState&lt;Attachment?> )</ID>
     <ID>LongParameterList:MediaGalleryPreviewActivityAttachmentState.kt$MediaGalleryPreviewActivityAttachmentState$( val name: String?, val url: String?, val thumbUrl: String?, val imageUrl: String?, val assetUrl: String?, val originalWidth: Int?, val originalHeight: Int?, val type: String?, )</ID>
     <ID>LongParameterList:MessageComposer.kt$( value: String, coolDownTime: Int, attachments: List&lt;Attachment>, validationErrors: List&lt;ValidationError>, ownCapabilities: Set&lt;String>, isInEditMode: Boolean, onSendMessage: (String, List&lt;Attachment>) -> Unit, )</ID>
     <ID>MagicNumber:AvatarPosition.kt$3</ID>
@@ -42,11 +41,6 @@
     <ID>MaxLineLength:MessageOptions.kt$iconPainter = painterResource(id = if (selectedMessage.pinned) R.drawable.stream_compose_ic_unpin_message else R.drawable.stream_compose_ic_pin_message)</ID>
     <ID>MaxLineLength:MessageOptions.kt$title = if (selectedMessage.pinned) R.string.stream_compose_unpin_message else R.string.stream_compose_pin_message</ID>
     <ID>MaxLineLength:StreamColors.kt$StreamColors$*</ID>
-    <ID>NoUnusedImports:io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewActivity.kt:19</ID>
     <ID>TooManyFunctions:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity : AppCompatActivity</ID>
-    <ID>UnusedImports:MediaGalleryPreviewActivity.kt$import android.Manifest</ID>
-    <ID>UnusedPrivateMember:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$attachments: List&lt;Attachment></ID>
-    <ID>UnusedPrivateMember:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$pagerState: PagerState</ID>
-    <ID>UnusedPrivateMember:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$private fun handleMediaAction( mediaGalleryPreviewAction: MediaGalleryPreviewAction, currentPage: Int, permissionHandler: PermissionHandler, attachments: List&lt;Attachment>, )</ID>
   </CurrentIssues>
 </SmellBaseline>

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
@@ -75,6 +75,7 @@ import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
@@ -109,6 +110,8 @@ import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.HorizontalPager
 import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
+import com.google.accompanist.permissions.ExperimentalPermissionsApi
+import com.google.accompanist.permissions.PermissionState
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.utils.Result
@@ -116,8 +119,6 @@ import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.compose.R
-import io.getstream.chat.android.compose.handlers.DownloadPermissionHandler
-import io.getstream.chat.android.compose.handlers.PermissionHandler
 import io.getstream.chat.android.compose.state.mediagallerypreview.Delete
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewAction
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewActivityState
@@ -139,6 +140,8 @@ import io.getstream.chat.android.compose.ui.components.avatar.Avatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.RetryHash
 import io.getstream.chat.android.compose.ui.util.rememberStreamImagePainter
+import io.getstream.chat.android.compose.util.attachmentDownloadState
+import io.getstream.chat.android.compose.util.onDownloadHandleRequest
 import io.getstream.chat.android.compose.viewmodel.mediapreview.MediaGalleryPreviewViewModel
 import io.getstream.chat.android.compose.viewmodel.mediapreview.MediaGalleryPreviewViewModelFactory
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -543,12 +546,16 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
      * @param pagerState The state of the pager, used to handle selected actions.
      * @param attachments The list of attachments for which we display options.
      */
+    @OptIn(ExperimentalPermissionsApi::class)
     @Composable
     private fun MediaGalleryPreviewOptionItem(
         mediaGalleryPreviewOption: MediaGalleryPreviewOption,
         pagerState: PagerState,
         attachments: List<Attachment>,
     ) {
+
+        val (writePermissionState, downloadPayload) = attachmentDownloadState()
+        val context = LocalContext.current
 
         Row(
             modifier = Modifier
@@ -559,14 +566,14 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
                     interactionSource = remember { MutableInteractionSource() },
                     indication = rememberRipple(),
                     onClick = {
-                        mediaGalleryPreviewViewModel.toggleMediaOptions(isShowingOptions = false)
-                        // TODO: Marin
-                        // handleMediaAction(
-                        //     mediaGalleryPreviewAction = mediaGalleryPreviewOption.action,
-                        //     currentPage = pagerState.currentPage,
-                        //     permissionHandler = downloadPermissionHandler,
-                        //     attachments = attachments
-                        // )
+                        handleMediaAction(
+                            context = context,
+                            mediaGalleryPreviewAction = mediaGalleryPreviewOption.action,
+                            currentPage = pagerState.currentPage,
+                            writePermissionState = writePermissionState,
+                            downloadPayload = downloadPayload,
+                            attachments = attachments
+                        )
                     },
                     enabled = mediaGalleryPreviewOption.isEnabled
                 ),
@@ -596,17 +603,21 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
     /**
      * Consumes the action user selected to perform for the current media attachment.
      *
+     * @param context The [Context] used to ask for handling permissions.
      * @param mediaGalleryPreviewAction The action the user selected.
      * @param currentPage The index of the current media attachment.
-     * @param permissionHandler Checks if we have the necessary permissions
-     * to perform an action if the action needs a specific Android permission.
      * @param attachments The list of attachments for which actions need to be handled.
+     * @param writePermissionState The current state of permissions.
+     * @param downloadPayload The attachment to be downloaded.
      */
+    @OptIn(ExperimentalPermissionsApi::class)
     private fun handleMediaAction(
+        context: Context,
         mediaGalleryPreviewAction: MediaGalleryPreviewAction,
         currentPage: Int,
-        permissionHandler: PermissionHandler,
         attachments: List<Attachment>,
+        writePermissionState: PermissionState,
+        downloadPayload: MutableState<Attachment?>
     ) {
         val message = mediaGalleryPreviewAction.message
 
@@ -629,10 +640,12 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
             }
             is Delete -> mediaGalleryPreviewViewModel.deleteCurrentMediaAttachment(attachments[currentPage])
             is SaveMedia -> {
-                permissionHandler
-                    .onHandleRequest(
-                        mapOf(DownloadPermissionHandler.PayloadAttachment to attachments[currentPage])
-                    )
+                onDownloadHandleRequest(
+                    context = context,
+                    payload = attachments[currentPage],
+                    permissionState = writePermissionState,
+                    downloadPayload = downloadPayload
+                )
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal

closes #4698 

### 🛠 Implementation details

Moved away from using a `ChatTheme` hosted permission handler.



### 🧪 Testing

1. Clean install the compose app on an API 28 or older phone/ emulator
2. Open an image in the gallery
3. Download the image

Result: Permissions should be asked for, once given the download should proceed.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
