### PR TITLE
Fix/typing indicator on channel list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Send `TypingStopEvent` whenever the message is sent or the messageComposer contains an empty text message. [#4904](https://github.com/GetStream/stream-chat-android/pull/4904)
 
 ### ✅ Added
 - Added `showDateSeparatorInEmptyThread: Boolean` to `MessageListController`. It is used to regulate whether date separators appear in empty threads. [#4742](https://github.com/GetStream/stream-chat-android/pull/4742)
@@ -91,6 +92,7 @@
 ### 🐞 Fixed
 - Fixed edit messages and reply messages with unsupported attachments. [#4757](https://github.com/GetStream/stream-chat-android/pull/4757)
 - Fixed `ChannelViewHolder` to show proper last message value. [#4901](https://github.com/GetStream/stream-chat-android/pull/4901)
+- Fixed `CnahnelViewHolder` to handle TypingIndicator visibility properly. [#4904](https://github.com/GetStream/stream-chat-android/pull/4904)
 
 ### ⬆️ Improved
 - Emails are highlighted and clickable in the message text. [#4833](https://github.com/GetStream/stream-chat-android/pull/4833)

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1052,7 +1052,7 @@ public final class io/getstream/chat/android/ui/common/utils/extensions/UserKt {
 
 public abstract interface class io/getstream/chat/android/ui/common/utils/typing/TypingUpdatesBuffer {
 	public abstract fun clear ()V
-	public abstract fun onKeystroke ()V
+	public abstract fun onKeystroke (Ljava/lang/String;)V
 }
 
 public final class io/getstream/sdk/chat/audio/recording/DefaultStreamMediaRecorder : io/getstream/sdk/chat/audio/recording/StreamMediaRecorder {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -351,7 +351,7 @@ public class MessageComposerController(
             state.value = state.value.copy(inputValue = input)
 
             if (canSendTypingUpdates.value) {
-                typingUpdatesBuffer.onKeystroke()
+                typingUpdatesBuffer.onKeystroke(input)
             }
             handleCommandSuggestions()
             handleValidationErrors()

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/typing/TypingUpdatesBuffer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/typing/TypingUpdatesBuffer.kt
@@ -29,8 +29,10 @@ public interface TypingUpdatesBuffer {
 
     /**
      * Should be called on every input change.
+     *
+     * @param [inputText] the current input text.
      */
-    public fun onKeystroke()
+    public fun onKeystroke(inputText: String)
 
     /**
      * Should send a stop typing event manually.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/typing/internal/DefaultTypingUpdatesBuffer.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/typing/internal/DefaultTypingUpdatesBuffer.kt
@@ -82,15 +82,25 @@ internal class DefaultTypingUpdatesBuffer(
     /**
      * Sets the value of [isTyping] only if there is
      * a change in state in order to not create unnecessary events.
-     *
      * Also resets the job used to time periods of typing activity.
+     * If the [inputText] is empty, it will call [onTypingStopped].
+     *
+     * @param [inputText] the current input text.
      */
-    override fun onKeystroke() {
-        if (!isTyping) {
-            isTyping = true
-        }
+    override fun onKeystroke(inputText: String) {
         isTypingTimerJob?.cancel()
-        isTypingTimerJob = coroutineScope.launch { startTypingTimer() }
+        when (inputText.isEmpty()) {
+            true -> {
+                isTyping = false
+                onTypingStopped()
+            }
+            false -> {
+                if (!isTyping) {
+                    isTyping = true
+                }
+                isTypingTimerJob = coroutineScope.launch { startTypingTimer() }
+            }
+        }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -215,8 +215,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                 }
 
                 val lastMessage = channelItem.channel.getLastMessage()
-                if (lastMessageChanged) {
+                if (lastMessageChanged || typingUsersChanged) {
+                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty() && lastMessage.isNotNull()
                     configureLastMessageLabelAndTimestamp(lastMessage)
+                    typingIndicatorView.setTypingUsers(channelItem.typingUsers)
                 }
 
                 if (readStateChanged || lastMessageChanged) {
@@ -225,11 +227,6 @@ internal class ChannelViewHolder @JvmOverloads constructor(
 
                 if (unreadCountChanged) {
                     configureUnreadCountBadge()
-                }
-
-                if (typingUsersChanged) {
-                    typingIndicatorView.setTypingUsers(channelItem.typingUsers)
-                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty() && lastMessage.isNotNull()
                 }
 
                 muteIcon.isVisible = channelItem.channel.isMuted
@@ -251,7 +248,6 @@ internal class ChannelViewHolder @JvmOverloads constructor(
     private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabelAndTimestamp(
         lastMessage: Message?,
     ) {
-        lastMessageLabel.isVisible = lastMessage.isNotNull()
         lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
 
         lastMessage ?: return run {


### PR DESCRIPTION
### 🎯 Goal
Typing Indicator wasn't being appropriately hidden after a message was received because the TypingStopped Event wasn't fired
Fix: https://github.com/GetStream/android-internal-board/issues/102

### 🎉 GIF

![](https://media.giphy.com/media/13GIgrGdslD9oQ/giphy.gif)