### PR TITLE
Upgrade StreamPuhs Dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -73,7 +73,7 @@ object Versions {
     internal const val SPOTLESS = "6.20.0"
     internal const val STFALCON_IMAGE_VIEWER = "1.0.1"
     internal const val STREAM_LOG = "1.1.4"
-    internal const val STREAM_PUSH = "1.1.5"
+    internal const val STREAM_PUSH = "1.1.6"
     internal const val STREAM_RESULT = "1.1.0"
     internal const val TEST_PARAMETER_INJECTOR = "1.12"
     internal const val THREETENBP = "1.6.8"


### PR DESCRIPTION
### 🎯 Goal
Upgrade Stream Push artifact to the [last version](https://github.com/GetStream/stream-android-push/releases/tag/v1.1.6) that fixes the race condition due to initializing the SDK after the first activity was created

### 🎉 GIF
![](https://media.giphy.com/media/iZGpuaRKdEZoI/giphy.gif)