### PR TITLE
[i88] Make message text style customizable on Compose 

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,11 +18,6 @@
       </option>
     </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value />
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -18,6 +18,11 @@
       </option>
     </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
+      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
+        <value />
+      </option>
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
+      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
       <option name="ALLOW_TRAILING_COMMA" value="true" />
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - Added `showDateSeparatorInEmptyThread: Boolean` to `MessagesViewModelFactory`. It is used to regulate whether date separators appear in empty threads. [#4742](https://github.com/GetStream/stream-chat-android/pull/4742)
 - Add `ThreadMessagesStart` that allows to control if the stack of thread messages starts at the bottom or the top. [#4807](https://github.com/GetStream/stream-chat-android/pull/4807)
 - Add `PickerMediaMode` that allows control if the camera recorder and/or take picture feature is allowed or not. [#4812](https://github.com/GetStream/stream-chat-android/pull/4812)
+- Added `MessageTheme` to customize the message components into `ChatTheme`. [#4856](https://github.com/GetStream/stream-chat-android/pull/4856)
 
 ### ⚠️ Changed
 - 🚨 Breaking change: Renamed `onHeaderActionClick` to `onHeaderTitleClick` in `MessagesScreen`. Change made in order to better reflect the handler's behavior. [#4535](https://github.com/GetStream/stream-chat-android/pull/4535)

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1312,6 +1312,8 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatTheme {
 	public final fun getMessageAlignmentProvider (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;
 	public final fun getMessageOptionsUserReactionAlignment (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/ui/common/state/messages/list/MessageOptionsUserReactionAlignment;
 	public final fun getMessagePreviewFormatter (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;
+	public final fun getOtherMessageTheme (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
+	public final fun getOwnMessageTheme (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
 	public final fun getQuotedAttachmentFactories (Landroidx/compose/runtime/Composer;I)Ljava/util/List;
 	public final fun getReactionIconFactory (Landroidx/compose/runtime/Composer;I)Lio/getstream/chat/android/compose/ui/util/ReactionIconFactory;
 	public final fun getReadCountEnabled (Landroidx/compose/runtime/Composer;I)Z
@@ -1322,7 +1324,33 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatTheme {
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/ChatThemeKt {
-	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Landroidx/compose/material/ripple/RippleTheme;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/compose/ui/util/ReactionIconFactory;Lio/getstream/chat/android/ui/common/helper/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lio/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory;Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;Lio/getstream/chat/android/ui/common/state/messages/list/MessageOptionsUserReactionAlignment;Ljava/util/List;ZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZLkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;IIII)V
+	public static final fun ChatTheme (ZLio/getstream/chat/android/compose/ui/theme/StreamColors;Lio/getstream/chat/android/compose/ui/theme/StreamDimens;Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamShapes;Landroidx/compose/material/ripple/RippleTheme;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/compose/ui/util/ReactionIconFactory;Lio/getstream/chat/android/ui/common/helper/DateFormatter;Lio/getstream/chat/android/compose/ui/util/ChannelNameFormatter;Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;Lio/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory;Lio/getstream/chat/android/compose/ui/util/MessageAlignmentProvider;Lio/getstream/chat/android/ui/common/state/messages/list/MessageOptionsUserReactionAlignment;Ljava/util/List;ZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZLio/getstream/chat/android/compose/ui/theme/MessageTheme;Lio/getstream/chat/android/compose/ui/theme/MessageTheme;Lkotlin/jvm/functions/Function2;Landroidx/compose/runtime/Composer;IIII)V
+}
+
+public final class io/getstream/chat/android/compose/ui/theme/MessageTheme {
+	public static final field $stable I
+	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/MessageTheme$Companion;
+	public synthetic fun <init> (Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/ui/text/TextStyle;JJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun component2-0d7_KjU ()J
+	public final fun component3 ()Landroidx/compose/ui/text/TextStyle;
+	public final fun component4-0d7_KjU ()J
+	public final fun component5-0d7_KjU ()J
+	public final fun copy-un15N7Q (Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/ui/text/TextStyle;JJ)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
+	public static synthetic fun copy-un15N7Q$default (Lio/getstream/chat/android/compose/ui/theme/MessageTheme;Landroidx/compose/ui/text/TextStyle;JLandroidx/compose/ui/text/TextStyle;JJILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBackgroundColor-0d7_KjU ()J
+	public final fun getDeletedBackgroundColor-0d7_KjU ()J
+	public final fun getQuotedBackgroundColor-0d7_KjU ()J
+	public final fun getQuotedTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public final fun getTextStyle ()Landroidx/compose/ui/text/TextStyle;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/compose/ui/theme/MessageTheme$Companion {
+	public final fun defaultOtherTheme (Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamColors;Landroidx/compose/runtime/Composer;II)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
+	public final fun defaultOwnTheme (Lio/getstream/chat/android/compose/ui/theme/StreamTypography;Lio/getstream/chat/android/compose/ui/theme/StreamColors;Landroidx/compose/runtime/Composer;II)Lio/getstream/chat/android/compose/ui/theme/MessageTheme;
 }
 
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {

--- a/stream-chat-android-compose/detekt-baseline.xml
+++ b/stream-chat-android-compose/detekt-baseline.xml
@@ -7,6 +7,7 @@
     <ID>ComplexCondition:Messages.kt$!endOfMessages &amp;&amp; index == messages.lastIndex &amp;&amp; messages.isNotEmpty() &amp;&amp; lazyListState.isScrollInProgress</ID>
     <ID>ComplexCondition:Messages.kt$!startOfMessages &amp;&amp; index == 0 &amp;&amp; messages.isNotEmpty() &amp;&amp; lazyListState.isScrollInProgress</ID>
     <ID>ComplexMethod:MessageOptions.kt$@Composable public fun defaultMessageOptionsState( selectedMessage: Message, currentUser: User?, isInThread: Boolean, ownCapabilities: Set&lt;String>, ): List&lt;MessageOptionItemState></ID>
+    <ID>ComplexMethod:QuotedMessageText.kt$@Composable public fun QuotedMessageText( message: Message, currentUser: User?, modifier: Modifier = Modifier, replyMessage: Message? = null, quoteMaxLines: Int = DefaultQuoteMaxLines, )</ID>
     <ID>ForbiddenComment:MessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
     <ID>ForbiddenComment:QuotedMessageText.kt$// TODO: Fix emoji font padding once this is resolved and exposed: https://issuetracker.google.com/issues/171394808</ID>
     <ID>LargeClass:MediaGalleryPreviewActivity.kt$MediaGalleryPreviewActivity : AppCompatActivity</ID>

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -67,9 +67,9 @@ public fun MessageText(
     val context = LocalContext.current
 
     val textColor = if (message.isMine(currentUser)) {
-        ChatTheme.colors.ownMessageText
+        ChatTheme.ownMessageTheme.textStyle.color
     } else {
-        ChatTheme.colors.otherMessageText
+        ChatTheme.otherMessageTheme.textStyle.color
     }
     val styledText = buildAnnotatedMessageText(message.text, textColor)
     val annotations = styledText.getStringAnnotations(0, styledText.lastIndex)
@@ -78,7 +78,11 @@ public fun MessageText(
     val style = when {
         message.isSingleEmoji() -> ChatTheme.typography.singleEmoji
         message.isFewEmoji() -> ChatTheme.typography.emojiOnly
-        else -> ChatTheme.typography.bodyBold
+        else -> if (message.isMine(currentUser)) {
+            ChatTheme.ownMessageTheme.textStyle
+        } else {
+            ChatTheme.otherMessageTheme.textStyle
+        }
     }
 
     if (annotations.isNotEmpty()) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageContent.kt
@@ -58,9 +58,9 @@ public fun QuotedMessageContent(
 
     // The quoted section color depends on the author of the reply.
     val messageBubbleColor = if (replyMessage?.isMine(currentUser) != false) {
-        ChatTheme.colors.ownMessageQuotedBackground
+        ChatTheme.ownMessageTheme.quotedBackgroundColor
     } else {
-        ChatTheme.colors.otherMessageQuotedBackground
+        ChatTheme.otherMessageTheme.quotedBackgroundColor
     }
 
     MessageBubble(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -58,7 +58,10 @@ public fun QuotedMessageText(
     val style = when {
         message.isSingleEmoji() -> ChatTheme.typography.singleEmoji
         message.isFewEmoji() -> ChatTheme.typography.emojiOnly
-        else -> ChatTheme.typography.bodyBold
+        else -> when (replyMessage?.isMine(currentUser) != false) {
+            true -> ChatTheme.ownMessageTheme.textStyle
+            else -> ChatTheme.otherMessageTheme.textStyle
+        }
     }
 
     val quotedMessageText = when {
@@ -89,9 +92,9 @@ public fun QuotedMessageText(
     }
 
     val textColor = if (replyMessage?.isMine(currentUser) != false) {
-        ChatTheme.colors.ownMessageQuotedText
+        ChatTheme.ownMessageTheme.textStyle.color
     } else {
-        ChatTheme.colors.otherMessageQuotedText
+        ChatTheme.otherMessageTheme.textStyle.color
     }
     val styledText = buildAnnotatedMessageText(quotedMessageText, textColor)
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -499,9 +499,14 @@ internal fun RegularMessageContent(
 
     val messageBubbleColor = when {
         message.isGiphyEphemeral() -> ChatTheme.colors.giphyMessageBackground
-        message.isDeleted() -> ChatTheme.colors.deletedMessagesBackground
-        ownsMessage -> ChatTheme.colors.ownMessagesBackground
-        else -> ChatTheme.colors.otherMessagesBackground
+        message.isDeleted() -> when (ownsMessage) {
+            true -> ChatTheme.ownMessageTheme.deletedBackgroundColor
+            else -> ChatTheme.otherMessageTheme.deletedBackgroundColor
+        }
+        else -> when (ownsMessage) {
+            true -> ChatTheme.ownMessageTheme.backgroundColor
+            else -> ChatTheme.otherMessageTheme.backgroundColor
+        }
     }
 
     if (!messageItem.isFailed()) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -111,6 +111,12 @@ private val LocalReadCountEnabled = compositionLocalOf<Boolean> {
             "Make sure to wrap all usages of Stream components in a ChatTheme."
     )
 }
+private val LocalOwnMessageTheme = compositionLocalOf<MessageTheme> {
+    error("No OwnMessageTheme provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
+}
+private val LocalOtherMessageTheme = compositionLocalOf<MessageTheme> {
+    error("No OtherMessageTheme provided! Make sure to wrap all usages of Stream components in a ChatTheme.")
+}
 
 /**
  * Our theme that provides all the important properties for styling to the user.
@@ -137,6 +143,8 @@ private val LocalReadCountEnabled = compositionLocalOf<Boolean> {
  * @param streamCdnImageResizing Sets the strategy for resizing images hosted on Stream's CDN. Disabled by default,
  * set [StreamCdnImageResizing.imageResizingEnabled] to true if you wish to enable resizing images. Note that resizing
  * applies only to images hosted on Stream's CDN which contain the original height (oh) and width (ow) query parameters.
+ * @param ownMessageTheme Theme of the current user messages.
+ * @param otherMessageTheme Theme of the other users messages.
  * @param content The content shown within the theme wrapper.
  */
 @Composable
@@ -166,6 +174,14 @@ public fun ChatTheme(
     videoThumbnailsEnabled: Boolean = true,
     streamCdnImageResizing: StreamCdnImageResizing = StreamCdnImageResizing.defaultStreamCdnImageResizing(),
     readCountEnabled: Boolean = true,
+    ownMessageTheme: MessageTheme = MessageTheme.defaultOwnTheme(
+        typography = typography,
+        colors = colors,
+    ),
+    otherMessageTheme: MessageTheme = MessageTheme.defaultOtherTheme(
+        typography = typography,
+        colors = colors,
+    ),
     content: @Composable () -> Unit,
 ) {
     LaunchedEffect(Unit) {
@@ -185,6 +201,8 @@ public fun ChatTheme(
         LocalDateFormatter provides dateFormatter,
         LocalChannelNameFormatter provides channelNameFormatter,
         LocalMessagePreviewFormatter provides messagePreviewFormatter,
+        LocalOwnMessageTheme provides ownMessageTheme,
+        LocalOtherMessageTheme provides otherMessageTheme,
         LocalStreamImageLoader provides imageLoaderFactory.imageLoader(LocalContext.current.applicationContext),
         LocalMessageAlignmentProvider provides messageAlignmentProvider,
         LocalMessageOptionsUserReactionAlignment provides messageOptionsUserReactionAlignment,
@@ -336,4 +354,20 @@ public object ChatTheme {
         @Composable
         @ReadOnlyComposable
         get() = LocalReadCountEnabled.current
+
+    /**
+    * Retrieves the current own [MessageTheme] at the call site's position in the hierarchy.
+    */
+    public val ownMessageTheme: MessageTheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalOwnMessageTheme.current
+
+    /**
+     * Retrieves the current other [MessageTheme] at the call site's position in the hierarchy.
+     */
+    public val otherMessageTheme: MessageTheme
+        @Composable
+        @ReadOnlyComposable
+        get() = LocalOtherMessageTheme.current
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -356,8 +356,8 @@ public object ChatTheme {
         get() = LocalReadCountEnabled.current
 
     /**
-    * Retrieves the current own [MessageTheme] at the call site's position in the hierarchy.
-    */
+     * Retrieves the current own [MessageTheme] at the call site's position in the hierarchy.
+     */
     public val ownMessageTheme: MessageTheme
         @Composable
         @ReadOnlyComposable

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageTheme.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+
+/**
+ * Represents message theming.
+ *
+ * @param textStyle The text style for the messages.
+ * @param backgroundColor The background color for the messages.
+ * @param quotedTextStyle The text style for the quoted messages contained in a reply.
+ * @param quotedBackgroundColor The background color for the quoted messages.
+ * @param deletedBackgroundColor The background color for the deleted messages.
+ */
+@Immutable
+public data class MessageTheme(
+    val textStyle: TextStyle,
+    val backgroundColor: Color,
+    val quotedTextStyle: TextStyle,
+    val quotedBackgroundColor: Color,
+    val deletedBackgroundColor: Color,
+) {
+    public companion object {
+
+        /**
+         * Builds the default message theme for the current user's messages.
+         *
+         * @return A [MessageTheme] instance holding our default theming.
+         */
+        @Composable
+        public fun defaultOwnTheme(
+            typography: StreamTypography = StreamTypography.defaultTypography(),
+            colors: StreamColors = when (isSystemInDarkTheme()) {
+                true -> StreamColors.defaultDarkColors()
+                else -> StreamColors.defaultColors()
+            },
+        ): MessageTheme = defaultTheme(own = true, typography = typography, colors = colors)
+
+        /**
+         * Builds the default message theme for other users' messages.
+         *
+         * @return A [MessageTheme] instance holding our default theming.
+         */
+        @Composable
+        public fun defaultOtherTheme(
+            typography: StreamTypography = StreamTypography.defaultTypography(),
+            colors: StreamColors = when (isSystemInDarkTheme()) {
+                true -> StreamColors.defaultDarkColors()
+                else -> StreamColors.defaultColors()
+            },
+        ): MessageTheme = defaultTheme(own = false, typography = typography, colors = colors)
+
+        @Composable
+        private fun defaultTheme(
+            own: Boolean,
+            typography: StreamTypography,
+            colors: StreamColors,
+        ): MessageTheme {
+            return MessageTheme(
+                textStyle = typography.bodyBold.copy(
+                    color = when (own) {
+                        true -> colors.ownMessageText
+                        else -> colors.otherMessageText
+                    },
+                ),
+                backgroundColor = when (own) {
+                    true -> colors.ownMessagesBackground
+                    else -> colors.otherMessagesBackground
+                },
+                quotedTextStyle = typography.bodyBold.copy(
+                    color = when (own) {
+                        true -> colors.ownMessageQuotedText
+                        else -> colors.otherMessageQuotedText
+                    },
+                ),
+                quotedBackgroundColor = when (own) {
+                    true -> colors.ownMessageQuotedBackground
+                    else -> colors.otherMessageQuotedBackground
+                },
+                deletedBackgroundColor = colors.deletedMessagesBackground,
+            )
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -80,13 +80,18 @@ public data class StreamColors(
     public val errorAccent: Color,
     public val infoAccent: Color,
     public val highlight: Color,
+    @Deprecated("Use MessageTheme.backgroundColor instead")
     public val ownMessagesBackground: Color,
+    @Deprecated("Use MessageTheme.backgroundColor instead")
     public val otherMessagesBackground: Color,
+    @Deprecated("Use MessageTheme.deletedBackgroundColor instead")
     public val deletedMessagesBackground: Color,
     public val giphyMessageBackground: Color,
     public val threadSeparatorGradientStart: Color,
     public val threadSeparatorGradientEnd: Color,
+    @Deprecated("Use MessageTheme.textStyle.color instead")
     public val ownMessageText: Color = textHighEmphasis,
+    @Deprecated("Use MessageTheme.textStyle.color instead")
     public val otherMessageText: Color = textHighEmphasis,
     public val imageBackgroundMessageList: Color,
     public val imageBackgroundMediaGalleryPicker: Color,
@@ -94,9 +99,13 @@ public data class StreamColors(
     public val videoBackgroundMediaGalleryPicker: Color,
     public val showMoreOverlay: Color,
     public val showMoreCountText: Color,
+    @Deprecated("Use MessageTheme.quotedBackgroundColor instead")
     public val ownMessageQuotedBackground: Color = otherMessagesBackground,
+    @Deprecated("Use MessageTheme.quotedBackgroundColor instead")
     public val otherMessageQuotedBackground: Color = ownMessagesBackground,
+    @Deprecated("Use MessageTheme.quotedTextStyle.color instead")
     public val ownMessageQuotedText: Color = textHighEmphasis,
+    @Deprecated("Use MessageTheme.quotedTextStyle.color instead")
     public val otherMessageQuotedText: Color = textHighEmphasis,
 ) {
 


### PR DESCRIPTION
### 🎯 Goal

Closes https://github.com/GetStream/android-internal-board/issues/88


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
