### PR TITLE
[i107] expose notification color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `R.color.stream_ic_notification` to the list of resources that can be overridden. [#4920](https://github.com/GetStream/stream-chat-android/pull/4920)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/ChatNotificationHandler.kt
@@ -25,6 +25,7 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import io.getstream.chat.android.client.R
 import io.getstream.chat.android.client.extensions.getUsersExcludingCurrent
@@ -165,6 +166,7 @@ internal class ChatNotificationHandler(
             .setDefaults(NotificationCompat.DEFAULT_ALL)
             .setAutoCancel(true)
             .setSmallIcon(R.drawable.stream_ic_notification)
+            .setColor(ContextCompat.getColor(context, R.color.stream_ic_notification))
             .setContentTitle(contentTitle)
             .setContentText(contentText)
             .setPriority(NotificationCompat.PRIORITY_HIGH)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/handler/MessagingStyleNotificationHandler.kt
@@ -26,6 +26,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.app.Person
+import androidx.core.content.ContextCompat
 import androidx.core.content.edit
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.R
@@ -90,6 +91,7 @@ internal class MessagingStyleNotificationHandler(
             val initialMessagingStyle = restoreMessagingStyle(channel) ?: createMessagingStyle(currentUser, channel)
             val notification = NotificationCompat.Builder(context, getNotificationChannelId())
                 .setSmallIcon(R.drawable.stream_ic_notification)
+                .setColor(ContextCompat.getColor(context, R.color.stream_ic_notification))
                 .setStyle(initialMessagingStyle.addMessage(message.toMessagingStyleMessage(context)))
                 .setContentIntent(contentPendingIntent)
                 .addAction(NotificationMessageReceiver.createReadAction(context, notificationId, channel, message))

--- a/stream-chat-android-client/src/main/res/values/colors.xml
+++ b/stream-chat-android-client/src/main/res/values/colors.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<resources>
+    <color name="stream_ic_notification">#00000000</color>
+</resources>


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/107

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
