### PR TITLE
[i208] center channel title when no last message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
-- Fixed channel title not being centered vertically when mo last messag exists. [#5040](https://github.com/GetStream/stream-chat-android/pull/5040)
+- Fixed channel title not being centered vertically when mo last message exists. [#5040](https://github.com/GetStream/stream-chat-android/pull/5040)
 
 ### ⬆️ Improved
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed channel title not being centered vertically when mo last messag exists. [#5040](https://github.com/GetStream/stream-chat-android/pull/5040)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -20,8 +20,6 @@ import android.content.res.ColorStateList
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewGroup.MarginLayoutParams
-import androidx.constraintlayout.widget.ConstraintLayout
-import androidx.core.view.doOnLayout
 import androidx.core.view.doOnNextLayout
 import androidx.core.view.doOnPreDraw
 import androidx.core.view.isVisible
@@ -266,18 +264,9 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             channelNameLabel.translationY = 0f
         } else if (channelNameLabel.height > 0) {
             channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
-        } else {
-            channelNameLabel.doOnLayout {
-                channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
-            }
+        } else channelNameLabel.doOnPreDraw {
+            channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
         }
-    }
-
-    private fun yDiffBetweenCenters(view1: View, view2: View): Float {
-        val cy1 = view1.top + view1.height / 2f
-        val cy2 = view2.top + view2.height / 2f
-
-        return abs(cy2 - cy1)
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureAvatarView() {
@@ -389,5 +378,13 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             height = style.itemVerticalSpacerHeight
         }
         guideline.setGuidelinePercent(style.itemVerticalSpacerPosition)
+    }
+
+    private companion object {
+        private fun yDiffBetweenCenters(view1: View, view2: View): Float {
+            val cy1 = view1.paddingTop + view1.top + view1.height / 2f
+            val cy2 = view2.paddingTop + view2.top + view2.height / 2f
+            return abs(cy2 - cy1)
+        }
     }
 }


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/208

### 🎨 UI Changes

Look at the **Some fancy channel** title position.

| Before | After |
| --- | --- |
| ![before_center_title](https://github.com/GetStream/stream-chat-android/assets/1286516/a14f2b5e-e2fe-4a92-8137-130603901090) | ![after_center_title](https://github.com/GetStream/stream-chat-android/assets/1286516/240a0eb9-cbf9-4708-baef-cd78801db394) |


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
