### PR TITLE
[i82] fix QueryChannelRequest.withWatchers setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed `QueryChannelRequest.withWatchers` to make `watchers` accessible in response. [#4848](https://github.com/GetStream/stream-chat-android/pull/4848)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/QueryChannelRequest.kt
@@ -48,6 +48,7 @@ public open class QueryChannelRequest : ChannelRequest<QueryChannelRequest> {
     }
 
     public open fun withWatchers(limit: Int, offset: Int): QueryChannelRequest {
+        state = true
         val watchers: MutableMap<String, Any> = HashMap()
         watchers[KEY_LIMIT] = limit
         watchers[KEY_OFFSET] = offset

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
@@ -16,41 +16,41 @@
 
 package io.getstream.chat.android.client.api.models
 
+import io.getstream.chat.android.test.randomInt
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import org.mockito.kotlin.any
 import java.util.UUID
 
 internal class QueryChannelRequestTests {
 
     @Test
-    fun `ensure 'withMembers' sets 'state' to True`() {
-        QueryChannelRequest().withMembers(any(), any()).apply {
+    fun `ensure withMembers sets state to True`() {
+        QueryChannelRequest().withMembers(randomInt(), randomInt()).apply {
             state `should be equal to` true
         }
     }
 
     @Test
-    fun `ensure 'withMessages' sets 'state' to True`() {
-        QueryChannelRequest().withMessages(any()).apply {
+    fun `ensure withMessages sets state to True`() {
+        QueryChannelRequest().withMessages(randomInt()).apply {
             state `should be equal to` true
         }
     }
 
     @ParameterizedTest
     @MethodSource("generatePaginationList")
-    fun `ensure paginated 'withMessages' sets 'state' to True`(pagination: Pagination) {
+    fun `ensure paginated withMessages sets state to True`(pagination: Pagination) {
         val messageId = UUID.randomUUID().toString()
-        QueryChannelRequest().withMessages(pagination, messageId, any()).apply {
+        QueryChannelRequest().withMessages(pagination, messageId, randomInt()).apply {
             state `should be equal to` true
         }
     }
 
     @Test
-    fun `ensure 'withWatchers' sets 'state' to True`() {
-        QueryChannelRequest().withWatchers(any(), any()).apply {
+    fun `ensure withWatchers sets state to True`() {
+        QueryChannelRequest().withWatchers(randomInt(), randomInt()).apply {
             state `should be equal to` true
         }
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
@@ -1,0 +1,47 @@
+package io.getstream.chat.android.client.api.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.kotlin.any
+import java.util.UUID
+
+internal class QueryChannelRequestTests {
+
+    @Test
+    fun `ensure 'withMembers' sets 'state' to True`() {
+        QueryChannelRequest().withMembers(any(), any()).apply {
+            state `should be equal to` true
+        }
+    }
+
+    @Test
+    fun `ensure 'withMessages' sets 'state' to True`() {
+        QueryChannelRequest().withMessages(any()).apply {
+            state `should be equal to` true
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("generatePaginationList")
+    fun `ensure paginated 'withMessages' sets 'state' to True`(pagination: Pagination) {
+        val messageId = UUID.randomUUID().toString()
+        QueryChannelRequest().withMessages(pagination, messageId, any()).apply {
+            state `should be equal to` true
+        }
+    }
+
+    @Test
+    fun `ensure 'withWatchers' sets 'state' to True`() {
+        QueryChannelRequest().withWatchers(any(), any()).apply {
+            state `should be equal to` true
+        }
+    }
+
+    internal companion object {
+        @JvmStatic
+        fun generatePaginationList() = Pagination.values().toList()
+    }
+
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/QueryChannelRequestTests.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.client.api.models
 
 import org.amshove.kluent.`should be equal to`
@@ -43,5 +59,4 @@ internal class QueryChannelRequestTests {
         @JvmStatic
         fun generatePaginationList() = Pagination.values().toList()
     }
-
 }


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/82

`QueryChannelRequest.withWatchers` should set `state` as `true` to make `watchers` accessible in response

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
