### PR TITLE
Fix socket reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Common changes for all artifacts
 ### 🐞 Fixed
 - When a message is sent, updated user is set. [#4814](https://github.com/GetStream/stream-chat-android/pull/4814)
+- Fix reconnection socket behavior. [#4820](https://github.com/GetStream/stream-chat-android/pull/4820)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -249,7 +249,7 @@ internal constructor(
             "The new Socket Implementation handle it internally"
     )
     private val lifecycleHandler = object : LifecycleHandler {
-        override fun resume() = reconnectSocket()
+        override fun resume() = reconnectSocket(false)
         override fun stopped() {
             socket.releaseConnection()
         }
@@ -1050,12 +1050,16 @@ internal constructor(
     }
 
     public fun reconnectSocket() {
+        reconnectSocket(true)
+    }
+
+    private fun reconnectSocket(forceReconnection: Boolean) {
         if (ToggleService.isSocketExperimental().not()) {
             when (socketStateService.state is SocketState.Disconnected) {
                 true -> when (val userState = userStateService.state) {
                     is UserState.UserSet, is UserState.AnonymousUserSet -> socket.reconnectUser(
                         userState.userOrError(),
-                        userState is UserState.AnonymousUserSet
+                        userState is UserState.AnonymousUserSet,
                     )
                     else -> error("Invalid user state $userState without user being set!")
                 }
@@ -1065,7 +1069,8 @@ internal constructor(
             when (val userState = userStateService.state) {
                 is UserState.UserSet, is UserState.AnonymousUserSet -> chatSocketExperimental.reconnectUser(
                     userState.userOrError(),
-                    userState is UserState.AnonymousUserSet
+                    userState is UserState.AnonymousUserSet,
+                    forceReconnection,
                 )
                 else -> error("Invalid user state $userState without user being set!")
             }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -36,6 +36,7 @@ import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.client.parser2.adapters.internal.StreamDateFormatter
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.client.socket.SocketFactory
+import io.getstream.chat.android.client.socket.experimental.ChatSocketStateService
 import io.getstream.chat.android.test.randomBoolean
 import io.getstream.chat.android.test.randomDate
 import io.getstream.chat.android.test.randomInt
@@ -109,6 +110,9 @@ internal object Mother {
         true -> randomAnonymousConnectionConf(endpoint, apiKey, user)
         false -> randomUserConnectionConf(endpoint, apiKey, user)
     }
+
+    fun randomConnectionType(): ChatSocketStateService.ConnectionType =
+        ChatSocketStateService.ConnectionType.values().random()
 
     fun mockedClientState(): ClientState {
         return object : ClientState {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenReconnectSocket.kt
@@ -22,7 +22,9 @@ import io.getstream.chat.android.client.clientstate.UserState
 import io.getstream.chat.android.client.models.User
 import io.getstream.chat.android.test.randomString
 import org.amshove.kluent.invoking
+import org.amshove.kluent.`should throw`
 import org.amshove.kluent.shouldThrow
+import org.amshove.kluent.`with message`
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
@@ -37,7 +39,9 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
     fun `Given idle connection state Should do nothing`() {
         val sut = Fixture().givenIdleConnectionState().clearSocketInvocations().get()
 
-        sut.reconnectSocket()
+        invoking {
+            sut.reconnectSocket()
+        } `should throw` IllegalStateException::class `with message` "Invalid user state null without user being set!"
 
         Mockito.verifyNoInteractions(socket)
     }
@@ -67,7 +71,7 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
 
         sut.reconnectSocket()
 
-        verify(socket).reconnectUser(user, isAnonymous = false)
+        verify(socket).reconnectUser(user, isAnonymous = false, forceReconnection = true)
     }
 
     @Test
@@ -77,7 +81,7 @@ internal class WhenReconnectSocket : BaseChatClientTest() {
 
         sut.reconnectSocket()
 
-        verify(socket).reconnectUser(user, isAnonymous = true)
+        verify(socket).reconnectUser(user, isAnonymous = true, forceReconnection = true)
     }
 
     @Disabled

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocket.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/observable/FakeSocket.kt
@@ -60,7 +60,7 @@ internal class FakeSocket(
         // no-op
     }
 
-    override fun releaseConnection() {
+    override fun releaseConnection(requested: Boolean) {
         // no-op
     }
 


### PR DESCRIPTION
### 🎯 Goal
Fix socket reconnection after a user performer `ChatClient.disconnectSocket()`
On `v5`we have currently 2 socket implementations and the patch has been applied to both implementations.
Fixed: https://github.com/GetStream/android-internal-board/issues/66

### 🎉 GIF

![](https://media.giphy.com/media/QvGCMeHuP1vLYl2hLb/giphy.gif)