### PR TITLE
Remove static access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Keep `Logic`and `State` instances even if the user is disconnected. [#4805](https://github.com/GetStream/stream-chat-android/pull/4805)
 
 ### ❌ Removed
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -297,12 +297,5 @@ internal class LogicRegistry internal constructor(
             "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
                 "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
         }
-
-        /**
-         * Clears cached [LogicRegistry] instance.
-         */
-        internal fun clear() {
-            instance = null
-        }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/state/StateRegistry.kt
@@ -198,12 +198,5 @@ public class StateRegistry private constructor(
             "Offline plugin must be configured in ChatClient. You must provide StreamOfflinePluginFactory as a " +
                 "PluginFactory to be able to use LogicRegistry and StateRegistry from the SDK"
         }
-
-        /**
-         * Clears cached [StateRegistry] instance.
-         */
-        internal fun clear() {
-            instance = null
-        }
     }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/factory/StreamStatePluginFactory.kt
@@ -298,7 +298,5 @@ public class StreamStatePluginFactory(
 
     private fun clearCachedInstance() {
         cachedStatePluginInstance = null
-        StateRegistry.clear()
-        LogicRegistry.clear()
     }
 }


### PR DESCRIPTION
### 🎯 Goal
When the user was disconnected, some instances was destroyed and could cause some error on the case the device is being used offline or with a poor network connection.

### 🎉 GIF

![](https://media.giphy.com/media/W4en6hGnBRgHHeXWKn/giphy.gif)