### PR TITLE
[i205] prevent duplicate SendMessage requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed duplicate send message requests. [5039](https://github.com/GetStream/stream-chat-android/pull/5039)
 
 ### ⬆️ Improved
 - Pass `message` with `result` in `SendMessageDebugger`. [#5037](https://github.com/GetStream/stream-chat-android/pull/5037)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -47,6 +47,7 @@ import io.getstream.chat.android.client.api.models.identifier.QueryChannelsIdent
 import io.getstream.chat.android.client.api.models.identifier.QueryMembersIdentifier
 import io.getstream.chat.android.client.api.models.identifier.SendEventIdentifier
 import io.getstream.chat.android.client.api.models.identifier.SendGiphyIdentifier
+import io.getstream.chat.android.client.api.models.identifier.SendMessageIdentifier
 import io.getstream.chat.android.client.api.models.identifier.SendReactionIdentifier
 import io.getstream.chat.android.client.api.models.identifier.ShuffleGiphyIdentifier
 import io.getstream.chat.android.client.api.models.identifier.UpdateMessageIdentifier
@@ -1697,6 +1698,8 @@ internal constructor(
                         debugger.onStop(result, newMessage)
                     }
                 }
+        }.share(userScope) {
+            SendMessageIdentifier(channelType, channelId, message.id)
         }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/identifier/Identifiers.kt
@@ -258,3 +258,19 @@ internal fun MarkReadIdentifier(
     result = 31 * result + channelId.hashCode()
     return result
 }
+
+/**
+ * Identifier for a [ChatClient.sendMessage] call.
+ */
+@Suppress("FunctionName", "MagicNumber")
+internal fun SendMessageIdentifier(
+    channelType: String,
+    channelId: String,
+    messageId: String,
+): Int {
+    var result = "SendMessage".hashCode()
+    result = 31 * result + channelType.hashCode()
+    result = 31 * result + channelId.hashCode()
+    result = 31 * result + messageId.hashCode()
+    return result
+}


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/205

### 🧪 Testing

<details>

<summary>Apply this patch</summary>

```
Subject: [PATCH] Test Patch
---
Index: stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt	(revision 8f53391c2381d45f79c932de72256277864b32fe)
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt	(date 1699309263806)
@@ -34,6 +34,7 @@
 import io.getstream.chat.android.client.sync.SyncState
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.client.utils.observable.Disposable
+import io.getstream.chat.android.client.utils.stringify
 import io.getstream.chat.android.core.internal.coroutines.Tube
 import io.getstream.chat.android.core.utils.date.diff
 import io.getstream.chat.android.models.Attachment
@@ -54,7 +55,10 @@
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.cancelChildren
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
@@ -583,15 +587,40 @@
             logger.w { "[retrySendingOfMessageWithSyncedAttachments] outdated sending($id)" }
             removeMessage(message).await()
         } else {
-            channelClient.sendMessage(message).await().also { result ->
-                when (result) {
-                    is Result.Success -> repos.insertMessage(
-                        message.copy(syncStatus = SyncStatus.COMPLETED),
-                    )
+            // channelClient.sendMessage(message).await().also { result ->
+            //     when (result) {
+            //         is Result.Success -> repos.insertMessage(
+            //             message.copy(syncStatus = SyncStatus.COMPLETED),
+            //         )
+            //
+            //         is Result.Failure -> if (result.value.isPermanent()) {
+            //             repos.markMessageAsFailed(message)
+            //         }
+            //     }
+            // }
+
+            coroutineScope {
+                listOf(
+                    async { channelClient.resendMessage(message) },
+                    async { channelClient.resendMessage(message) }
+                ).awaitAll().first()
+            }
+        }
+    }
+
+    private suspend fun ChannelClient.resendMessage(
+        message: Message,
+    ): Result<Message> {
+        logger.i { "[resendMessage] message.id: ${message.cid}" }
+        return sendMessage(message).await().also { result ->
+            logger.v { "[resendMessage] completed: ${result.stringify { it.cid }}" }
+            when (result) {
+                is Result.Success -> repos.insertMessage(
+                    message.copy(syncStatus = SyncStatus.COMPLETED),
+                )
 
-                    is Result.Failure -> if (result.value.isPermanent()) {
-                        repos.markMessageAsFailed(message)
-                    }
+                is Result.Failure -> if (result.value.isPermanent()) {
+                    repos.markMessageAsFailed(message)
                 }
             }
         }
```

</details>

- Apply patch
- Connect ProxyMan or CharlesProxy
- Launch app
- Login and to to any channel
- Enabled Airplane mode
- Send message
- Disable Airplane mode

Make sure that you can see a single request in ProxyMan or CharlesProxy

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
