### PR TITLE
Handle ban/unban events in ChannelState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### ✅ Added
 - Added `ChatClientDebugger` and `SendMessageDebugger` to debug an internal flow of `ChatClient`. [#4823](https://github.com/GetStream/stream-chat-android/pull/4823)
+- Added `ChannelUserBannedEvent.shadow` property to know if the user is shadow-banned or standard banned. [#4835](https://github.com/GetStream/stream-chat-android/pull/4835)
 
 ### ⚠️ Changed
 
@@ -37,6 +38,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- The `ChannelStateLogic` class keeps members updated after ban/unban events are received. [#4836](https://github.com/GetStream/stream-chat-android/pull/4836)
 
 ### ✅ Added
 

--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
@@ -581,7 +581,8 @@ public class TestDataHelper {
             channel2.type,
             channel2.id,
             user1,
-            null
+            null,
+            false,
         )
     }
     public val user1Unbanned: ChannelUserUnbannedEvent by lazy {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1218,7 +1218,7 @@ public final class io/getstream/chat/android/client/events/ChannelUpdatedEvent :
 }
 
 public final class io/getstream/chat/android/client/events/ChannelUserBannedEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/UserEvent {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Z)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
@@ -1227,8 +1227,9 @@ public final class io/getstream/chat/android/client/events/ChannelUserBannedEven
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lio/getstream/chat/android/client/models/User;
 	public final fun component8 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;)Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;Z)Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/User;Ljava/util/Date;ZILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelUserBannedEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelType ()Ljava/lang/String;
@@ -1236,6 +1237,7 @@ public final class io/getstream/chat/android/client/events/ChannelUserBannedEven
 	public fun getCreatedAt ()Ljava/util/Date;
 	public final fun getExpiration ()Ljava/util/Date;
 	public fun getRawCreatedAt ()Ljava/lang/String;
+	public final fun getShadow ()Z
 	public fun getType ()Ljava/lang/String;
 	public fun getUser ()Lio/getstream/chat/android/client/models/User;
 	public fun hashCode ()I

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -588,6 +588,7 @@ private fun ChannelUserBannedEventDto.toDomain(): ChannelUserBannedEvent {
         channelId = channel_id,
         user = user.toDomain(),
         expiration = expiration,
+        shadow = shadow ?: false,
     )
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -376,6 +376,7 @@ internal data class ChannelUserBannedEventDto(
     val channel_id: String,
     val user: DownstreamUserDto,
     val expiration: Date?,
+    val shadow: Boolean?,
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -540,6 +540,7 @@ public data class ChannelUserBannedEvent(
     override val channelId: String,
     override val user: User,
     val expiration: Date?,
+    val shadow: Boolean,
 ) : CidEvent(), UserEvent
 
 /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
@@ -109,13 +109,19 @@ public fun Channel.updateMember(member: Member?): Channel {
  *
  * @param memberUserId Updated member user id.
  * @param banned Shows whether a user is banned or not in this channel.
+ * @param shadow Shows whether a user is shadow banned or not in this channel.
  */
 @InternalStreamChatApi
-public fun Channel.updateMemberBanned(memberUserId: String?, banned: Boolean): Channel {
+public fun Channel.updateMemberBanned(
+    memberUserId: String?,
+    banned: Boolean,
+    shadow: Boolean,
+): Channel {
     members = members.map { member ->
         member.apply {
             if (this.user.id == memberUserId) {
                 this.banned = banned
+                this.shadowBanned = shadow
             }
         }
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -511,7 +511,8 @@ internal object EventArguments {
         channelType = channelType,
         channelId = channelId,
         user = user,
-        expiration = date
+        expiration = date,
+        shadow = false,
     )
     private val globalUserBannedEvent = GlobalUserBannedEvent(
         type = EventType.USER_BANNED,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerImpl.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerImpl.kt
@@ -371,7 +371,7 @@ internal class EventHandlerImpl(
                 is ChannelUserBannedEvent -> {
                     batch.getCurrentChannel(event.cid)?.let { channel ->
                         batch.addChannel(
-                            channel.updateMemberBanned(event.user.id, banned = true)
+                            channel.updateMemberBanned(event.user.id, banned = true, event.shadow)
                                 .updateMembershipBanned(event.user.id, banned = true)
                         )
                     }
@@ -379,7 +379,7 @@ internal class EventHandlerImpl(
                 is ChannelUserUnbannedEvent -> {
                     batch.getCurrentChannel(event.cid)?.let { channel ->
                         batch.addChannel(
-                            channel.updateMemberBanned(event.user.id, banned = false)
+                            channel.updateMemberBanned(event.user.id, banned = false, false)
                                 .updateMembershipBanned(event.user.id, banned = false)
                         )
                     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/event/handler/internal/EventHandlerSequential.kt
@@ -476,7 +476,7 @@ internal class EventHandlerSequential(
                 is ChannelUserBannedEvent -> {
                     batch.getCurrentChannel(event.cid)?.let { channel ->
                         batch.addChannel(
-                            channel.updateMemberBanned(event.user.id, banned = true)
+                            channel.updateMemberBanned(event.user.id, banned = true, event.shadow)
                                 .updateMembershipBanned(event.user.id, banned = true)
                         )
                     }
@@ -484,7 +484,7 @@ internal class EventHandlerSequential(
                 is ChannelUserUnbannedEvent -> {
                     batch.getCurrentChannel(event.cid)?.let { channel ->
                         batch.addChannel(
-                            channel.updateMemberBanned(event.user.id, banned = false)
+                            channel.updateMemberBanned(event.user.id, banned = false, false)
                                 .updateMembershipBanned(event.user.id, banned = false)
                         )
                     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelLogic.kt
@@ -598,8 +598,20 @@ internal class ChannelLogic(
                     mute.channel.cid == mutableState.cid
                 }.let(channelStateLogic::updateMute)
             }
-            is ChannelUserBannedEvent,
-            is ChannelUserUnbannedEvent,
+            is ChannelUserBannedEvent -> {
+                channelStateLogic.updateMemberBanned(
+                    memberUserId = event.user.id,
+                    banned = true,
+                    shadow = event.shadow
+                )
+            }
+            is ChannelUserUnbannedEvent -> {
+                channelStateLogic.updateMemberBanned(
+                    memberUserId = event.user.id,
+                    banned = false,
+                    shadow = false
+                )
+            }
             is NotificationChannelDeletedEvent,
             is NotificationInvitedEvent,
             is ConnectedEvent,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -273,6 +273,30 @@ internal class ChannelStateLogic(
     }
 
     /**
+     * Updates banned state of a member.
+     *
+     * @param memberUserId Updated member user id.
+     * @param banned Shows whether a user is banned or not in this channel.
+     * @param shadow Shows whether a user is shadow banned or not in this channel.
+     */
+    fun updateMemberBanned(
+        memberUserId: String?,
+        banned: Boolean,
+        shadow: Boolean,
+    ) {
+        mutableState.upsertMembers(
+            mutableState.members.value.map { member ->
+                member.apply {
+                    if (this.user.id == memberUserId) {
+                        this.banned = banned
+                        this.shadowBanned = shadow
+                    }
+                }
+            }
+        )
+    }
+
+    /**
      * Deletes channel.
      *
      * @param deleteDate The date when the channel was deleted.


### PR DESCRIPTION
### 🎯 Goal
Handle properly ban/unban events on ChannelState 

### 🛠 Implementation details
The `ChannelUserBannedEvent` contains a new property to let us know whether it is a shadow or a standard ban.
It has been appropriately handled on DB and State instances

### 🎉 GIF
![](https://media.giphy.com/media/xT5LMWFpowvd3jcv9C/giphy.gif)
