### PR TITLE
Feature/channel typing indicator v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,12 +98,15 @@
 - Added `showDateSeparatorInEmptyThread: Boolean` to `MessageListViewModelFactory`. It is used to regulate whether date separators appear in empty threads. [#4742](https://github.com/GetStream/stream-chat-android/pull/4742)
 - Added the ability to choose `PickerMediaMode` that allows control if the camera recorder and/or take picture feature is allowed or not in `MessageComposerView` via xml attributes. [#4812](https://github.com/GetStream/stream-chat-android/pull/4812)
   * `streamUiMessageComposerAttachmentsPickerMediaMode`
+- Added Typing Users list to `ChannelItem`. [#4868](https://github.com/GetStream/stream-chat-android/pull/4868)
+- Added typing indicator on `ChannelLitsView`. [#4868](https://github.com/GetStream/stream-chat-android/pull/4868)
 
 ### ⚠️ Changed
 - Replaced the method parameter `replyMessageId: String` with `replyTo: Message` inside `ReplyMessageClickListener.onReplyClick()`. The new parameter now contains the complete message to which the reply was made. [#4639](https://github.com/GetStream/stream-chat-android/pull/4639)
 - Added the parameter `parentId: String?` to `AttachmentGalleryResultItem`. It is used to indicate when a message is belongs to a thread. Same has been added to the extension function `Attachment.toAttachmentGalleryResultItem()`. [#4639](https://github.com/GetStream/stream-chat-android/pull/4639)
 - Added the parameter `parentMessageId: String?` to the class `MessageListViewModel.ShowMessage`. If the message you want to scroll to is a thread message, pass in its parent message ID, otherwise you can pass in `null`. [#4639](https://github.com/GetStream/stream-chat-android/pull/4639)
 - 🚨 Breaking change: Removed `ChatUI.showThreadSeparatorInEmptyThread`. It has been replaced by `MessageListController.showDateSeparatorInEmptyThread`. If you are using our `ViewModel` factory, `MessageListViewModelFactory.showDateSeparatorInEmptyThread` will pass the parameter through to the `MessageListController` contained by `MessageListViewMode`. [#4742](https://github.com/GetStream/stream-chat-android/pull/4742)
+- Create new `bind()` method on `BaseChannelListItemViewHolder` that takes as parameter `ChannelItem`. [#4868](https://github.com/GetStream/stream-chat-android/pull/4868)
 
 ### ❌ Removed
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/channels/ChannelList.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/channels/ChannelList.java
@@ -20,6 +20,7 @@ import io.getstream.chat.android.models.Filters;
 import io.getstream.chat.android.models.querysort.QuerySortByField;
 import io.getstream.chat.android.ui.ChatUI;
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListView;
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem;
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff;
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.BaseChannelListItemViewHolder;
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.ChannelListItemViewHolderFactory;
@@ -114,8 +115,8 @@ public class ChannelList extends Fragment {
             }
 
             @Override
-            public void bind(@NonNull Channel channel, @NonNull ChannelListPayloadDiff diff) {
-                this.channel = channel;
+            public void bind(@NonNull ChannelListItem.ChannelItem channelItem, @NonNull ChannelListPayloadDiff diff) {
+                this.channel = channelItem.getChannel();
                 binding.channelAvatarView.setChannel(channel);
                 String channelName = ChatUI.getChannelNameFormatter().formatChannelName(
                         channel,

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelList.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/channels/ChannelList.kt
@@ -15,6 +15,7 @@ import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListView
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.ChannelListItemViewHolderFactory
@@ -112,8 +113,8 @@ private class ChannelList : Fragment() {
                 binding.root.setOnClickListener { channelClickListener.onClick(channel) }
             }
 
-            override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
-                this.channel = channel
+            override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+                this.channel = channelItem.channel
 
                 binding.channelAvatarView.setChannel(channel)
                 binding.channelNameTextView.text = ChatUI.channelNameFormatter.formatChannelName(

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsViewHolderFactory.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedGroupsViewHolderFactory.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListView
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.ChannelListItemViewHolderFactory
@@ -52,8 +53,8 @@ class ChatInfoSharedGroupsViewHolder(
         binding.root.setOnClickListener { channelClickListener.onClick(channel) }
     }
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
-        this.channel = channel
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+        this.channel = channelItem.channel
 
         binding.apply {
             channelAvatarView.setChannel(channel)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -343,12 +343,14 @@ public abstract class io/getstream/chat/android/ui/feature/channels/list/adapter
 }
 
 public final class io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem : io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem {
-	public fun <init> (Lio/getstream/chat/android/models/Channel;)V
+	public fun <init> (Lio/getstream/chat/android/models/Channel;Ljava/util/List;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Channel;
-	public final fun copy (Lio/getstream/chat/android/models/Channel;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
+	public final fun component2 ()Ljava/util/List;
+	public final fun copy (Lio/getstream/chat/android/models/Channel;Ljava/util/List;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/models/Channel;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
+	public final fun getTypingUsers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -366,7 +366,7 @@ public final class io/getstream/chat/android/ui/feature/channels/list/adapter/Ch
 }
 
 public final class io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff {
-	public fun <init> (ZZZZZZZ)V
+	public fun <init> (ZZZZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -374,14 +374,16 @@ public final class io/getstream/chat/android/ui/feature/channels/list/adapter/Ch
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Z
-	public final fun copy (ZZZZZZZ)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;ZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
+	public final fun component8 ()Z
+	public final fun copy (ZZZZZZZZ)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;ZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarViewChanged ()Z
 	public final fun getExtraDataChanged ()Z
 	public final fun getLastMessageChanged ()Z
 	public final fun getNameChanged ()Z
 	public final fun getReadStateChanged ()Z
+	public final fun getTypingUsersChanged ()Z
 	public final fun getUnreadCountChanged ()Z
 	public final fun getUsersChanged ()Z
 	public final fun hasDifference ()Z

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -390,7 +390,7 @@ public final class io/getstream/chat/android/ui/feature/channels/list/adapter/Ch
 
 public abstract class io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/BaseChannelListItemViewHolder : androidx/recyclerview/widget/RecyclerView$ViewHolder {
 	public fun <init> (Landroid/view/View;)V
-	public abstract fun bind (Lio/getstream/chat/android/models/Channel;Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;)V
+	public abstract fun bind (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;)V
 }
 
 public class io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/ChannelListItemViewHolderFactory {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem.kt
@@ -17,8 +17,9 @@
 package io.getstream.chat.android.ui.feature.channels.list.adapter
 
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.User
 
 public sealed class ChannelListItem {
-    public data class ChannelItem(val channel: Channel) : ChannelListItem()
+    public data class ChannelItem(val channel: Channel, val typingUsers: List<User>) : ChannelListItem()
     public object LoadingMoreItem : ChannelListItem()
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff.kt
@@ -24,10 +24,17 @@ public data class ChannelListPayloadDiff(
     val readStateChanged: Boolean,
     val unreadCountChanged: Boolean,
     val extraDataChanged: Boolean,
+    val typingUsersChanged: Boolean,
 ) {
-    public fun hasDifference(): Boolean {
-        return nameChanged || avatarViewChanged || usersChanged || lastMessageChanged || readStateChanged || unreadCountChanged || extraDataChanged
-    }
+    public fun hasDifference(): Boolean =
+        nameChanged
+            .or(avatarViewChanged)
+            .or(usersChanged)
+            .or(lastMessageChanged)
+            .or(readStateChanged)
+            .or(unreadCountChanged)
+            .or(extraDataChanged)
+            .or(typingUsersChanged)
 
     public operator fun plus(other: ChannelListPayloadDiff): ChannelListPayloadDiff =
         copy(
@@ -38,5 +45,6 @@ public data class ChannelListPayloadDiff(
             readStateChanged = readStateChanged || other.readStateChanged,
             unreadCountChanged = unreadCountChanged || other.unreadCountChanged,
             extraDataChanged = extraDataChanged || other.extraDataChanged,
+            typingUsersChanged = typingUsersChanged || other.typingUsersChanged,
         )
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
@@ -54,7 +54,7 @@ internal class ChannelListItemAdapter(
     private fun bind(position: Int, holder: BaseChannelListItemViewHolder, payload: ChannelListPayloadDiff) {
         when (val channelItem = getItem(position)) {
             is ChannelListItem.LoadingMoreItem -> Unit
-            is ChannelListItem.ChannelItem -> holder.bind(channelItem.channel, payload)
+            is ChannelListItem.ChannelItem -> holder.bind(channelItem, payload)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
@@ -75,6 +75,7 @@ internal class ChannelListItemAdapter(
             readStateChanged = true,
             unreadCountChanged = true,
             extraDataChanged = true,
+            typingUsersChanged = true
         )
 
         val EMPTY_CHANNEL_LIST_ITEM_PAYLOAD_DIFF: ChannelListPayloadDiff = ChannelListPayloadDiff(
@@ -85,6 +86,7 @@ internal class ChannelListItemAdapter(
             readStateChanged = false,
             unreadCountChanged = false,
             extraDataChanged = false,
+            typingUsersChanged = false
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemDiffCallback.kt
@@ -17,10 +17,12 @@
 package io.getstream.chat.android.ui.feature.channels.list.adapter.internal
 
 import androidx.recyclerview.widget.DiffUtil
+import io.getstream.chat.android.client.extensions.getMembersExcludingCurrent
 import io.getstream.chat.android.ui.common.extensions.internal.cast
 import io.getstream.chat.android.ui.common.extensions.internal.safeCast
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
-import io.getstream.chat.android.ui.utils.extensions.diff
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
+import io.getstream.chat.android.ui.utils.extensions.getLastMessage
 
 internal object ChannelListItemDiffCallback : DiffUtil.ItemCallback<ChannelListItem>() {
     override fun areItemsTheSame(oldItem: ChannelListItem, newItem: ChannelListItem): Boolean {
@@ -42,8 +44,7 @@ internal object ChannelListItemDiffCallback : DiffUtil.ItemCallback<ChannelListI
         return when (oldItem) {
             is ChannelListItem.ChannelItem -> {
                 oldItem
-                    .channel
-                    .diff(newItem.cast<ChannelListItem.ChannelItem>().channel)
+                    .diff(newItem.cast())
                     .hasDifference()
                     .not()
             }
@@ -56,7 +57,19 @@ internal object ChannelListItemDiffCallback : DiffUtil.ItemCallback<ChannelListI
         // only called if their contents aren't the same, so they must be channel items and not loading items
         return oldItem
             .cast<ChannelListItem.ChannelItem>()
-            .channel
-            .diff(newItem.cast<ChannelListItem.ChannelItem>().channel)
+            .diff(newItem.cast())
+    }
+    private fun ChannelListItem.ChannelItem.diff(other: ChannelListItem.ChannelItem): ChannelListPayloadDiff {
+        val usersChanged = channel.getMembersExcludingCurrent() != other.channel.getMembersExcludingCurrent()
+        return ChannelListPayloadDiff(
+            nameChanged = channel.name != other.channel.name,
+            avatarViewChanged = usersChanged,
+            usersChanged = usersChanged,
+            readStateChanged = channel.read != other.channel.read,
+            lastMessageChanged = channel.getLastMessage() != other.channel.getLastMessage(),
+            unreadCountChanged = channel.unreadCount != other.channel.unreadCount && other.channel.unreadCount != null,
+            extraDataChanged = channel.extraData != other.channel.extraData,
+            typingUsersChanged = typingUsers != other.typingUsers,
+        )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/BaseChannelListItemViewHolder.kt
@@ -18,9 +18,9 @@ package io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder
 
 import android.view.View
 import androidx.recyclerview.widget.RecyclerView
-import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 
 public abstract class BaseChannelListItemViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-    public abstract fun bind(channel: Channel, diff: ChannelListPayloadDiff)
+    public abstract fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff)
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelListLoadingMoreViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelListLoadingMoreViewHolder.kt
@@ -17,8 +17,8 @@
 package io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.internal
 
 import android.view.ViewGroup
-import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListViewStyle
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.BaseChannelListItemViewHolder
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
@@ -28,5 +28,5 @@ internal class ChannelListLoadingMoreViewHolder(
     style: ChannelListViewStyle,
 ) : BaseChannelListItemViewHolder(parent.streamThemeInflater.inflate(style.loadingMoreView, parent, false)) {
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff): Unit = Unit
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff): Unit = Unit
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -225,6 +225,11 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureUnreadCountBadge()
                 }
 
+                if (typingUsersChanged) {
+                    typingIndicatorView.setTypingUsers(channelItem.typingUsers)
+                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty()
+                }
+
                 muteIcon.isVisible = channelItem.channel.isMuted
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -36,6 +36,7 @@ import io.getstream.chat.android.ui.databinding.StreamUiChannelListItemForegroun
 import io.getstream.chat.android.ui.databinding.StreamUiChannelListItemViewBinding
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListView
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListViewStyle
+import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.ui.feature.channels.list.adapter.viewholder.SwipeViewHolder
 import io.getstream.chat.android.ui.font.setTextStyle
@@ -116,10 +117,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         }
     }
 
-    override fun bind(channel: Channel, diff: ChannelListPayloadDiff) {
-        this.channel = channel
+    override fun bind(channelItem: ChannelListItem.ChannelItem, diff: ChannelListPayloadDiff) {
+        this.channel = channelItem.channel
 
-        configureForeground(diff, channel)
+        configureForeground(diff, channelItem)
         configureBackground()
 
         listener?.onRestoreSwipePosition(this, absoluteAdapterPosition)
@@ -200,10 +201,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         this.optionsCount = optionsCount
     }
 
-    private fun configureForeground(diff: ChannelListPayloadDiff, channel: Channel) {
+    private fun configureForeground(diff: ChannelListPayloadDiff, channelItem: ChannelListItem.ChannelItem) {
         binding.itemForegroundView.apply {
             diff.run {
-                if (nameChanged || (channel.isAnonymousChannel() && diff.usersChanged)) {
+                if (nameChanged || (channelItem.channel.isAnonymousChannel() && diff.usersChanged)) {
                     configureChannelNameLabel()
                 }
 
@@ -211,7 +212,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureAvatarView()
                 }
 
-                val lastMessage = channel.getLastMessage()
+                val lastMessage = channelItem.channel.getLastMessage()
                 if (lastMessageChanged) {
                     configureLastMessageLabelAndTimestamp(lastMessage)
                 }
@@ -224,7 +225,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                     configureUnreadCountBadge()
                 }
 
-                muteIcon.isVisible = channel.isMuted
+                muteIcon.isVisible = channelItem.channel.isMuted
             }
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Channel.kt
@@ -18,14 +18,12 @@ package io.getstream.chat.android.ui.utils.extensions
 
 import android.content.Context
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.extensions.getMembersExcludingCurrent
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
-import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListPayloadDiff
 import io.getstream.chat.android.uiutils.extension.getMembersStatusText
 import io.getstream.chat.android.uiutils.extension.getPreviewMessage
 
@@ -64,19 +62,6 @@ public fun Channel.getMembersStatusText(
  * @return Last message from the channel or null if it doesn't exist.
  */
 public fun Channel.getLastMessage(): Message? = getPreviewMessage(ChatUI.currentUserProvider.getCurrentUser())
-
-internal fun Channel.diff(other: Channel): ChannelListPayloadDiff {
-    val usersChanged = getMembersExcludingCurrent() != other.getMembersExcludingCurrent()
-    return ChannelListPayloadDiff(
-        nameChanged = name != other.name,
-        avatarViewChanged = usersChanged,
-        usersChanged = usersChanged,
-        readStateChanged = read != other.read,
-        lastMessageChanged = getLastMessage() != other.getLastMessage(),
-        unreadCountChanged = unreadCount != other.unreadCount && other.unreadCount != null,
-        extraDataChanged = extraData != other.extraData
-    )
-}
 
 internal fun Channel.readCount(message: Message): Int {
     val currentUser = ChatClient.instance().globalState.user.value

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -14,7 +14,8 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/foregroundView"
@@ -44,12 +45,19 @@
         android:maxLines="1"
         android:textAppearance="@style/StreamUiTextAppearance.BodyBold"
         android:textDirection="locale"
-        app:layout_constraintBottom_toTopOf="@+id/lastMessageLabel"
+        app:layout_constraintBottom_toTopOf="@+id/guideline"
         app:layout_constraintEnd_toStartOf="@+id/muteIcon"
         app:layout_constraintStart_toEndOf="@+id/channelAvatarView"
-        app:layout_constraintTop_toTopOf="parent"
         app:layout_constraintVertical_chainStyle="packed"
         tools:text="Gebruiker, Usuario, Benutzer"
+        />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_percent="0.50"
         />
 
     <TextView
@@ -61,10 +69,24 @@
         android:maxLines="1"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
-        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
         app:layout_constraintEnd_toStartOf="@+id/messageStatusImageView"
-        app:layout_constraintTop_toBottomOf="@+id/channelNameLabel"
+        app:layout_constraintTop_toBottomOf="@+id/guideline"
+        tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a."
+        />
+
+    <io.getstream.chat.android.ui.widgets.typing.TypingIndicatorView
+        android:id="@+id/typingIndicatorView"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="12dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textAppearance="@style/StreamUiTextAppearance.Footnote"
+        android:textDirection="locale"
+        app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
+        app:layout_constraintEnd_toStartOf="@+id/messageStatusImageView"
+        app:layout_constraintTop_toBottomOf="@+id/guideline"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a."
         />
 
@@ -75,7 +97,7 @@
         android:layout_marginEnd="8dp"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
-        app:layout_constraintBaseline_toBaselineOf="@+id/lastMessageLabel"
+        app:layout_constraintTop_toTopOf="@id/guideline"
         app:layout_constraintEnd_toEndOf="parent"
         tools:text="3:00PM"
         />
@@ -85,9 +107,9 @@
         android:layout_width="16dp"
         android:layout_height="16dp"
         android:layout_marginEnd="3dp"
-        app:layout_constraintBottom_toBottomOf="@+id/lastMessageLabel"
+        app:layout_constraintBottom_toBottomOf="@+id/lastMessageTimeLabel"
         app:layout_constraintEnd_toStartOf="@+id/lastMessageTimeLabel"
-        app:layout_constraintTop_toTopOf="@+id/lastMessageLabel"
+        app:layout_constraintTop_toTopOf="@+id/lastMessageTimeLabel"
         tools:ignore="ContentDescription"
         tools:src="@drawable/stream_ui_ic_check_double"
         />

--- a/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/uicomponents/channels/ChannelListItemViewTest.kt
+++ b/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/uicomponents/channels/ChannelListItemViewTest.kt
@@ -110,6 +110,7 @@ class ChannelListItemViewTest : ScreenshotTest {
             readStateChanged = true,
             unreadCountChanged = true,
             extraDataChanged = true,
+            typingUsersChanged = true
         )
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Add typing indicator on the channel list view.
Fix: https://github.com/GetStream/stream-chat-android/issues/4747

### 🛠 Implementation details
Added typing users to `ChannelItem` entity and adding a new `bind()` method  that take as argument the `ChannelItem` instance instead of the `Channel`

### 🎉 GIF
![](https://media.giphy.com/media/JwKwd3pdkjOtVl36kJ/giphy.gif)
