### PR TITLE
[i103] ChannelViewHolder shows invalid last message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed `ChannelViewHolder` to show proper last message value. [#4900](https://github.com/GetStream/stream-chat-android/pull/4900)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -232,7 +232,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
 
                 if (typingUsersChanged) {
                     typingIndicatorView.setTypingUsers(channelItem.typingUsers)
-                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty()
+                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty() && lastMessage.isNotNull()
                 }
 
                 muteIcon.isVisible = channelItem.channel.isMuted
@@ -257,7 +257,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         lastMessageLabel.isVisible = lastMessage.isNotNull()
         lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
 
-        lastMessage ?: return
+        lastMessage ?: return run {
+            lastMessageLabel.text = ""
+            lastMessageTimeLabel.text = ""
+        }
 
         lastMessageLabel.text = ChatUI.messagePreviewFormatter.formatMessagePreview(
             channel = channel,


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/103

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
