### PR TITLE
[i118] Fix NPE in StreamWebSocket (onFailure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed NPE in `StreamWebSocket.onFailure`. [#4942](https://github.com/GetStream/stream-chat-android/pull/4942)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocketTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocketTest.kt
@@ -55,6 +55,14 @@ internal class StreamWebSocketTest {
     }
 
     @Test
+    fun `Class can be created correctly with listener invoked during creation`() {
+        StreamWebSocket(parser, socketCreator = {
+            it.onFailure(webSocket, IllegalStateException(), null)
+            webSocket
+        })
+    }
+
+    @Test
     fun `When a chatEvent is sent, websocket should send a parsed event`() {
         val chatEvent = mock<ChatEvent>()
         val textEvent = randomString()


### PR DESCRIPTION
Closes: https://github.com/GetStream/android-internal-board/issues/118

Corresponding PR for **v5**: https://github.com/GetStream/stream-chat-android/pull/4943

The `eventFlow` field is initialsed after the `webSocketListener`. We have seen crashes where `eventFlow` is null when accessed from onFailure() callback too early. This can probably happen because`socketCreator()` is supplied through the constructor and if there is an immediate (synchronous) failure during the socket creation then it will deliver `onFailure()` within the initialisation of the parent class (`StreamWebSocket`) before `eventFlow` was even initialised (despite that it's a `val`).