### PR TITLE
Remove unncessary Room DAO transations

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelDao.kt
@@ -33,7 +33,6 @@ internal interface ChannelDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertMany(channelEntities: List<ChannelEntity>)
 
-    @Transaction
     @Query("SELECT cid FROM $CHANNEL_ENTITY_TABLE_NAME")
     suspend fun selectAllCids(): List<String>
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channelconfig/internal/ChannelConfigDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channelconfig/internal/ChannelConfigDao.kt
@@ -47,7 +47,6 @@ internal interface ChannelConfigDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertCommands(commands: List<CommandInnerEntity>)
 
-    @Transaction
     @Query("SELECT * FROM stream_chat_channel_config LIMIT 100")
     suspend fun selectAll(): List<ChannelConfigEntity>
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -39,7 +39,6 @@ internal interface MessageDao {
         insertReactions(messageEntities.flatMap { it.latestReactions + it.ownReactions })
     }
 
-    @Transaction
     fun deleteAttachments(messageIds: List<String>) {
         messageIds.chunked(SQLITE_MAX_VARIABLE_NUMBER).forEach(::deleteAttachmentsChunked)
     }
@@ -47,7 +46,6 @@ internal interface MessageDao {
     @Query("DELETE FROM attachment_inner_entity WHERE messageId in (:messageIds)")
     fun deleteAttachmentsChunked(messageIds: List<String>)
 
-    @Transaction
     suspend fun insert(messageEntity: MessageEntity) = insert(listOf(messageEntity))
 
     @Insert(onConflict = OnConflictStrategy.IGNORE)
@@ -91,7 +89,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END ASC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForChannelNewerThan(
         cid: String,
         limit: Int = 100,
@@ -107,7 +104,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END ASC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForChannelEqualOrNewerThan(
         cid: String,
         limit: Int = 100,
@@ -123,7 +119,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END DESC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForChannelOlderThan(
         cid: String,
         limit: Int = 100,
@@ -139,7 +134,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END DESC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForChannelEqualOrOlderThan(
         cid: String,
         limit: Int = 100,
@@ -154,7 +148,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END DESC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForChannel(cid: String, limit: Int = 100): List<MessageEntity>
 
     @Query(
@@ -165,7 +158,6 @@ internal interface MessageDao {
             "ELSE createdAt " +
             "END DESC LIMIT :limit",
     )
-    @Transaction
     suspend fun messagesForThread(messageId: String, limit: Int = 100): List<MessageEntity>
 
     @Query(
@@ -182,20 +174,16 @@ internal interface MessageDao {
     )
     suspend fun deleteMessage(cid: String, messageId: String)
 
-    @Transaction
     suspend fun select(ids: List<String>): List<MessageEntity> {
         return ids.chunked(SQLITE_MAX_VARIABLE_NUMBER).flatMap { messageIds -> selectChunked(messageIds) }
     }
 
     @Query("SELECT * FROM $MESSAGE_ENTITY_TABLE_NAME WHERE id IN (:ids)")
-    @Transaction
     suspend fun selectChunked(ids: List<String>): List<MessageEntity>
 
     @Query("SELECT * FROM $MESSAGE_ENTITY_TABLE_NAME WHERE id IN (:id)")
-    @Transaction
     suspend fun select(id: String): MessageEntity?
 
-    @Transaction
     suspend fun selectWaitForAttachments(): List<MessageEntity> {
         return selectBySyncStatus(SyncStatus.AWAITING_ATTACHMENTS)
     }
@@ -206,7 +194,6 @@ internal interface MessageDao {
             "ORDER BY CASE WHEN createdAt IS NULL THEN createdLocallyAt ELSE createdAt END ASC " +
             "LIMIT :limit",
     )
-    @Transaction
     suspend fun selectBySyncStatus(syncStatus: SyncStatus, limit: Int = NO_LIMIT): List<MessageEntity>
 
     @Query(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/ReplyMessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/ReplyMessageDao.kt
@@ -28,7 +28,6 @@ import io.getstream.chat.android.offline.repository.domain.message.attachment.in
 internal interface ReplyMessageDao {
 
     @Query("SELECT * FROM $REPLY_MESSAGE_ENTITY_TABLE_NAME WHERE id = :id")
-    @Transaction
     suspend fun selectById(id: String): ReplyMessageEntity?
 
     @Transaction

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/queryChannels/internal/QueryChannelsDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/queryChannels/internal/QueryChannelsDao.kt
@@ -27,7 +27,6 @@ internal interface QueryChannelsDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(queryChannelsEntity: QueryChannelsEntity)
 
-    @Transaction
     @Query("SELECT * FROM $QUERY_CHANNELS_ENTITY_TABLE_NAME WHERE $QUERY_CHANNELS_ENTITY_TABLE_NAME.id=:id")
     suspend fun select(id: String): QueryChannelsEntity?
 


### PR DESCRIPTION
We are doing too many Room transactions - for insert/update/delete we don't need to declare a `@Transaction` - that's ignored because these are always running in a transaction. Using a `@Transaction` at Room DAO level only makes sense for composite functions that do multiple calls (e.g. multiple inserts).

Official docs: https://developer.android.com/reference/androidx/room/Transaction 

Maybe this will also lower the amount of crashes we get like this one:
https://github.com/GetStream/stream-chat-android/issues/4907 
Which I think is a platform bug described for example here:
https://issuetracker.google.com/issues/37001653 
But maybe our amount of transactions is triggering the platform bug more often?...