### PR TITLE
[i215] Make default composer components extensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 
 ### ⚠️ Changed
 - Made `MessageReplyView` publicly available. [#5057](https://github.com/GetStream/stream-chat-android/pull/5057)
+- Made `MessageComposerContent` descendants extensible/reusable. [#5061](https://github.com/GetStream/stream-chat-android/pull/5061) 
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/ChatFragment.kt
@@ -53,6 +53,7 @@ import io.getstream.chat.android.ui.message.list.viewmodel.bindView
 import io.getstream.chat.android.ui.message.list.viewmodel.factory.MessageListViewModelFactory
 import io.getstream.chat.ui.sample.common.navigateSafely
 import io.getstream.chat.ui.sample.databinding.FragmentChatBinding
+import io.getstream.chat.ui.sample.feature.chat.composer.CustomMessageComposerLeadingContent
 import io.getstream.chat.ui.sample.feature.common.ConfirmationDialogFragment
 import io.getstream.chat.ui.sample.util.extensions.useAdjustResize
 import java.util.Calendar
@@ -193,6 +194,7 @@ class ChatFragment : Fragment() {
                     }
                 }
             }
+
             binding.messageListView.setMessageReplyHandler { _, message ->
                 messageComposerViewModel.performMessageAction(Reply(message))
             }
@@ -212,6 +214,12 @@ class ChatFragment : Fragment() {
                     messageComposerViewModel.performMessageAction(Reply(message))
                 }
             }
+        }
+
+        if (OVERRIDE_LEADING_CONTENT) {
+            binding.messageComposerView.setLeadingContent(
+                CustomMessageComposerLeadingContent(requireContext())
+            )
         }
     }
 
@@ -302,5 +310,9 @@ class ChatFragment : Fragment() {
         }
         val chatError = error() as ChatNetworkError
         return chatError.streamCode == 4
+    }
+
+    private companion object {
+        private const val OVERRIDE_LEADING_CONTENT = false
     }
 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/composer/CustomMessageComposerLeadingContent.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/composer/CustomMessageComposerLeadingContent.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2023 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.ui.sample.feature.chat.composer
+
+import android.content.Context
+import android.util.AttributeSet
+import io.getstream.chat.android.common.composer.MessageComposerState
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.ui.message.composer.content.DefaultMessageComposerLeadingContent
+
+@OptIn(ExperimentalStreamChatApi::class)
+class CustomMessageComposerLeadingContent : DefaultMessageComposerLeadingContent {
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
+    constructor(context: Context, attrs: AttributeSet?, defStyleAttr: Int) : super(context, attrs, defStyleAttr)
+
+    override fun renderState(state: MessageComposerState) {
+        super.renderState(state)
+        binding.attachmentsButton.isEnabled = state.attachments.isEmpty()
+    }
+}

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2232,78 +2232,147 @@ public final class io/getstream/chat/android/ui/message/composer/attachment/fact
 	public fun onCreateViewHolder (Landroid/view/ViewGroup;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/ui/message/composer/attachment/AttachmentPreviewViewHolder;
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCenterContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public abstract interface class io/getstream/chat/android/ui/message/composer/content/AttachmentAdapter {
+	public abstract fun getItemCount ()I
+	public abstract fun setAttachments (Ljava/util/List;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/composer/content/CommandSuggestionsAdapter {
+	public abstract fun getItemCount ()I
+	public abstract fun setItems (Ljava/util/List;)V
+}
+
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCenterContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field attachmentsAdapter Lio/getstream/chat/android/ui/message/composer/content/AttachmentAdapter;
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultCenterContentBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
+	protected fun buildAdapter (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)Landroidx/recyclerview/widget/RecyclerView$Adapter;
 	public final fun getAttachmentRemovalListener ()Lkotlin/jvm/functions/Function1;
+	protected final fun getAttachmentsAdapter ()Lio/getstream/chat/android/ui/message/composer/content/AttachmentAdapter;
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultCenterContentBinding;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public final fun getTextInputChangeListener ()Lkotlin/jvm/functions/Function1;
+	protected fun renderAttachmentState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected fun renderReplyState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected fun renderTextInputState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
 	public final fun setAttachmentRemovalListener (Lkotlin/jvm/functions/Function1;)V
+	protected final fun setAttachmentsAdapter (Lio/getstream/chat/android/ui/message/composer/content/AttachmentAdapter;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultCenterContentBinding;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 	public final fun setTextInputChangeListener (Lkotlin/jvm/functions/Function1;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCommandSuggestionsContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerCommandSuggestionsContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
+	protected fun buildAdapter (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)Landroidx/recyclerview/widget/RecyclerView$Adapter;
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;
 	public final fun getCommandSelectionListener ()Lkotlin/jvm/functions/Function1;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;)V
 	public final fun setCommandSelectionListener (Lkotlin/jvm/functions/Function1;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerFooterContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerFooterContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultFooterContentBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
 	public final fun getAlsoSendToChannelSelectionListener ()Lkotlin/jvm/functions/Function1;
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultFooterContentBinding;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
 	public final fun setAlsoSendToChannelSelectionListener (Lkotlin/jvm/functions/Function1;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultFooterContentBinding;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerHeaderContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerHeaderContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultHeaderContentBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultHeaderContentBinding;
 	public final fun getDismissActionClickListener ()Lkotlin/jvm/functions/Function0;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultHeaderContentBinding;)V
 	public final fun setDismissActionClickListener (Lkotlin/jvm/functions/Function0;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerLeadingContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerLeadingContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultLeadingContentBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
 	public final fun getAttachmentsButtonClickListener ()Lkotlin/jvm/functions/Function0;
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultLeadingContentBinding;
 	public final fun getCommandsButtonClickListener ()Lkotlin/jvm/functions/Function0;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
 	public final fun setAttachmentsButtonClickListener (Lkotlin/jvm/functions/Function0;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultLeadingContentBinding;)V
 	public final fun setCommandsButtonClickListener (Lkotlin/jvm/functions/Function0;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerMentionSuggestionsContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerMentionSuggestionsContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field adapter Lio/getstream/chat/android/ui/message/composer/content/MentionSuggestionsAdapter;
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
+	protected fun buildAdapter (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)Landroidx/recyclerview/widget/RecyclerView$Adapter;
+	protected final fun getAdapter ()Lio/getstream/chat/android/ui/message/composer/content/MentionSuggestionsAdapter;
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;
 	public final fun getMentionSelectionListener ()Lkotlin/jvm/functions/Function1;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected final fun setAdapter (Lio/getstream/chat/android/ui/message/composer/content/MentionSuggestionsAdapter;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiSuggestionListViewBinding;)V
 	public final fun setMentionSelectionListener (Lkotlin/jvm/functions/Function1;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
 }
 
-public final class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerTrailingContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+public class io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerTrailingContent : android/widget/FrameLayout, io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {
+	protected field binding Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultTrailingContentBinding;
+	protected field style Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun <init> (Landroid/content/Context;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;)V
 	public fun <init> (Landroid/content/Context;Landroid/util/AttributeSet;I)V
 	public fun attachContext (Lio/getstream/chat/android/ui/message/composer/MessageComposerContext;)V
+	protected final fun getBinding ()Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultTrailingContentBinding;
 	public final fun getSendMessageButtonClickListener ()Lkotlin/jvm/functions/Function0;
+	protected final fun getStyle ()Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;
 	public fun renderState (Lio/getstream/chat/android/common/composer/MessageComposerState;)V
+	protected final fun setBinding (Lio/getstream/chat/android/ui/databinding/StreamUiMessageComposerDefaultTrailingContentBinding;)V
 	public final fun setSendMessageButtonClickListener (Lkotlin/jvm/functions/Function0;)V
+	protected final fun setStyle (Lio/getstream/chat/android/ui/message/composer/MessageComposerViewStyle;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/message/composer/content/MentionSuggestionsAdapter {
+	public abstract fun getItemCount ()I
+	public abstract fun setItems (Ljava/util/List;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/message/composer/content/MessageComposerContent {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/MessageComposerView.kt
@@ -294,6 +294,14 @@ public class MessageComposerView : ConstraintLayout {
     ) where V : View, V : MessageComposerContent {
         binding.leadingContent.removeAllViews()
         binding.leadingContent.addView(contentView.attachContext(), layoutParams)
+        if (contentView is DefaultMessageComposerLeadingContent) {
+            if (contentView.attachmentsButtonClickListener == null) {
+                contentView.attachmentsButtonClickListener = { attachmentsButtonClickListener() }
+            }
+            if (contentView.commandsButtonClickListener == null) {
+                contentView.commandsButtonClickListener = { commandsButtonClickListener() }
+            }
+        }
     }
 
     /**
@@ -315,6 +323,14 @@ public class MessageComposerView : ConstraintLayout {
     ) where V : View, V : MessageComposerContent {
         binding.centerContent.removeAllViews()
         binding.centerContent.addView(contentView.attachContext(), layoutParams)
+        if (contentView is DefaultMessageComposerCenterContent) {
+            if (contentView.textInputChangeListener == null) {
+                contentView.textInputChangeListener = { textInputChangeListener(it) }
+            }
+            if (contentView.attachmentRemovalListener == null) {
+                contentView.attachmentRemovalListener = { attachmentRemovalListener(it) }
+            }
+        }
     }
 
     /**
@@ -337,6 +353,11 @@ public class MessageComposerView : ConstraintLayout {
     ) where V : View, V : MessageComposerContent {
         binding.trailingContent.removeAllViews()
         binding.trailingContent.addView(contentView.attachContext(), layoutParams)
+        if (contentView is DefaultMessageComposerTrailingContent) {
+            if (contentView.sendMessageButtonClickListener == null) {
+                contentView.sendMessageButtonClickListener = { sendMessageButtonClickListener() }
+            }
+        }
     }
 
     /**
@@ -358,6 +379,11 @@ public class MessageComposerView : ConstraintLayout {
     ) where V : View, V : MessageComposerContent {
         binding.footerContent.removeAllViews()
         binding.footerContent.addView(contentView.attachContext(), layoutParams)
+        if (contentView is DefaultMessageComposerFooterContent) {
+            if (contentView.alsoSendToChannelSelectionListener == null) {
+                contentView.alsoSendToChannelSelectionListener = { alsoSendToChannelSelectionListener(it) }
+            }
+        }
     }
 
     /**
@@ -379,6 +405,11 @@ public class MessageComposerView : ConstraintLayout {
     ) where V : View, V : MessageComposerContent {
         binding.headerContent.removeAllViews()
         binding.headerContent.addView(contentView.attachContext(), layoutParams)
+        if (contentView is DefaultMessageComposerHeaderContent) {
+            if (contentView.dismissActionClickListener == null) {
+                contentView.dismissActionClickListener = { dismissActionClickListener() }
+            }
+        }
     }
 
     /**
@@ -392,6 +423,11 @@ public class MessageComposerView : ConstraintLayout {
      */
     public fun <V> setMentionSuggestionsContent(contentView: V) where V : View, V : MessageComposerContent {
         mentionSuggestionsContentOverride = contentView.attachContext()
+        if (contentView is DefaultMessageComposerMentionSuggestionsContent) {
+            if (contentView.mentionSelectionListener == null) {
+                contentView.mentionSelectionListener = { mentionSelectionListener(it) }
+            }
+        }
     }
 
     /**
@@ -405,6 +441,11 @@ public class MessageComposerView : ConstraintLayout {
      */
     public fun <V> setCommandSuggestionsContent(contentView: V) where V : View, V : MessageComposerContent {
         commandSuggestionsContentOverride = contentView.attachContext()
+        if (contentView is DefaultMessageComposerCommandSuggestionsContent) {
+            if (contentView.commandSelectionListener == null) {
+                contentView.commandSelectionListener = { commandSelectionListener(it) }
+            }
+        }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerFooterContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerFooterContent.kt
@@ -35,21 +35,21 @@ import io.getstream.chat.android.ui.message.composer.MessageComposerViewStyle
  * Represents the default content shown at the bottom of [MessageComposerView].
  */
 @ExperimentalStreamChatApi
-public class DefaultMessageComposerFooterContent : FrameLayout, MessageComposerContent {
+public open class DefaultMessageComposerFooterContent : FrameLayout, MessageComposerContent {
     /**
      * Generated binding class for the XML layout.
      */
-    private lateinit var binding: StreamUiMessageComposerDefaultFooterContentBinding
+    protected lateinit var binding: StreamUiMessageComposerDefaultFooterContentBinding
 
     /**
      * The style for [MessageComposerView].
      */
-    private lateinit var style: MessageComposerViewStyle
+    protected lateinit var style: MessageComposerViewStyle
 
     /**
      * Selection listener for the "also send to channel" checkbox.
      */
-    public var alsoSendToChannelSelectionListener: (Boolean) -> Unit = {}
+    public var alsoSendToChannelSelectionListener: ((Boolean) -> Unit)? = null
 
     public constructor(context: Context) : this(context, null)
 
@@ -69,7 +69,7 @@ public class DefaultMessageComposerFooterContent : FrameLayout, MessageComposerC
     private fun init() {
         binding = StreamUiMessageComposerDefaultFooterContentBinding.inflate(streamThemeInflater, this)
         binding.alsoSendToChannelCheckBox.setOnCheckedChangeListener { _, _ ->
-            alsoSendToChannelSelectionListener(binding.alsoSendToChannelCheckBox.isChecked)
+            alsoSendToChannelSelectionListener?.invoke(binding.alsoSendToChannelCheckBox.isChecked)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerHeaderContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerHeaderContent.kt
@@ -35,21 +35,21 @@ import io.getstream.chat.android.ui.message.composer.MessageComposerViewStyle
  * Represents the default content shown at the top of [MessageComposerView].
  */
 @ExperimentalStreamChatApi
-public class DefaultMessageComposerHeaderContent : FrameLayout, MessageComposerContent {
+public open class DefaultMessageComposerHeaderContent : FrameLayout, MessageComposerContent {
     /**
      * Generated binding class for the XML layout.
      */
-    private lateinit var binding: StreamUiMessageComposerDefaultHeaderContentBinding
+    protected lateinit var binding: StreamUiMessageComposerDefaultHeaderContentBinding
 
     /**
      * The style for [MessageComposerView].
      */
-    private lateinit var style: MessageComposerViewStyle
+    protected lateinit var style: MessageComposerViewStyle
 
     /**
      * Click listener for the dismiss action button.
      */
-    public var dismissActionClickListener: () -> Unit = {}
+    public var dismissActionClickListener: (() -> Unit)? = null
 
     public constructor(context: Context) : this(context, null)
 
@@ -68,7 +68,7 @@ public class DefaultMessageComposerHeaderContent : FrameLayout, MessageComposerC
      */
     private fun init() {
         binding = StreamUiMessageComposerDefaultHeaderContentBinding.inflate(streamThemeInflater, this)
-        binding.dismissInputModeButton.setOnClickListener { dismissActionClickListener() }
+        binding.dismissInputModeButton.setOnClickListener { dismissActionClickListener?.invoke() }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerLeadingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerLeadingContent.kt
@@ -39,26 +39,26 @@ import io.getstream.chat.android.ui.utils.extensions.setBorderlessRipple
  * Represents the default content shown at the start of [MessageComposerView].
  */
 @ExperimentalStreamChatApi
-public class DefaultMessageComposerLeadingContent : FrameLayout, MessageComposerContent {
+public open class DefaultMessageComposerLeadingContent : FrameLayout, MessageComposerContent {
     /**
      * Generated binding class for the XML layout.
      */
-    private lateinit var binding: StreamUiMessageComposerDefaultLeadingContentBinding
+    protected lateinit var binding: StreamUiMessageComposerDefaultLeadingContentBinding
 
     /**
      * The style for [MessageComposerView].
      */
-    private lateinit var style: MessageComposerViewStyle
+    protected lateinit var style: MessageComposerViewStyle
 
     /**
      * Click listener for the pick attachments button.
      */
-    public var attachmentsButtonClickListener: () -> Unit = {}
+    public var attachmentsButtonClickListener: (() -> Unit)? = null
 
     /**
      * Click listener for the pick commands button.
      */
-    public var commandsButtonClickListener: () -> Unit = {}
+    public var commandsButtonClickListener: (() -> Unit)? = null
 
     public constructor(context: Context) : this(context, null)
 
@@ -77,8 +77,8 @@ public class DefaultMessageComposerLeadingContent : FrameLayout, MessageComposer
      */
     private fun init() {
         binding = StreamUiMessageComposerDefaultLeadingContentBinding.inflate(streamThemeInflater, this)
-        binding.attachmentsButton.setOnClickListener { attachmentsButtonClickListener() }
-        binding.commandsButton.setOnClickListener { commandsButtonClickListener() }
+        binding.attachmentsButton.setOnClickListener { attachmentsButtonClickListener?.invoke() }
+        binding.commandsButton.setOnClickListener { commandsButtonClickListener?.invoke() }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/message/composer/content/DefaultMessageComposerTrailingContent.kt
@@ -39,21 +39,21 @@ import io.getstream.chat.android.ui.message.composer.MessageComposerViewStyle
  * Represents the default content shown at the end of [MessageComposerView].
  */
 @ExperimentalStreamChatApi
-public class DefaultMessageComposerTrailingContent : FrameLayout, MessageComposerContent {
+public open class DefaultMessageComposerTrailingContent : FrameLayout, MessageComposerContent {
     /**
      * Generated binding class for the XML layout.
      */
-    private lateinit var binding: StreamUiMessageComposerDefaultTrailingContentBinding
+    protected lateinit var binding: StreamUiMessageComposerDefaultTrailingContentBinding
 
     /**
      * The style for [MessageComposerView].
      */
-    private lateinit var style: MessageComposerViewStyle
+    protected lateinit var style: MessageComposerViewStyle
 
     /**
      * Click listener for the send message button.
      */
-    public var sendMessageButtonClickListener: () -> Unit = {}
+    public var sendMessageButtonClickListener: (() -> Unit)? = null
 
     public constructor(context: Context) : this(context, null)
 
@@ -72,7 +72,7 @@ public class DefaultMessageComposerTrailingContent : FrameLayout, MessageCompose
      */
     private fun init() {
         binding = StreamUiMessageComposerDefaultTrailingContentBinding.inflate(streamThemeInflater, this)
-        binding.sendMessageButton.setOnClickListener { sendMessageButtonClickListener() }
+        binding.sendMessageButton.setOnClickListener { sendMessageButtonClickListener?.invoke() }
     }
 
     /**


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/215

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
