### PR TITLE
[4720] Fix videos without thumbnails being unclickable

### DIFF
--- a/stream-chat-android-ui-components/detekt-baseline.xml
+++ b/stream-chat-android-ui-components/detekt-baseline.xml
@@ -4,6 +4,7 @@
   <CurrentIssues>
     <ID>ComplexCondition:AttachmentDestination.kt$AttachmentDestination$attachment.isFile() || attachment.isVideo() || attachment.isAudio() || attachment.mimeType?.contains(VIDEO_MIME_TYPE_PREFIX) == true</ID>
     <ID>ComplexCondition:FileAttachmentsView.kt$FileAttachmentViewHolder$item.uploadState is Attachment.UploadState.Idle || item.uploadState is Attachment.UploadState.InProgress || (item.uploadState is Attachment.UploadState.Success &amp;&amp; item.fileSize == 0)</ID>
+    <ID>ComplexCondition:MediaAttachmentView.kt$MediaAttachmentView$attachment.isImage() || (attachment.isVideo() &amp;&amp; ChatUI.videoThumbnailsEnabled &amp;&amp; attachment.thumbUrl != null)</ID>
     <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.deleteMessageEnabled &amp;&amp; (canDeleteAnyMessage || (isOwnMessage &amp;&amp; canDeleteOwnMessage))</ID>
     <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.editMessageEnabled &amp;&amp; ((isOwnMessage &amp;&amp; canEditOwnMessage) || canEditAnyMessage) &amp;&amp; selectedMessage.command != AttachmentType.GIPHY</ID>
     <ID>ComplexCondition:MessageOptionItemsFactory.kt$DefaultMessageOptionItemsFactory$style.threadsEnabled &amp;&amp; !isInThread &amp;&amp; isMessageSynced &amp;&amp; canThreadReply</ID>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/MediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/MediaAttachmentView.kt
@@ -133,13 +133,14 @@ internal class MediaAttachmentView : ConstraintLayout {
     fun showAttachment(attachment: Attachment, andMoreCount: Int = NO_MORE_COUNT) {
         val url =
             if (attachment.isImage() ||
-                (attachment.isVideo() && ChatUI.videoThumbnailsEnabled)
+                (attachment.isVideo() && ChatUI.videoThumbnailsEnabled && attachment.thumbUrl != null)
             ) {
                 attachment.imagePreviewUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing)
                     ?: attachment.titleLink ?: attachment.ogUrl ?: attachment.upload ?: return
             } else {
                 null
             }
+
         val showMore = {
             if (andMoreCount > NO_MORE_COUNT) {
                 showMoreCount(andMoreCount)


### PR DESCRIPTION
### 🎯 Goal

Closes #4720 

### 🛠 Implementation details

Implemented an if check which avoids parsing dimension if the thumbnail of a video is null. This action would previously result in an early return.

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| ![Screenshot_1678798304](https://user-images.githubusercontent.com/37080097/225006916-cdc7a32c-7de3-41f8-b224-f4677d101386.png) | ![Screenshot_1678798274](https://user-images.githubusercontent.com/37080097/225006929-5a6bbd30-8cad-4af8-99f5-6f40a4a45295.png) |

### 🧪 Testing

<details>

<summary>Patch which disables video thumbnails uploading</summary>

```
Index: stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt	(revision 9f76a2722fb6b47a01504c92926575ec83505b41)
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt	(date 1678797976321)
@@ -266,14 +266,14 @@
                     imageUrl = url
                 }
                 AttachmentType.VIDEO -> {
-                    imageUrl = thumbUrl
+                    // imageUrl = thumbUrl
                     assetUrl = url
                 }
                 else -> {
                     assetUrl = url
                 }
             }
-            this.thumbUrl = thumbUrl
+            // this.thumbUrl = thumbUrl
             if (title.isNullOrBlank()) {
                 title = file.name
             }
```

</details>

1. Apply the patch above
2. Go to a channel and send videos. They should not contain thumbnails.
3. Click on the videos you've sent.

Expectation: On `develop` the videos will not have the play icon and will be unclickable. When launching an app built from this branch, they should have the play icon and be clickable.


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media4.giphy.com/media/l4dqF0Aw5S8xXKHP5j/giphy.gif?cid=ecf05e47029ooze70ksxmrwzyk72ncrcch3pk3oswtevpggv&rid=giphy.gif&ct=g)
