### PR TITLE
[i208] center channel title when no last message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed channel title not being centered vertically when mo last message exists. [#5043](https://github.com/GetStream/stream-chat-android/pull/5043)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -263,8 +263,10 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             channelNameLabel.translationY = 0f
         } else if (channelNameLabel.height > 0) {
             channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
-        } else channelNameLabel.doOnPreDraw {
-            channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
+        } else {
+            channelNameLabel.doOnPreDraw {
+                channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
+            }
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/208

### 🎨 UI Changes

Look at the **Some fancy channel** title position.

| Before | After |
| --- | --- |
| ![before_center_title](https://github.com/GetStream/stream-chat-android/assets/1286516/a14f2b5e-e2fe-4a92-8137-130603901090) | ![after_center_title](https://github.com/GetStream/stream-chat-android/assets/1286516/240a0eb9-cbf9-4708-baef-cd78801db394) |

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
