### PR TITLE
[i116] Extend PushMessage to access extra data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fixed NPE in `StreamWebSocket.onFailure`. [#4942](https://github.com/GetStream/stream-chat-android/pull/4942)
 
 ### ⬆️ Improved
+- Extended `PushMessage` to access extra data [#4945](https://github.com/GetStream/stream-chat-android/pull/4945)
 
 ### ✅ Added
 

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -72,7 +72,7 @@ object Versions {
     internal const val SPOTLESS = "6.20.0"
     internal const val STFALCON_IMAGE_VIEWER = "1.0.1"
     internal const val STREAM_LOG = "1.1.4"
-    internal const val STREAM_PUSH = "1.1.3"
+    internal const val STREAM_PUSH = "1.1.4"
     internal const val STREAM_RESULT = "1.1.0"
     internal const val TEST_PARAMETER_INJECTOR = "1.12"
     internal const val THREETENBP = "1.6.8"

--- a/stream-chat-android-client/detekt-baseline.xml
+++ b/stream-chat-android-client/detekt-baseline.xml
@@ -27,6 +27,7 @@
     <ID>MaxLineLength:StringExtensionsKtTest.kt$StringExtensionsKtTest.Companion$"https://us-east.stream-io-cdn.com/1/images/IMAGE_NAME.jpg?Key-Pair-Id=SODHGWNRLG&amp;Policy=akIjUneI9Kmbds2&amp;Signature=dsnIjJ8-gfdgihih8-GkhdfgfdGFG32--KHJDFj349sfsdf~SFDf2~Fsdfgrg3~kjnooi23Jig-Kjoih34iW~k7Jbe2~Jnk33j-Fsiniiz2~Sfj23iJihn-Jinfnsiw2kS&amp;oh=$originalHeight&amp;ow=$originalWidth"</ID>
     <ID>MaxLineLength:WaveformExtractor.kt$WaveformExtractor$logger.v { "[handle16bit] this.totalSamples: $totalSamples, sampleRate: $sampleRate, duration: $durationInSeconds" }</ID>
     <ID>SwallowedException:WaveformExtractor.kt$WaveformExtractor$e: Exception</ID>
+    <ID>TooGenericExceptionCaught:StreamPayloadParser.kt$StreamPayloadParser$e: Throwable</ID>
     <ID>TooGenericExceptionCaught:WaveformExtractor.kt$WaveformExtractor$e: Exception</ID>
     <ID>UnusedPrivateMember:StreamAudioPlayer.kt$StreamMediaPlayer$private fun normalize(uri: String): String</ID>
   </CurrentIssues>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/parser/StreamPayloadParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/parser/StreamPayloadParser.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.notifications.parser
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.Types
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.log.StreamLog
+
+/**
+ * Helper class for parsing the payload of a push message.
+ */
+@InternalStreamChatApi
+public object StreamPayloadParser {
+
+    private const val TAG = "StreamPayloadParser"
+
+    private val mapAdapter: JsonAdapter<MutableMap<String, Any?>> by lazy {
+        Moshi.Builder()
+            .build()
+            .adapter(Types.newParameterizedType(Map::class.java, String::class.java, Any::class.java))
+    }
+
+    /**
+     * Parses the [json] string into a [Map] of [String] to [Any].
+     */
+    public fun parse(json: String?): Map<String, Any?> {
+        return try {
+            json?.takeIf { it.isNotBlank() }?.let { mapAdapter.fromJson(it) } ?: emptyMap()
+        } catch (e: Throwable) {
+            StreamLog.e(TAG, e) { "[parse] failed: $json" }
+            emptyMap()
+        }
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/notifications/parser/StreamPayloadParserTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/notifications/parser/StreamPayloadParserTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.notifications.parser
+
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+public class StreamPayloadParserTest {
+
+    @Test
+    public fun parseNullContent() {
+        val parsedMap = StreamPayloadParser.parse(null)
+        parsedMap shouldBeEqualTo emptyMap()
+    }
+
+    @Test
+    public fun parseEmptyContent() {
+        val jsonString = ""
+
+        val parsedMap = StreamPayloadParser.parse(jsonString)
+        parsedMap shouldBeEqualTo emptyMap()
+    }
+
+    @Test
+    public fun parseExpectedContent() {
+        val jsonString = """{
+                "file_type": "file",
+                "message": "Retro",
+                "sender_name": "Dmitrii Bychkov",
+                "unread_message_count": "8",
+                "nested_object": {
+                    "key1": "value1",
+                    "key2": "value2",
+                    "key3": null,
+                    "key4": "null"
+                },
+                "nested_array": [
+                    "item1",
+                    "item2",
+                    "item3"
+                ]
+            }"""
+
+        val parsedMap = StreamPayloadParser.parse(jsonString)
+        parsedMap shouldBeEqualTo mapOf(
+            "file_type" to "file",
+            "message" to "Retro",
+            "sender_name" to "Dmitrii Bychkov",
+            "unread_message_count" to "8",
+            "nested_object" to mapOf(
+                "key1" to "value1",
+                "key2" to "value2",
+                "key3" to null,
+                "key4" to "null",
+            ),
+            "nested_array" to listOf(
+                "item1",
+                "item2",
+                "item3",
+            ),
+        )
+    }
+}

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -1297,16 +1297,22 @@ public final class io/getstream/chat/android/models/OrFilterObject : io/getstrea
 }
 
 public final class io/getstream/chat/android/models/PushMessage {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/models/PushMessage;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/PushMessage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/models/PushMessage;
+	public final fun component4 ()Ljava/util/Map;
+	public final fun component5 ()Ljava/util/Map;
+	public final fun component6 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;)Lio/getstream/chat/android/models/PushMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/PushMessage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Map;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/PushMessage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ljava/lang/String;
 	public final fun getChannelType ()Ljava/lang/String;
+	public final fun getExtraData ()Ljava/util/Map;
+	public final fun getGetstream ()Ljava/util/Map;
 	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getMetadata ()Ljava/util/Map;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/PushMessage.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/PushMessage.kt
@@ -20,4 +20,7 @@ public data class PushMessage(
     val messageId: String,
     val channelId: String,
     val channelType: String,
+    val getstream: Map<String, Any?>,
+    val extraData: Map<String, Any?>,
+    val metadata: Map<String, Any?>,
 )


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/116

Related PR: https://github.com/GetStream/stream-android-push/pull/9

Corresponding PR in **v5**: https://github.com/GetStream/stream-chat-android/pull/4940

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
