### PR TITLE
[ISSUE-4756] Creating preview of unsupported attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed edit messages with unsupported attachments. [#4757](https://github.com/GetStream/stream-chat-android/pull/4757)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Fixed edit messages with unsupported attachments. [#4757](https://github.com/GetStream/stream-chat-android/pull/4757)
+- Fixed edit messages and reply messages with unsupported attachments. [#4757](https://github.com/GetStream/stream-chat-android/pull/4757)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2205,6 +2205,12 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/vi
 	public fun generateQuotedAttachmentView (Lio/getstream/chat/android/models/Message;Landroid/view/ViewGroup;)Landroid/view/View;
 }
 
+public final class io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory : io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactory {
+	public fun <init> ()V
+	public fun canHandle (Lio/getstream/chat/android/models/Message;)Z
+	public fun generateQuotedAttachmentView (Lio/getstream/chat/android/models/Message;Landroid/view/ViewGroup;)Landroid/view/View;
+}
+
 public abstract class io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/InnerAttachmentViewHolder {
 	public fun <init> (Landroid/view/View;)V
 	public final fun getContext ()Landroid/content/Context;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/FallbackAttachmentPreviewFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/FallbackAttachmentPreviewFactory.kt
@@ -16,11 +16,12 @@
 
 package io.getstream.chat.android.ui.feature.messages.composer.attachment.preview.factory
 
-import android.view.View
 import android.view.ViewGroup
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.ui.databinding.StreamUiUnsupportedAttachmentPreviewBinding
 import io.getstream.chat.android.ui.feature.messages.composer.MessageComposerViewStyle
 import io.getstream.chat.android.ui.feature.messages.composer.attachment.preview.AttachmentPreviewViewHolder
+import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
 /**
  * A fallback [AttachmentPreviewFactory] for attachments unhandled by other factories.
@@ -49,17 +50,26 @@ public class FallbackAttachmentPreviewFactory : AttachmentPreviewFactory {
         attachmentRemovalListener: (Attachment) -> Unit,
         style: MessageComposerViewStyle?,
     ): AttachmentPreviewViewHolder {
-        return FallbackAttachmentPreviewViewHolder(View(parentView.context))
+        return StreamUiUnsupportedAttachmentPreviewBinding
+            .inflate(parentView.context.streamThemeInflater, parentView, false)
+            .let { binding ->
+                FallbackAttachmentPreviewViewHolder(binding, attachmentRemovalListener)
+            }
     }
 
     /**
      * An empty ViewHolder as we don't display unsupported attachment types.
      *
-     * @param itemView The view that this ViewHolder controls.
+     * @param binding [StreamUiUnsupportedAttachmentPreviewBinding] generated for the layout.
+     * @param attachmentRemovalListener Click listener for the remove attachment button.
      */
     private class FallbackAttachmentPreviewViewHolder(
-        itemView: View,
-    ) : AttachmentPreviewViewHolder(itemView) {
-        override fun bind(attachment: Attachment) = Unit
+        private val binding: StreamUiUnsupportedAttachmentPreviewBinding,
+        private val attachmentRemovalListener: (Attachment) -> Unit,
+    ) : AttachmentPreviewViewHolder(binding.root) {
+        override fun bind(attachment: Attachment) {
+            binding.titleImageView.text = attachment.title
+            binding.removeButton.setOnClickListener { attachmentRemovalListener(attachment) }
+        }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/DefaultQuotedAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/DefaultQuotedAttachmentView.kt
@@ -52,13 +52,13 @@ internal class DefaultQuotedAttachmentView : AppCompatImageView {
     }
 
     private lateinit var style: DefaultQuotedAttachmentViewStyle
-    private lateinit var attachment: Attachment
+    private var attachment: Attachment? = null
 
     override fun onAttachedToWindow() {
         super.onAttachedToWindow()
 
         layoutParams = layoutParams.apply {
-            when (attachment.type) {
+            when (attachment?.type) {
                 AttachmentType.FILE, AttachmentType.VIDEO -> {
                     width = style.fileAttachmentWidth
                     height = style.fileAttachmentHeight
@@ -102,6 +102,6 @@ internal class DefaultQuotedAttachmentView : AppCompatImageView {
     }
 
     private fun init(context: Context) {
-        this.style = io.getstream.chat.android.ui.feature.messages.list.DefaultQuotedAttachmentViewStyle(context)
+        this.style = DefaultQuotedAttachmentViewStyle(context)
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment
+
+import android.view.View
+import android.view.ViewGroup
+import io.getstream.chat.android.client.utils.attachment.isFile
+import io.getstream.chat.android.client.utils.attachment.isGiphy
+import io.getstream.chat.android.client.utils.attachment.isImage
+import io.getstream.chat.android.client.utils.attachment.isVideo
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.feature.messages.list.adapter.view.internal.DefaultQuotedAttachmentView
+
+/**
+ * Factory for attachments we support by default.
+ */
+public class FallbackQuotedAttachmentMessageFactory : QuotedAttachmentFactory {
+
+    /**
+     * @param message The quoted message with the attachments we wish to render.
+     *
+     * @return If the factory can handle the given quoted message attachment or not.
+     */
+    override fun canHandle(message: Message): Boolean = true
+
+    /**
+     * Generates a [DefaultQuotedAttachmentView] to render the attachment.
+     *
+     * @param message The quoted message holding the attachments.
+     * @param parent The parent [ViewGroup] in which the attachment will be rendered.
+     *
+     * @return [DefaultQuotedAttachmentView] that will be rendered inside the quoted message.
+     */
+    override fun generateQuotedAttachmentView(message: Message, parent: ViewGroup): View {
+        return DefaultQuotedAttachmentView(parent.context).apply {
+            setImageResource(R.drawable.stream_ui_ic_file)
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
@@ -18,10 +18,6 @@ package io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.at
 
 import android.view.View
 import android.view.ViewGroup
-import io.getstream.chat.android.client.utils.attachment.isFile
-import io.getstream.chat.android.client.utils.attachment.isGiphy
-import io.getstream.chat.android.client.utils.attachment.isImage
-import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.feature.messages.list.adapter.view.internal.DefaultQuotedAttachmentView

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/FallbackQuotedAttachmentMessageFactory.kt
@@ -23,7 +23,8 @@ import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.feature.messages.list.adapter.view.internal.DefaultQuotedAttachmentView
 
 /**
- * Factory for attachments we support by default.
+ * Factory for attachments that the SDK falls back when all the other [QuotedAttachmentFactory] don't support the
+ * attachment type. It simply shows a file icon with the attachment title.
  */
 public class FallbackQuotedAttachmentMessageFactory : QuotedAttachmentFactory {
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager.kt
@@ -48,11 +48,9 @@ public class QuotedAttachmentFactoryManager(
         message: Message,
         parent: ViewGroup,
     ) {
-        val quotedAttachmentFactory = quotedAttachmentFactories.firstOrNull { it.canHandle(message) }
-        val view = quotedAttachmentFactory?.generateQuotedAttachmentView(message, parent)
-            ?: ChatUI.attachmentFactoryManager.createViewHolder(message, null, parent).apply {
-                onBindViewHolder(message)
-            }.itemView
+        val quotedAttachmentFactory =
+            quotedAttachmentFactories.firstOrNull { it.canHandle(message) } ?: FallbackQuotedAttachmentMessageFactory()
+        val view = quotedAttachmentFactory.generateQuotedAttachmentView(message, parent)
 
         parent.removeAllViews()
         parent.addView(view)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/UnsupportedAttachmentFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/UnsupportedAttachmentFactory.kt
@@ -16,11 +16,8 @@
 
 package io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment
 
-import android.content.Context
 import android.content.res.ColorStateList
-import android.util.AttributeSet
 import android.view.ViewGroup
-import android.widget.FrameLayout
 import com.google.android.material.shape.CornerFamily
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
@@ -31,7 +28,6 @@ import io.getstream.chat.android.ui.databinding.StreamUiUnsupportedAttachmentVie
 import io.getstream.chat.android.ui.feature.messages.list.UnsupportedAttachmentViewStyle
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListListenerContainer
 import io.getstream.chat.android.ui.font.setTextStyle
-import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
 /**
@@ -62,43 +58,22 @@ public class UnsupportedAttachmentFactory : AttachmentFactory {
         listeners: MessageListListenerContainer?,
         parent: ViewGroup,
     ): InnerAttachmentViewHolder {
-        return object : InnerAttachmentViewHolder(UnsupportedAttachmentsView(parent.context)) {}
-    }
+        val binding = StreamUiUnsupportedAttachmentViewBinding
+            .inflate(parent.context.streamThemeInflater, parent, false)
 
-    /**
-     * View used to display unsupported attachments.
-     */
-    private class UnsupportedAttachmentsView : FrameLayout {
+        val style = UnsupportedAttachmentViewStyle(parent.context, null)
 
-        private val binding = StreamUiUnsupportedAttachmentViewBinding.inflate(streamThemeInflater, this, true)
-
-        private lateinit var style: UnsupportedAttachmentViewStyle
-
-        constructor(context: Context) : this(context, null, 0)
-
-        constructor(context: Context, attrs: AttributeSet?) : this(context, attrs, 0)
-
-        constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(
-            context.createStreamThemeWrapper(),
-            attrs,
-            defStyleAttr
-        ) {
-            init(attrs)
+        val shapeAppearanceModel = ShapeAppearanceModel.Builder()
+            .setAllCorners(CornerFamily.ROUNDED, style.cornerRadius.toFloat())
+            .build()
+        binding.attachmentContainer.background = MaterialShapeDrawable(shapeAppearanceModel).apply {
+            fillColor = ColorStateList.valueOf(style.backgroundColor)
+            strokeColor = ColorStateList.valueOf(style.strokeColor)
+            strokeWidth = style.strokeWidth.toFloat()
         }
+        binding.titleImageView.setTextStyle(style.titleTextStyle)
 
-        private fun init(attrs: AttributeSet?) {
-            style = UnsupportedAttachmentViewStyle(context, attrs)
-
-            val shapeAppearanceModel = ShapeAppearanceModel.Builder()
-                .setAllCorners(CornerFamily.ROUNDED, style.cornerRadius.toFloat())
-                .build()
-            binding.attachmentContainer.background = MaterialShapeDrawable(shapeAppearanceModel).apply {
-                fillColor = ColorStateList.valueOf(style.backgroundColor)
-                strokeColor = ColorStateList.valueOf(style.strokeColor)
-                strokeWidth = style.strokeWidth.toFloat()
-            }
-            binding.titleImageView.setTextStyle(style.titleTextStyle)
-        }
+        return object : InnerAttachmentViewHolder(binding.root) {}
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_unsupported_attachment_preview.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_unsupported_attachment_preview.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/attachmentContainer"
+    android:layout_width="@dimen/stream_ui_message_composer_file_attachment_width"
+    android:layout_height="@dimen/stream_ui_message_composer_attachment_height"
+    android:layout_margin="4dp"
+    android:padding="6dp"
+    >
+
+    <ImageView
+        android:id="@+id/iconImageView"
+        android:layout_width="@dimen/stream_ui_attachment_dialog_file_type_width"
+        android:layout_height="@dimen/stream_ui_attachment_dialog_file_type_height"
+        android:layout_marginStart="6dp"
+        android:scaleType="centerCrop"
+        android:src="@drawable/stream_ui_ic_file"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription"
+        />
+
+    <TextView
+        android:id="@+id/titleImageView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/stream_ui_spacing_medium"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_medium"
+        android:text="Unsupported attachment"
+        android:textAppearance="@style/StreamUiTextAppearance.Body"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/iconImageView"
+        app:layout_constraintTop_toTopOf="parent"
+        />
+
+    <ImageButton
+        android:id="@+id/removeButton"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:background="@drawable/stream_ui_attachment_cancel_background"
+        android:cropToPadding="true"
+        android:src="@drawable/stream_ui_ic_close_white"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0"
+        tools:ignore="ContentDescription"
+        />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### 🎯 Goal

Fix the preview of unsupported attachments.

### 🛠 Implementation details

Changing the view that returns in `FallbackAttachmentPreviewFactory`. 

### 🎨 UI Changes


| Before | After |
| --- | --- |
| ![Screenshot_20230330-123230 (2)](https://user-images.githubusercontent.com/10619102/228827329-42bd5b4d-759b-40d6-afc8-df4f7882485c.png) | ![Screenshot_20230330-135029](https://user-images.githubusercontent.com/10619102/228827332-71846568-1916-4907-87b2-9105e4d44077.png) |

_Add relevant videos_

### 🧪 Testing

Make `FileAttachmentPreviewFactory.canHandle` and `MediaAttachmentPreviewFactory.canHandle` return false so no attachment is supported and you can see the behaviour. 

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- ~[ ] New code is covered by unit tests~
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/10619102/228826962-ace08578-edc6-4482-9cb4-f647674d04a3.gif)

