### PR TITLE
[4746] [v6] Enable Removing Reply View

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -860,7 +860,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle$Companion;
-	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IF)V
+	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IF)V
 	public final fun component1 ()I
 	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component11 ()I
@@ -879,50 +879,51 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun component23 ()I
 	public final fun component24 ()Ljava/lang/String;
 	public final fun component25 ()I
-	public final fun component26 ()Landroid/graphics/drawable/Drawable;
-	public final fun component27 ()Ljava/lang/Integer;
+	public final fun component26 ()Z
+	public final fun component27 ()Landroid/graphics/drawable/Drawable;
 	public final fun component28 ()Ljava/lang/Integer;
-	public final fun component29 ()F
+	public final fun component29 ()Ljava/lang/Integer;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
 	public final fun component30 ()F
-	public final fun component31 ()I
+	public final fun component31 ()F
 	public final fun component32 ()I
 	public final fun component33 ()I
 	public final fun component34 ()I
-	public final fun component35 ()Z
-	public final fun component36 ()Landroid/graphics/drawable/Drawable;
-	public final fun component37 ()Ljava/lang/Integer;
-	public final fun component38 ()Z
-	public final fun component39 ()Landroid/graphics/drawable/Drawable;
+	public final fun component35 ()I
+	public final fun component36 ()Z
+	public final fun component37 ()Landroid/graphics/drawable/Drawable;
+	public final fun component38 ()Ljava/lang/Integer;
+	public final fun component39 ()Z
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component40 ()Ljava/lang/Integer;
-	public final fun component41 ()Z
-	public final fun component42 ()Landroid/graphics/drawable/Drawable;
-	public final fun component43 ()Ljava/lang/String;
-	public final fun component44 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component45 ()Ljava/lang/String;
-	public final fun component46 ()Landroid/graphics/drawable/Drawable;
-	public final fun component47 ()Ljava/lang/String;
-	public final fun component48 ()Landroid/graphics/drawable/Drawable;
+	public final fun component40 ()Landroid/graphics/drawable/Drawable;
+	public final fun component41 ()Ljava/lang/Integer;
+	public final fun component42 ()Z
+	public final fun component43 ()Landroid/graphics/drawable/Drawable;
+	public final fun component44 ()Ljava/lang/String;
+	public final fun component45 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component46 ()Ljava/lang/String;
+	public final fun component47 ()Landroid/graphics/drawable/Drawable;
+	public final fun component48 ()Ljava/lang/String;
 	public final fun component49 ()Landroid/graphics/drawable/Drawable;
 	public final fun component5 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component50 ()Z
-	public final fun component51 ()Landroid/graphics/drawable/Drawable;
-	public final fun component52 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component53 ()Landroid/graphics/drawable/Drawable;
-	public final fun component54 ()I
-	public final fun component55 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component56 ()I
-	public final fun component57 ()F
-	public final fun component58 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component59 ()I
+	public final fun component50 ()Landroid/graphics/drawable/Drawable;
+	public final fun component51 ()Z
+	public final fun component52 ()Landroid/graphics/drawable/Drawable;
+	public final fun component53 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component54 ()Landroid/graphics/drawable/Drawable;
+	public final fun component55 ()I
+	public final fun component56 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component57 ()I
+	public final fun component58 ()F
+	public final fun component59 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component6 ()Landroid/graphics/drawable/Drawable;
-	public final fun component60 ()F
+	public final fun component60 ()I
+	public final fun component61 ()F
 	public final fun component7 ()I
 	public final fun component8 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IF)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
+	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IF)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIIZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlsoSendToChannelCheckboxDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getAlsoSendToChannelCheckboxText ()Ljava/lang/String;
@@ -963,6 +964,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun getMessageInputMentionsHandlingEnabled ()Z
 	public final fun getMessageInputScrollbarEnabled ()Z
 	public final fun getMessageInputScrollbarFadingEnabled ()Z
+	public final fun getMessageInputShowReplyView ()Z
 	public final fun getMessageInputTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getMessageInputVideoAttachmentIconBackgroundColor ()Ljava/lang/Integer;
 	public final fun getMessageInputVideoAttachmentIconCornerRadius ()F

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
@@ -65,6 +65,7 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param messageInputMaxLines The maximum number of message input lines.
  * @param messageInputCannotSendHintText The input hint text in case we can't send messages in this channel.
  * @param messageInputInputType The [InputType] to be applied to the message input edit text.
+ * @param messageInputShowReplyView Whether to show the default reply view inside the message input or not.
  * @param messageInputVideoAttachmentIconDrawable Overlays a drawable above video attachments.
  * By default, used to display a play button.
  * @param messageInputVideoAttachmentIconDrawableTint Sets the tint of the drawable overlaid above video attachments.
@@ -102,12 +103,20 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param cooldownTimerBackgroundDrawable Background drawable for cooldown timer.
  * @param messageReplyBackgroundColor Sets the background color of the quoted message bubble visible in the composer
  * when replying to a message.
- * @param messageReplyTextStyle Sets the style of the text inside the quoted message bubble visible in the composer
- * when replying to a message.
- * @param messageReplyMessageBackgroundStrokeColor Sets the color of the stroke of the quoted message bubble visible
- * in the composer when replying to a message.
- * @param messageReplyMessageBackgroundStrokeWidth Sets the width of the stroke of the quoted message bubble visible
- * in the composer when replying to a message.
+ * @param messageReplyTextStyleMine  Sets the style of the text inside the quoted message bubble visible in the composer
+ * when replying to a message. Applied to messages sent by the current user.
+ * @param messageReplyMessageBackgroundStrokeColorMine Sets the color of the stroke of the quoted message bubble visible
+ * in the composer when replying to a message. Applied to messages sent by the current user.
+ * @param messageReplyMessageBackgroundStrokeWidthMine Sets the width of the stroke of the quoted message bubble visible
+ * in the composer when replying to a message. Applied to messages sent by the current user.
+ * @param messageReplyTextStyleTheirs  Sets the style of the text inside the quoted message bubble visible in the
+ * composer when replying to a message. Applied to messages sent by users other than the currently logged in one.
+ * @param messageReplyMessageBackgroundStrokeColorTheirs Sets the color of the stroke of the quoted message bubble
+ * visible in the composer when replying to a message. Applied to messages sent by users other than the currently
+ * logged in one.
+ * @param messageReplyMessageBackgroundStrokeWidthTheirs Sets the width of the stroke of the quoted message bubble
+ * visible in the composer when replying to a message. Applied to messages sent by users other than the currently
+ * logged in one.
  */
 public data class MessageComposerViewStyle(
     @ColorInt public val backgroundColor: Int,
@@ -138,6 +147,7 @@ public data class MessageComposerViewStyle(
     public val messageInputMaxLines: Int,
     public val messageInputCannotSendHintText: String,
     public val messageInputInputType: Int,
+    public val messageInputShowReplyView: Boolean,
     public val messageInputVideoAttachmentIconDrawable: Drawable,
     @ColorInt public val messageInputVideoAttachmentIconDrawableTint: Int?,
     @ColorInt public val messageInputVideoAttachmentIconBackgroundColor: Int?,
@@ -549,6 +559,11 @@ public data class MessageComposerViewStyle(
                         InputType.TYPE_TEXT_FLAG_CAP_SENTENCES
                 )
 
+                val messageInputShowReplyView = a.getBoolean(
+                    R.styleable.MessageComposerView_streamUiMessageComposerShowMessageReplyView,
+                    true
+                )
+
                 val messageInputVideoAttachmentIconDrawable =
                     a.getDrawable(R.styleable.MessageComposerView_streamUiMessageComposerMessageInputVideoAttachmentIconDrawable)
                         ?: ContextCompat.getDrawable(context, R.drawable.stream_ui_ic_play)!!
@@ -701,6 +716,7 @@ public data class MessageComposerViewStyle(
                     messageInputMaxLines = messageInputMaxLines,
                     messageInputCannotSendHintText = messageInputCannotSendHintText,
                     messageInputInputType = messageInputInputType,
+                    messageInputShowReplyView = messageInputShowReplyView,
                     messageInputVideoAttachmentIconDrawable = messageInputVideoAttachmentIconDrawable,
                     messageInputVideoAttachmentIconDrawableTint = messageInputVideoAttachmentIconDrawableTint,
                     messageInputVideoAttachmentIconBackgroundColor = messageInputVideoAttachmentIconBackgroundColor,
@@ -744,7 +760,6 @@ public data class MessageComposerViewStyle(
                     messageReplyTextStyleTheirs = messageReplyTextStyleTheirs,
                     messageReplyMessageBackgroundStrokeColorTheirs = messageReplyMessageBackgroundStrokeColorTheirs,
                     messageReplyMessageBackgroundStrokeWidthTheirs = messageReplyMessageBackgroundStrokeWidthTheirs,
-
                 ).let(TransformStyle.messageComposerStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerCenterContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerCenterContent.kt
@@ -167,6 +167,8 @@ public class DefaultMessageComposerCenterContent : FrameLayout, MessageComposerC
      * @param state The state that will be used to render the updated UI.
      */
     private fun renderReplyState(state: MessageComposerState) {
+        if (!style.messageInputShowReplyView) return
+
         val action = state.action
         if (action is Reply) {
             val quotedMessage = action.message

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
@@ -175,6 +175,8 @@
 
         <attr name="streamUiMessageComposerCooldownTimerBackgroundDrawable" format="reference" />
 
+        <attr name="streamUiMessageComposerShowMessageReplyView" format="boolean" />
+
         <!-- Sets the background color of the quoted message bubble visible in the input when
          replying to a message. Applied both when replying to messages owned by the currently
          logged-in user and messages owned by other users. -->


### PR DESCRIPTION
### 🎯 Goal

`v6` implementation of the following PR: https://github.com/GetStream/stream-chat-android/pull/4746

Enable the control to show/hide the reply view inside the default implementation of the `MessageComposerView` center content.

### 🛠 Implementation details

Added `messageInputShowReplyView` to `MessageComposerViewStyle`.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![Screenshot_1679499962](https://user-images.githubusercontent.com/38032787/226964530-04222411-2a95-4339-8a57-2db0e2300ded.png)  | ![Screenshot_1679499938](https://user-images.githubusercontent.com/38032787/226964562-c7be3aca-fa46-49b0-9ef7-1c1ece8441d0.png)  |

### 🧪 Testing

1. Run this branch without patch and reply to a message. The replyView should be visible.
2. Run this branch with the patch and repeat. ReplyView should not be visible.

<details>

<summary>Test patch</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(revision 7ccee46a2deaee24293e00c8daa718b8c8a3676f)
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_chat.xml	(date 1680792111055)
@@ -51,6 +51,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/messageListView"
+        app:streamUiMessageComposerShowMessageReplyView="false"
         />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


```

</details>


### ☑️Contributor Checklist

#### General
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![giphy](https://user-images.githubusercontent.com/38032787/226965713-1e364a83-3ef3-4040-87b2-7c27d43c4ca9.gif)