### PR TITLE
Feature/channel typing indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,8 +66,11 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added Typing Users list to `ChannelItem`. [#4867](https://github.com/GetStream/stream-chat-android/pull/4867)
+- Added typing indicator on `ChannelLitsView`. [#4867](https://github.com/GetStream/stream-chat-android/pull/4867)
 
 ### ⚠️ Changed
+- Create new `bind()` method on `BaseChannelListItemViewHolder` that takes as parameter `ChannelItem`. [#4867](https://github.com/GetStream/stream-chat-android/pull/4867)
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsViewHolderFactory.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsViewHolderFactory.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.channel.list.ChannelListView
+import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.ChannelListItemViewHolderFactory
@@ -51,8 +52,8 @@ class ChatInfoSharedGroupsViewHolder(
         binding.root.setOnClickListener { channelClickListener.onClick(channel) }
     }
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
-        this.channel = channel
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+        this.channel = channelItem.channel
 
         binding.apply {
             avatarView.setChannelData(channel)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1145,7 +1145,7 @@ public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelList
 }
 
 public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff {
-	public fun <init> (ZZZZZZZ)V
+	public fun <init> (ZZZZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -1153,14 +1153,16 @@ public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelList
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Z
-	public final fun copy (ZZZZZZZ)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;ZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
+	public final fun component8 ()Z
+	public final fun copy (ZZZZZZZZ)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;ZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarViewChanged ()Z
 	public final fun getExtraDataChanged ()Z
 	public final fun getLastMessageChanged ()Z
 	public final fun getNameChanged ()Z
 	public final fun getReadStateChanged ()Z
+	public final fun getTypingUsersChanged ()Z
 	public final fun getUnreadCountChanged ()Z
 	public final fun getUsersChanged ()Z
 	public final fun hasDifference ()Z

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1169,7 +1169,8 @@ public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelList
 
 public abstract class io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder : androidx/recyclerview/widget/RecyclerView$ViewHolder {
 	public fun <init> (Landroid/view/View;)V
-	public abstract fun bind (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;)V
+	public fun bind (Lio/getstream/chat/android/client/models/Channel;Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;)V
+	public fun bind (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff;)V
 }
 
 public class io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListItemViewHolderFactory {

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1122,12 +1122,14 @@ public abstract class io/getstream/chat/android/ui/channel/list/adapter/ChannelL
 }
 
 public final class io/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem : io/getstream/chat/android/ui/channel/list/adapter/ChannelListItem {
-	public fun <init> (Lio/getstream/chat/android/client/models/Channel;)V
+	public fun <init> (Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;)V
 	public final fun component1 ()Lio/getstream/chat/android/client/models/Channel;
-	public final fun copy (Lio/getstream/chat/android/client/models/Channel;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/client/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/client/models/Channel;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/ui/channel/list/adapter/ChannelListItem$ChannelItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Lio/getstream/chat/android/client/models/Channel;
+	public final fun getTypingUsers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListItem.kt
@@ -17,8 +17,9 @@
 package io.getstream.chat.android.ui.channel.list.adapter
 
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.client.models.User
 
 public sealed class ChannelListItem {
-    public data class ChannelItem(val channel: Channel) : ChannelListItem()
+    public data class ChannelItem(val channel: Channel, val typingUsers: List<User>) : ChannelListItem()
     public object LoadingMoreItem : ChannelListItem()
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/ChannelListPayloadDiff.kt
@@ -24,10 +24,17 @@ public data class ChannelListPayloadDiff(
     val readStateChanged: Boolean,
     val unreadCountChanged: Boolean,
     val extraDataChanged: Boolean,
+    val typingUsersChanged: Boolean,
 ) {
-    public fun hasDifference(): Boolean {
-        return nameChanged || avatarViewChanged || usersChanged || lastMessageChanged || readStateChanged || unreadCountChanged || extraDataChanged
-    }
+    public fun hasDifference(): Boolean =
+        nameChanged
+            .or(avatarViewChanged)
+            .or(usersChanged)
+            .or(lastMessageChanged)
+            .or(readStateChanged)
+            .or(unreadCountChanged)
+            .or(extraDataChanged)
+            .or(typingUsersChanged)
 
     public operator fun plus(other: ChannelListPayloadDiff): ChannelListPayloadDiff =
         copy(
@@ -38,5 +45,6 @@ public data class ChannelListPayloadDiff(
             readStateChanged = readStateChanged || other.readStateChanged,
             unreadCountChanged = unreadCountChanged || other.unreadCountChanged,
             extraDataChanged = extraDataChanged || other.extraDataChanged,
+            typingUsersChanged = typingUsersChanged || other.typingUsersChanged,
         )
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
@@ -54,7 +54,7 @@ internal class ChannelListItemAdapter(
     private fun bind(position: Int, holder: BaseChannelListItemViewHolder, payload: ChannelListPayloadDiff) {
         when (val channelItem = getItem(position)) {
             is ChannelListItem.LoadingMoreItem -> Unit
-            is ChannelListItem.ChannelItem -> holder.bind(channelItem.channel, payload)
+            is ChannelListItem.ChannelItem -> holder.bind(channelItem, payload)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/internal/ChannelListItemAdapter.kt
@@ -75,6 +75,7 @@ internal class ChannelListItemAdapter(
             readStateChanged = true,
             unreadCountChanged = true,
             extraDataChanged = true,
+            typingUsersChanged = true
         )
 
         val EMPTY_CHANNEL_LIST_ITEM_PAYLOAD_DIFF: ChannelListPayloadDiff = ChannelListPayloadDiff(
@@ -85,6 +86,7 @@ internal class ChannelListItemAdapter(
             readStateChanged = false,
             unreadCountChanged = false,
             extraDataChanged = false,
+            typingUsersChanged = false
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
@@ -19,8 +19,20 @@ package io.getstream.chat.android.ui.channel.list.adapter.viewholder
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
 import io.getstream.chat.android.client.models.Channel
+import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 
 public abstract class BaseChannelListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    public abstract fun bind(channel: Channel, diff: ChannelListPayloadDiff)
+
+    @Deprecated(
+        message = "This method is deprecated, and will be removed on V6",
+        replaceWith = ReplaceWith(
+            expression = "this.bind(channelItem, diff)",
+            imports = arrayOf("io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem")
+        )
+    )
+    public open fun bind(channel: Channel, diff: ChannelListPayloadDiff) { }
+    public open fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+        bind(channelItem.channel, diff)
+    }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelListLoadingMoreViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelListLoadingMoreViewHolder.kt
@@ -17,8 +17,8 @@
 package io.getstream.chat.android.ui.channel.list.adapter.viewholder.internal
 
 import android.view.ViewGroup
-import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.ui.channel.list.ChannelListViewStyle
+import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.common.extensions.internal.streamThemeInflater
@@ -28,5 +28,5 @@ internal class ChannelListLoadingMoreViewHolder(
     style: ChannelListViewStyle,
 ) : BaseChannelListItemViewHolder(parent.streamThemeInflater.inflate(style.loadingMoreView, parent, false)) {
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff): Unit = Unit
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff): Unit = Unit
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.channel.list.ChannelListView
 import io.getstream.chat.android.ui.channel.list.ChannelListViewStyle
+import io.getstream.chat.android.ui.channel.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.channel.list.adapter.viewholder.SwipeViewHolder
 import io.getstream.chat.android.ui.common.extensions.getCreatedAtOrThrow
@@ -119,10 +120,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         }
     }
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
-        this.channel = channel
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+        this.channel = channelItem.channel
 
-        configureForeground(diff, channel)
+        configureForeground(diff, channelItem)
         configureBackground()
 
         listener?.onRestoreSwipePosition(this, absoluteAdapterPosition)
@@ -203,10 +204,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         this.optionsCount = optionsCount
     }
 
-    private fun configureForeground(diff: ChannelListPayloadDiff, channel: Channel) {
+    private fun configureForeground(diff: ChannelListPayloadDiff, channelItem: ChannelListItem.ChannelItem) {
         binding.itemForegroundView.apply {
             diff.run {
-                if (nameChanged || (channel.isAnonymousChannel() && diff.usersChanged)) {
+                if (nameChanged || (channelItem.channel.isAnonymousChannel() && diff.usersChanged)) {
                     configureChannelNameLabel()
                 }
 
@@ -214,7 +215,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureAvatarView()
                 }
 
-                val lastMessage = channel.getLastMessage()
+                val lastMessage = channelItem.channel.getLastMessage()
                 if (lastMessageChanged) {
                     configureLastMessageLabelAndTimestamp(lastMessage)
                 }
@@ -227,7 +228,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureUnreadCountBadge()
                 }
 
-                muteIcon.isVisible = channel.isMuted
+                muteIcon.isVisible = channelItem.channel.isMuted
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -228,6 +228,11 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureUnreadCountBadge()
                 }
 
+                if (typingUsersChanged) {
+                    typingIndicatorView.setTypingUsers(channelItem.typingUsers)
+                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty()
+                }
+
                 muteIcon.isVisible = channelItem.channel.isMuted
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/Channel.kt
@@ -17,25 +17,9 @@
 package io.getstream.chat.android.ui.common.extensions.internal
 
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.extensions.getMemberExcludingCurrent
 import io.getstream.chat.android.client.models.Channel
 import io.getstream.chat.android.client.models.Message
-import io.getstream.chat.android.ui.channel.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.common.extensions.getCreatedAtOrThrow
-import io.getstream.chat.android.ui.common.extensions.getLastMessage
-
-internal fun Channel.diff(other: Channel): ChannelListPayloadDiff {
-    val usersChanged = getMemberExcludingCurrent() != other.getMemberExcludingCurrent()
-    return ChannelListPayloadDiff(
-        nameChanged = name != other.name,
-        avatarViewChanged = usersChanged,
-        usersChanged = usersChanged,
-        readStateChanged = read != other.read,
-        lastMessageChanged = getLastMessage() != other.getLastMessage(),
-        unreadCountChanged = unreadCount != other.unreadCount && other.unreadCount != null,
-        extraDataChanged = extraData != other.extraData
-    )
-}
 
 internal fun Channel.isMessageRead(message: Message): Boolean {
     val currentUser = ChatClient.instance().getCurrentUser()

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -14,7 +14,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/foregroundView"
@@ -44,12 +45,19 @@
         android:maxLines="1"
         android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
         android:textDirection="locale"
-        app:layout_constraintBottom_toTopOf="@+id/lastMessageLabel"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
         app:layout_constraintEnd_toStartOf="@+id/muteIcon"
         app:layout_constraintStart_toEndOf="@+id/avatarView"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="Gebruiker, Usuario, Benutzer"
+        />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.50"
         />
 
     <TextView
@@ -61,10 +69,24 @@
         android:maxLines="1"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
         app:layout_constraintEnd_toStartOf="@+id/messageStatusImageView"
-        app:layout_constraintTop_toBottomOf="@+id/channelNameLabel"
+        app:layout_constraintTop_toBottomOf="@+id/guideline"
+        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a."
+        />
+
+    <io.getstream.chat.android.ui.typing.TypingIndicatorView
+        android:id="@+id/typingIndicatorView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="12dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/StreamUiTextAppearance.Footnote"
+        android:textDirection="locale"
+        app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
+        app:layout_constraintEnd_toStartOf="@+id/messageStatusImageView"
+        app:layout_constraintTop_toBottomOf="@+id/guideline"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a."
         />
 
@@ -75,7 +97,7 @@
         android:layout_marginEnd="8dp"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
-        app:layout_constraintBaseline_toBaselineOf="@+id/lastMessageLabel"
+        app:layout_constraintTop_toTopOf="@id/guideline"
         app:layout_constraintEnd_toEndOf="parent"
         tools:text="3:00PM"
         />
@@ -85,9 +107,9 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_marginEnd="3dp"
-        app:layout_constraintBottom_toBottomOf="@+id/lastMessageLabel"
+        app:layout_constraintBottom_toBottomOf="@+id/lastMessageTimeLabel"
         app:layout_constraintEnd_toStartOf="@+id/lastMessageTimeLabel"
-        app:layout_constraintTop_toTopOf="@+id/lastMessageLabel"
+        app:layout_constraintTop_toTopOf="@+id/lastMessageTimeLabel"
         tools:ignore="ContentDescription"
         tools:src="@drawable/stream_ui_ic_check_double"
         />

--- a/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/uicomponents/channels/ChannelListItemViewTest.kt
+++ b/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/uicomponents/channels/ChannelListItemViewTest.kt
@@ -109,6 +109,7 @@ class ChannelListItemViewTest : ScreenshotTest {
             readStateChanged = true,
             unreadCountChanged = true,
             extraDataChanged = true,
+            typingUsersChanged = true
         )
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Add typing indicator on the channel list view.
Fix: https://github.com/GetStream/stream-chat-android/issues/4747

### 🛠 Implementation details
Added typing users to `ChannelItem` entity and adding a new `bind()` method  that take as argument the `ChannelItem` instance instead of the `Channel`

### 🎉 GIF
![](https://media.giphy.com/media/JwKwd3pdkjOtVl36kJ/giphy.gif)
