### PR TITLE
disable ThrottlingPlugin

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -103,7 +103,6 @@ import io.getstream.chat.android.client.persistance.repository.noop.NoOpReposito
 import io.getstream.chat.android.client.plugin.DependencyResolver
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
-import io.getstream.chat.android.client.plugin.factory.ThrottlingPluginFactory
 import io.getstream.chat.android.client.scope.ClientScope
 import io.getstream.chat.android.client.scope.UserScope
 import io.getstream.chat.android.client.setup.state.ClientState
@@ -3244,7 +3243,7 @@ internal constructor(
          * @see [Plugin]
          * @see [PluginFactory]
          */
-        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf(ThrottlingPluginFactory)
+        protected val pluginFactories: MutableList<PluginFactory> = mutableListOf()
 
         /**
          * Create a [ChatClient] instance based on the current configuration

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/ThrottlingPlugin.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.plugin
 
 import io.getstream.chat.android.models.User
+import io.getstream.log.StreamLog
 import io.getstream.result.Error
 import io.getstream.result.Result
 import kotlin.reflect.KClass
@@ -31,7 +32,9 @@ internal class ThrottlingPlugin : Plugin {
         return when {
             deltaLastMarkReadAt > MARK_READ_THROTTLE_MS -> Result.Success(Unit)
                 .also { lastMarkReadMap[channelId] = now }
-            else -> Result.Failure(Error.GenericError("Mark read throttled"))
+            else -> Result.Failure(Error.GenericError("Mark read throttled")).also {
+                StreamLog.w("ThrottlingPlugin") { "[onChannelMarkReadPrecondition] read is ignored ($channelId)" }
+            }
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Disable `ThrottlingPlugin` for now, since it causes issues with read attempts when you reopen channel with unread messages within 3 seconds window.


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
