### PR TITLE
Declare a Data Sync foreground service type for `LoadNotificationDataWorker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fix background service used to sync data when a Push Notification is received on Android 14. [#4997](https://github.com/GetStream/stream-chat-android/pull/4997)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/AndroidManifest.xml
+++ b/stream-chat-android-client/src/main/AndroidManifest.xml
@@ -22,6 +22,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <application>
 
@@ -47,6 +48,12 @@
                 <action android:name="io.getstream.chat.android.REPLY" />
             </intent-filter>
         </receiver>
+
+        <service
+            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:foregroundServiceType="dataSync"
+            tools:node="merge"
+            />
     </application>
 
 </manifest>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
@@ -20,6 +20,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
@@ -85,13 +86,22 @@ internal class LoadNotificationDataWorker(
     }
 
     private fun createForegroundInfo(): ForegroundInfo {
-        return ForegroundInfo(
-            NOTIFICATION_ID,
-            createForegroundNotification(
-                notificationChannelId = context.getString(R.string.stream_chat_other_notifications_channel_id),
-                notificationChannelName = context.getString(R.string.stream_chat_other_notifications_channel_name),
-            ),
+        val foregroundNotification = createForegroundNotification(
+            notificationChannelId = context.getString(R.string.stream_chat_other_notifications_channel_id),
+            notificationChannelName = context.getString(R.string.stream_chat_other_notifications_channel_name),
         )
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                foregroundNotification,
+                FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+            )
+        } else {
+            ForegroundInfo(
+                NOTIFICATION_ID,
+                foregroundNotification,
+            )
+        }
     }
 
     private fun createForegroundNotification(


### PR DESCRIPTION
### 🎯 Goal
Starting on Android 14, whenever a Background Service is started, it needs to declare which type it is.
In our case, we use it to sync data in our database and the type to be used needs to be `FOREGROUND_SERVICE_TYPE_DATA_SYNC`

Fix: #4995


### 🎉 GIF

![](https://media.giphy.com/media/l0K4gA8yTvAokRsek/giphy.gif)