### PR TITLE
[i74] fix multiline support in XML message composer

### DIFF
--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_center_content.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_center_content.xml
@@ -62,7 +62,8 @@
         <androidx.appcompat.widget.AppCompatEditText
             android:id="@+id/messageEditText"
             android:layout_width="0dp"
-            android:layout_height="@dimen/stream_ui_message_composer_center_content_height"
+            android:layout_height="wrap_content"
+            android:minHeight="@dimen/stream_ui_message_composer_center_content_height"
             android:background="@null"
             android:ellipsize="end"
             android:hint="@string/stream_ui_message_composer_hint_normal"


### PR DESCRIPTION
### 🎯 Goal

Fix multiline support in XML message Composer.
No ticket for this.
It's a side-effect of https://github.com/GetStream/stream-chat-android/pull/4828

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
