### PR TITLE
add caching to date parser

### DIFF
--- a/stream-chat-android-client/detekt-baseline.xml
+++ b/stream-chat-android-client/detekt-baseline.xml
@@ -9,6 +9,10 @@
     <ID>LongMethod:ChatSocket.kt$ChatSocket$@Suppress("ComplexMethod") private fun observeSocketStateService(): Job</ID>
     <ID>LongMethod:PinnedMessagesRequest.kt$PinnedMessagesRequest.Companion$fun create( limit: Int, sort: QuerySorter&lt;Message>, pagination: PinnedMessagesPagination, ): PinnedMessagesRequest</ID>
     <ID>LongParameterList:BaseChatModule.kt$BaseChatModule$( private val appContext: Context, private val clientScope: ClientScope, private val userScope: UserScope, private val config: ChatClientConfig, private val notificationsHandler: NotificationHandler, private val notificationConfig: NotificationConfig, private val fileUploader: FileUploader? = null, private val tokenManager: TokenManager = TokenManagerImpl(), private val customOkHttpClient: OkHttpClient? = null, private val clientDebugger: ChatClientDebugger? = null, private val lifecycle: Lifecycle, private val httpClientConfig: (OkHttpClient.Builder) -> OkHttpClient.Builder = { it }, )</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$100</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$10000</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$100f</ID>
+    <ID>MagicNumber:StreamDateFormatter.kt$StreamDateFormatter$300</ID>
     <ID>MagicNumber:WaveformExtractor.kt$WaveformExtractor$127f</ID>
     <ID>MagicNumber:WaveformExtractor.kt$WaveformExtractor$16</ID>
     <ID>MagicNumber:WaveformExtractor.kt$WaveformExtractor$1_000_000f</ID>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/DateAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/DateAdapter.kt
@@ -28,7 +28,7 @@ import java.util.Date
 @InternalStreamChatApi
 public class DateAdapter : JsonAdapter<Date>() {
 
-    private val streamDateFormatter = StreamDateFormatter()
+    private val streamDateFormatter = StreamDateFormatter("DateAdapter", cacheEnabled = true)
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: Date?) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/ExactDateAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/ExactDateAdapter.kt
@@ -28,7 +28,7 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 @InternalStreamChatApi
 internal class ExactDateAdapter : JsonAdapter<ExactDate>() {
 
-    private val streamDateFormatter = StreamDateFormatter()
+    private val streamDateFormatter = StreamDateFormatter("ExactDateAdapter")
 
     @ToJson
     override fun toJson(writer: JsonWriter, value: ExactDate?) {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
@@ -16,11 +16,17 @@
 
 package io.getstream.chat.android.client.parser2.adapters.internal
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.collection.LruCache
 import io.getstream.chat.android.client.utils.threadLocal
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
-import io.getstream.logging.StreamLog
+import io.getstream.log.taggedLogger
 import java.text.SimpleDateFormat
+import java.time.Instant
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
@@ -32,11 +38,12 @@ import java.util.concurrent.atomic.AtomicInteger
 @InternalStreamChatApi
 public class StreamDateFormatter(
     private val src: String? = null,
-    private val cacheEnabled: Boolean = false
+    private val cacheEnabled: Boolean = false,
 ) {
 
+    private val logger by taggedLogger("StreamDateFormatter")
+
     private companion object {
-        const val TAG = "StreamDateFormatter"
         const val STATS = true
         const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         const val DATE_FORMAT_WITHOUT_NANOSECONDS = "yyyy-MM-dd'T'HH:mm:ss'Z'"
@@ -46,6 +53,14 @@ public class StreamDateFormatter(
         SimpleDateFormat(DATE_FORMAT, Locale.US).apply {
             timeZone = TimeZone.getTimeZone("UTC")
         }
+    }
+
+    // DateTimeFormatter is thread-safe.
+    @delegate:RequiresApi(Build.VERSION_CODES.O)
+    private val dateFormat26: DateTimeFormatter by lazy {
+        DateTimeFormatter.ofPattern(DATE_FORMAT)
+            .withLocale(Locale.US)
+            .withZone(ZoneId.of(ZoneOffset.UTC.id))
     }
 
     private val dateFormatWithoutNanoseconds: SimpleDateFormat by threadLocal {
@@ -74,7 +89,7 @@ public class StreamDateFormatter(
         if (STATS && cacheEnabled && allRequests % 100 == 0) {
             val hitRate = cacheHit.toDouble() / allRequests
             val hitRatePercent = (hitRate * 10000).toInt() / 100f
-            StreamLog.v(TAG) { "[parse] cache hit rate($src): $hitRatePercent% ($cacheHit / $allRequests)" }
+            logger.v { "[parse] cache hit rate($src): $hitRatePercent% ($cacheHit / $allRequests)" }
         }
     }
 
@@ -89,7 +104,13 @@ public class StreamDateFormatter(
             null
         } else {
             try {
-                dateFormat.parse(rawValue)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    // Java Instant is up to 4x faster for parsing
+                    // and can parse the date both with and without nano-seconds
+                    Date.from(Instant.parse(rawValue))
+                } else {
+                    dateFormat.parse(rawValue)
+                }
             } catch (_: Throwable) {
                 try {
                     dateFormatWithoutNanoseconds.parse(rawValue)
@@ -116,5 +137,11 @@ public class StreamDateFormatter(
     /**
      * Formats the [Date] in the standard way to Stream's API
      */
-    public fun format(date: Date): String = dateFormat.format(date)
+    public fun format(date: Date): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            dateFormat26.format(date.toInstant())
+        } else {
+            dateFormat.format(date)
+        }
+    }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/internal/StreamDateFormatter.kt
@@ -16,20 +16,28 @@
 
 package io.getstream.chat.android.client.parser2.adapters.internal
 
+import androidx.collection.LruCache
 import io.getstream.chat.android.client.utils.threadLocal
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.logging.StreamLog
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * This class handles parse and format date in the standard way of Stream.
  */
 @InternalStreamChatApi
-public class StreamDateFormatter {
+public class StreamDateFormatter(
+    private val src: String? = null,
+    private val cacheEnabled: Boolean = false
+) {
 
     private companion object {
+        const val TAG = "StreamDateFormatter"
+        const val STATS = true
         const val DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
         const val DATE_FORMAT_WITHOUT_NANOSECONDS = "yyyy-MM-dd'T'HH:mm:ss'Z'"
     }
@@ -48,10 +56,35 @@ public class StreamDateFormatter {
 
     internal val datePattern = DATE_FORMAT
 
+    private val cache by lazy { LruCache<String, Date>(300) }
+    private val cacheHit = AtomicInteger()
+    private val allRequests = AtomicInteger()
+
     /**
      * Parses the [String] to [Date] in the standard way to Stream's API
      */
     internal fun parse(rawValue: String): Date? {
+        logCacheHitStats()
+        return parseInternal(rawValue)
+    }
+
+    private fun logCacheHitStats() {
+        val allRequests = allRequests.get()
+        val cacheHit = cacheHit.get()
+        if (STATS && cacheEnabled && allRequests % 100 == 0) {
+            val hitRate = cacheHit.toDouble() / allRequests
+            val hitRatePercent = (hitRate * 10000).toInt() / 100f
+            StreamLog.v(TAG) { "[parse] cache hit rate($src): $hitRatePercent% ($cacheHit / $allRequests)" }
+        }
+    }
+
+    private fun parseInternal(rawValue: String): Date? {
+        allRequests.incrementAndGet()
+        val cachedValue = fetchFromCache(rawValue)
+        if (cachedValue != null) {
+            cacheHit.incrementAndGet()
+            return cachedValue
+        }
         return if (rawValue.isEmpty()) {
             null
         } else {
@@ -64,7 +97,20 @@ public class StreamDateFormatter {
                     null
                 }
             }
+        }.also {
+            saveToCache(rawValue, it)
         }
+    }
+
+    private fun fetchFromCache(rawValue: String): Date? {
+        if (!cacheEnabled) return null
+        return cache[rawValue]
+    }
+
+    private fun saveToCache(rawValue: String, date: Date?) {
+        if (!cacheEnabled) return
+        if (date == null) return
+        cache.put(rawValue, date)
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Add caching to Date parsing.

And also use Java Instant and DateTimeFormatter for >= API 26. These implemenations are considerably faster, in our use-case it's 4x faster on a Pixel 4a:

Average OLD format time 3ms ,total time spent 7948ms
Average NEW format time 0ms,total time spent 1908ms

Average OLD parse time 4ms ,total time spent 7995ms
Average NEW new parse time 1ms ,total time spent 2643ms

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
