### PR TITLE
[i72] make emails clickable in messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@
 - Fixed edit messages and reply messages with unsupported attachments. [#4757](https://github.com/GetStream/stream-chat-android/pull/4757)
 
 ### ⬆️ Improved
+- Emails are highlighted and clickable in the message text. [#4833](https://github.com/GetStream/stream-chat-android/pull/4833)
 
 ### ✅ Added
 - Added `ChatUI.streamCdnImageResizing` which allows resizing images where they appear as previews, such as the message list, attachment gallery overview or user and channel avatars. Only images hosted by Stream's CDN which contain original width and height query parameters can be resized. Image resizing is a paid feature and is disabled by default, you can enable it by overriding the aforementioned `ChatUI.streamCdnImageResizing` property with with an instance that has `StreamCdnImageResizing.imageResizingEnabled` set to true. Pricing can be found [here](https://getstream.io/chat/pricing/). [#4600](https://github.com/GetStream/stream-chat-android/pull/4600)
@@ -103,6 +104,7 @@
 ### ⬆️ Improved
 - Updated Compose compiler version to `1.4.3`. [#4697](https://github.com/GetStream/stream-chat-android/pull/4697)
 - Added `ChatClient.clearPersistence()` to be able to clear local data even if the user is not connected. [#4797](https://github.com/GetStream/stream-chat-android/pull/4797)
+- Emails are highlighted and clickable in the message text. [#4833](https://github.com/GetStream/stream-chat-android/pull/4833)
 
 ### ✅ Added
 - Added `onChannelAvatarClick` handler to `MessageListHeader`. [#4545](https://github.com/GetStream/stream-chat-android/pull/4545)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/Linkify.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/Linkify.kt
@@ -50,7 +50,7 @@ public object Linkify {
 
     /**
      * Scans the provided TextView and turns all occurrences
-     * of the link types into clickable links (Currently only support web urls).
+     * of the link types into clickable links.
      * If matches are found the movement method for the TextView is set to
      * LinkMovementMethod.
      *
@@ -88,6 +88,10 @@ public object Linkify {
         gatherLinks(
             links, text, PatternsCompat.AUTOLINK_WEB_URL, arrayOf("http://", "https://", "rtsp://"),
             Linkify.sUrlMatchFilter, null
+        )
+        gatherLinks(
+            links, text, PatternsCompat.AUTOLINK_EMAIL_ADDRESS, arrayOf("mailto:"),
+            null, null
         )
 
         pruneOverlaps(links, text)

--- a/stream-chat-android-ui-utils/src/main/kotlin/io/getstream/chat/android/uiutils/extension/String.kt
+++ b/stream-chat-android-ui-utils/src/main/kotlin/io/getstream/chat/android/uiutils/extension/String.kt
@@ -32,6 +32,7 @@ public fun String.containsLinks(): Boolean {
  * they can be opened using [android.content.Intent.ACTION_VIEW]
  */
 public fun String.addSchemeToUrlIfNeeded(): String = when {
+    this.startsWith("mailto:") -> this
     this.startsWith("http://") -> this
     this.startsWith("https://") -> this
     else -> "http://$this"


### PR DESCRIPTION
### 🎯 Goal

Make emails clickable in messages.
Closes: https://github.com/GetStream/android-internal-board/issues/72

### 🎨 UI Changes

| Before | After |
| --- | --- |
| ![email_before](https://github.com/GetStream/stream-chat-android/assets/1286516/d8a69f6f-05b3-4522-847e-cf91aed4c877) | ![email_after](https://github.com/GetStream/stream-chat-android/assets/1286516/22438203-1922-4c86-a620-72d4bf13011f) |

### 🧪 Testing

- open Compose or XML app
- go to any Channel
- post a message with email
- make sure email is highlighted 
- tap on email
- make sure you're redirected to an email app


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
