### PR TITLE
Disable R8 full Mode

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,8 @@ org.gradle.jvmargs=-Xmx4g -XX:+HeapDumpOnOutOfMemoryError -XX:+UseParallelGC -Dl
 android.useAndroidX=true
 org.gradle.parallel=true
 org.gradle.caching=true
-android.enableR8.fullMode=true
 android.nonTransitiveRClass=false
+
+# Disabled R8 full mode
+android.enableR8.fullMode=false
+android.suppressUnsupportedCompileSdk=34


### PR DESCRIPTION
Disable full R8 Mode.

Since Gradle 8.0, R8 full mode is enabled by default, and it optimizes all source codes more aggressively. For that reason, workflows for our sample projects' release build are getting broken: https://github.com/GetStream/stream-chat-android/actions/runs/6412468811/job/17409835800

More info:
- https://developer.android.com/build/releases/gradle-plugin#default-changes
- https://r8.googlesource.com/r8/+/refs/heads/master/compatibility-faq.md

We can add strict proguard rules, but it seems to be overkill for sample apps. Just simply disabling the R8 full mode resolves this problem.