### PR TITLE
Throttling MarkRead Events (V6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Create Throttling mechanism for `MarkRead` Events [#4975](https://github.com/GetStream/stream-chat-android/pull/4975)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -103,6 +103,7 @@ import io.getstream.chat.android.client.persistance.repository.noop.NoOpReposito
 import io.getstream.chat.android.client.plugin.DependencyResolver
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
+import io.getstream.chat.android.client.plugin.factory.ThrottlingPluginFactory
 import io.getstream.chat.android.client.scope.ClientScope
 import io.getstream.chat.android.client.scope.UserScope
 import io.getstream.chat.android.client.setup.state.ClientState
@@ -3243,7 +3244,7 @@ internal constructor(
          * @see [Plugin]
          * @see [PluginFactory]
          */
-        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf()
+        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf(ThrottlingPluginFactory)
 
         /**
          * Create a [ChatClient] instance based on the current configuration

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin
+
+import io.getstream.chat.android.models.User
+import io.getstream.result.Error
+import io.getstream.result.Result
+import kotlin.reflect.KClass
+
+internal class ThrottlingPlugin : Plugin {
+    override val errorHandler = null
+    private val lastMarkReadMap: MutableMap<String, Long> = mutableMapOf()
+
+    override suspend fun onChannelMarkReadPrecondition(channelType: String, channelId: String): Result<Unit> {
+        val now = System.currentTimeMillis()
+        val deltaLastMarkReadAt = now - (lastMarkReadMap[channelId] ?: 0)
+        return when {
+            deltaLastMarkReadAt > MARK_READ_THROTTLE_MS -> Result.Success(Unit)
+                .also { lastMarkReadMap[channelId] = now }
+            else -> Result.Failure(Error.GenericError("Mark read throttled"))
+        }
+    }
+
+    override fun <T : Any> resolveDependency(klass: KClass<T>): T? = null
+    override fun onUserSet(user: User) { /* No-op */ }
+    override fun onUserDisconnected() {
+        lastMarkReadMap.clear()
+    }
+
+    companion object {
+        const val MARK_READ_THROTTLE_MS = 3000L
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/factory/ThrottlingPluginFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/factory/ThrottlingPluginFactory.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.factory
+
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.client.plugin.ThrottlingPlugin
+import io.getstream.chat.android.models.User
+import kotlin.reflect.KClass
+
+internal object ThrottlingPluginFactory : PluginFactory {
+    override fun <T : Any> resolveDependency(klass: KClass<T>): T? = null
+    override fun get(user: User): Plugin = ThrottlingPlugin()
+}


### PR DESCRIPTION
### 🎯 Goal 
Create a plugin to throttle the number of MarkRead events the SDK sends to backend

### 🎉 GIF

![](https://media.giphy.com/media/l0NgQIwNvU9AUuaY0/giphy.gif)