### PR TITLE
MessageComposerView show reply view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `messageInputShowReplyView` to `MessageComposerViewStyle` to determine whether to show or hide the default reply view inside center content. [#4746](https://github.com/GetStream/stream-chat-android/pull/4746)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1985,7 +1985,7 @@ public final class io/getstream/chat/android/ui/message/composer/MessageComposer
 
 public final class io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle$Companion;
-	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IF)V
+	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IF)V
 	public final fun component1 ()I
 	public final fun component10 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component11 ()I
@@ -2005,40 +2005,41 @@ public final class io/getstream/chat/android/ui/message/composer/MessageComposer
 	public final fun component24 ()Ljava/lang/String;
 	public final fun component25 ()I
 	public final fun component26 ()Z
-	public final fun component27 ()Landroid/graphics/drawable/Drawable;
-	public final fun component28 ()Ljava/lang/Integer;
-	public final fun component29 ()Z
+	public final fun component27 ()Z
+	public final fun component28 ()Landroid/graphics/drawable/Drawable;
+	public final fun component29 ()Ljava/lang/Integer;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
-	public final fun component30 ()Landroid/graphics/drawable/Drawable;
-	public final fun component31 ()Ljava/lang/Integer;
-	public final fun component32 ()Z
-	public final fun component33 ()Landroid/graphics/drawable/Drawable;
-	public final fun component34 ()Ljava/lang/String;
-	public final fun component35 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component36 ()Ljava/lang/String;
-	public final fun component37 ()Landroid/graphics/drawable/Drawable;
-	public final fun component38 ()Ljava/lang/String;
-	public final fun component39 ()Landroid/graphics/drawable/Drawable;
+	public final fun component30 ()Z
+	public final fun component31 ()Landroid/graphics/drawable/Drawable;
+	public final fun component32 ()Ljava/lang/Integer;
+	public final fun component33 ()Z
+	public final fun component34 ()Landroid/graphics/drawable/Drawable;
+	public final fun component35 ()Ljava/lang/String;
+	public final fun component36 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component37 ()Ljava/lang/String;
+	public final fun component38 ()Landroid/graphics/drawable/Drawable;
+	public final fun component39 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component40 ()Landroid/graphics/drawable/Drawable;
-	public final fun component41 ()Z
-	public final fun component42 ()Landroid/graphics/drawable/Drawable;
-	public final fun component43 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component44 ()Landroid/graphics/drawable/Drawable;
-	public final fun component45 ()I
-	public final fun component46 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component47 ()I
-	public final fun component48 ()F
-	public final fun component49 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component41 ()Landroid/graphics/drawable/Drawable;
+	public final fun component42 ()Z
+	public final fun component43 ()Landroid/graphics/drawable/Drawable;
+	public final fun component44 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component45 ()Landroid/graphics/drawable/Drawable;
+	public final fun component46 ()I
+	public final fun component47 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component48 ()I
+	public final fun component49 ()F
 	public final fun component5 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
-	public final fun component50 ()I
-	public final fun component51 ()F
+	public final fun component50 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
+	public final fun component51 ()I
+	public final fun component52 ()F
 	public final fun component6 ()Landroid/graphics/drawable/Drawable;
 	public final fun component7 ()I
 	public final fun component8 ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IF)Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IFIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
+	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IF)Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;ZZLio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/common/style/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/common/style/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/common/style/TextStyle;IFLio/getstream/chat/android/ui/common/style/TextStyle;IFIILjava/lang/Object;)Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlsoSendToChannelCheckboxDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getAlsoSendToChannelCheckboxText ()Ljava/lang/String;
@@ -2079,6 +2080,7 @@ public final class io/getstream/chat/android/ui/message/composer/MessageComposer
 	public final fun getMessageInputMentionsHandlingEnabled ()Z
 	public final fun getMessageInputScrollbarEnabled ()Z
 	public final fun getMessageInputScrollbarFadingEnabled ()Z
+	public final fun getMessageInputShowReplyView ()Z
 	public final fun getMessageInputTextStyle ()Lio/getstream/chat/android/ui/common/style/TextStyle;
 	public final fun getMessageReplyBackgroundColor ()I
 	public final fun getMessageReplyMessageBackgroundStrokeColorMine ()I

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt
@@ -64,6 +64,7 @@ import io.getstream.chat.android.ui.utils.extensions.getDrawableCompat
  * @param messageInputMaxLines The maximum number of message input lines.
  * @param messageInputCannotSendHintText The input hint text in case we can't send messages in this channel.
  * @param messageInputInputType The [InputType] to be applied to the message input edit text.
+ * @param messageInputShowReplyView Whether to show the default reply view inside the message input or not.
  * @param attachmentsButtonVisible If the button to pick attachments is displayed.
  * @param attachmentsButtonIconDrawable The icon for the attachments button.
  * @param attachmentsButtonRippleColor Ripple color of the attachments button.
@@ -122,6 +123,7 @@ public data class MessageComposerViewStyle(
     public val messageInputMaxLines: Int,
     public val messageInputCannotSendHintText: String,
     public val messageInputInputType: Int,
+    public val messageInputShowReplyView: Boolean,
     // Leading content
     public val attachmentsButtonVisible: Boolean,
     public val attachmentsButtonIconDrawable: Drawable,
@@ -524,6 +526,11 @@ public data class MessageComposerViewStyle(
                         InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
                 )
 
+                val messageInputShowReplyView = a.getBoolean(
+                    R.styleable.MessageComposerView_streamUiMessageComposerShowMessageReplyView,
+                    true
+                )
+
                 val mediumTypeface = ResourcesCompat.getFont(context, R.font.stream_roboto_medium) ?: Typeface.DEFAULT
 
                 val messageReplyBackgroundColor: Int =
@@ -625,6 +632,7 @@ public data class MessageComposerViewStyle(
                     messageInputMaxLines = messageInputMaxLines,
                     messageInputCannotSendHintText = messageInputCannotSendHintText,
                     messageInputInputType = messageInputInputType,
+                    messageInputShowReplyView = messageInputShowReplyView,
                     // Leading content
                     attachmentsButtonVisible = attachmentsButtonVisible,
                     attachmentsButtonIconDrawable = attachmentsButtonIconDrawable,
@@ -655,7 +663,6 @@ public data class MessageComposerViewStyle(
                     messageReplyTextStyleTheirs = messageReplyTextStyleTheirs,
                     messageReplyMessageBackgroundStrokeColorTheirs = messageReplyMessageBackgroundStrokeColorTheirs,
                     messageReplyMessageBackgroundStrokeWidthTheirs = messageReplyMessageBackgroundStrokeWidthTheirs,
-
                 ).let(TransformStyle.messageComposerStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCenterContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCenterContent.kt
@@ -166,6 +166,8 @@ public class DefaultMessageComposerCenterContent : FrameLayout, MessageComposerC
      * @param state The state that will be used to render the updated UI.
      */
     private fun renderReplyState(state: MessageComposerState) {
+        if (!style.messageInputShowReplyView) return
+
         val action = state.action
         if (action is Reply) {
             val quotedMessage = action.message

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
@@ -151,6 +151,8 @@
 
         <attr name="streamUiMessageComposerCooldownTimerBackgroundDrawable" format="reference" />
 
+        <attr name="streamUiMessageComposerShowMessageReplyView" format="boolean" />
+
         <!-- Sets the background color of the quoted message bubble visible in the input when
          replying to a message. Applied both when replying to messages owned by the currently
          logged-in user and messages owned by other users. -->


### PR DESCRIPTION
### 🎯 Goal

Enable the control to show/hide the reply view inside the default implementation of the `MessageComposerView` center content.

### 🛠 Implementation details

Added `messageInputShowReplyView` to `MessageComposerViewStyle`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1679499962](https://user-images.githubusercontent.com/38032787/226964530-04222411-2a95-4339-8a57-2db0e2300ded.png)  | ![Screenshot_1679499938](https://user-images.githubusercontent.com/38032787/226964562-c7be3aca-fa46-49b0-9ef7-1c1ece8441d0.png)  |

### 🧪 Testing

Run this branch without patch and reply to a message. The replyView should be visible.
Run this branch with the patch and repeat. ReplyView should not be visible.

<details>

<summary>Test patch</summary>

```
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt	(revision c6776dc1b44f37f476280d74d4d31eaee6b6299d)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerViewStyle.kt	(date 1679500814058)
@@ -528,7 +528,7 @@
 
                 val messageInputShowReplyView = a.getBoolean(
                     R.styleable.MessageComposerView_streamUiMessageComposerShowMessageReplyView,
-                    true
+                    false
                 )
 
                 val mediumTypeface = ResourcesCompat.getFont(context, R.font.stream_roboto_medium) ?: Typeface.DEFAULT

```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/38032787/226965713-1e364a83-3ef3-4040-87b2-7c27d43c4ca9.gif)