### PR TITLE
[4749] [v6] Expose Attachment clicks

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -337,7 +337,7 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Comp
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContentKt {
-	public static final fun FileAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun FileAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun FileAttachmentImage (Lio/getstream/chat/android/models/Attachment;Landroidx/compose/runtime/Composer;I)V
 	public static final fun FileAttachmentItem (Lio/getstream/chat/android/models/Attachment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
@@ -351,12 +351,12 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/File
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileUploadContentKt {
-	public static final fun FileUploadContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun FileUploadContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 	public static final fun FileUploadItem (Lio/getstream/chat/android/models/Attachment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContentKt {
-	public static final fun GiphyAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Landroidx/compose/runtime/Composer;II)V
+	public static final fun GiphyAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ImageAttachmentPreviewContentKt {
@@ -364,11 +364,11 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Imag
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContentKt {
-	public static final fun LinkAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;ILandroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun LinkAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;ILandroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContentKt {
-	public static final fun MediaAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MediaAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentPreviewContentKt {
@@ -394,10 +394,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Unsu
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$FileAttachmentFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$FileAttachmentFactoryKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function5;
-	public static field lambda-2 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function5;
-	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$MediaAttachmentFactoryKt {
@@ -423,29 +421,24 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Comp
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
-public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt {
-	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$UploadAttachmentFactoryKt;
-	public static field lambda-1 Lkotlin/jvm/functions/Function4;
-	public fun <init> ()V
-	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-}
-
 public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactoryKt {
-	public static final fun FileAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static final fun FileAttachmentFactory (Lkotlin/jvm/functions/Function2;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static synthetic fun FileAttachmentFactory$default (Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactoryKt {
-	public static final fun GiphyAttachmentFactory (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
-	public static synthetic fun GiphyAttachmentFactory$default (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static final fun GiphyAttachmentFactory (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static synthetic fun GiphyAttachmentFactory$default (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactoryKt {
-	public static final fun LinkAttachmentFactory (I)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static final fun LinkAttachmentFactory (ILkotlin/jvm/functions/Function2;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static synthetic fun LinkAttachmentFactory$default (ILkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactoryKt {
-	public static final fun MediaAttachmentFactory (IZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
-	public static synthetic fun MediaAttachmentFactory$default (IZLkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static final fun MediaAttachmentFactory (IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static synthetic fun MediaAttachmentFactory$default (IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/QuotedAttachmentFactoryKt {
@@ -457,7 +450,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Unsu
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactoryKt {
-	public static final fun UploadAttachmentFactory ()Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static final fun UploadAttachmentFactory (Lkotlin/jvm/functions/Function2;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
+	public static synthetic fun UploadAttachmentFactory$default (Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/attachments/AttachmentFactory;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/ComposableSingletons$MediaGalleryPreviewActivityKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -310,8 +310,8 @@ public class io/getstream/chat/android/compose/ui/attachments/AttachmentFactory 
 public final class io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories {
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;
-	public final fun defaultFactories (ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Z)Ljava/util/List;
-	public static synthetic fun defaultFactories$default (Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZILjava/lang/Object;)Ljava/util/List;
+	public final fun defaultFactories (ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function2;)Ljava/util/List;
+	public static synthetic fun defaultFactories$default (Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/util/List;
 	public final fun defaultQuotedFactories ()Ljava/util/List;
 }
 

--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -19,6 +19,8 @@
     <ID>LongMethod:MessageItem.kt$@Composable internal fun RegularMessageContent( messageItem: MessageItemState, modifier: Modifier = Modifier, onLongItemClick: (Message) -> Unit = {}, onGiphyActionClick: (GiphyAction) -> Unit = {}, onQuotedMessageClick: (Message) -> Unit = {}, onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {}, )</ID>
     <ID>LongMethod:MessageOptions.kt$@Composable public fun defaultMessageOptionsState( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, ): List&lt;MessageOptionItemState></ID>
     <ID>LongMethod:StreamTypography.kt$StreamTypography.Companion$public fun defaultTypography(fontFamily: FontFamily? = null): StreamTypography</ID>
+    <ID>LongParameterList:MediaAttachmentContent.kt$( attachment: Attachment, message: Message, skipEnrichUrl: Boolean, onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {}, onLongItemClick: (Message) -> Unit, onContentItemClick: ( mediaGalleryPreviewLauncher: ManagedActivityResultLauncher&lt;MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>, message: Message, attachmentPosition: Int, videoThumbnailsEnabled: Boolean, streamCdnImageResizing: StreamCdnImageResizing, skipEnrichUrl: Boolean, ) -> Unit, overlayContent: @Composable (attachmentType: String?) -> Unit, )</ID>
+    <ID>LongParameterList:MediaAttachmentContent.kt$( mediaGalleryPreviewLauncher: ManagedActivityResultLauncher&lt;MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>, message: Message, attachmentPosition: Int, videoThumbnailsEnabled: Boolean, streamCdnImageResizing: StreamCdnImageResizing, skipEnrichUrl: Boolean, )</ID>
     <ID>LongParameterList:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity$( context: Context, mediaGalleryPreviewAction: MediaGalleryPreviewAction, currentPage: Int, attachments: List&lt;Attachment>, writePermissionState: PermissionState, downloadPayload: MutableState&lt;Attachment?>, )</ID>
     <ID>LongParameterList:MediaGalleryPreviewActivityAttachmentState.kt$MediaGalleryPreviewActivityAttachmentState$( val name: String?, val url: String?, val thumbUrl: String?, val imageUrl: String?, val assetUrl: String?, val originalWidth: Int?, val originalHeight: Int?, val type: String?, )</ID>
     <ID>LongParameterList:MessageComposer.kt$( value: String, coolDownTime: Int, attachments: List&lt;Attachment>, validationErrors: List&lt;ValidationError>, ownCapabilities: Set&lt;String>, isInEditMode: Boolean, onSendMessage: (String, List&lt;Attachment>) -> Unit, )</ID>
@@ -37,9 +39,12 @@
     <ID>MagicNumber:TypingIndicatorAnimatedDot.kt$0.5f</ID>
     <ID>MaxLineLength:AttachmentsPickerTabFactories.kt$AttachmentsPickerTabFactories$*</ID>
     <ID>MaxLineLength:ChatTheme.kt$error("No attachments picker tab factories provided! Make sure to wrap all usages of Stream components in a ChatTheme.")</ID>
+    <ID>MaxLineLength:MediaAttachmentContent.kt$mediaGalleryPreviewLauncher: ManagedActivityResultLauncher&lt;MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?></ID>
+    <ID>MaxLineLength:MediaAttachmentFactory.kt$mediaGalleryPreviewLauncher: ManagedActivityResultLauncher&lt;MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?></ID>
     <ID>MaxLineLength:MessageOptions.kt$iconPainter = painterResource(id = if (selectedMessage.pinned) R.drawable.stream_compose_ic_unpin_message else R.drawable.stream_compose_ic_pin_message)</ID>
     <ID>MaxLineLength:MessageOptions.kt$title = if (selectedMessage.pinned) R.string.stream_compose_unpin_message else R.string.stream_compose_pin_message</ID>
     <ID>MaxLineLength:MessagesScreen.kt$*</ID>
+    <ID>MaxLineLength:StreamAttachmentFactories.kt$StreamAttachmentFactories$mediaGalleryPreviewLauncher: ManagedActivityResultLauncher&lt;MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?></ID>
     <ID>MaxLineLength:StreamColors.kt$StreamColors$*</ID>
     <ID>TooManyFunctions:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity : AppCompatActivity</ID>
   </CurrentIssues>

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -17,12 +17,14 @@
 package io.getstream.chat.android.compose.ui.attachments
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResult
+import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClicked
 import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClicked
 import io.getstream.chat.android.compose.ui.attachments.factory.FileAttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.factory.GiphyAttachmentFactory
@@ -39,7 +41,6 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
 import io.getstream.chat.android.ui.common.utils.GiphySizingMode
-import io.getstream.chat.android.uiutils.extension.isUploading
 
 /**
  * Provides different attachment factories that build custom message content based on a given attachment.
@@ -85,29 +86,9 @@ public object StreamAttachmentFactories {
         onUploadContentItemClicked: (
             Attachment,
             List<AttachmentPreviewHandler>,
-        ) -> Unit = { attachment, previewHandlers ->
-            if (!attachment.isUploading()) {
-                previewHandlers
-                    .firstOrNull { it.canHandle(attachment) }
-                    ?.handleAttachmentPreview(attachment)
-            }
-        },
-        onLinkContentItemClicked: (context: Context, previewUrl: String) -> Unit = { context, previewUrl ->
-            context.startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse(previewUrl)
-                )
-            )
-        },
-        onGiphyContentItemClick: (context: Context, Url: String) -> Unit = { context, url ->
-            context.startActivity(
-                Intent(
-                    Intent.ACTION_VIEW,
-                    Uri.parse(url)
-                )
-            )
-        },
+        ) -> Unit = ::onFileUploadContentItemClicked,
+        onLinkContentItemClicked: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClicked,
+        onGiphyContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClicked,
         onMediaContentItemClick: (
             mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
             message: Message,
@@ -117,13 +98,9 @@ public object StreamAttachmentFactories {
             skipEnrichUrl: Boolean,
         ) -> Unit = ::onMediaAttachmentContentItemClicked,
         onFileContentItemClick: (
-            previewHandler: List<AttachmentPreviewHandler>,
+            previewHandlers: List<AttachmentPreviewHandler>,
             attachment: Attachment,
-        ) -> Unit = { previewHandlers, attachment ->
-            previewHandlers
-                .firstOrNull { it.canHandle(attachment) }
-                ?.handleAttachmentPreview(attachment)
-        },
+        ) -> Unit = ::onFileAttachmentContentItemClicked,
     ): List<AttachmentFactory> = listOf(
         UploadAttachmentFactory(
             onContentItemClicked = onUploadContentItemClicked

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -82,7 +82,10 @@ public object StreamAttachmentFactories {
         giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
         contentScale: ContentScale = ContentScale.Crop,
         skipEnrichUrl: Boolean = false,
-        onUploadContentItemClicked: (Attachment, List<AttachmentPreviewHandler>) -> Unit = { attachment, previewHandlers ->
+        onUploadContentItemClicked: (
+            Attachment,
+            List<AttachmentPreviewHandler>,
+        ) -> Unit = { attachment, previewHandlers ->
             if (!attachment.isUploading()) {
                 previewHandlers
                     .firstOrNull { it.canHandle(attachment) }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -21,11 +21,11 @@ import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.Image
 import androidx.compose.ui.layout.ContentScale
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResult
-import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClicked
-import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClicked
-import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClicked
-import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClicked
-import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClick
+import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClick
+import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClick
+import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClick
+import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClick
 import io.getstream.chat.android.compose.ui.attachments.factory.FileAttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.factory.GiphyAttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.factory.LinkAttachmentFactory
@@ -68,8 +68,8 @@ public object StreamAttachmentFactories {
      * @param contentScale Used to determine the way Giphys are scaled inside the [Image] composable.
      * @param skipEnrichUrl Used by the media gallery. If set to true will skip enriching URLs when you update the
      * message by deleting an attachment contained within it. Set to false by default.
-     * @param onUploadContentItemClicked Lambda called when a uploading attachment content item gets clicked.
-     * @param onLinkContentItemClicked Lambda called when a link attachment content item gets clicked.
+     * @param onUploadContentItemClick Lambda called when a uploading attachment content item gets clicked.
+     * @param onLinkContentItemClick Lambda called when a link attachment content item gets clicked.
      * @param onGiphyContentItemClick Lambda called when a giphy attachment content item gets clicked.
      * @param onMediaContentItemClick Lambda called when a image or video attachment content item gets clicked.
      * @param onFileContentItemClick Lambda called when a file attachment content item gets clicked.
@@ -83,12 +83,12 @@ public object StreamAttachmentFactories {
         giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
         contentScale: ContentScale = ContentScale.Crop,
         skipEnrichUrl: Boolean = false,
-        onUploadContentItemClicked: (
+        onUploadContentItemClick: (
             Attachment,
             List<AttachmentPreviewHandler>,
-        ) -> Unit = ::onFileUploadContentItemClicked,
-        onLinkContentItemClicked: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClicked,
-        onGiphyContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClicked,
+        ) -> Unit = ::onFileUploadContentItemClick,
+        onLinkContentItemClick: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClick,
+        onGiphyContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClick,
         onMediaContentItemClick: (
             mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
             message: Message,
@@ -96,18 +96,18 @@ public object StreamAttachmentFactories {
             videoThumbnailsEnabled: Boolean,
             streamCdnImageResizing: StreamCdnImageResizing,
             skipEnrichUrl: Boolean,
-        ) -> Unit = ::onMediaAttachmentContentItemClicked,
+        ) -> Unit = ::onMediaAttachmentContentItemClick,
         onFileContentItemClick: (
             previewHandlers: List<AttachmentPreviewHandler>,
             attachment: Attachment,
-        ) -> Unit = ::onFileAttachmentContentItemClicked,
+        ) -> Unit = ::onFileAttachmentContentItemClick,
     ): List<AttachmentFactory> = listOf(
         UploadAttachmentFactory(
-            onContentItemClicked = onUploadContentItemClicked
+            onContentItemClick = onUploadContentItemClick
         ),
         LinkAttachmentFactory(
             linkDescriptionMaxLines = linkDescriptionMaxLines,
-            onContentItemClicked = onLinkContentItemClicked,
+            onContentItemClick = onLinkContentItemClick,
         ),
         GiphyAttachmentFactory(
             giphyInfoType = giphyInfoType,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -66,17 +66,17 @@ import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
  * @param modifier Modifier for styling.
- * @param onItemClicked Lambda called when an item gets clicked.
+ * @param onItemClick Lambda called when an item gets clicked.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 public fun FileAttachmentContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
-    onItemClicked: (
+    onItemClick: (
         previewHandlers: List<AttachmentPreviewHandler>,
         attachment: Attachment,
-    ) -> Unit = ::onFileAttachmentContentItemClicked,
+    ) -> Unit = ::onFileAttachmentContentItemClick,
 ) {
     val (message, onItemLongClick) = attachmentState
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -98,7 +98,7 @@ public fun FileAttachmentContent(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = {
-                            onItemClicked(previewHandlers, attachment)
+                            onItemClick(previewHandlers, attachment)
                         },
                         onLongClick = { onItemLongClick(message) },
                     ),
@@ -251,7 +251,7 @@ public fun FileAttachmentImage(attachment: Attachment) {
  * will be looked for.
  * @param attachment The attachment being clicked.
  */
-internal fun onFileAttachmentContentItemClicked(
+internal fun onFileAttachmentContentItemClick(
     previewHandlers: List<AttachmentPreviewHandler>,
     attachment: Attachment,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -74,13 +74,9 @@ public fun FileAttachmentContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
     onItemClicked: (
-        previewHandler: List<AttachmentPreviewHandler>,
+        previewHandlers: List<AttachmentPreviewHandler>,
         attachment: Attachment,
-    ) -> Unit = { previewHandlers, attachment ->
-        previewHandlers
-            .firstOrNull { it.canHandle(attachment) }
-            ?.handleAttachmentPreview(attachment)
-    },
+    ) -> Unit = ::onFileAttachmentContentItemClicked,
 ) {
     val (message, onItemLongClick) = attachmentState
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -246,4 +242,20 @@ public fun FileAttachmentImage(attachment: Attachment) {
         contentDescription = null,
         contentScale = if (isImage || isVideoWithThumbnails) ContentScale.Crop else ContentScale.Fit
     )
+}
+
+/**
+ * Handles clicks on individual file attachment content items.
+ *
+ * @param previewHandlers A list of preview handlers from which a suitable handler
+ * will be looked for.
+ * @param attachment The attachment being clicked.
+ */
+internal fun onFileAttachmentContentItemClicked(
+    previewHandlers: List<AttachmentPreviewHandler>,
+    attachment: Attachment,
+) {
+    previewHandlers
+        .firstOrNull { it.canHandle(attachment) }
+        ?.handleAttachmentPreview(attachment)
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -49,6 +49,7 @@ import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
+import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.MimeTypeIconProvider
 import io.getstream.chat.android.compose.ui.util.rememberStreamImagePainter
@@ -65,12 +66,21 @@ import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
  * @param modifier Modifier for styling.
+ * @param onItemClicked Lambda called when an item gets clicked.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 public fun FileAttachmentContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
+    onItemClicked: (
+        previewHandler: List<AttachmentPreviewHandler>,
+        attachment: Attachment,
+    ) -> Unit = { previewHandlers, attachment ->
+        previewHandlers
+            .firstOrNull { it.canHandle(attachment) }
+            ?.handleAttachmentPreview(attachment)
+    },
 ) {
     val (message, onItemLongClick) = attachmentState
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -92,9 +102,7 @@ public fun FileAttachmentContent(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = {
-                            previewHandlers
-                                .firstOrNull { it.canHandle(attachment) }
-                                ?.handleAttachmentPreview(attachment)
+                            onItemClicked(previewHandlers, attachment)
                         },
                         onLongClick = { onItemLongClick(message) },
                     ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
+import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
@@ -51,12 +52,20 @@ import io.getstream.chat.android.uiutils.extension.isUploading
  *
  * @param attachmentState The state of this attachment.
  * @param modifier Modifier for styling.
+ * @param onItemClick Lambda called when an item gets clicked.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 public fun FileUploadContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
+    onItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = { attachment, previewHandlers ->
+        if (!attachment.isUploading()) {
+            previewHandlers
+                .firstOrNull { it.canHandle(attachment) }
+                ?.handleAttachmentPreview(attachment)
+        }
+    },
 ) {
     val message = attachmentState.message
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -71,11 +80,7 @@ public fun FileUploadContent(
                         indication = null,
                         interactionSource = remember { MutableInteractionSource() },
                         onClick = {
-                            if (!attachment.isUploading()) {
-                                previewHandlers
-                                    .firstOrNull { it.canHandle(attachment) }
-                                    ?.handleAttachmentPreview(attachment)
-                            }
+                            onItemClick(attachment, previewHandlers)
                         },
                         onLongClick = { }
                     ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -59,7 +59,7 @@ import io.getstream.chat.android.uiutils.extension.isUploading
 public fun FileUploadContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
-    onItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClicked,
+    onItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClick,
 ) {
     val message = attachmentState.message
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -179,7 +179,7 @@ private fun ProgressInfo(uploadedBytes: Long, totalBytes: Long) {
  * @param previewHandlers A list of preview handlers from which a suitable handler
  * will be looked for.
  */
-internal fun onFileUploadContentItemClicked(
+internal fun onFileUploadContentItemClick(
     attachment: Attachment,
     previewHandlers: List<AttachmentPreviewHandler>,
 ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -59,13 +59,7 @@ import io.getstream.chat.android.uiutils.extension.isUploading
 public fun FileUploadContent(
     attachmentState: AttachmentState,
     modifier: Modifier = Modifier,
-    onItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = { attachment, previewHandlers ->
-        if (!attachment.isUploading()) {
-            previewHandlers
-                .firstOrNull { it.canHandle(attachment) }
-                ?.handleAttachmentPreview(attachment)
-        }
-    },
+    onItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClicked,
 ) {
     val message = attachmentState.message
     val previewHandlers = ChatTheme.attachmentPreviewHandlers
@@ -175,5 +169,23 @@ private fun ProgressInfo(uploadedBytes: Long, totalBytes: Long) {
             style = ChatTheme.typography.footnote,
             color = ChatTheme.colors.textLowEmphasis
         )
+    }
+}
+
+/**
+ * Handles clicks on individual file upload content items.
+ *
+ * @param attachment The attachment being clicked.
+ * @param previewHandlers A list of preview handlers from which a suitable handler
+ * will be looked for.
+ */
+internal fun onFileUploadContentItemClicked(
+    attachment: Attachment,
+    previewHandlers: List<AttachmentPreviewHandler>,
+) {
+    if (!attachment.isUploading()) {
+        previewHandlers
+            .firstOrNull { it.canHandle(attachment) }
+            ?.handleAttachmentPreview(attachment)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -81,14 +81,7 @@ public fun GiphyAttachmentContent(
     giphyInfoType: GiphyInfoType = GiphyInfoType.ORIGINAL,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
-    onItemClick: (context: Context, previewUrl: String) -> Unit = { context, previewUrl ->
-        context.startActivity(
-            Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse(previewUrl)
-            )
-        )
-    },
+    onItemClick: (context: Context, previewUrl: String) -> Unit = ::onGiphyAttachmentContentClicked,
 ) {
     val context = LocalContext.current
     val (message, onLongItemClick) = attachmentState
@@ -214,4 +207,19 @@ private fun calculateResultingDimensions(
     } else {
         DpSize((giphyWidth.value * resultingRatio).dp, maxHeight)
     }
+}
+
+/**
+ * Handles clicks on Giphy attachment content.
+ *
+ * @param context Context needed to start the Activity.
+ * @param previewUrl The url of the Giphy attachment being clicked.
+ */
+internal fun onGiphyAttachmentContentClicked(context: Context, previewUrl: String) {
+    context.startActivity(
+        Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse(previewUrl)
+        )
+    )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.attachments.content
 
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -67,9 +68,9 @@ import io.getstream.chat.android.ui.common.utils.giphyInfo
  * [StreamDimens.attachmentsContentGiphyWidth] and [StreamDimens.attachmentsContentGiphyHeight]
  * dimensions, however you can still clip maximum dimensions using [StreamDimens.attachmentsContentGiphyMaxWidth]
  * and [StreamDimens.attachmentsContentGiphyMaxHeight].
- *
  * Setting it to fixed size mode will make it respect all given dimensions.
  * @param contentScale Used to determine the way Giphys are scaled inside the [Image] composable.
+ * @param onItemClick Lambda called when an item gets clicked.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Suppress("LongMethod")
@@ -80,6 +81,14 @@ public fun GiphyAttachmentContent(
     giphyInfoType: GiphyInfoType = GiphyInfoType.ORIGINAL,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
+    onItemClick: (context: Context, previewUrl: String) -> Unit = { context, previewUrl ->
+        context.startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(previewUrl)
+            )
+        )
+    },
 ) {
     val context = LocalContext.current
     val (message, onLongItemClick) = attachmentState
@@ -149,12 +158,7 @@ public fun GiphyAttachmentContent(
                 indication = null,
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = {
-                    context.startActivity(
-                        Intent(
-                            Intent.ACTION_VIEW,
-                            Uri.parse(previewUrl)
-                        )
-                    )
+                    onItemClick(context, previewUrl)
                 },
                 onLongClick = { onLongItemClick(message) }
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -81,7 +81,7 @@ public fun GiphyAttachmentContent(
     giphyInfoType: GiphyInfoType = GiphyInfoType.ORIGINAL,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
-    onItemClick: (context: Context, previewUrl: String) -> Unit = ::onGiphyAttachmentContentClicked,
+    onItemClick: (context: Context, previewUrl: String) -> Unit = ::onGiphyAttachmentContentClick,
 ) {
     val context = LocalContext.current
     val (message, onLongItemClick) = attachmentState
@@ -215,7 +215,7 @@ private fun calculateResultingDimensions(
  * @param context Context needed to start the Activity.
  * @param previewUrl The url of the Giphy attachment being clicked.
  */
-internal fun onGiphyAttachmentContentClicked(context: Context, previewUrl: String) {
+internal fun onGiphyAttachmentContentClick(context: Context, previewUrl: String) {
     context.startActivity(
         Intent(
             Intent.ACTION_VIEW,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -74,7 +74,7 @@ public fun LinkAttachmentContent(
     attachmentState: AttachmentState,
     linkDescriptionMaxLines: Int,
     modifier: Modifier = Modifier,
-    onItemClick: (context: Context, Url: String) -> Unit = ::onLinkAttachmentContentClicked,
+    onItemClick: (context: Context, Url: String) -> Unit = ::onLinkAttachmentContentClick,
 ) {
     val (message, onLongItemClick) = attachmentState
 
@@ -212,7 +212,7 @@ private fun LinkAttachmentDescription(description: String, linkDescriptionMaxLin
  * @param context Context needed to start the Activity.
  * @param url The url of the link attachment being clicked.
  */
-internal fun onLinkAttachmentContentClicked(context: Context, url: String) {
+internal fun onLinkAttachmentContentClick(context: Context, url: String) {
     context.startActivity(
         Intent(
             Intent.ACTION_VIEW,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -74,14 +74,7 @@ public fun LinkAttachmentContent(
     attachmentState: AttachmentState,
     linkDescriptionMaxLines: Int,
     modifier: Modifier = Modifier,
-    onItemClick: (context: Context, Url: String) -> Unit = { context, url ->
-        context.startActivity(
-            Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse(url)
-            )
-        )
-    },
+    onItemClick: (context: Context, Url: String) -> Unit = ::onLinkAttachmentContentClicked,
 ) {
     val (message, onLongItemClick) = attachmentState
 
@@ -210,5 +203,20 @@ private fun LinkAttachmentDescription(description: String, linkDescriptionMaxLin
         color = ChatTheme.colors.textHighEmphasis,
         maxLines = linkDescriptionMaxLines,
         overflow = TextOverflow.Ellipsis
+    )
+}
+
+/**
+ * Handles clicks on link attachment content.
+ *
+ * @param context Context needed to start the Activity.
+ * @param url The url of the link attachment being clicked.
+ */
+internal fun onLinkAttachmentContentClicked(context: Context, url: String) {
+    context.startActivity(
+        Intent(
+            Intent.ACTION_VIEW,
+            Uri.parse(url)
+        )
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.compose.ui.attachments.content
 
 import android.content.ActivityNotFoundException
+import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.widget.Toast
@@ -63,8 +64,9 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  *
  * @param attachmentState - The state of the attachment, holding the root modifier, the message
  * and the onLongItemClick handler.
- *
  * @param linkDescriptionMaxLines - The limit of how many lines we show for the link description.
+ * @param modifier Modifier for styling.
+ * @param onItemClick Lambda called when an item gets clicked.
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -72,6 +74,14 @@ public fun LinkAttachmentContent(
     attachmentState: AttachmentState,
     linkDescriptionMaxLines: Int,
     modifier: Modifier = Modifier,
+    onItemClick: (context: Context, Url: String) -> Unit = { context, url ->
+        context.startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(url)
+            )
+        )
+    },
 ) {
     val (message, onLongItemClick) = attachmentState
 
@@ -103,12 +113,13 @@ public fun LinkAttachmentContent(
                 interactionSource = remember { MutableInteractionSource() },
                 onClick = {
                     try {
-                        context.startActivity(
-                            Intent(
-                                Intent.ACTION_VIEW,
-                                Uri.parse(urlWithScheme)
-                            )
-                        )
+                        if (urlWithScheme != null) {
+                            onItemClick(context, urlWithScheme)
+                        } else {
+                            Toast
+                                .makeText(context, errorMessage, Toast.LENGTH_LONG)
+                                .show()
+                        }
                     } catch (e: ActivityNotFoundException) {
                         e.printStackTrace()
                         Toast

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -106,7 +106,7 @@ public fun MediaAttachmentContent(
         videoThumbnailsEnabled: Boolean,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
-    ) -> Unit = ::onMediaAttachmentContentItemClicked,
+    ) -> Unit = ::onMediaAttachmentContentItemClick,
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit = { attachmentType ->
         if (attachmentType == AttachmentType.VIDEO) {
             PlayButton()
@@ -572,7 +572,7 @@ private const val EqualDimensionsRatio = 1f
  * a link attachment. Used when updating the message from the gallery by doing actions
  * such as deleting an attachment.
  */
-internal fun onMediaAttachmentContentItemClicked(
+internal fun onMediaAttachmentContentItemClick(
     mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
     message: Message,
     attachmentPosition: Int,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.attachments.content
 
+import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
@@ -72,6 +73,7 @@ import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
+import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
 import io.getstream.chat.android.uiutils.extension.hasLink
@@ -86,6 +88,7 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  * in a group when previewing Media attachments in the message list.
  * @param skipEnrichUrl Used by the media gallery. If set to true will skip enriching URLs when you update the message
  * by deleting an attachment contained within it. Set to false by default.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  * @param itemOverlayContent Represents the content overlaid above individual items.
  * By default it is used to display a play button over video previews.
  */
@@ -96,6 +99,14 @@ public fun MediaAttachmentContent(
     modifier: Modifier = Modifier,
     maximumNumberOfPreviewedItems: Int = 4,
     skipEnrichUrl: Boolean = false,
+    onContentItemClick: (
+        mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+        message: Message,
+        attachmentPosition: Int,
+        videoThumbnailsEnabled: Boolean,
+        streamCdnImageResizing: StreamCdnImageResizing,
+        skipEnrichUrl: Boolean,
+    ) -> Unit = ::onMediaAttachmentContentItemClicked,
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit = { attachmentType ->
         if (attachmentType == AttachmentType.VIDEO) {
             PlayButton()
@@ -130,6 +141,7 @@ public fun MediaAttachmentContent(
                 onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                 onLongItemClick = onLongItemClick,
                 skipEnrichUrl = skipEnrichUrl,
+                onContentItemClick = onContentItemClick,
                 overlayContent = itemOverlayContent,
             )
         } else {
@@ -142,6 +154,7 @@ public fun MediaAttachmentContent(
                 skipEnrichUrl = skipEnrichUrl,
                 onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                 onLongItemClick = onLongItemClick,
+                onContentItemClick = onContentItemClick,
                 itemOverlayContent = itemOverlayContent
             )
         }
@@ -158,6 +171,7 @@ public fun MediaAttachmentContent(
  * @param onMediaGalleryPreviewResult The result of the activity used for propagating
  * actions such as media attachment selection, deletion, etc.
  * @param onLongItemClick Lambda that gets called when an item is long clicked.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  * @param overlayContent Represents the content overlaid above attachment previews.
  * Usually used to display a play button over video previews.
  */
@@ -168,6 +182,14 @@ internal fun SingleMediaAttachment(
     skipEnrichUrl: Boolean,
     onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {},
     onLongItemClick: (Message) -> Unit,
+    onContentItemClick: (
+        mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+        message: Message,
+        attachmentPosition: Int,
+        videoThumbnailsEnabled: Boolean,
+        streamCdnImageResizing: StreamCdnImageResizing,
+        skipEnrichUrl: Boolean,
+    ) -> Unit,
     overlayContent: @Composable (attachmentType: String?) -> Unit,
 ) {
     val isVideo = attachment.isVideo()
@@ -208,6 +230,7 @@ internal fun SingleMediaAttachment(
         onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
         onLongItemClick = onLongItemClick,
         skipEnrichUrl = skipEnrichUrl,
+        onItemClick = onContentItemClick,
         overlayContent = overlayContent,
     )
 }
@@ -226,6 +249,7 @@ internal fun SingleMediaAttachment(
  * @param onMediaGalleryPreviewResult The result of the activity used for propagating
  * actions such as media attachment selection, deletion, etc.
  * @param onLongItemClick Lambda that gets called when an item is long clicked.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  * @param itemOverlayContent Represents the content overlaid above individual items.
  * Usually used to display a play button over video previews.
  */
@@ -240,6 +264,14 @@ internal fun RowScope.MultipleMediaAttachments(
     skipEnrichUrl: Boolean,
     onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {},
     onLongItemClick: (Message) -> Unit,
+    onContentItemClick: (
+        mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+        message: Message,
+        attachmentPosition: Int,
+        videoThumbnailsEnabled: Boolean,
+        streamCdnImageResizing: StreamCdnImageResizing,
+        skipEnrichUrl: Boolean,
+    ) -> Unit,
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit,
 ) {
 
@@ -260,6 +292,7 @@ internal fun RowScope.MultipleMediaAttachments(
                     attachmentPosition = attachmentIndex,
                     onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                     onLongItemClick = onLongItemClick,
+                    onItemClick = onContentItemClick,
                     overlayContent = itemOverlayContent,
                 )
             }
@@ -288,6 +321,7 @@ internal fun RowScope.MultipleMediaAttachments(
                             attachmentPosition = attachmentIndex,
                             onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                             onLongItemClick = onLongItemClick,
+                            onItemClick = onContentItemClick,
                             overlayContent = itemOverlayContent
                         )
 
@@ -308,6 +342,7 @@ internal fun RowScope.MultipleMediaAttachments(
                         attachmentPosition = attachmentIndex,
                         onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                         onLongItemClick = onLongItemClick,
+                        onItemClick = onContentItemClick,
                         overlayContent = itemOverlayContent
                     )
                 }
@@ -329,6 +364,7 @@ internal fun RowScope.MultipleMediaAttachments(
  * @param onMediaGalleryPreviewResult The result of the activity used for propagating
  * actions such as media attachment selection, deletion, etc.
  * @param onLongItemClick Lambda that gets called when the item is long clicked.
+ * @param onItemClick Lambda called when an item gets clicked.
  * @param modifier Modifier used for styling.
  * @param overlayContent Represents the content overlaid above attachment previews.
  * Usually used to display a play button over video previews.
@@ -344,6 +380,14 @@ internal fun MediaAttachmentContentItem(
     onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit,
     onLongItemClick: (Message) -> Unit,
     modifier: Modifier = Modifier,
+    onItemClick: (
+        mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+        message: Message,
+        attachmentPosition: Int,
+        videoThumbnailsEnabled: Boolean,
+        streamCdnImageResizing: StreamCdnImageResizing,
+        skipEnrichUrl: Boolean,
+    ) -> Unit,
     overlayContent: @Composable (attachmentType: String?) -> Unit,
 ) {
     val connectionState by ChatClient.instance().clientState.connectionState.collectAsState()
@@ -401,14 +445,13 @@ internal fun MediaAttachmentContentItem(
                 indication = rememberRipple(),
                 onClick = {
                     if (message.syncStatus == SyncStatus.COMPLETED) {
-                        mixedMediaPreviewLauncher.launch(
-                            MediaGalleryPreviewContract.Input(
-                                message = message,
-                                initialPosition = attachmentPosition,
-                                videoThumbnailsEnabled = areVideosEnabled,
-                                streamCdnImageResizing = streamCdnImageResizing,
-                                skipEnrichUrl = skipEnrichUrl,
-                            )
+                        onItemClick(
+                            mixedMediaPreviewLauncher,
+                            message,
+                            attachmentPosition,
+                            areVideosEnabled,
+                            streamCdnImageResizing,
+                            skipEnrichUrl,
                         )
                     } else {
                         onLongItemClick(message)
@@ -517,3 +560,33 @@ internal fun MediaAttachmentShowMoreOverlay(
  * Composable when calling [Modifier.aspectRatio].
  */
 private const val EqualDimensionsRatio = 1f
+
+/**
+ * Handles click on individual image or video attachment content items.
+ *
+ * @param mediaGalleryPreviewLauncher The launcher used for launching the media gallery after
+ * clicking on an attachment.
+ * @param message The message which contains the attachment.
+ * @param attachmentPosition The position (inside the message) of the attachment being clicked on.
+ * @param skipEnrichUrl Whether the URL should skip being enriched, i.e. rendered as
+ * a link attachment. Used when updating the message from the gallery by doing actions
+ * such as deleting an attachment.
+ */
+internal fun onMediaAttachmentContentItemClicked(
+    mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+    message: Message,
+    attachmentPosition: Int,
+    videoThumbnailsEnabled: Boolean,
+    streamCdnImageResizing: StreamCdnImageResizing,
+    skipEnrichUrl: Boolean,
+) {
+    mediaGalleryPreviewLauncher.launch(
+        MediaGalleryPreviewContract.Input(
+            message = message,
+            initialPosition = attachmentPosition,
+            videoThumbnailsEnabled = videoThumbnailsEnabled,
+            streamCdnImageResizing = streamCdnImageResizing,
+            skipEnrichUrl = skipEnrichUrl,
+        )
+    )
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -88,7 +88,7 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  * in a group when previewing Media attachments in the message list.
  * @param skipEnrichUrl Used by the media gallery. If set to true will skip enriching URLs when you update the message
  * by deleting an attachment contained within it. Set to false by default.
- * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param onItemClick Lambda called when an item gets clicked.
  * @param itemOverlayContent Represents the content overlaid above individual items.
  * By default it is used to display a play button over video previews.
  */
@@ -99,7 +99,7 @@ public fun MediaAttachmentContent(
     modifier: Modifier = Modifier,
     maximumNumberOfPreviewedItems: Int = 4,
     skipEnrichUrl: Boolean = false,
-    onContentItemClick: (
+    onItemClick: (
         mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
         message: Message,
         attachmentPosition: Int,
@@ -141,7 +141,7 @@ public fun MediaAttachmentContent(
                 onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                 onLongItemClick = onLongItemClick,
                 skipEnrichUrl = skipEnrichUrl,
-                onContentItemClick = onContentItemClick,
+                onContentItemClick = onItemClick,
                 overlayContent = itemOverlayContent,
             )
         } else {
@@ -154,7 +154,7 @@ public fun MediaAttachmentContent(
                 skipEnrichUrl = skipEnrichUrl,
                 onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
                 onLongItemClick = onLongItemClick,
-                onContentItemClick = onContentItemClick,
+                onContentItemClick = onItemClick,
                 itemOverlayContent = itemOverlayContent
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -31,11 +31,11 @@ import io.getstream.chat.android.uiutils.extension.isAnyFileType
  * An [AttachmentFactory] that validates attachments as files and uses [FileAttachmentContent] to
  * build the UI for the message.
  *
- * @param onContentItemClicked Lambda called when an item gets clicked.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
 public fun FileAttachmentFactory(
-    onContentItemClicked: (
+    onContentItemClick: (
         previewHandler: List<AttachmentPreviewHandler>,
         attachment: Attachment,
     ) -> Unit = { previewHandlers, attachment ->
@@ -60,7 +60,7 @@ public fun FileAttachmentFactory(
                 .wrapContentHeight()
                 .width(ChatTheme.dimens.attachmentsContentFileWidth),
             attachmentState = state,
-            onItemClicked = onContentItemClicked,
+            onItemClicked = onContentItemClick,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentPreviewContent
-import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClick
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
@@ -39,7 +39,7 @@ public fun FileAttachmentFactory(
     onContentItemClick: (
         previewHandlers: List<AttachmentPreviewHandler>,
         attachment: Attachment,
-    ) -> Unit = ::onFileAttachmentContentItemClicked,
+    ) -> Unit = ::onFileAttachmentContentItemClick,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments ->
         attachments.any { it.isAnyFileType() }
@@ -57,7 +57,7 @@ public fun FileAttachmentFactory(
                 .wrapContentHeight()
                 .width(ChatTheme.dimens.attachmentsContentFileWidth),
             attachmentState = state,
-            onItemClicked = onContentItemClick,
+            onItemClick = onContentItemClick,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentPreviewContent
+import io.getstream.chat.android.compose.ui.attachments.content.onFileAttachmentContentItemClicked
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
@@ -36,13 +37,9 @@ import io.getstream.chat.android.uiutils.extension.isAnyFileType
 @Suppress("FunctionName")
 public fun FileAttachmentFactory(
     onContentItemClick: (
-        previewHandler: List<AttachmentPreviewHandler>,
+        previewHandlers: List<AttachmentPreviewHandler>,
         attachment: Attachment,
-    ) -> Unit = { previewHandlers, attachment ->
-        previewHandlers
-            .firstOrNull { it.canHandle(attachment) }
-            ?.handleAttachmentPreview(attachment)
-    },
+    ) -> Unit = ::onFileAttachmentContentItemClicked,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments ->
         attachments.any { it.isAnyFileType() }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -22,15 +22,28 @@ import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentPreviewContent
+import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.uiutils.extension.isAnyFileType
 
 /**
  * An [AttachmentFactory] that validates attachments as files and uses [FileAttachmentContent] to
  * build the UI for the message.
+ *
+ * @param onContentItemClicked Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
-public fun FileAttachmentFactory(): AttachmentFactory = AttachmentFactory(
+public fun FileAttachmentFactory(
+    onContentItemClicked: (
+        previewHandler: List<AttachmentPreviewHandler>,
+        attachment: Attachment,
+    ) -> Unit = { previewHandlers, attachment ->
+        previewHandlers
+            .firstOrNull { it.canHandle(attachment) }
+            ?.handleAttachmentPreview(attachment)
+    },
+): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments ->
         attachments.any { it.isAnyFileType() }
     },
@@ -46,7 +59,8 @@ public fun FileAttachmentFactory(): AttachmentFactory = AttachmentFactory(
             modifier = modifier
                 .wrapContentHeight()
                 .width(ChatTheme.dimens.attachmentsContentFileWidth),
-            attachmentState = state
+            attachmentState = state,
+            onItemClicked = onContentItemClicked,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.android.compose.ui.attachments.factory
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
@@ -40,9 +43,9 @@ import io.getstream.chat.android.ui.common.utils.GiphySizingMode
  * [StreamDimens.attachmentsContentGiphyWidth] and [StreamDimens.attachmentsContentGiphyHeight]
  * dimensions, however you can still clip maximum dimensions using [StreamDimens.attachmentsContentGiphyMaxWidth]
  * and [StreamDimens.attachmentsContentGiphyMaxHeight].
- *
  * Setting it to fixed size mode will make it respect all given dimensions.
  * @param contentScale Used to determine the way Giphys are scaled inside the [Image] composable.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  *
  * @return Returns an instance of [AttachmentFactory] that is used to handle Giphys.
  */
@@ -51,6 +54,14 @@ public fun GiphyAttachmentFactory(
     giphyInfoType: GiphyInfoType = GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
+    onContentItemClick: (context: Context, Url: String) -> Unit = { context, url ->
+        context.startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(url)
+            )
+        )
+    }
 ): AttachmentFactory =
     AttachmentFactory(
         canHandle = { attachments -> attachments.any(Attachment::isGiphy) },
@@ -61,6 +72,7 @@ public fun GiphyAttachmentFactory(
                 giphyInfoType = giphyInfoType,
                 giphySizingMode = giphySizingMode,
                 contentScale = contentScale,
+                onItemClick = onContentItemClick,
             )
         },
     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -17,8 +17,6 @@
 package io.getstream.chat.android.compose.ui.attachments.factory
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.runtime.Composable
@@ -26,6 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.GiphyAttachmentContent
+import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClicked
 import io.getstream.chat.android.compose.ui.theme.StreamDimens
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
@@ -54,14 +53,7 @@ public fun GiphyAttachmentFactory(
     giphyInfoType: GiphyInfoType = GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
-    onContentItemClick: (context: Context, Url: String) -> Unit = { context, url ->
-        context.startActivity(
-            Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse(url)
-            )
-        )
-    }
+    onContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClicked
 ): AttachmentFactory =
     AttachmentFactory(
         canHandle = { attachments -> attachments.any(Attachment::isGiphy) },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.layout.ContentScale
 import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.GiphyAttachmentContent
-import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onGiphyAttachmentContentClick
 import io.getstream.chat.android.compose.ui.theme.StreamDimens
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
@@ -53,7 +53,7 @@ public fun GiphyAttachmentFactory(
     giphyInfoType: GiphyInfoType = GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
-    onContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClicked
+    onContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClick
 ): AttachmentFactory =
     AttachmentFactory(
         canHandle = { attachments -> attachments.any(Attachment::isGiphy) },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -23,7 +23,7 @@ import androidx.compose.runtime.Composable
 import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.LinkAttachmentContent
-import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClick
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.uiutils.extension.hasLink
 
@@ -34,12 +34,12 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  * Has no "preview content", given that this attachment only exists after being sent.
  *
  * @param linkDescriptionMaxLines - The limit of how many lines we show for the link description.
- * @param onContentItemClicked Lambda called when an item gets clicked.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
 public fun LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
-    onContentItemClicked: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClicked,
+    onContentItemClick: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClick,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { links -> links.any { it.hasLink() && !it.isGiphy() } },
     content = @Composable { modifier, state ->
@@ -49,7 +49,7 @@ public fun LinkAttachmentFactory(
                 .wrapContentHeight(),
             attachmentState = state,
             linkDescriptionMaxLines = linkDescriptionMaxLines,
-            onItemClick = onContentItemClicked,
+            onItemClick = onContentItemClick,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -17,14 +17,13 @@
 package io.getstream.chat.android.compose.ui.attachments.factory
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.LinkAttachmentContent
+import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClicked
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.uiutils.extension.hasLink
 
@@ -40,14 +39,7 @@ import io.getstream.chat.android.uiutils.extension.hasLink
 @Suppress("FunctionName")
 public fun LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
-    onContentItemClicked: (context: Context, previewUrl: String) -> Unit = { context, previewUrl ->
-        context.startActivity(
-            Intent(
-                Intent.ACTION_VIEW,
-                Uri.parse(previewUrl)
-            )
-        )
-    },
+    onContentItemClicked: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClicked,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { links -> links.any { it.hasLink() && !it.isGiphy() } },
     content = @Composable { modifier, state ->

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.android.compose.ui.attachments.factory
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
@@ -32,10 +35,19 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  * Has no "preview content", given that this attachment only exists after being sent.
  *
  * @param linkDescriptionMaxLines - The limit of how many lines we show for the link description.
+ * @param onContentItemClicked Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
 public fun LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
+    onContentItemClicked: (context: Context, previewUrl: String) -> Unit = { context, previewUrl ->
+        context.startActivity(
+            Intent(
+                Intent.ACTION_VIEW,
+                Uri.parse(previewUrl)
+            )
+        )
+    },
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { links -> links.any { it.hasLink() && !it.isGiphy() } },
     content = @Composable { modifier, state ->
@@ -44,7 +56,8 @@ public fun LinkAttachmentFactory(
                 .width(ChatTheme.dimens.attachmentsContentLinkWidth)
                 .wrapContentHeight(),
             attachmentState = state,
-            linkDescriptionMaxLines = linkDescriptionMaxLines
+            linkDescriptionMaxLines = linkDescriptionMaxLines,
+            onItemClick = onContentItemClicked,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
@@ -99,7 +99,7 @@ public fun MediaAttachmentFactory(
                 maximumNumberOfPreviewedItems = maximumNumberOfPreviewedItems,
                 itemOverlayContent = itemOverlayContent,
                 skipEnrichUrl = skipEnrichUrl,
-                onContentItemClick = onContentItemClick,
+                onItemClick = onContentItemClick,
             )
         }
     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.attachments.factory
 
+import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,11 +31,16 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
+import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResult
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.MediaAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.MediaAttachmentPreviewContent
 import io.getstream.chat.android.compose.ui.attachments.content.PlayButton
+import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewContract
 import io.getstream.chat.android.models.AttachmentType
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 
 /**
  * An [AttachmentFactory] that is able to handle Image and Video attachments.
@@ -43,6 +49,7 @@ import io.getstream.chat.android.models.AttachmentType
  * in a group when previewing Media attachments in the message list. Values between 4 and 8 are optimal.
  * @param skipEnrichUrl Used by the media gallery. If set to true will skip enriching URLs when you update the message
  * by deleting an attachment contained within it. Set to false by default.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  * @param itemOverlayContent Represents the content overlaid above individual items.
  * By default it is used to display a play button over video previews.
  * @param previewItemOverlayContent Represents the content overlaid above individual preview items.
@@ -52,6 +59,14 @@ import io.getstream.chat.android.models.AttachmentType
 public fun MediaAttachmentFactory(
     maximumNumberOfPreviewedItems: Int = 4,
     skipEnrichUrl: Boolean = false,
+    onContentItemClick: (
+        mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
+        message: Message,
+        attachmentPosition: Int,
+        videoThumbnailsEnabled: Boolean,
+        streamCdnImageResizing: StreamCdnImageResizing,
+        skipEnrichUrl: Boolean,
+    ) -> Unit = ::onMediaAttachmentContentItemClicked,
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit = { attachmentType ->
         if (attachmentType == AttachmentType.VIDEO) {
             DefaultItemOverlayContent()
@@ -84,6 +99,7 @@ public fun MediaAttachmentFactory(
                 maximumNumberOfPreviewedItems = maximumNumberOfPreviewedItems,
                 itemOverlayContent = itemOverlayContent,
                 skipEnrichUrl = skipEnrichUrl,
+                onContentItemClick = onContentItemClick,
             )
         }
     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
@@ -36,7 +36,7 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.MediaAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.MediaAttachmentPreviewContent
 import io.getstream.chat.android.compose.ui.attachments.content.PlayButton
-import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClick
 import io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewContract
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
@@ -66,7 +66,7 @@ public fun MediaAttachmentFactory(
         videoThumbnailsEnabled: Boolean,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
-    ) -> Unit = ::onMediaAttachmentContentItemClicked,
+    ) -> Unit = ::onMediaAttachmentContentItemClick,
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit = { attachmentType ->
         if (attachmentType == AttachmentType.VIDEO) {
             DefaultItemOverlayContent()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileUploadContent
+import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClicked
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
@@ -34,13 +35,7 @@ import io.getstream.chat.android.uiutils.extension.isUploading
  */
 @Suppress("FunctionName")
 public fun UploadAttachmentFactory(
-    onContentItemClicked: (Attachment, List<AttachmentPreviewHandler>) -> Unit = { attachment, previewHandlers ->
-        if (!attachment.isUploading()) {
-            previewHandlers
-                .firstOrNull { it.canHandle(attachment) }
-                ?.handleAttachmentPreview(attachment)
-        }
-    },
+    onContentItemClicked: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClicked,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.isUploading() } },
     content = @Composable { modifier, state ->

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -21,7 +21,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileUploadContent
-import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClicked
+import io.getstream.chat.android.compose.ui.attachments.content.onFileUploadContentItemClick
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
@@ -31,11 +31,11 @@ import io.getstream.chat.android.uiutils.extension.isUploading
  * An [AttachmentFactory] that validates and shows uploading attachments using [FileUploadContent].
  * Has no "preview content", given that this attachment only exists after being sent.
  *
- * @param onContentItemClicked Lambda called when an item gets clicked.
+ * @param onContentItemClick Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
 public fun UploadAttachmentFactory(
-    onContentItemClicked: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClicked,
+    onContentItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClick,
 ): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.isUploading() } },
     content = @Composable { modifier, state ->
@@ -44,7 +44,7 @@ public fun UploadAttachmentFactory(
                 .wrapContentHeight()
                 .width(ChatTheme.dimens.attachmentsContentFileUploadWidth),
             attachmentState = state,
-            onItemClick = onContentItemClicked,
+            onItemClick = onContentItemClick,
         )
     },
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -21,22 +21,35 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.FileUploadContent
+import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.uiutils.extension.isUploading
 
 /**
  * An [AttachmentFactory] that validates and shows uploading attachments using [FileUploadContent].
  * Has no "preview content", given that this attachment only exists after being sent.
+ *
+ * @param onContentItemClicked Lambda called when an item gets clicked.
  */
 @Suppress("FunctionName")
-public fun UploadAttachmentFactory(): AttachmentFactory = AttachmentFactory(
+public fun UploadAttachmentFactory(
+    onContentItemClicked: (Attachment, List<AttachmentPreviewHandler>) -> Unit = { attachment, previewHandlers ->
+        if (!attachment.isUploading()) {
+            previewHandlers
+                .firstOrNull { it.canHandle(attachment) }
+                ?.handleAttachmentPreview(attachment)
+        }
+    },
+): AttachmentFactory = AttachmentFactory(
     canHandle = { attachments -> attachments.any { it.isUploading() } },
     content = @Composable { modifier, state ->
         FileUploadContent(
             modifier = modifier
                 .wrapContentHeight()
                 .width(ChatTheme.dimens.attachmentsContentFileUploadWidth),
-            attachmentState = state
+            attachmentState = state,
+            onItemClick = onContentItemClicked,
         )
     },
 )


### PR DESCRIPTION
### 🎯 Goal

This is the `v6` implementation of https://github.com/GetStream/stream-chat-android/pull/4754 

### 🛠 Implementation details

Exposed click lambdas throught their respective content and factory environments.

### 🧪 Testing

Test A - Making sure past functionality is preserved

1. Launch the compose app and open a channel
2. Upload attachments of various types (Image, Link, Giphy, File [.pdf, audio, etc.])
3. Click on all of those once uploaded, and also test clicking on those that are still uploading

Test B - Making sure new functionality works

<details>

<summary>Override clicks patch</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 07ff9d81ba868fbe587c7df4cedc8a9558ca0b12)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1680776425232)
@@ -19,6 +19,7 @@
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.widget.Toast
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -50,6 +51,7 @@
 import io.getstream.chat.android.compose.sample.ChatApp
 import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResultType
+import io.getstream.chat.android.compose.ui.attachments.StreamAttachmentFactories
 import io.getstream.chat.android.compose.ui.components.composer.MessageInput
 import io.getstream.chat.android.compose.ui.components.messageoptions.defaultMessageOptionsState
 import io.getstream.chat.android.compose.ui.components.reactionpicker.ReactionsPicker
@@ -93,7 +95,25 @@
         super.onCreate(savedInstanceState)
 
         setContent {
-            ChatTheme(dateFormatter = ChatApp.dateFormatter) {
+            ChatTheme(dateFormatter = ChatApp.dateFormatter,
+                attachmentFactories = StreamAttachmentFactories.defaultFactories(
+                    onUploadContentItemClick = { _, _ ->
+                        "Upload".toastMe(applicationContext)
+                    },
+                    onLinkContentItemClick = { _, _ ->
+                        "Link".toastMe(applicationContext)
+                    },
+                    onGiphyContentItemClick = { _, _ ->
+                        "Giphy".toastMe(applicationContext)
+                    },
+                    onMediaContentItemClick = { _, _, _, _,_,_ ->
+                        "Media".toastMe(applicationContext)
+                    },
+                    onFileContentItemClick = { _, _ ->
+                        "File".toastMe(applicationContext)
+                    }
+                )
+            ) {
                 MessagesScreen(
                     viewModelFactory = factory,
                     onBackPressed = { finish() },
@@ -105,6 +125,10 @@
         }
     }
 
+    private fun String.toastMe(context: Context){
+        Toast.makeText(context, this, Toast.LENGTH_SHORT).show()
+    }
+
     @Composable
     fun MyCustomUi() {
         val isShowingAttachments = attachmentsPickerViewModel.isShowingAttachments


```

</details>

1. Launch the compose app and open a channel
2. Upload attachments of various types (Image, Link, Giphy, File [.pdf, audio, etc.])
3. Click on all of those once uploaded, and also test clicking on those that are still uploading

Expected: Clicking on different types should make them toast which type they are

### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the ~~`develop`~~`v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media3.giphy.com/media/eyYr00F5HSZ58V5yHs/giphy.gif?cid=ecf05e474w6pee9dmii3hyufbie7c6bywm4zkkg7qy7y31w6&rid=giphy.gif&ct=g)
