### PR TITLE
[i108] make itemAnimator as nullable param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Changed `MessageListView.setCustomItemAnimator` signature to allow passing `null` to reset the item animator. [#4934](https://github.com/GetStream/stream-chat-android/pull/4934)
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/list/MessageListView.kt
@@ -838,7 +838,7 @@ public class MessageListView : ConstraintLayout {
      * @param itemAnimator The ItemAnimator being set. If null, no animations will occur when changes occur
      * to the items in this MessageListView.
      */
-    public fun setCustomItemAnimator(itemAnimator: ItemAnimator) {
+    public fun setCustomItemAnimator(itemAnimator: ItemAnimator?) {
         binding.chatMessagesRV.itemAnimator = itemAnimator
     }
 


### PR DESCRIPTION
### 🎯 Goal

Relates to https://github.com/GetStream/android-internal-board/issues/108

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `v5` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
