### PR TITLE
add caching to date parser

### DIFF
--- a/stream-chat-android-client/detekt-baseline.xml
+++ b/stream-chat-android-client/detekt-baseline.xml
@@ -8,6 +8,10 @@
     <ID>ForbiddenComment:MessageUtils.kt$// TODO: type should be a sealed/class or enum at the client level</ID>
     <ID>LongParameterList:BaseChatModule.kt$BaseChatModule$( private val appContext: Context, private val clientScope: ClientScope, private val userScope: UserScope, private val config: ChatClientConfig, private val notificationsHandler: NotificationHandler, private val notificationConfig: NotificationConfig, private val fileUploader: FileUploader? = null, private val tokenManager: TokenManager = TokenManagerImpl(), private val customOkHttpClient: OkHttpClient? = null, private val lifecycle: Lifecycle, private val httpClientConfig: (OkHttpClient.Builder) -> OkHttpClient.Builder = { it }, )</ID>
     <ID>MagicNumber:Attachment.kt$Attachment$9</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$100</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$10000</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$100f</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$300</ID>
     <ID>MaxLineLength:Message.kt$*</ID>
     <ID>MaxLineLength:Reaction.kt$*</ID>
     <ID>MaxLineLength:UserStateServiceTests.kt$UserStateServiceTests.Fixture$suspend fun givenUserSetState(user: User = Mother.randomUser())</ID>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/DateAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/DateAdapter.kt
@@ -28,7 +28,7 @@ import java.util.Date
 @InternalStreamChatApi
 public class DateAdapter : JsonAdapter<Date>() {
 
-    private val streamDateFormatter = StreamDateFormatter()
+    private val streamDateFormatter = StreamDateFormatter("DateAdapter", cacheEnabled = true)
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: Date?) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/ExactDateAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/ExactDateAdapter.kt
@@ -28,7 +28,7 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 @InternalStreamChatApi
 internal class ExactDateAdapter : JsonAdapter<ExactDate>() {
 
-    private val streamDateFormatter = StreamDateFormatter()
+    private val streamDateFormatter = StreamDateFormatter("ExactDateAdapter")
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: ExactDate?) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
@@ -16,20 +16,28 @@
 
 package io.getstream.chat.android.client.parser2.adapters.internal
 
+import androidx.collection.LruCache
 import io.getstream.chat.android.client.utils.threadLocal
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.logging.StreamLog
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * This class handles parse and format date in the standard way of Stream.
  */
 @InternalStreamChatApi
-public class StreamDateFormatter {
+public class StreamDateFormatter(
+    private val src: String? = null,
+    private val cacheEnabled: Boolean = false
+) {
 
     private companion object {
+        const val TAG = "StreamDateFormatter"
+        const val STATS = true
         const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         const val DATE_FORMAT_WITHOUT_NANOSECONDS = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     }
@@ -48,10 +56,35 @@ public class StreamDateFormatter {
 
     internal val datePattern = DATE_FORMAT
 
+    private val cache by lazy { LruCache<String, Date>(300) }
+    private val cacheHit = AtomicInteger()
+    private val allRequests = AtomicInteger()
+
     /**
      * Parses the [String] to [Date] in the standard way to Stream's API
      */
     internal fun parse(rawValue: String): Date? {
+        logCacheHitStats()
+        return parseInternal(rawValue)
+    }
+
+    private fun logCacheHitStats() {
+        val allRequests = allRequests.get()
+        val cacheHit = cacheHit.get()
+        if (STATS && cacheEnabled && allRequests % 100 == 0) {
+            val hitRate = cacheHit.toDouble() / allRequests
+            val hitRatePercent = (hitRate * 10000).toInt() / 100f
+            StreamLog.v(TAG) { "[parse] cache hit rate($src): $hitRatePercent% ($cacheHit / $allRequests)" }
+        }
+    }
+
+    private fun parseInternal(rawValue: String): Date? {
+        allRequests.incrementAndGet()
+        val cachedValue = fetchFromCache(rawValue)
+        if (cachedValue != null) {
+            cacheHit.incrementAndGet()
+            return cachedValue
+        }
         return if (rawValue.isEmpty()) {
             null
         } else {
@@ -64,7 +97,20 @@ public class StreamDateFormatter {
                     null
                 }
             }
+        }.also {
+            saveToCache(rawValue, it)
         }
+    }
+
+    private fun fetchFromCache(rawValue: String): Date? {
+        if (!cacheEnabled) return null
+        return cache[rawValue]
+    }
+
+    private fun saveToCache(rawValue: String, date: Date?) {
+        if (!cacheEnabled) return
+        if (date == null) return
+        cache.put(rawValue, date)
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Add caching to Date parsing.

And also use Java Instant and DateTimeFormatter for >= API 26. These implemenations are considerably faster, in our use-case it's 4x faster on a Pixel 4a:

Average OLD format time 3ms ,total time spent 7948ms
Average NEW format time 0ms,total time spent 1908ms

Average OLD parse time 4ms ,total time spent 7995ms
Average NEW new parse time 1ms ,total time spent 2643ms

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
