### PR TITLE
[ISSUE-4705] Fix: Reply to an image inside gallery from a thread

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/com/getstream/sdk/chat/viewmodel/messages/MessageListViewModel.kt
@@ -246,6 +246,19 @@ public class MessageListViewModel(
     public val user: LiveData<User?> = clientState.user.asLiveData()
 
     /**
+     * Gives us information if we're currently in the [Mode.Thread] mode.
+     */
+    private val isInThread: Boolean
+        get() = currentMode is Mode.Thread
+
+    /**
+     * Provides the current [MessageListItemLiveData]
+     * It chooses between [threadListData] and [messageListData] based on if we're in a thread or not.
+     */
+    private val currentMessageListData: MessageListItemLiveData?
+        get() = if (isInThread) threadListData else messageListData
+
+    /**
      * The logger used to print to errors, warnings, information
      * and other things to log.
      */
@@ -715,7 +728,7 @@ public class MessageListViewModel(
      * @return The [Message] with the ID, if it exists.
      */
     public fun getMessageWithId(messageId: String): Message? {
-        val messageItem = messageListData?.value?.items?.firstOrNull {
+        val messageItem = currentMessageListData?.value?.items?.firstOrNull {
             it is MessageListItem.MessageItem && it.message.id == messageId
         }
 


### PR DESCRIPTION
### 🎯 Goal

Allow users to reply to an image inside gallery view from a thread.

### 🛠 Implementation details

Modify _getMessageWithId_ function to make it look to thread messages if necessary.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://user-images.githubusercontent.com/38032787/221912578-b14d464e-96eb-4d6b-88f3-f2df26cbeeb0.mp4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://user-images.githubusercontent.com/54546499/230797101-87ece10b-4b73-413e-b461-6037e88981b3.webm" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

1. Send an image in a thread
2. Open it
3. Try to reply to it

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

<img src="https://media.giphy.com/media/hrXNuM1Ei9ajmaUiTs/giphy.gif">

