### PR TITLE
Throttling MarkRead Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Create Throttling mechanism for `MarkRead` Events [#4974](https://github.com/GetStream/stream-chat-android/pull/4974)
 
 ### ✅ Added
 - Added `Message.deletedReplyCount` property. [#4960](https://github.com/GetStream/stream-chat-android/pull/4960)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -139,6 +139,7 @@ import io.getstream.chat.android.client.persistance.repository.noop.NoOpReposito
 import io.getstream.chat.android.client.plugin.DependencyResolver
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
+import io.getstream.chat.android.client.plugin.factory.ThrottlingPluginFactory
 import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
 import io.getstream.chat.android.client.plugin.listeners.CreateChannelListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteMessageListener
@@ -3219,7 +3220,7 @@ internal constructor(
          * @see [Plugin]
          * @see [PluginFactory]
          */
-        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf()
+        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf(ThrottlingPluginFactory)
 
         /**
          * Create a [ChatClient] instance based on the current configuration

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin
+
+import io.getstream.chat.android.client.errors.ChatError
+import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
+import io.getstream.chat.android.client.utils.Result
+
+internal class ThrottlingPlugin : Plugin, ChannelMarkReadListener {
+    override val name: String = "ThrottlingPlugin"
+
+    private val lastMarkReadMap: MutableMap<String, Long> = mutableMapOf()
+
+    override suspend fun onChannelMarkReadPrecondition(channelType: String, channelId: String): Result<Unit> {
+        val now = System.currentTimeMillis()
+        val deltaLastMarkReadAt = now - (lastMarkReadMap[channelId] ?: 0)
+        return when {
+            deltaLastMarkReadAt > MARK_READ_THROTTLE_MS -> Result(Unit).also { lastMarkReadMap[channelId] = now }
+            else -> Result(ChatError("Mark read throttled"))
+        }
+    }
+
+    companion object {
+        const val MARK_READ_THROTTLE_MS = 3000L
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/factory/ThrottlingPluginFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/factory/ThrottlingPluginFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.factory
+
+import io.getstream.chat.android.client.models.User
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.client.plugin.ThrottlingPlugin
+
+internal object ThrottlingPluginFactory : PluginFactory {
+    override fun get(user: User): Plugin = ThrottlingPlugin()
+}


### PR DESCRIPTION
### 🎯 Goal 
Create a plugin to throttle the number of MarkRead events the SDK sends to backend

### 🎉 GIF

![](https://media.giphy.com/media/l0NgQIwNvU9AUuaY0/giphy.gif)