### PR TITLE
Keep v6 as "unreleased" version

### DIFF
--- a/docusaurus/android-docusaurus-dontent-docs.plugin.js
+++ b/docusaurus/android-docusaurus-dontent-docs.plugin.js
@@ -3,16 +3,16 @@ module.exports = {
     [
       '@docusaurus/plugin-content-docs',
       {
-        lastVersion: 'current',
+        lastVersion: '5.x.x',
         versions: {
           current: {
-            label: 'v6',
+            label: 'v6-Beta',
+            path: 'next'
           },
           '5.x.x': {
             label: 'v5',
-            path: 'v5',
-            banner: 'unmaintained'
-          },
+            banner: 'none'
+          }
         }
       }
     ]


### PR DESCRIPTION
### 🎯 Goal
Keep v6 as "unreleased" version
The current version will be our current v5 version and v6 will be under the `/next` path

### 🎉 GIF

![](https://media.giphy.com/media/3o7TKBcOTDTFR6gn6M/giphy.gif)