### PR TITLE
[i209] allow override channel options visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 - Fixed channel title not being centered vertically when mo last message exists. [#5040](https://github.com/GetStream/stream-chat-android/pull/5040)
 
 ### ⬆️ Improved
+- Allow override channel's delete option visibility. [#5044](https://github.com/GetStream/stream-chat-android/pull/5044)
 
 ### ✅ Added
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListVisibilityContainerImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/ChannelListVisibilityContainerImpl.kt
@@ -17,11 +17,12 @@
 package io.getstream.chat.android.ui.channel.list.adapter.viewholder
 
 import com.getstream.sdk.chat.utils.ListenerDelegate
+import io.getstream.chat.android.client.models.ChannelCapabilities
 import io.getstream.chat.android.ui.channel.list.ChannelListView.ChannelOptionVisibilityPredicate
 
 internal class ChannelListVisibilityContainerImpl(
-    isMoreOptionsVisible: ChannelOptionVisibilityPredicate = ChannelOptionVisibilityPredicate.DEFAULT,
-    isDeleteOptionVisible: ChannelOptionVisibilityPredicate = ChannelOptionVisibilityPredicate.DEFAULT,
+    isMoreOptionsVisible: ChannelOptionVisibilityPredicate = moreOptionsDefault,
+    isDeleteOptionVisible: ChannelOptionVisibilityPredicate = deleteOptionDefault,
 ) : ChannelListVisibilityContainer {
 
     override var isMoreOptionsVisible: ChannelOptionVisibilityPredicate by ListenerDelegate(isMoreOptionsVisible) { realPredicate ->
@@ -33,6 +34,18 @@ internal class ChannelListVisibilityContainerImpl(
     override var isDeleteOptionVisible: ChannelOptionVisibilityPredicate by ListenerDelegate(isDeleteOptionVisible) { realPredicate ->
         ChannelOptionVisibilityPredicate { channel ->
             realPredicate().invoke(channel)
+        }
+    }
+
+    private companion object {
+        val moreOptionsDefault: ChannelOptionVisibilityPredicate = ChannelOptionVisibilityPredicate {
+            // "more options" is visible by default
+            true
+        }
+
+        val deleteOptionDefault: ChannelOptionVisibilityPredicate = ChannelOptionVisibilityPredicate {
+            // "delete option" is visible if the channel's ownCapabilities contains the delete capability
+            it.ownCapabilities.contains(ChannelCapabilities.DELETE_CHANNEL)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/channel/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -29,7 +29,6 @@ import com.getstream.sdk.chat.utils.formatDate
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.isAnonymousChannel
 import io.getstream.chat.android.client.models.Channel
-import io.getstream.chat.android.client.models.ChannelCapabilities
 import io.getstream.chat.android.client.models.Message
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.client.utils.SyncStatus
@@ -112,6 +111,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                                 ?.user
                                 ?.let(userClickListener::onClick)
                         }
+
                         else -> channelClickListener.onClick(channel)
                     }
                 }
@@ -209,8 +209,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             }
         }
         binding.itemBackgroundView.deleteImageView.apply {
-            val canDeleteChannel = channel.ownCapabilities.contains(ChannelCapabilities.DELETE_CHANNEL)
-            if (style.deleteEnabled && canDeleteChannel && isDeleteOptionVisible(channel)) {
+            if (style.deleteEnabled && isDeleteOptionVisible(channel)) {
                 isVisible = true
                 getDeleteOptionIcon.invoke(channel)?.also { setImageDrawable(it) }
                 optionsCount++


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/209

### 🛠 Implementation details

Instead having the following condition in `ChannelViewHolder`
```kotlin
channel.ownCapabilities.contains(ChannelCapabilities.DELETE_CHANNEL)
```
It now was used as a default condition for `isDeleteOptionVisible: ChannelOptionVisibilityPredicate`


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
