### PR TITLE
Fix build issues with JDK 17 in offline and client module

### DIFF
--- a/stream-chat-android-client/build.gradle
+++ b/stream-chat-android-client/build.gradle
@@ -52,6 +52,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
                 '-opt-in=kotlin.RequiresOptIn',
                 '-opt-in=io.getstream.chat.android.core.internal.InternalStreamChatApi',
         ]
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -52,6 +52,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
                 '-opt-in=kotlin.RequiresOptIn',
                 '-opt-in=io.getstream.chat.android.core.internal.InternalStreamChatApi',
         ]
+        jvmTarget = JavaVersion.VERSION_11.toString()
     }
 }
 


### PR DESCRIPTION
The sample project `stream-chat-android-ui-components-sample` will not compile on a default Android Studio installation with Java 17 because it uses `stream-chat-android-offline` and similarly with `stream-chat-android-client` and these one doesn't set the Kotlin jvmTarget to Java 11 to match with other modules that use Java 11. This will cause a build error:

> 'compileDebugJavaWithJavac' task (current target is 11) and 'kspDebugKotlin' task (current target is 17) jvm target compatibility should be set to the same Java version.