### PR TITLE
[4743] Fix scrolling issues in threads

### DIFF
--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -940,6 +940,10 @@ public final class io/getstream/chat/android/ui/common/utils/extensions/ContextK
 	public static final fun wasPermissionRequested (Landroid/content/Context;Ljava/lang/String;)Z
 }
 
+public final class io/getstream/chat/android/ui/common/utils/extensions/FlowKt {
+	public static final fun onFirst (Lkotlinx/coroutines/flow/Flow;Lkotlin/jvm/functions/Function1;)Lkotlinx/coroutines/flow/Flow;
+}
+
 public final class io/getstream/chat/android/ui/common/utils/extensions/MessageFooterVisibilityKt {
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -90,6 +90,7 @@ import io.getstream.chat.android.ui.common.state.messages.list.ThreadDateSeparat
 import io.getstream.chat.android.ui.common.state.messages.list.TypingItemState
 import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.ui.common.utils.extensions.isModerationFailed
+import io.getstream.chat.android.ui.common.utils.extensions.onFirst
 import io.getstream.chat.android.ui.common.utils.extensions.shouldShowMessageFooter
 import io.getstream.log.TaggedLogger
 import io.getstream.log.taggedLogger
@@ -547,10 +548,17 @@ public class MessageListController(
                     parentMessageId = threadId,
                     endOfNewMessagesReached = true
                 )
+            }.onFirst {
+                // Set the last message in the list of message items as the last loaded thread message
+                // when the thread is initially loaded.
+                lastLoadedThreadMessage =
+                    (it.messageItems.lastOrNull { it is MessageItemState } as? MessageItemState)?.message
             }.collect { newState ->
                 val newLastMessage =
                     (newState.messageItems.lastOrNull { it is MessageItemState } as? MessageItemState)?.message
+
                 val newMessageState = getNewMessageState(newLastMessage, lastLoadedThreadMessage)
+
                 _threadListState.value = newState.copy(newMessageState = newMessageState)
                 if (newMessageState != null) lastLoadedThreadMessage = newLastMessage
             }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Flow.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Flow.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.utils.extensions
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onEach
+
+/**
+ * Calls the [onFirst] lambda when the first element is emitted by the upstream [Flow].
+ *
+ * @param onFirst The lambda called when the first element is emmited by the upstream [Flow].
+ *
+ * @return The upstream [Flow] this operator was called on.
+ */
+public fun <T> Flow<T>.onFirst(onFirst: (T) -> Unit): Flow<T> {
+    var wasFirstEmission = false
+
+    return onEach {
+        if (wasFirstEmission) return@onEach
+        wasFirstEmission = true
+        onFirst(it)
+    }
+}

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2914,7 +2914,7 @@ public final class io/getstream/chat/android/ui/utils/extensions/MessageListItem
 }
 
 public final class io/getstream/chat/android/ui/utils/extensions/MessageListStateKt {
-	public static final fun toMessageListItemWrapper (Lio/getstream/chat/android/ui/common/state/messages/list/MessageListState;)Lio/getstream/chat/android/ui/model/MessageListItemWrapper;
+	public static final fun toMessageListItemWrapper (Lio/getstream/chat/android/ui/common/state/messages/list/MessageListState;Z)Lio/getstream/chat/android/ui/model/MessageListItemWrapper;
 }
 
 public final class io/getstream/chat/android/ui/utils/extensions/UserKt {

--- a/stream-chat-android-ui-components/detekt-baseline.xml
+++ b/stream-chat-android-ui-components/detekt-baseline.xml
@@ -56,6 +56,7 @@
     <ID>MagicNumber:MessageListScrollHelper.kt$MessageListScrollHelper$3</ID>
     <ID>MagicNumber:MessageListView.kt$MessageListView$20</ID>
     <ID>MagicNumber:MessageListView.kt$MessageListView$500</ID>
+    <ID>MagicNumber:MessageListViewModel.kt$MessageListViewModel$5</ID>
     <ID>MagicNumber:MessageOptionsUserReactionOrientation.kt$MessageOptionsUserReactionOrientation.BY_USER_INVERTED$3</ID>
     <ID>MagicNumber:TypingIndicatorAnimationView.kt$TypingDrawable$0.5f</ID>
     <ID>MagicNumber:TypingIndicatorAnimationView.kt$TypingDrawable$255</ID>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/MessageListScrollHelper.kt
@@ -101,25 +101,34 @@ internal class MessageListScrollHelper(
                         return
                     }
 
-                    val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
-                    val lastPotentiallyVisibleItemPosition = currentList.indexOfLast { it.isValid() }
-                    bottomOffset = lastPotentiallyVisibleItemPosition - lastVisibleItemPosition
-                    isAtBottom = bottomOffset == 0 && areNewestMessagesLoaded
-
-                    scrollButtonView.isVisible = shouldScrollToBottomBeVisible(bottomOffset)
+                    scrollButtonView.isVisible = shouldScrollToBottomBeVisible()
                 }
             }
         )
     }
 
     /**
-     * Determines whether the scroll to bottom button should be visible or not.
+     * Calculates the bottom offset by comparing the position of the last visible item
+     * with the position of the last potentially visible item.
      *
-     * @param bottomOffset The offset of last visible item and the last potentially visible item.
+     * @return The bottom offset.
+     */
+    private fun calculateBottomOffset(): Int {
+        val lastVisibleItemPosition = layoutManager.findLastVisibleItemPosition()
+        val lastPotentiallyVisibleItemPosition = currentList.indexOfLast { it.isValid() }
+
+        return lastPotentiallyVisibleItemPosition - lastVisibleItemPosition
+    }
+
+    /**
+     * Determines whether the scroll to bottom button should be visible or not.
      *
      * @return Whether the scroll to bottom button should be visible or not.
      */
-    private fun shouldScrollToBottomBeVisible(bottomOffset: Int): Boolean {
+    private fun shouldScrollToBottomBeVisible(): Boolean {
+        bottomOffset = calculateBottomOffset()
+        isAtBottom = bottomOffset <= 0 && areNewestMessagesLoaded
+
         return when {
             adapter.itemCount == 0 -> false
             !areNewestMessagesLoaded -> true
@@ -185,15 +194,15 @@ internal class MessageListScrollHelper(
         areNewestMessagesLoaded: Boolean,
     ) {
         this.areNewestMessagesLoaded = areNewestMessagesLoaded
-        scrollButtonView.isVisible = shouldScrollToBottomBeVisible(bottomOffset)
+        scrollButtonView.isVisible = shouldScrollToBottomBeVisible()
 
         if (shouldKeepScrollPosition(areNewestMessagesLoaded, hasNewMessages)) {
             return
         }
 
         if (isThreadStart) {
-            layoutManager.scrollToPosition(0)
-        } else if (shouldScrollToBottom(isInitialList, areNewestMessagesLoaded, hasNewMessages)) {
+            layoutManager.scrollToPosition(currentList.lastIndex)
+        } else if (!adapter.isThread && shouldScrollToBottom(isInitialList, areNewestMessagesLoaded, hasNewMessages)) {
             layoutManager.scrollToPosition(currentList.lastIndex)
             callback.onLastMessageRead()
         }
@@ -226,7 +235,8 @@ internal class MessageListScrollHelper(
     }
 
     private fun MessageListItem.isValid(): Boolean {
-        return this is MessageListItem.MessageItem && !(this.isTheirs && this.message.isDeleted())
+        return (this is MessageListItem.MessageItem && !(this.isTheirs && this.message.isDeleted())) ||
+            (this is MessageListItem.ThreadSeparatorItem)
     }
 
     internal fun setScrollToBottomHandler(onScrollToBottomHandler: MessageListView.OnScrollToBottomHandler) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/MessageListScrollHelper.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/MessageListScrollHelper.kt
@@ -196,13 +196,13 @@ internal class MessageListScrollHelper(
         this.areNewestMessagesLoaded = areNewestMessagesLoaded
         scrollButtonView.isVisible = shouldScrollToBottomBeVisible()
 
-        if (shouldKeepScrollPosition(areNewestMessagesLoaded, hasNewMessages)) {
+        if (!isThreadStart && shouldKeepScrollPosition(areNewestMessagesLoaded, hasNewMessages)) {
             return
         }
 
         if (isThreadStart) {
             layoutManager.scrollToPosition(currentList.lastIndex)
-        } else if (!adapter.isThread && shouldScrollToBottom(isInitialList, areNewestMessagesLoaded, hasNewMessages)) {
+        } else if (shouldScrollToBottom(isInitialList, areNewestMessagesLoaded, hasNewMessages)) {
             layoutManager.scrollToPosition(currentList.lastIndex)
             callback.onLastMessageRead()
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/MessageListState.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/MessageListState.kt
@@ -23,9 +23,11 @@ import io.getstream.chat.android.ui.model.MessageListItemWrapper
 /**
  * Converts the common [MessageListState] to ui-components [MessageListItemWrapper].
  *
+ * @param isInThread Whether the message list is currently in thread mode or not.
+ *
  * @return [MessageListItemWrapper] derived from [MessageListState].
  */
-public fun MessageListState.toMessageListItemWrapper(): MessageListItemWrapper {
+public fun MessageListState.toMessageListItemWrapper(isInThread: Boolean): MessageListItemWrapper {
     var messagesList: List<MessageListItem> = messageItems.map { it.toUiMessageListItem() }
 
     if (isLoadingOlderMessages) messagesList = messagesList + listOf(MessageListItem.LoadingMoreIndicatorItem)
@@ -35,6 +37,7 @@ public fun MessageListState.toMessageListItemWrapper(): MessageListItemWrapper {
         items = messagesList,
         hasNewMessages = newMessageState != null,
         isTyping = messagesList.firstOrNull { it is MessageListItem.TypingItem } != null,
-        areNewestMessagesLoaded = endOfNewMessagesReached
+        areNewestMessagesLoaded = endOfNewMessagesReached,
+        isThread = isInThread
     )
 }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -42,6 +42,7 @@ import io.getstream.chat.android.ui.model.MessageListItemWrapper
 import io.getstream.chat.android.ui.viewmodel.messages.MessageListViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.AfterEach
@@ -66,6 +67,7 @@ internal class MessageListViewModelTest {
     fun tearDown() {
         MutableGlobalStateInstance.clearState()
     }
+
     @Test
     fun `Given initial state remains unchanged Should be in loading state`() = runTest {
         val viewModel = Fixture()
@@ -74,6 +76,8 @@ internal class MessageListViewModelTest {
             .get()
 
         val state = viewModel.state.observeAll()
+
+        advanceUntilIdle()
 
         state.last() shouldBeEqualTo MessageListViewModel.State.Loading
     }
@@ -92,6 +96,8 @@ internal class MessageListViewModelTest {
             .get()
 
         val state = viewModel.state.observeAll()
+
+        advanceUntilIdle()
 
         val expectedState = MessageListViewModel.State.Result(
             messageListItem = MessageListItemWrapper(


### PR DESCRIPTION
### 🎯 Goal

closes #4743

### 🛠 Implementation details

Altered logic conditions around the scroll logic.

### 🎨 UI Changes

#### Auto Scrolling Issues

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/37080097/226987093-1c05880c-11bf-48d5-af81-1a764600f02f.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/37080097/226987082-7474352c-51a3-4ed0-8855-5d62e6775caf.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


#### Scroll to Bottom button issues

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/37080097/226987094-fec6e310-603f-4dca-a0c3-fa7b6dce4182.mp4" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/37080097/226987089-077aa778-33e7-4219-a353-ef4fe1016b89.mp4" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

The testing section will consist of two large wholes, one testing that the changes have fixed the behavior that was previously faulty, the other checking that no previously correct behaviour has been broken by the new changes.

#### First test set - Validating fixed behaviour

Test A - Autoscroll behavior

1. Log in with a user and visit a thread that has multiple pages, there's two with 90+ messages in the channel `hiya` (visible to user Jc)
2. Navigate to the thread and paginate all the way to the top
3. Exit the thread and enter it again
4. Once again navigate all the way to the top

Expectation: On the develop branch, step 4 will trigger an automatic scroll to the bottom, on this branch, the behaviour should be fixed.

Test B - Scroll to bottom appearing when shouldn't

1. Log in with a user and navigate to a message that has a tall verical photo, also available in the `hiya` channel
2. Open a new thread

Expectation: On `develop`, the scroll to bottom button should appear when even when it should not appear, on this branch it should apear only when neccessary. You might need to try a couple of times before you reproduce the issue

#### Second test set - Making sure no new anomalous behavior has ben introduced

Test A - Making sure that new own messages trigger scroll

1. Enter a channel and paginate way up
2. Send a new message from the same device
3. Repeat for a thread

Expectation: Own messages should make the list autoscroll to the bottom

Test B - Making sure another users messages don't trigger scroll

1. Enter a channel and paginate way up
2. Send a new message from a different device logged in with a different user
3. Repeat for a thread

Expectation: Other user's messages messages should not make the list autoscroll to the bottom

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media4.giphy.com/media/8CAFRDokyQkhi/giphy.gif?cid=ecf05e471j67zjmzhcunbu20i76dloctn94v1d1ygf12qnox&rid=giphy.gif&ct=g)
