### PR TITLE
[V5] Use shortService instead of dataSync for our workmanager job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Use shortService instead of dataSync for our workmanager job. [#5042](https://github.com/GetStream/stream-chat-android/pull/5042)
 
 ### ✅ Added
 

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Configuration.kt
@@ -1,7 +1,7 @@
 package io.getstream.chat.android
 
 object Configuration {
-    const val compileSdk = 33
+    const val compileSdk = 34
     const val targetSdk = 32
     const val sampleTargetSdk = 33
     const val minSdk = 21

--- a/stream-chat-android-client/src/main/AndroidManifest.xml
+++ b/stream-chat-android-client/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_DATA_SYNC"/>
 
     <application>
 
@@ -37,7 +36,7 @@
 
         <service
             android:name="androidx.work.impl.foreground.SystemForegroundService"
-            android:foregroundServiceType="dataSync"
+            android:foregroundServiceType="shortService"
             tools:node="merge"
             />
     </application>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/notifications/LoadNotificationDataWorker.kt
@@ -20,7 +20,7 @@ import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.content.Context
-import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_DATA_SYNC
+import android.content.pm.ServiceInfo.FOREGROUND_SERVICE_TYPE_SHORT_SERVICE
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
@@ -84,11 +84,11 @@ internal class LoadNotificationDataWorker(
             notificationChannelId = context.getString(R.string.stream_chat_other_notifications_channel_id),
             notificationChannelName = context.getString(R.string.stream_chat_other_notifications_channel_name),
         )
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
             ForegroundInfo(
                 NOTIFICATION_ID,
                 foregroundNotification,
-                FOREGROUND_SERVICE_TYPE_DATA_SYNC,
+                FOREGROUND_SERVICE_TYPE_SHORT_SERVICE,
             )
         } else {
             ForegroundInfo(


### PR DESCRIPTION
### 🎯 Goal
Starting on Android 14, whenever a Background Service is started, it needs to declare which type it is.
On #5001 a DataSync service was declared to be able to sync our DB after a PN is received. This permission requires updating Google Play Console App Content data with a video showing functionality using this permission. All our customers would need to update the Google Play Console App Content to complaint with Google Play Policy. 
To avoid it, we can use [ShortService](https://developer.android.com/about/versions/14/changes/fgs-types-required#short-service) foreground service type instead that doesn't require any new permission.

### 🎉 GIF

![](https://media.giphy.com/media/qSLGhGwr9JSkpZGyC5/giphy.gif)