### PR TITLE
[4724] Improve Sample App PN Reliability

### DIFF
--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -37,6 +37,7 @@
         <activity
             android:name=".ui.StartupActivity"
             android:exported="true"
+            android:launchMode="singleInstance"
             >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
### 🎯 Goal

closes #4724 

### 🛠 Implementation details

Change the activity launch modes so that if `MessagesActivity` is active in the stack it gets recreated with new arguments.

### 🧪 Testing

1. Launch the Compose app
2. Receive a PN, click on the PN and then kill the app
3. Receive a PN again, click on it and background the app
4. Receive a PN again and click on it

Expected: On `develop`, every subsequent PN click will not focus on the message because the VM is in memory and not getting reinitialized. When launched from the branch contained in this PR, it should always focus the correct message.

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media3.giphy.com/media/0A477fjlRXL1n2LVgJ/giphy.gif?cid=ecf05e472gjdnsttf5h2ome5kqwa8gh92mvvgyjzp1dbi5ld&rid=giphy.gif&ct=g)
