### PR TITLE
Refactor static access

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -62,7 +62,6 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun getMessagesWithAttachments (Ljava/lang/String;Ljava/lang/String;IILjava/util/List;)Lio/getstream/chat/android/client/call/Call;
 	public static final fun getOFFLINE_SUPPORT_ENABLED ()Z
 	public final fun getPinnedMessages (Ljava/lang/String;Ljava/lang/String;ILio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/client/api/models/PinnedMessagesPagination;)Lio/getstream/chat/android/client/call/Call;
-	public final fun getPlugins ()Ljava/util/List;
 	public final fun getReactions (Ljava/lang/String;II)Lio/getstream/chat/android/client/call/Call;
 	public final fun getReplies (Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
 	public final fun getRepliesMore (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/chat/android/client/call/Call;
@@ -134,7 +133,6 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public static synthetic fun sendReaction$default (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/Reaction;ZLjava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/client/call/Call;
 	public final fun setLogicRegistry (Lio/getstream/chat/android/client/channel/state/ChannelStateLogicProvider;)V
 	public static final fun setOFFLINE_SUPPORT_ENABLED (Z)V
-	public final fun setPlugins (Ljava/util/List;)V
 	public static final fun setVERSION_PREFIX_HEADER (Lio/getstream/chat/android/client/header/VersionPrefixHeader;)V
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/chat/android/client/call/Call;
 	public final fun showChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -266,13 +266,21 @@ internal constructor(
      * Resolves dependency [T] within the provided plugin [P].
      *
      * @see [Plugin]
+     * @throws IllegalStateException if plugin was not added or dependency is not found.
      */
     @InternalStreamChatApi
-    public inline fun <reified P : Plugin, reified T : Any> resolveDependency(): T? {
+    @Throws(IllegalStateException::class)
+    public inline fun <reified P : Plugin, reified T : Any> resolveDependency(): T {
         val resolver = plugins.find { plugin ->
             plugin is P && plugin is DependencyResolver
         } as? DependencyResolver
-        return resolver?.resolveDependency(T::class)
+            ?: throw IllegalStateException(
+                "Plugin '${P::class.qualifiedName}' was not found. Did you init it within ChatClient?"
+            )
+        return resolver.resolveDependency(T::class)
+            ?: throw IllegalStateException(
+                "Dependency '${T::class.qualifiedName}' was not resolved from plugin '${P::class.qualifiedName}'"
+            )
     }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -259,8 +259,8 @@ internal constructor(
      *
      * @see [Plugin]
      */
-    @PublishedApi
-    internal var plugins: List<Plugin> = emptyList()
+    @InternalStreamChatApi
+    public var plugins: List<Plugin> = emptyList()
 
     /**
      * Resolves dependency [T] within the provided plugin [P].

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/errorhandler/factory/ErrorHandlerFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/errorhandler/factory/ErrorHandlerFactory.kt
@@ -17,7 +17,6 @@
 package io.getstream.chat.android.client.errorhandler.factory
 
 import io.getstream.chat.android.client.errorhandler.ErrorHandler
-import io.getstream.chat.android.client.persistance.repository.ChannelRepository
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
 /**
@@ -33,5 +32,5 @@ public interface ErrorHandlerFactory {
      *
      * @return The [ErrorHandler] instance.
      */
-    public fun create(channelRepository: ChannelRepository): ErrorHandler
+    public fun create(): ErrorHandler
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client
+
+import io.getstream.chat.android.client.errorhandler.ErrorHandler
+import io.getstream.chat.android.client.plugin.DependencyResolver
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.models.User
+import kotlinx.coroutines.test.TestResult
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.invoking
+import org.amshove.kluent.`should be`
+import org.amshove.kluent.`should throw`
+import org.amshove.kluent.`with message`
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import kotlin.reflect.KClass
+
+public class DependencyResolverTest {
+
+    @Test
+    public fun `Should throw an exception if plugin was not found`(): TestResult = runTest {
+        val client = Fixture()
+            .get()
+
+        invoking {
+            client.resolveDependency<PluginDependency, SomeDependency>()
+        }
+            .`should throw`(IllegalStateException::class)
+            .`with message`("Plugin 'io.getstream.chat.android.client.DependencyResolverTest.PluginDependency' was not found. Did you init it within ChatClient?")
+    }
+
+    @Test
+    public fun `Should throw an exception if dependency was not found`(): TestResult = runTest {
+        val client = Fixture()
+            .with(PluginDependency(emptyMap()))
+            .get()
+
+        invoking {
+            client.resolveDependency<PluginDependency, SomeDependency>()
+        }
+            .`should throw`(IllegalStateException::class)
+            .`with message`("Dependency 'io.getstream.chat.android.client.DependencyResolverTest.SomeDependency' was not resolved from plugin 'io.getstream.chat.android.client.DependencyResolverTest.PluginDependency'")
+    }
+
+    @Test
+    public fun `Should return expected dependency`(): TestResult = runTest {
+        val expectedDependency = SomeDependency()
+        val client = Fixture()
+            .with(PluginDependency(mapOf(SomeDependency::class to expectedDependency)))
+            .get()
+
+        val result = client.resolveDependency<PluginDependency, SomeDependency>()
+
+        result `should be` expectedDependency
+    }
+
+    private class Fixture {
+        var plugins: List<Plugin> = emptyList()
+
+        fun with(plugin: Plugin) = apply {
+            plugins = plugins + plugin
+        }
+
+        suspend fun get(): ChatClient = ChatClient(
+            config = mock(),
+            api = mock(),
+            notifications = mock(),
+            tokenManager = mock(),
+            userCredentialStorage = mock(),
+            userStateService = mock(),
+            tokenUtils = mock(),
+            clientScope = mock(),
+            userScope = mock(),
+            retryPolicy = mock(),
+            appSettingsManager = mock(),
+            chatSocket = mock(),
+            pluginFactories = mock(),
+            repositoryFactoryProvider = mock(),
+            clientState = mock(),
+        ).apply {
+            this.plugins = this@Fixture.plugins
+        }
+    }
+
+    private class PluginDependency(
+        private val classes: Map<KClass<*>, Any>,
+    ) : Plugin, DependencyResolver {
+        override val errorHandler: ErrorHandler? = null
+        override fun onUserSet(user: User) {
+            /** NO-OP */
+        }
+
+        override fun onUserDisconnected() {
+            /** NO-OP */
+        }
+
+        @InternalStreamChatApi
+        override fun <T : Any> resolveDependency(klass: KClass<T>): T? =
+            classes[klass] as? T
+    }
+
+    private class SomeDependency
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.ui.common.state.messages.list.NewMessageState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel responsible for handling all the business logic & state for the list of messages.
@@ -200,7 +201,9 @@ public class MessageListViewModel(
      * @param message The selected message with a thread.
      */
     public fun openMessageThread(message: Message) {
-        messageListController.enterThreadMode(message)
+        viewModelScope.launch {
+            messageListController.enterThreadMode(message)
+        }
     }
 
     /**
@@ -229,7 +232,9 @@ public class MessageListViewModel(
      * @param messageAction The action the user chose.
      */
     public fun performMessageAction(messageAction: MessageAction) {
-        messageListController.performMessageAction(messageAction)
+        viewModelScope.launch {
+            messageListController.performMessageAction(messageAction)
+        }
     }
 
     /**

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -33,7 +33,7 @@ import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -43,6 +43,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
@@ -58,6 +59,11 @@ import java.util.Date
 @ExperimentalCoroutinesApi
 @ExtendWith(TestCoroutineExtension::class)
 internal class ChannelListViewModelTest {
+
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
 
     @Test
     fun `Given channel list in loading state When showing the channel list Should show loading state`() = runTest {
@@ -272,13 +278,10 @@ internal class ChannelListViewModelTest {
         private val initialSort: QuerySorter<Channel> = querySort,
         private val initialFilters: FilterObject? = queryFilter,
     ) {
-        private val globalState: GlobalMutableState = mock()
         private val clientState: ClientState = mock()
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            GlobalMutableState.instance = globalState
-
             val statePlugin: StatePlugin = mock()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
@@ -288,11 +291,11 @@ internal class ChannelListViewModelTest {
         }
 
         fun givenCurrentUser(currentUser: User = User(id = "Jc")) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelMutes(channelMutes: List<ChannelMute> = emptyList()) = apply {
-            whenever(globalState.channelMutes) doReturn MutableStateFlow(channelMutes)
+            MutableGlobalStateInstance.setChannelMutes(channelMutes)
         }
 
         fun givenIsOffline(isOffline: Boolean = false) = apply {
@@ -339,7 +342,7 @@ internal class ChannelListViewModelTest {
                 chatClient = chatClient,
                 initialSort = initialSort,
                 initialFilters = initialFilters,
-                chatEventHandlerFactory = ChatEventHandlerFactory(clientState, globalState)
+                chatEventHandlerFactory = ChatEventHandlerFactory(clientState, MutableGlobalStateInstance)
             )
         }
     }

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
@@ -276,9 +277,11 @@ internal class ChannelListViewModelTest {
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
 
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.channel(any())) doReturn channelClient
             whenever(chatClient.channel(any(), any())) doReturn channelClient
             whenever(chatClient.clientState) doReturn clientState

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/imagepreview/ImagePreviewViewModelTest.kt
@@ -21,13 +21,15 @@ import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
+import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -36,6 +38,11 @@ import org.mockito.kotlin.whenever
 
 @ExperimentalCoroutinesApi
 internal class ImagePreviewViewModelTest {
+
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
 
     @Test
     fun `Given a message with image attachments When showing image gallery Should show the gallery`() = runTest {
@@ -76,16 +83,14 @@ internal class ImagePreviewViewModelTest {
         private val messageId: String = MESSAGE_ID,
     ) {
 
-        private val globalState: GlobalMutableState = mock()
         private val clientState: ClientState = mock()
 
         init {
-            GlobalMutableState.instance = globalState
             whenever(chatClient.clientState) doReturn mock()
         }
 
         fun givenCurrentUser(currentUser: User = User(id = "Jc")) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenAttachments(attachments: MutableList<Attachment>) = apply {
@@ -110,6 +115,9 @@ internal class ImagePreviewViewModelTest {
     }
 
     companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
         private const val MESSAGE_ID = "message-id"
         private val attachment1 = Attachment(type = "image", imageUrl = "http://example.com/img1.png")
         private val attachment2 = Attachment(type = "image", imageUrl = "http://example.com/img2.png")

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -357,8 +358,10 @@ internal class MessageComposerViewModelTest {
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.compose.viewmodel.messages
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.channel.state.ChannelState
-import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelData
@@ -29,7 +28,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.ui.common.feature.messages.composer.MessageComposerController
@@ -44,6 +43,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
@@ -57,6 +57,11 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 @ExtendWith(TestCoroutineExtension::class)
 internal class MessageComposerViewModelTest {
+
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
 
     @Test
     fun `Given message composer When typing a message Should display the message`() = runTest {
@@ -353,20 +358,16 @@ internal class MessageComposerViewModelTest {
         private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
         private val maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE,
     ) {
-        private val globalState: GlobalMutableState = mock()
-        private val clientState: ClientState = mock()
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            GlobalMutableState.instance = globalState
             val statePlugin: StatePlugin = mock()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
-            whenever(chatClient.clientState) doReturn clientState
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.models.MessagesState
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -116,9 +117,11 @@ internal class MessageListViewModelTest {
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
 
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.clientState) doReturn clientState
         }
 

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
@@ -163,7 +163,6 @@ internal class MessageListViewModelTest {
                 whenever(it.loadingOlderMessages) doReturn MutableStateFlow(false)
             }
             whenever(stateRegistry.channel(any(), any())) doReturn channelState
-            whenever(stateRegistry.scope) doReturn testCoroutines.scope
         }
 
         fun get(): MessageListViewModel {

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
@@ -29,7 +29,7 @@ import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.ui.common.feature.messages.list.MessageListController
@@ -40,6 +40,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should not be`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
@@ -53,6 +54,10 @@ import java.util.Date
 @ExperimentalCoroutinesApi
 internal class MessageListViewModelTest {
 
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
     @Test
     fun `Given message list When showing the message list Should update the messages state`() = runTest {
         val messageState = MessagesState.Result(listOf(message1, message2))
@@ -112,13 +117,10 @@ internal class MessageListViewModelTest {
         private val chatClient: ChatClient = mock(),
         private val channelId: String = CID,
     ) {
-        private val globalState: GlobalMutableState = mock()
         private val clientState: ClientState = mock()
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            GlobalMutableState.instance = globalState
-
             val statePlugin: StatePlugin = mock()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
@@ -126,7 +128,7 @@ internal class MessageListViewModelTest {
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -5,11 +5,6 @@ public final class io/getstream/chat/android/state/BuildConfig {
 	public fun <init> ()V
 }
 
-public final class io/getstream/chat/android/state/errorhandler/StateErrorHandlerFactory : io/getstream/chat/android/client/errorhandler/factory/ErrorHandlerFactory {
-	public fun <init> ()V
-	public fun create (Lio/getstream/chat/android/client/persistance/repository/ChannelRepository;)Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
-}
-
 public abstract class io/getstream/chat/android/state/event/handler/chat/BaseChatEventHandler : io/getstream/chat/android/state/event/handler/chat/ChatEventHandler {
 	public fun <init> ()V
 	public fun handleChannelEvent (Lio/getstream/chat/android/client/events/HasChannel;Lio/getstream/chat/android/models/FilterObject;)Lio/getstream/chat/android/state/event/handler/chat/EventHandlingResult;

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -137,7 +137,6 @@ public abstract interface class io/getstream/chat/android/state/plugin/state/cha
 }
 
 public abstract interface class io/getstream/chat/android/state/plugin/state/global/GlobalState {
-	public abstract fun clearState ()V
 	public abstract fun getBanned ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getChannelMutes ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getChannelUnreadCount ()Lkotlinx/coroutines/flow/StateFlow;
@@ -145,9 +144,6 @@ public abstract interface class io/getstream/chat/android/state/plugin/state/glo
 	public abstract fun getTotalUnreadCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getTypingChannels ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getUser ()Lkotlinx/coroutines/flow/StateFlow;
-}
-
-public final class io/getstream/chat/android/state/plugin/state/global/internal/GlobalMutableState$Companion {
 }
 
 public abstract class io/getstream/chat/android/state/plugin/state/querychannels/ChannelsStateData {

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -78,9 +78,9 @@ public final class io/getstream/chat/android/state/extensions/ChatClientExtensio
 	public static final fun cancelEphemeralMessage (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/client/call/Call;
 	public static final fun downloadAttachment (Lio/getstream/chat/android/client/ChatClient;Landroid/content/Context;Lio/getstream/chat/android/models/Attachment;)Lio/getstream/chat/android/client/call/Call;
 	public static final fun getGlobalState (Lio/getstream/chat/android/client/ChatClient;)Lio/getstream/chat/android/state/plugin/state/global/GlobalState;
-	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;I)Lio/getstream/chat/android/state/plugin/state/channel/thread/ThreadState;
-	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;)Lio/getstream/chat/android/state/plugin/state/channel/thread/ThreadState;
-	public static synthetic fun getRepliesAsState$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;ILjava/lang/Object;)Lio/getstream/chat/android/state/plugin/state/channel/thread/ThreadState;
+	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun getRepliesAsState$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun getState (Lio/getstream/chat/android/client/ChatClient;)Lio/getstream/chat/android/state/plugin/state/StateRegistry;
 	public static final fun getStateConfig (Lio/getstream/chat/android/client/ChatClient;)Lio/getstream/chat/android/state/plugin/config/StatePluginConfig;
 	public static final fun loadMessageById (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/call/Call;

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -120,15 +120,11 @@ public final class io/getstream/chat/android/state/plugin/factory/StreamStatePlu
 }
 
 public final class io/getstream/chat/android/state/plugin/state/StateRegistry {
-	public static final field Companion Lio/getstream/chat/android/state/plugin/state/StateRegistry$Companion;
-	public synthetic fun <init> (Lkotlinx/coroutines/flow/StateFlow;Lio/getstream/chat/android/client/persistance/repository/MessageRepository;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/Job;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/flow/StateFlow;Lkotlinx/coroutines/Job;Lkotlinx/coroutines/CoroutineScope;)V
 	public final fun channel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/client/channel/state/ChannelState;
 	public final fun clear ()V
 	public final fun queryChannels (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;)Lio/getstream/chat/android/state/plugin/state/querychannels/QueryChannelsState;
 	public final fun thread (Ljava/lang/String;)Lio/getstream/chat/android/state/plugin/state/channel/thread/ThreadState;
-}
-
-public final class io/getstream/chat/android/state/plugin/state/StateRegistry$Companion {
 }
 
 public abstract interface class io/getstream/chat/android/state/plugin/state/channel/thread/ThreadState {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/errorhandler/StateErrorHandlerFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/errorhandler/StateErrorHandlerFactory.kt
@@ -16,23 +16,25 @@
 
 package io.getstream.chat.android.state.errorhandler
 
-import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.errorhandler.factory.ErrorHandlerFactory
-import io.getstream.chat.android.client.persistance.repository.ChannelRepository
+import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
+import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.state.errorhandler.internal.CreateChannelErrorHandlerImpl
 import io.getstream.chat.android.state.errorhandler.internal.DeleteReactionErrorHandlerImpl
 import io.getstream.chat.android.state.errorhandler.internal.QueryMembersErrorHandlerImpl
 import io.getstream.chat.android.state.errorhandler.internal.SendReactionErrorHandlerImpl
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
-import io.getstream.chat.android.state.plugin.state.StateRegistry
+import kotlinx.coroutines.CoroutineScope
 
-public class StateErrorHandlerFactory : ErrorHandlerFactory {
+internal class StateErrorHandlerFactory(
+    private val scope: CoroutineScope,
+    private val logicRegistry: LogicRegistry,
+    private val clientState: ClientState,
+    private val repositoryFacade: RepositoryFacade,
+) : ErrorHandlerFactory {
 
-    override fun create(channelRepository: ChannelRepository): ErrorHandler {
-        val scope = StateRegistry.get().scope
-        val logicRegistry = LogicRegistry.get()
-        val clientState = ChatClient.instance().clientState
+    override fun create(): ErrorHandler {
 
         val deleteReactionErrorHandler = DeleteReactionErrorHandlerImpl(
             scope = scope,
@@ -43,13 +45,13 @@ public class StateErrorHandlerFactory : ErrorHandlerFactory {
         val createChannelErrorHandler = CreateChannelErrorHandlerImpl(
             scope = scope,
             clientState = clientState,
-            channelRepository = channelRepository,
+            channelRepository = repositoryFacade,
         )
 
         val queryMembersErrorHandler = QueryMembersErrorHandlerImpl(
             scope = scope,
             clientState = clientState,
-            channelRepository = channelRepository
+            channelRepository = repositoryFacade
         )
 
         val sendReactionErrorHandler = SendReactionErrorHandlerImpl(scope = scope, clientState = clientState)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventBatchUpdate.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventBatchUpdate.kt
@@ -26,7 +26,7 @@ import io.getstream.chat.android.client.utils.message.latestOrNull
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import io.getstream.chat.android.state.utils.internal.isChannelMutedForCurrentUser
 import io.getstream.log.StreamLog
 import io.getstream.log.taggedLogger
@@ -54,7 +54,7 @@ import io.getstream.log.taggedLogger
 internal class EventBatchUpdate private constructor(
     private val id: Int,
     private val currentUserId: String?,
-    private val mutableGlobalState: MutableGlobalState,
+    private val globalState: GlobalState,
     private val repos: RepositoryFacade,
     private val channelMap: MutableMap<String, Channel>,
     private val messageMap: MutableMap<String, Message>,
@@ -80,7 +80,7 @@ internal class EventBatchUpdate private constructor(
                 if (message.shouldIncrementUnreadCount(
                         currentUserId = currentUserId,
                         lastMessageAtDate = lastReadDate,
-                        isChannelMuted = mutableGlobalState.isChannelMutedForCurrentUser(channel.cid)
+                        isChannelMuted = globalState.isChannelMutedForCurrentUser(channel.cid)
                     )
                 ) {
                     channel.incrementUnreadCount(currentUserId, message.createdAt)
@@ -175,7 +175,7 @@ internal class EventBatchUpdate private constructor(
         }
 
         suspend fun build(
-            mutableGlobalState: MutableGlobalState,
+            globalState: GlobalState,
             repos: RepositoryFacade,
             currentUserId: String?
         ): EventBatchUpdate {
@@ -192,7 +192,7 @@ internal class EventBatchUpdate private constructor(
             return EventBatchUpdate(
                 id,
                 currentUserId,
-                mutableGlobalState,
+                globalState,
                 repos,
                 channelMap.toMutableMap(),
                 messageMap.toMutableMap(),

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -49,7 +49,7 @@ import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.channel.thread.ThreadState
 import io.getstream.chat.android.state.plugin.state.global.GlobalState
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
@@ -78,7 +78,7 @@ public val ChatClient.state: StateRegistry
  * [GlobalState] instance that contains information about the current user, unreads, etc.
  */
 public val ChatClient.globalState: GlobalState
-    get() = GlobalMutableState.get(clientState)
+    get() = MutableGlobalStateInstance
 
 /**
  * [StatePluginConfig] instance used to configure [io.getstream.chat.android.state.plugin.internal.StatePlugin]

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -145,7 +145,7 @@ public fun ChatClient.watchChannelAsState(
  * @return [ThreadState]
  */
 @JvmOverloads
-public fun ChatClient.getRepliesAsState(
+public suspend fun ChatClient.getRepliesAsState(
     messageId: String,
     messageLimit: Int,
     coroutineScope: CoroutineScope = CoroutineScope(DispatcherProvider.IO),
@@ -183,7 +183,7 @@ public suspend fun ChatClient.awaitRepliesAsState(
  */
 private fun <T> ChatClient.getStateOrNull(
     coroutineScope: CoroutineScope,
-    producer: () -> T,
+    producer: suspend () -> T,
 ): StateFlow<T?> {
     return globalState.user.map { it?.id }.distinctUntilChanged().map { userId ->
         if (userId == null) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -45,6 +45,7 @@ import io.getstream.chat.android.state.extensions.internal.parseAttachmentNameFr
 import io.getstream.chat.android.state.extensions.internal.requestsAsState
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.internal.ConfigSingleton
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.channel.thread.ThreadState
 import io.getstream.chat.android.state.plugin.state.global.GlobalState
@@ -71,10 +72,7 @@ import java.util.Locale
  */
 public val ChatClient.state: StateRegistry
     @Throws(IllegalArgumentException::class)
-    get() = requireNotNull(StateRegistry.get()) {
-        "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
-            "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
-    }
+    get() = resolveDependency<StatePlugin, StateRegistry>()
 
 /**
  * [GlobalState] instance that contains information about the current user, unreads, etc.

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -52,6 +52,7 @@ import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutabl
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -205,7 +206,7 @@ private fun <T> ChatClient.getStateOrNull(
  */
 @CheckResult
 public fun ChatClient.setMessageForReply(cid: String, message: Message?): Call<Unit> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
 
         when (val cidValidationResult = validateCidWithResult(cid)) {
             is Result.Success -> {
@@ -229,7 +230,7 @@ public fun ChatClient.setMessageForReply(cid: String, message: Message?): Call<U
  */
 @CheckResult
 public fun ChatClient.downloadAttachment(context: Context, attachment: Attachment): Call<Unit> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         val logger by taggedLogger("Chat:DownloadAttachment")
 
         try {
@@ -263,7 +264,7 @@ public fun ChatClient.downloadAttachment(context: Context, attachment: Attachmen
  * @return The channel wrapped in [Call]. This channel contains older requested messages.
  */
 public fun ChatClient.loadOlderMessages(cid: String, messageLimit: Int): Call<Channel> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         when (val cidValidationResult = validateCidWithResult(cid)) {
             is Result.Success -> {
                 val (channelType, channelId) = cid.cidToTypeAndId()
@@ -280,7 +281,7 @@ public fun ChatClient.loadNewerMessages(
     baseMessageId: String,
     messageLimit: Int,
 ): Call<Channel> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         when (val cidValidationResult = validateCidWithResult(channelCid)) {
             is Result.Success -> {
                 val (channelType, channelId) = channelCid.cidToTypeAndId()
@@ -301,7 +302,7 @@ public fun ChatClient.loadNewerMessages(
  * @return Executable async [Call] responsible for canceling ephemeral message.
  */
 public fun ChatClient.cancelEphemeralMessage(message: Message): Call<Boolean> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         when (val cidValidationResult = validateCidWithResult(message.cid)) {
             is Result.Success -> {
                 try {
@@ -361,7 +362,7 @@ public fun ChatClient.loadMessageById(
     cid: String,
     messageId: String,
 ): Call<Message> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         loadMessageByIdInternal(cid, messageId)
     }
 }
@@ -414,7 +415,7 @@ public fun ChatClient.loadNewestMessages(
     messageLimit: Int,
     userPresence: Boolean = true,
 ): Call<Channel> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         when (val cidValidationResult = validateCidWithResult(cid)) {
             is Result.Success -> {
                 val (channelType, channelId) = cid.cidToTypeAndId()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -336,7 +336,7 @@ public fun ChatClient.cancelEphemeralMessage(message: Message): Call<Boolean> {
 public fun ChatClient.getMessageUsingCache(
     messageId: String,
 ): Call<Message> {
-    return CoroutineCall(state.scope) {
+    return CoroutineCall(inheritScope { SupervisorJob(it) }) {
         val message = logic.getMessageById(messageId) ?: logic.getMessageByIdFromDb(messageId)
 
         if (message != null) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.state.extensions.internal
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.state.extensions.state
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.internal.ChatClientStateCalls
 import kotlinx.coroutines.CoroutineScope
@@ -26,10 +27,7 @@ import kotlinx.coroutines.CoroutineScope
  * [LogicRegistry] instance that contains all objects responsible for handling logic in offline plugin.
  */
 internal val ChatClient.logic: LogicRegistry
-    get() = requireNotNull(LogicRegistry.get()) {
-        "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
-            "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
-    }
+    get() = resolveDependency<StatePlugin, LogicRegistry>()
 
 /**
  * Intermediate class to request ChatClient class as states

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
@@ -17,7 +17,6 @@
 package io.getstream.chat.android.state.extensions.internal
 
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.state.extensions.state
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.internal.ChatClientStateCalls
@@ -35,4 +34,4 @@ internal val ChatClient.logic: LogicRegistry
  * @return [ChatClientStateCalls]
  */
 internal fun ChatClient.requestsAsState(scope: CoroutineScope): ChatClientStateCalls =
-    ChatClientStateCalls(this, state, scope)
+    ChatClientStateCalls(this, scope)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/internal/ChatClient.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.state.extensions.internal
 
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.internal.ChatClientStateCalls
@@ -34,4 +35,4 @@ internal val ChatClient.logic: LogicRegistry
  * @return [ChatClientStateCalls]
  */
 internal fun ChatClient.requestsAsState(scope: CoroutineScope): ChatClientStateCalls =
-    ChatClientStateCalls(this, scope)
+    ChatClientStateCalls(this, globalState, scope)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.errorhandler.StateErrorHandlerFactory
 import io.getstream.chat.android.state.event.handler.internal.EventHandler
 import io.getstream.chat.android.state.event.handler.internal.EventHandlerSequential
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
@@ -139,7 +140,15 @@ public class StreamStatePluginFactory(
             }
         }
 
+        val stateErrorHandlerFactory = StateErrorHandlerFactory(
+            scope = scope,
+            logicRegistry = logic,
+            clientState = clientState,
+            repositoryFacade = repositoryFacade
+        )
+
         return StatePlugin(
+            errorHandlerFactory = stateErrorHandlerFactory,
             logic = logic,
             repositoryFacade = repositoryFacade,
             clientState = clientState,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.state.plugin.internal.ConfigSingleton
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.state.sync.internal.OfflineSyncFirebaseMessagingHandler
 import io.getstream.chat.android.state.sync.internal.SyncManager
 import io.getstream.log.StreamLog
@@ -88,12 +88,10 @@ public class StreamStatePluginFactory(
         val chatClient = ChatClient.instance()
         val repositoryFacade = chatClient.repositoryFacade
         val clientState = chatClient.clientState
-        val globalState = GlobalMutableState.get(chatClient.clientState).apply {
-            clearState()
-        }
+        MutableGlobalStateInstance.clearState()
 
         val stateRegistry = StateRegistry(
-            globalState.user,
+            MutableGlobalStateInstance.user,
             repositoryFacade.observeLatestUsers(),
             scope.coroutineContext.job,
             scope
@@ -103,7 +101,7 @@ public class StreamStatePluginFactory(
 
         val logic = LogicRegistry(
             stateRegistry = stateRegistry,
-            globalState = globalState,
+            mutableGlobalState = MutableGlobalStateInstance,
             userPresence = config.userPresence,
             repos = repositoryFacade,
             client = chatClient,
@@ -130,7 +128,7 @@ public class StreamStatePluginFactory(
             client = chatClient,
             logicRegistry = logic,
             stateRegistry = stateRegistry,
-            mutableGlobalState = globalState,
+            mutableGlobalState = MutableGlobalStateInstance,
             repos = repositoryFacade,
             syncedEvents = syncManager.syncedEvents,
             sideEffect = syncManager::awaitSyncing
@@ -157,7 +155,7 @@ public class StreamStatePluginFactory(
             stateRegistry = stateRegistry,
             syncManager = syncManager,
             eventHandler = eventHandler,
-            globalState = globalState,
+            globalState = MutableGlobalStateInstance,
             queryingChannelsFree = isQueryingFree
         )
     }
@@ -169,7 +167,7 @@ public class StreamStatePluginFactory(
         client: ChatClient,
         logicRegistry: LogicRegistry,
         stateRegistry: StateRegistry,
-        mutableGlobalState: GlobalMutableState,
+        mutableGlobalState: MutableGlobalStateInstance,
         repos: RepositoryFacade,
         sideEffect: suspend () -> Unit,
         syncedEvents: Flow<List<ChatEvent>>,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -90,7 +90,6 @@ public class StreamStatePluginFactory(
         val clientState = chatClient.clientState
         val globalState = GlobalMutableState.get(chatClient.clientState).apply {
             clearState()
-            setUser(user)
         }
 
         val stateRegistry = StateRegistry(

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -93,8 +93,11 @@ public class StreamStatePluginFactory(
             setUser(user)
         }
 
-        val stateRegistry = StateRegistry.create(
-            scope.coroutineContext.job, scope, globalState.user, repositoryFacade, repositoryFacade.observeLatestUsers()
+        val stateRegistry = StateRegistry(
+            globalState.user,
+            repositoryFacade.observeLatestUsers(),
+            scope.coroutineContext.job,
+            scope
         )
 
         val isQueryingFree = MutableStateFlow(true)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -99,7 +99,7 @@ public class StreamStatePluginFactory(
 
         val isQueryingFree = MutableStateFlow(true)
 
-        val logic = LogicRegistry.create(
+        val logic = LogicRegistry(
             stateRegistry = stateRegistry,
             globalState = globalState,
             userPresence = config.userPresence,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -109,6 +109,7 @@ public class StatePlugin internal constructor(
     override var errorHandler: ErrorHandler = errorHandlerFactory.create()
 
     override fun onUserSet(user: User) {
+        globalState.setUser(user)
         syncManager.start()
         eventHandler.startListening()
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -125,6 +125,7 @@ public class StatePlugin internal constructor(
     public override fun <T : Any> resolveDependency(klass: KClass<T>): T? = when (klass) {
         SyncHistoryManager::class -> syncManager as T
         EventHandler::class -> eventHandler as T
+        LogicRegistry::class -> logic as T
         else -> null
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -126,6 +126,7 @@ public class StatePlugin internal constructor(
         SyncHistoryManager::class -> syncManager as T
         EventHandler::class -> eventHandler as T
         LogicRegistry::class -> logic as T
+        StateRegistry::class -> stateRegistry as T
         else -> null
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -39,7 +39,6 @@ import io.getstream.chat.android.client.plugin.listeners.TypingEventListener
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.state.errorhandler.StateErrorHandlerFactory
 import io.getstream.chat.android.state.event.handler.internal.EventHandler
 import io.getstream.chat.android.state.plugin.listener.internal.ChannelMarkReadListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.DeleteMessageListenerState
@@ -80,6 +79,7 @@ import kotlin.reflect.KClass
 @InternalStreamChatApi
 @Suppress("LongParameterList")
 public class StatePlugin internal constructor(
+    private val errorHandlerFactory: ErrorHandlerFactory,
     private val logic: LogicRegistry,
     private val repositoryFacade: RepositoryFacade,
     private val clientState: ClientState,
@@ -87,7 +87,7 @@ public class StatePlugin internal constructor(
     private val syncManager: SyncManager,
     private val eventHandler: EventHandler,
     private val globalState: MutableGlobalState,
-    private val queryingChannelsFree: MutableStateFlow<Boolean>
+    private val queryingChannelsFree: MutableStateFlow<Boolean>,
 ) : Plugin,
     DependencyResolver,
     QueryChannelsListener by QueryChannelsListenerState(logic, queryingChannelsFree),
@@ -106,10 +106,7 @@ public class StatePlugin internal constructor(
     TypingEventListener by TypingEventListenerState(stateRegistry),
     SendAttachmentListener by SendAttachmentListenerState(logic) {
 
-    private val errorHandlerFactory: ErrorHandlerFactory =
-        StateErrorHandlerFactory()
-
-    override var errorHandler: ErrorHandler = errorHandlerFactory.create(repositoryFacade)
+    override var errorHandler: ErrorHandler = errorHandlerFactory.create()
 
     override fun onUserSet(user: User) {
         syncManager.start()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/UnreadCountLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/UnreadCountLogic.kt
@@ -27,7 +27,7 @@ import io.getstream.chat.android.client.utils.buffer.StartStopBuffer
 import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.state.plugin.state.channel.internal.ChannelMutableState
-import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import io.getstream.chat.android.state.utils.internal.isChannelMutedForCurrentUser
 import io.getstream.log.StreamLog
 import kotlinx.coroutines.flow.StateFlow
@@ -44,7 +44,7 @@ private const val COUNT_BUFFER_LIMIT = 100
  * logic, only counting logic.
  *
  * @param mutableState [ChannelMutableState]
- * @param globalMutableState [MutableGlobalState]
+ * @param globalState [GlobalState]
  * @param unreadTrigger StateFlow<Boolean> Trigger of the count with control and the SDK is able or not able to count
  * the unread messages to avoid race conditions.
  * @param countBuffer [StartStopBuffer] The buffer that holds the counting and keeps the events to be counted in a later
@@ -52,7 +52,7 @@ private const val COUNT_BUFFER_LIMIT = 100
  */
 internal class UnreadCountLogic(
     private val mutableState: ChannelMutableState,
-    private val globalMutableState: MutableGlobalState,
+    private val globalState: GlobalState,
     private val unreadTrigger: StateFlow<Boolean>,
     private val countBuffer: StartStopBuffer<ChatEvent> = StartStopBuffer(
         bufferLimit = COUNT_BUFFER_LIMIT,
@@ -109,7 +109,7 @@ internal class UnreadCountLogic(
      * Perform count the a new message arrive.
      */
     private fun performCount(message: Message) {
-        val user = globalMutableState.user.value ?: return
+        val user = globalState.user.value ?: return
         val currentUserId = user.id
 
         /* Only one thread can access this logic per time. If two messages pass the shouldIncrementUnreadCount at the
@@ -126,7 +126,7 @@ internal class UnreadCountLogic(
                     message.shouldIncrementUnreadCount(
                         currentUserId = currentUserId,
                         lastMessageAtDate = lastMessageSeenDate,
-                        isChannelMuted = globalMutableState.isChannelMutedForCurrentUser(mutableState.cid)
+                        isChannelMuted = globalState.isChannelMutedForCurrentUser(mutableState.cid)
                     )
 
             val formatter = SimpleDateFormat("yyyy-MM-dd HH:mm:ss''SSS", Locale.ENGLISH)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -50,7 +50,7 @@ import java.util.concurrent.ConcurrentHashMap
 @Suppress("LongParameterList")
 internal class LogicRegistry internal constructor(
     private val stateRegistry: StateRegistry,
-    private val globalState: MutableGlobalState,
+    private val mutableGlobalState: MutableGlobalState,
     private val userPresence: Boolean,
     private val repos: RepositoryFacade,
     private val client: ChatClient,
@@ -98,10 +98,10 @@ internal class LogicRegistry internal constructor(
             val mutableState = stateRegistry.mutableChannel(channelType, channelId)
             val stateLogic = ChannelStateLogic(
                 mutableState = mutableState,
-                globalMutableState = globalState,
+                globalMutableState = mutableGlobalState,
                 searchLogic = SearchLogic(mutableState),
                 coroutineScope = coroutineScope,
-                unreadCountLogic = UnreadCountLogic(mutableState, globalState, queryingChannelsFree)
+                unreadCountLogic = UnreadCountLogic(mutableState, mutableGlobalState, queryingChannelsFree)
             )
 
             ChannelLogic(
@@ -233,6 +233,6 @@ internal class LogicRegistry internal constructor(
         queryChannels.clear()
         channels.clear()
         threads.clear()
-        globalState.clearState()
+        mutableGlobalState.clearState()
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -35,10 +35,8 @@ import io.getstream.chat.android.state.plugin.logic.querychannels.internal.Query
 import io.getstream.chat.android.state.plugin.logic.querychannels.internal.QueryChannelsLogic
 import io.getstream.chat.android.state.plugin.logic.querychannels.internal.QueryChannelsStateLogic
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
 import io.getstream.chat.android.state.plugin.state.querychannels.internal.toMutableState
-import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.StateFlow
 import java.util.concurrent.ConcurrentHashMap
@@ -236,67 +234,5 @@ internal class LogicRegistry internal constructor(
         channels.clear()
         threads.clear()
         globalState.clearState()
-    }
-
-    internal companion object {
-        private var instance: LogicRegistry? = null
-
-        private val logger by taggedLogger("Chat:LogicRegistry")
-
-        /**
-         * Creates and returns new instance of LogicRegistry.
-         *
-         * @param stateRegistry [StateRegistry].
-         * @param globalState [GlobalMutableState] state of the SDK.
-         * @param userPresence True if userPresence should be enabled, false otherwise.
-         * @param repos [RepositoryFacade] to interact with local data sources.
-         * @param client An instance of [ChatClient].
-         *
-         * @return Instance of [LogicRegistry].
-         *
-         * @throws IllegalStateException if instance is not null.
-         */
-        @Suppress("LongParameterList")
-        internal fun create(
-            stateRegistry: StateRegistry,
-            globalState: MutableGlobalState,
-            userPresence: Boolean,
-            repos: RepositoryFacade,
-            client: ChatClient,
-            coroutineScope: CoroutineScope,
-            queryingChannelsFree: StateFlow<Boolean>
-        ): LogicRegistry {
-            if (instance != null) {
-                logger.e {
-                    "LogicRegistry instance is already created. " +
-                        "Avoid creating multiple instances to prevent ambiguous state. Use LogicRegistry.get()"
-                }
-            }
-            return LogicRegistry(
-                stateRegistry = stateRegistry,
-                globalState = globalState,
-                userPresence = userPresence,
-                repos = repos,
-                client = client,
-                coroutineScope = coroutineScope,
-                queryingChannelsFree = queryingChannelsFree
-            )
-                .also { logicRegistry ->
-                    instance = logicRegistry
-                }
-        }
-
-        /**
-         * Gets the current Singleton of LogicRegistry. If the initialization is not set yet, it throws exception.
-         *
-         * @return Singleton instance of [LogicRegistry].
-         *
-         * @throws IllegalArgumentException if instance is null.
-         */
-        @Throws(IllegalArgumentException::class)
-        internal fun get(): LogicRegistry = requireNotNull(instance) {
-            "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
-                "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
-        }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/StateRegistry.kt
@@ -17,7 +17,6 @@
 package io.getstream.chat.android.state.plugin.state
 
 import io.getstream.chat.android.client.channel.state.ChannelState
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.FilterObject
 import io.getstream.chat.android.models.User
@@ -44,8 +43,8 @@ import java.util.concurrent.ConcurrentHashMap
 public class StateRegistry constructor(
     private val userStateFlow: StateFlow<User?>,
     private var latestUsers: StateFlow<Map<String, User>>,
-    internal val job: Job,
-    @property:InternalStreamChatApi public val scope: CoroutineScope,
+    private val job: Job,
+    private val scope: CoroutineScope,
 ) {
     private val queryChannels: ConcurrentHashMap<Pair<FilterObject, QuerySorter<Channel>>, QueryChannelsMutableState> =
         ConcurrentHashMap()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/GlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/GlobalState.kt
@@ -67,9 +67,4 @@ public interface GlobalState {
      * @see [TypingEvent]
      */
     public val typingChannels: StateFlow<Map<String, TypingEvent>>
-
-    /**
-     * Clears the state of [GlobalState].
-     */
-    public fun clearState()
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.state.plugin.state.global.internal
 
-import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.models.ChannelMute
 import io.getstream.chat.android.models.Mute
 import io.getstream.chat.android.models.TypingEvent
@@ -28,9 +27,6 @@ import io.getstream.chat.android.state.plugin.state.global.GlobalState
  * Mutable global state of [StatePlugin].
  */
 internal interface MutableGlobalState : GlobalState {
-
-    val clientState: ClientState
-
     fun setUser(user: User)
 
     fun setTotalUnreadCount(totalUnreadCount: Int)
@@ -50,4 +46,9 @@ internal interface MutableGlobalState : GlobalState {
      * @param typingEvent [TypingEvent] with information about typing users. Current user is excluded.
      */
     fun tryEmitTypingEvent(cid: String, typingEvent: TypingEvent)
+
+    /**
+     * Clears the state of [GlobalState].
+     */
+    public fun clearState()
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalStateInstance.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalStateInstance.kt
@@ -18,21 +18,16 @@
 
 package io.getstream.chat.android.state.plugin.state.global.internal
 
-import androidx.annotation.VisibleForTesting
-import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.ChannelMute
 import io.getstream.chat.android.models.Mute
 import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
 @InternalStreamChatApi
-public class GlobalMutableState private constructor(
-    override val clientState: ClientState,
-) : MutableGlobalState {
+public object MutableGlobalStateInstance : MutableGlobalState {
 
     private val _totalUnreadCount = MutableStateFlow(0)
     private val _channelUnreadCount = MutableStateFlow(0)
@@ -57,26 +52,6 @@ public class GlobalMutableState private constructor(
     override val typingChannels: StateFlow<Map<String, TypingEvent>> = _typingChannels
 
     override val user: StateFlow<User?> = _user
-
-    public companion object {
-
-        @InternalStreamChatApi
-        @VisibleForTesting
-        @Volatile
-        public var instance: GlobalMutableState? = null
-
-        /**
-         * Gets the singleton of [GlobalMutableState] or creates it in the first call.
-         */
-        @InternalStreamChatApi
-        public fun get(clientState: ClientState): GlobalMutableState {
-            return instance ?: synchronized(this) {
-                instance ?: GlobalMutableState(clientState).also { globalState ->
-                    instance = globalState
-                }
-            }
-        }
-    }
 
     override fun clearState() {
         _user.value = null
@@ -123,5 +98,3 @@ public class GlobalMutableState private constructor(
         _typingChannels.tryEmit(typingChannelsCopy)
     }
 }
-
-internal fun GlobalState.toMutableState(): GlobalMutableState = this as GlobalMutableState

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/internal/ChatClientStateCalls.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/internal/ChatClientStateCalls.kt
@@ -23,47 +23,65 @@ import io.getstream.chat.android.client.call.launch
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
+import io.getstream.chat.android.state.extensions.globalState
+import io.getstream.chat.android.state.extensions.state
 import io.getstream.chat.android.state.model.querychannels.pagination.internal.QueryChannelPaginationRequest
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.channel.thread.ThreadState
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
 
 /**
  * Adapter for [ChatClient] that wraps some of it's request.
  */
 internal class ChatClientStateCalls(
     private val chatClient: ChatClient,
-    private val state: StateRegistry,
     private val scope: CoroutineScope,
 ) {
     private val logger by taggedLogger("ChatClientState")
 
+    /**
+     * Deferred value of StateRegistry.
+     * It needs to be accessed after the user is connected to be sure needed plugins are initialized.
+     */
+    private val deferredState: Deferred<StateRegistry> = scope.async(start = CoroutineStart.LAZY) {
+        chatClient.globalState.user.first { it != null }
+        chatClient.state
+    }
+
     /** Reference request of the channels query. */
-    internal fun queryChannels(
+    internal suspend fun queryChannels(
         request: QueryChannelsRequest,
         chatEventHandlerFactory: ChatEventHandlerFactory,
     ): QueryChannelsState {
         logger.d { "querying state for channels" }
         chatClient.queryChannels(request).launch(scope)
-        return state.queryChannels(request.filter, request.querySort)
+        return deferredState
+            .await()
+            .queryChannels(request.filter, request.querySort)
             .also { queryChannelsState -> queryChannelsState.chatEventHandlerFactory = chatEventHandlerFactory }
     }
 
     /** Reference request of the channel query. */
-    private fun queryChannel(
+    private suspend fun queryChannel(
         channelType: String,
         channelId: String,
         request: QueryChannelRequest,
     ): ChannelState {
         logger.d { "querying state for channel with id: $channelId" }
         chatClient.queryChannel(channelType, channelId, request).launch(scope)
-        return state.channel(channelType, channelId)
+        return deferredState
+            .await()
+            .channel(channelType, channelId)
     }
 
     /** Reference request of the watch channel query. */
-    internal fun watchChannel(cid: String, messageLimit: Int, userPresence: Boolean): ChannelState {
+    internal suspend fun watchChannel(cid: String, messageLimit: Int, userPresence: Boolean): ChannelState {
         logger.d { "watching channel with cid: $cid" }
         val (channelType, channelId) = cid.cidToTypeAndId()
         val request = QueryChannelPaginationRequest(messageLimit)
@@ -76,10 +94,12 @@ internal class ChatClientStateCalls(
     }
 
     /** Reference request of the get thread replies query. */
-    internal fun getReplies(messageId: String, messageLimit: Int): ThreadState {
+    internal suspend fun getReplies(messageId: String, messageLimit: Int): ThreadState {
         logger.d { "getting replied for message with id: $messageId" }
         chatClient.getReplies(messageId, messageLimit).launch(scope)
-        return state.thread(messageId)
+        return deferredState
+            .await()
+            .thread(messageId)
     }
 
     /**
@@ -98,6 +118,8 @@ internal class ChatClientStateCalls(
     internal suspend fun awaitReplies(messageId: String, messageLimit: Int): ThreadState {
         logger.d { "getting replied for message with id: $messageId" }
         chatClient.getReplies(messageId, messageLimit).await()
-        return state.thread(messageId)
+        return deferredState
+            .await()
+            .thread(messageId)
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/internal/ChatClientStateCalls.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/internal/ChatClientStateCalls.kt
@@ -23,11 +23,11 @@ import io.getstream.chat.android.client.call.launch
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
-import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.chat.android.state.extensions.state
 import io.getstream.chat.android.state.model.querychannels.pagination.internal.QueryChannelPaginationRequest
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.channel.thread.ThreadState
+import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
@@ -41,6 +41,7 @@ import kotlinx.coroutines.flow.first
  */
 internal class ChatClientStateCalls(
     private val chatClient: ChatClient,
+    private val globalState: GlobalState,
     private val scope: CoroutineScope,
 ) {
     private val logger by taggedLogger("ChatClientState")
@@ -50,7 +51,7 @@ internal class ChatClientStateCalls(
      * It needs to be accessed after the user is connected to be sure needed plugins are initialized.
      */
     private val deferredState: Deferred<StateRegistry> = scope.async(start = CoroutineStart.LAZY) {
-        chatClient.globalState.user.first { it != null }
+        globalState.user.first { it != null }
         chatClient.state
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncMessagesWork.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncMessagesWork.kt
@@ -49,9 +49,7 @@ internal class SyncMessagesWork(
 
             client.logic.channel(type, id) // Adds this channel to logic - Now it is an active channel
 
-            val syncManager = client.resolveDependency<StatePlugin, SyncHistoryManager>() ?: error(
-                "No SyncHistoryManager found in StatePlugin."
-            )
+            val syncManager = client.resolveDependency<StatePlugin, SyncHistoryManager>()
             syncManager.sync()
 
             Result.success()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/utils/internal/ChannelUtils.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/utils/internal/ChannelUtils.kt
@@ -16,7 +16,7 @@
 
 package io.getstream.chat.android.state.utils.internal
 
-import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.chat.android.state.plugin.state.global.GlobalState
 
 /**
  * Checks the given CID against the CIDs of channels muted for the current user.
@@ -24,6 +24,6 @@ import io.getstream.chat.android.state.plugin.state.global.internal.MutableGloba
  *
  * @param cid CID of the channel currently being checked.
  */
-internal fun MutableGlobalState.isChannelMutedForCurrentUser(cid: String): Boolean {
+internal fun GlobalState.isChannelMutedForCurrentUser(cid: String): Boolean {
     return channelMutes.value.any { mutedChannel -> mutedChannel.channel.cid == cid }
 }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/events/TypingEventsTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/events/TypingEventsTest.kt
@@ -169,11 +169,10 @@ internal class TypingEventsTest {
         }
 
     private class Fixture(scope: CoroutineScope, user: User) {
-        private val stateRegistry = StateRegistry.create(
+        private val stateRegistry = StateRegistry(
             job = mock(),
             scope = scope,
             userStateFlow = MutableStateFlow(user),
-            messageRepository = mock(),
             latestUsers = MutableStateFlow(emptyMap()),
         )
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/SyncManagerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/SyncManagerTest.kt
@@ -35,7 +35,7 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.logic.channel.internal.ChannelLogic
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.state.sync.internal.SyncManager
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -45,6 +45,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
@@ -71,7 +72,6 @@ internal class SyncManagerTest {
     private lateinit var chatClient: ChatClient
     private lateinit var logicRegistry: LogicRegistry
     private lateinit var stateRegistry: StateRegistry
-    private lateinit var globalState: GlobalMutableState
     private lateinit var clientState: ClientState
     private lateinit var repositoryFacade: RepositoryFacade
     private lateinit var user: User
@@ -95,9 +95,8 @@ internal class SyncManagerTest {
             on(it.getActiveChannelsLogic()) doReturn listOf(channelLogic)
         }
         stateRegistry = mock()
-        globalState = mock {
-            on(it.user) doReturn MutableStateFlow(user)
-        }
+        MutableGlobalStateInstance.clearState()
+        MutableGlobalStateInstance.setUser(user)
         clientState = mock {
             on(it.connectionState) doReturn connectionState
         }
@@ -108,6 +107,11 @@ internal class SyncManagerTest {
                 on(it.selectReactionIdsBySyncStatus(any())) doReturn emptyList()
             }
         }
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
     }
 
     @Test

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -55,8 +55,8 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun dismissAllMessageActions ()V
 	public final fun dismissMessageAction (Lio/getstream/chat/android/ui/common/state/messages/MessageAction;)V
 	public final fun enterNormalMode ()V
-	public final fun enterThreadMode (Lio/getstream/chat/android/models/Message;I)V
-	public static synthetic fun enterThreadMode$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;IILjava/lang/Object;)V
+	public final fun enterThreadMode (Lio/getstream/chat/android/models/Message;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun enterThreadMode$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun flagMessage$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getChannel ()Lkotlinx/coroutines/flow/StateFlow;
@@ -91,7 +91,7 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public static synthetic fun muteUser$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
 	public final fun onCleared ()V
 	public final fun performGiphyAction (Lio/getstream/chat/android/ui/common/state/messages/list/GiphyAction;)V
-	public final fun performMessageAction (Lio/getstream/chat/android/ui/common/state/messages/MessageAction;)V
+	public final fun performMessageAction (Lio/getstream/chat/android/ui/common/state/messages/MessageAction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun pinMessage (Lio/getstream/chat/android/models/Message;)V
 	public final fun reactToMessage (Lio/getstream/chat/android/models/Reaction;Lio/getstream/chat/android/models/Message;)V
 	public final fun removeAttachment (Ljava/lang/String;Lio/getstream/chat/android/models/Attachment;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -839,7 +839,7 @@ public class MessageListController(
      * @param parentMessage The root [Message] which contains the thread we want to show.
      * @param messageLimit The size of the message list page to load.
      */
-    public fun enterThreadMode(parentMessage: Message, messageLimit: Int = this.messageLimit) {
+    public suspend fun enterThreadMode(parentMessage: Message, messageLimit: Int = this.messageLimit) {
         val channelState = channelState.value ?: return
         _messageActions.value = _messageActions.value + Reply(parentMessage)
         val state = chatClient.getRepliesAsState(parentMessage.id, messageLimit)
@@ -1128,7 +1128,7 @@ public class MessageListController(
      *
      * @param messageAction The action the user chose.
      */
-    public fun performMessageAction(messageAction: MessageAction) {
+    public suspend fun performMessageAction(messageAction: MessageAction) {
         removeOverlay()
 
         when (messageAction) {

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -28,7 +28,7 @@ import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.test.createDate
@@ -44,6 +44,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
@@ -287,25 +288,28 @@ internal class MessageListControllerTests {
             dateSeparatorCount `should be equal to` 3
         }
 
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
+
     private class Fixture(
         private val chatClient: ChatClient = mock(),
         private val channelId: String = CID,
     ) {
-        private val globalState: GlobalMutableState = mock()
         private val clientState: ClientState = mock()
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            GlobalMutableState.instance = globalState
-
             val statePlugin: StatePlugin = mock()
+            MutableGlobalStateInstance.clearState()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.clientState) doReturn clientState
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.MessagesState
 import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -294,9 +296,11 @@ internal class MessageListControllerTests {
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
 
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.clientState) doReturn clientState
         }
 

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -339,7 +339,6 @@ internal class MessageListControllerTests {
                 whenever(it.loadingOlderMessages) doReturn MutableStateFlow(false)
             }
             whenever(stateRegistry.channel(any(), any())) doReturn channelState
-            whenever(stateRegistry.scope) doReturn testCoroutines.scope
         }
 
         fun get(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.call.Call
 import io.getstream.chat.android.client.call.enqueue
@@ -53,6 +54,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onSubscription
+import kotlinx.coroutines.launch
 import io.getstream.chat.android.state.utils.Event as EventWrapper
 
 /**
@@ -399,7 +401,9 @@ public class MessageListViewModel(
      * @param parentMessage The message with the thread we want to observe.
      */
     private fun onThreadModeEntered(parentMessage: Message) {
-        messageListController.enterThreadMode(parentMessage)
+        viewModelScope.launch {
+            messageListController.enterThreadMode(parentMessage)
+        }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/MockChatClientBuilder.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/MockChatClientBuilder.kt
@@ -20,7 +20,9 @@ import io.getstream.chat.android.client.ChatClient
 import org.mockito.kotlin.mock
 
 public class MockChatClientBuilder(
-    private val builderFunction: () -> ChatClient = { mock() }
+    private val builderFunction: () -> ChatClient = {
+        mock()
+    }
 ) : ChatClient.ChatClientBuilder() {
     override fun internalBuild(): ChatClient = builderFunction()
 }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -248,12 +250,13 @@ internal class ChannelListViewModelTest {
         private val clientState: ClientState = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
 
             whenever(chatClient.channel(any())) doReturn channelClient
             whenever(chatClient.channel(any(), any())) doReturn channelClient
-
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.clientState) doReturn clientState
         }
 

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
@@ -30,7 +30,7 @@ import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.state.plugin.state.querychannels.ChannelsStateData
 import io.getstream.chat.android.state.plugin.state.querychannels.QueryChannelsState
 import io.getstream.chat.android.test.InstantTaskExecutorExtension
@@ -43,6 +43,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
@@ -61,6 +62,10 @@ internal class ChannelListViewModelTest {
     @RegisterExtension
     val instantExecutorExtension: InstantTaskExecutorExtension = InstantTaskExecutorExtension()
 
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
     @Test
     fun `Given channel list in loading state When showing the channel list Should show loading state`() =
         runTest {
@@ -245,13 +250,10 @@ internal class ChannelListViewModelTest {
         private val initialFilters: FilterObject? = queryFilter,
     ) {
 
-        private val globalState: GlobalMutableState = mock()
         private val stateRegistry: StateRegistry = mock()
         private val clientState: ClientState = mock()
 
         init {
-            GlobalMutableState.instance = globalState
-
             whenever(chatClient.channel(any())) doReturn channelClient
             whenever(chatClient.channel(any(), any())) doReturn channelClient
             val statePlugin: StatePlugin = mock()
@@ -261,12 +263,12 @@ internal class ChannelListViewModelTest {
         }
 
         fun givenCurrentUser(currentUser: User = User(id = "Jc")) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
             whenever(chatClient.getCurrentUser()) doReturn currentUser
         }
 
         fun givenChannelMutes(channelMutes: List<ChannelMute> = emptyList()) = apply {
-            whenever(globalState.channelMutes) doReturn MutableStateFlow(channelMutes)
+            MutableGlobalStateInstance.setChannelMutes(channelMutes)
         }
 
         fun givenChannelsQuery(channels: List<Channel> = emptyList()) = apply {
@@ -309,7 +311,10 @@ internal class ChannelListViewModelTest {
                 chatClient = chatClient,
                 sort = initialSort,
                 filter = initialFilters,
-                chatEventHandlerFactory = ChatEventHandlerFactory(clientState = clientState, globalState = globalState)
+                chatEventHandlerFactory = ChatEventHandlerFactory(
+                    clientState = clientState,
+                    globalState = MutableGlobalStateInstance
+                )
             )
         }
     }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
@@ -302,7 +302,6 @@ internal class ChannelListViewModelTest {
                 whenever(it.nextPageRequest) doReturn MutableStateFlow(nextPageRequest)
             }
             whenever(stateRegistry.queryChannels(any(), any())) doReturn queryChannelsState
-            whenever(stateRegistry.scope) doReturn testCoroutines.scope
         }
 
         fun get(): ChannelListViewModel {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.ui.viewmodels.messages
 
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.channel.state.ChannelState
-import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelData
@@ -29,7 +28,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
 import io.getstream.chat.android.ui.common.feature.messages.composer.MessageComposerController
@@ -45,6 +44,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
@@ -58,6 +58,11 @@ import org.mockito.kotlin.whenever
 @ExperimentalCoroutinesApi
 @ExtendWith(TestCoroutineExtension::class)
 internal class MessageComposerViewModelTest {
+
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
 
     @Test
     fun `Given message composer When typing a message Should display the message`() = runTest {
@@ -354,20 +359,16 @@ internal class MessageComposerViewModelTest {
         private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
         private val maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE,
     ) {
-        private val globalState: GlobalMutableState = mock()
-        private val clientState: ClientState = mock()
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            GlobalMutableState.instance = globalState
             val statePlugin: StatePlugin = mock()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
-            whenever(chatClient.clientState) doReturn clientState
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.test.TestCoroutineExtension
@@ -358,8 +359,10 @@ internal class MessageComposerViewModelTest {
         private val stateRegistry: StateRegistry = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -29,7 +29,7 @@ import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
-import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalStateInstance
 import io.getstream.chat.android.test.InstantTaskExecutorExtension
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.test.asCall
@@ -44,6 +44,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
@@ -61,6 +62,10 @@ internal class MessageListViewModelTest {
     @RegisterExtension
     val instantExecutorExtension: InstantTaskExecutorExtension = InstantTaskExecutorExtension()
 
+    @AfterEach
+    fun tearDown() {
+        MutableGlobalStateInstance.clearState()
+    }
     @Test
     fun `Given initial state remains unchanged Should be in loading state`() = runTest {
         val viewModel = Fixture()
@@ -216,13 +221,10 @@ internal class MessageListViewModelTest {
         private val chatClient: ChatClient = MockChatClientBuilder().build(),
         private val channelId: String = CID,
     ) {
-        private val globalState: GlobalMutableState = mock()
         private val stateRegistry: StateRegistry = mock()
         private val clientState: ClientState = mock()
 
         init {
-            GlobalMutableState.instance = globalState
-
             val statePlugin: StatePlugin = mock()
             whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
             whenever(chatClient.plugins) doReturn listOf(statePlugin)
@@ -230,7 +232,7 @@ internal class MessageListViewModelTest {
         }
 
         fun givenCurrentUser(currentUser: User = user1) = apply {
-            whenever(globalState.user) doReturn MutableStateFlow(currentUser)
+            MutableGlobalStateInstance.setUser(currentUser)
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -284,7 +284,6 @@ internal class MessageListViewModelTest {
                 whenever(it.loadingNewerMessages) doReturn MutableStateFlow(false)
             }
             whenever(stateRegistry.channel(any(), any())) doReturn channelState
-            whenever(stateRegistry.scope) doReturn testCoroutines.scope
         }
 
         fun get(): MessageListViewModel {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.models.MessagesState
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.internal.StatePlugin
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.internal.GlobalMutableState
 import io.getstream.chat.android.test.InstantTaskExecutorExtension
@@ -47,6 +48,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -219,9 +221,11 @@ internal class MessageListViewModelTest {
         private val clientState: ClientState = mock()
 
         init {
-            StateRegistry.instance = stateRegistry
             GlobalMutableState.instance = globalState
 
+            val statePlugin: StatePlugin = mock()
+            whenever(statePlugin.resolveDependency(eq(StateRegistry::class))) doReturn stateRegistry
+            whenever(chatClient.plugins) doReturn listOf(statePlugin)
             whenever(chatClient.clientState) doReturn clientState
         }
 


### PR DESCRIPTION
### 🎯 Goal
We were using some classes with the old approach to have it as a singleton and obtain it by `get()` method returning an exception if it wasn't initialized yet.
This old way is not needed anymore as we have our own "DepencencyResolver" to find dependencies from plugins that were added to the SDK.
Fix: #4717

### 🛠 Implementation details
Configure `StatePlugin` to provide needed dependencies.
`ChatClient::resolveDependency()` method has been update to provide better error on the case plugins wasn't initialized properly


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![](https://media.giphy.com/media/ZBbJtoKNA7RBNgHTHV/giphy-downsized.gif)
