### PR TITLE
[i118] Fix NPE in StreamWebSocket (onFailure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed NPE in `StreamWebSocket.onFailure`. [#4943](https://github.com/GetStream/stream-chat-android/pull/4943)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocket.kt
@@ -38,7 +38,9 @@ internal class StreamWebSocket(
     private val parser: ChatParser,
     socketCreator: (WebSocketListener) -> WebSocket,
 ) {
-    private val webSocketListener = object : WebSocketListener() {
+    private val eventFlow = MutableSharedFlow<StreamWebSocketEvent>(extraBufferCapacity = EVENTS_BUFFER_SIZE)
+
+    private val webSocket = socketCreator(object : WebSocketListener() {
         override fun onMessage(webSocket: WebSocket, text: String) {
             eventFlow.tryEmit(parseMessage(text))
         }
@@ -57,9 +59,7 @@ internal class StreamWebSocket(
                 eventFlow.tryEmit(StreamWebSocketEvent.Error(ChatNetworkError.create(ChatErrorCode.SOCKET_CLOSED)))
             }
         }
-    }
-    private val webSocket = socketCreator(webSocketListener)
-    private val eventFlow = MutableSharedFlow<StreamWebSocketEvent>(extraBufferCapacity = EVENTS_BUFFER_SIZE)
+    })
 
     fun send(chatEvent: ChatEvent): Boolean = webSocket.send(parser.toJson(chatEvent))
     fun close(): Boolean = webSocket.close(CLOSE_SOCKET_CODE, CLOSE_SOCKET_REASON)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocketTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/experimental/ws/StreamWebSocketTest.kt
@@ -53,6 +53,14 @@ internal class StreamWebSocketTest {
     }
 
     @Test
+    fun `Class can be created correctly with listener invoked during creation`() {
+        StreamWebSocket(parser, socketCreator = {
+            it.onFailure(webSocket, IllegalStateException(), null)
+            webSocket
+        })
+    }
+
+    @Test
     fun `When a chatEvent is sent, websocket should send a parsed event`() {
         val chatEvent = mock<ChatEvent>()
         val textEvent = randomString()


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/118

Corresponding PR for **v6**: https://github.com/GetStream/stream-chat-android/pull/4942

### 🛠 Implementation details

The `eventFlow` field is initialsed after the `webSocketListener`. We have seen crashes where `eventFlow` is null when accessed from onFailure() callback too early. This can probably happen because`socketCreator()` is supplied through the constructor and if there is an immediate (synchronous) failure during the socket creation then it will deliver `onFailure()` within the initialisation of the parent class (`StreamWebSocket`) before `eventFlow` was even initialised (despite that it's a `val`).

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `v5` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
