### PR TITLE
[i212] allow composer icons customizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,25 @@
 
 ### ✅ Added
 - Added `MessageComposerViewModel.bindViewDefaults` which preserves the default view bindings. [#5060](https://github.com/GetStream/stream-chat-android/pull/5060)
+- Added UI customizations for message composer. [#5064](https://github.com/GetStream/stream-chat-android/pull/5064)
+  * `MessageComposerViewStyle.commandSuggestionsTitleIconDrawableTintColor`
+  * `MessageComposerViewStyle.mentionSuggestionItemIconDrawableTintColor`
+  * `MessageComposerViewStyle.attachmentsButtonIconTintList`
+  * `MessageComposerViewStyle.commandsButtonIconTintList`
+  * `MessageComposerViewStyle.sendMessageButtonIconTintList`
+  * `MessageComposerViewStyle.audioRecordingButtonIconTintList`
 
 ### ⚠️ Changed
 - Made `MessageReplyView` publicly available. [#5058](https://github.com/GetStream/stream-chat-android/pull/5058)
+- Deprecated `MessageListItemStyle.textStyleMessageDeleted`. Use `MessageListItemStyle.textStyleMessageDeletedMine` and `MessageListItemStyle.textStyleMessageDeletedTheirs` instead.  [#5050](https://github.com/GetStream/stream-chat-android/pull/5050)
+- Deprecated `MessageListItemStyle.messageDeletedBackground`. Use `MessageListItemStyle.messageDeletedBackgroundMine` and `MessageListItemStyle.messageDeletedBackgroundTheirs` instead.  [#5050](https://github.com/GetStream/stream-chat-android/pull/5050)
+- Deprecated `MessageListItemStyle.buttonIconDrawableTintColor`. Use one of the params listed below instead. [#5064](https://github.com/GetStream/stream-chat-android/pull/5064)
+  * `MessageComposerViewStyle.commandSuggestionsTitleIconDrawableTintColor`
+  * `MessageComposerViewStyle.mentionSuggestionItemIconDrawableTintColor`
+  * `MessageComposerViewStyle.attachmentsButtonIconTintList`
+  * `MessageComposerViewStyle.commandsButtonIconTintList`
+  * `MessageComposerViewStyle.sendMessageButtonIconTintList`
+  * `MessageComposerViewStyle.audioRecordingButtonIconTintList`
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -954,45 +954,45 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle$Companion;
-	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;IIIZZZLandroid/graphics/drawable/Drawable;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;)V
+	public fun <init> (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIIZZZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;)V
 	public final fun component1 ()I
-	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component11 ()I
-	public final fun component12 ()Landroid/graphics/drawable/Drawable;
-	public final fun component13 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component14 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/String;
+	public final fun component11 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component12 ()I
+	public final fun component13 ()Landroid/graphics/drawable/Drawable;
+	public final fun component14 ()Ljava/lang/Integer;
 	public final fun component15 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component16 ()Z
-	public final fun component17 ()Z
-	public final fun component18 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component19 ()Landroid/graphics/drawable/Drawable;
+	public final fun component16 ()Ljava/lang/String;
+	public final fun component17 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component18 ()Z
+	public final fun component19 ()Z
 	public final fun component2 ()Ljava/lang/Integer;
-	public final fun component20 ()Landroid/graphics/drawable/Drawable;
-	public final fun component21 ()Z
-	public final fun component22 ()Z
-	public final fun component23 ()I
-	public final fun component24 ()Ljava/lang/String;
+	public final fun component20 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component21 ()Landroid/graphics/drawable/Drawable;
+	public final fun component22 ()Landroid/graphics/drawable/Drawable;
+	public final fun component23 ()Z
+	public final fun component24 ()Z
 	public final fun component25 ()I
-	public final fun component26 ()Z
-	public final fun component27 ()Landroid/graphics/drawable/Drawable;
-	public final fun component28 ()Ljava/lang/Integer;
-	public final fun component29 ()Ljava/lang/Integer;
+	public final fun component26 ()Ljava/lang/String;
+	public final fun component27 ()I
+	public final fun component28 ()Z
+	public final fun component29 ()Landroid/graphics/drawable/Drawable;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
-	public final fun component30 ()F
-	public final fun component31 ()F
-	public final fun component32 ()I
-	public final fun component33 ()I
+	public final fun component30 ()Ljava/lang/Integer;
+	public final fun component31 ()Ljava/lang/Integer;
+	public final fun component32 ()F
+	public final fun component33 ()F
 	public final fun component34 ()I
 	public final fun component35 ()I
-	public final fun component36 ()Ljava/lang/String;
-	public final fun component37 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component38 ()Landroid/graphics/drawable/Drawable;
-	public final fun component39 ()Ljava/lang/Integer;
+	public final fun component36 ()I
+	public final fun component37 ()I
+	public final fun component38 ()Ljava/lang/String;
+	public final fun component39 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component40 ()Ljava/lang/String;
-	public final fun component41 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component42 ()Landroid/graphics/drawable/Drawable;
-	public final fun component43 ()Ljava/lang/Integer;
+	public final fun component40 ()Landroid/graphics/drawable/Drawable;
+	public final fun component41 ()Ljava/lang/Integer;
+	public final fun component42 ()Ljava/lang/String;
+	public final fun component43 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component44 ()Landroid/graphics/drawable/Drawable;
 	public final fun component45 ()Ljava/lang/Integer;
 	public final fun component46 ()Landroid/graphics/drawable/Drawable;
@@ -1002,61 +1002,69 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun component5 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component50 ()Landroid/graphics/drawable/Drawable;
 	public final fun component51 ()Ljava/lang/Integer;
-	public final fun component52 ()Z
-	public final fun component53 ()Landroid/graphics/drawable/Drawable;
-	public final fun component54 ()Ljava/lang/Integer;
-	public final fun component55 ()Z
-	public final fun component56 ()Landroid/graphics/drawable/Drawable;
+	public final fun component52 ()Landroid/graphics/drawable/Drawable;
+	public final fun component53 ()Ljava/lang/Integer;
+	public final fun component54 ()Z
+	public final fun component55 ()Landroid/graphics/drawable/Drawable;
+	public final fun component56 ()Landroid/content/res/ColorStateList;
 	public final fun component57 ()Ljava/lang/Integer;
 	public final fun component58 ()Z
 	public final fun component59 ()Landroid/graphics/drawable/Drawable;
 	public final fun component6 ()Landroid/graphics/drawable/Drawable;
-	public final fun component60 ()Ljava/lang/String;
-	public final fun component61 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component62 ()Ljava/lang/String;
+	public final fun component60 ()Landroid/content/res/ColorStateList;
+	public final fun component61 ()Ljava/lang/Integer;
+	public final fun component62 ()Z
 	public final fun component63 ()Landroid/graphics/drawable/Drawable;
 	public final fun component64 ()Ljava/lang/String;
-	public final fun component65 ()Landroid/graphics/drawable/Drawable;
-	public final fun component66 ()Landroid/graphics/drawable/Drawable;
-	public final fun component67 ()Z
-	public final fun component68 ()Landroid/graphics/drawable/Drawable;
-	public final fun component69 ()I
-	public final fun component7 ()I
-	public final fun component70 ()I
-	public final fun component71 ()I
-	public final fun component72 ()Z
-	public final fun component73 ()Z
-	public final fun component74 ()Z
-	public final fun component75 ()Landroid/graphics/drawable/Drawable;
+	public final fun component65 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component66 ()Ljava/lang/String;
+	public final fun component67 ()Landroid/graphics/drawable/Drawable;
+	public final fun component68 ()Ljava/lang/String;
+	public final fun component69 ()Landroid/graphics/drawable/Drawable;
+	public final fun component7 ()Ljava/lang/Integer;
+	public final fun component70 ()Landroid/graphics/drawable/Drawable;
+	public final fun component71 ()Z
+	public final fun component72 ()Landroid/graphics/drawable/Drawable;
+	public final fun component73 ()Landroid/content/res/ColorStateList;
+	public final fun component74 ()I
+	public final fun component75 ()I
 	public final fun component76 ()I
-	public final fun component77 ()I
-	public final fun component78 ()I
-	public final fun component79 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component8 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component77 ()Z
+	public final fun component78 ()Z
+	public final fun component79 ()Z
+	public final fun component8 ()I
 	public final fun component80 ()Landroid/graphics/drawable/Drawable;
-	public final fun component81 ()I
-	public final fun component82 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component81 ()Landroid/content/res/ColorStateList;
+	public final fun component82 ()I
 	public final fun component83 ()I
-	public final fun component84 ()F
+	public final fun component84 ()I
 	public final fun component85 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component86 ()I
-	public final fun component87 ()F
-	public final fun component88 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;
-	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;IIIZZZLandroid/graphics/drawable/Drawable;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;IIIZZZLandroid/graphics/drawable/Drawable;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;IIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
+	public final fun component86 ()Landroid/graphics/drawable/Drawable;
+	public final fun component87 ()I
+	public final fun component88 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component89 ()I
+	public final fun component9 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component90 ()F
+	public final fun component91 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component92 ()I
+	public final fun component93 ()F
+	public final fun component94 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;
+	public final fun copy (ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIIZZZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;ILjava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;ZZLio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZILjava/lang/String;IZLandroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/Integer;FFIIIILjava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;Landroid/graphics/drawable/Drawable;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;Ljava/lang/Integer;ZLandroid/graphics/drawable/Drawable;Ljava/lang/String;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Ljava/lang/String;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIIZZZLandroid/graphics/drawable/Drawable;Landroid/content/res/ColorStateList;IIILio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/font/TextStyle;IFLio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;IIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAlsoSendToChannelCheckboxDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getAlsoSendToChannelCheckboxText ()Ljava/lang/String;
 	public final fun getAlsoSendToChannelCheckboxTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getAlsoSendToChannelCheckboxVisible ()Z
 	public final fun getAttachmentsButtonIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getAttachmentsButtonIconTintList ()Landroid/content/res/ColorStateList;
 	public final fun getAttachmentsButtonRippleColor ()Ljava/lang/Integer;
 	public final fun getAttachmentsButtonVisible ()Z
 	public final fun getAttachmentsPickerDialogStyle ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogStyle;
 	public final fun getAudioRecordingButtonEnabled ()Z
 	public final fun getAudioRecordingButtonHeight ()I
 	public final fun getAudioRecordingButtonIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getAudioRecordingButtonIconTintList ()Landroid/content/res/ColorStateList;
 	public final fun getAudioRecordingButtonPadding ()I
 	public final fun getAudioRecordingButtonPreferred ()Z
 	public final fun getAudioRecordingButtonVisible ()Z
@@ -1084,9 +1092,11 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun getCommandSuggestionItemCommandNameTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getCommandSuggestionsBackgroundColor ()I
 	public final fun getCommandSuggestionsTitleIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getCommandSuggestionsTitleIconDrawableTintColor ()Ljava/lang/Integer;
 	public final fun getCommandSuggestionsTitleText ()Ljava/lang/String;
 	public final fun getCommandSuggestionsTitleTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getCommandsButtonIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getCommandsButtonIconTintList ()Landroid/content/res/ColorStateList;
 	public final fun getCommandsButtonRippleColor ()Ljava/lang/Integer;
 	public final fun getCommandsButtonVisible ()Z
 	public final fun getCooldownTimerBackgroundDrawable ()Landroid/graphics/drawable/Drawable;
@@ -1096,6 +1106,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun getEditModeIconDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getEditModeText ()Ljava/lang/String;
 	public final fun getMentionSuggestionItemIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getMentionSuggestionItemIconDrawableTintColor ()Ljava/lang/Integer;
 	public final fun getMentionSuggestionItemMentionText ()Ljava/lang/String;
 	public final fun getMentionSuggestionItemMentionTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getMentionSuggestionItemUsernameTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
@@ -1132,6 +1143,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/Messag
 	public final fun getSendMessageButtonEnabled ()Z
 	public final fun getSendMessageButtonHeight ()I
 	public final fun getSendMessageButtonIconDrawable ()Landroid/graphics/drawable/Drawable;
+	public final fun getSendMessageButtonIconTintList ()Landroid/content/res/ColorStateList;
 	public final fun getSendMessageButtonPadding ()I
 	public final fun getSendMessageButtonWidth ()I
 	public fun hashCode ()I
@@ -1593,8 +1605,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/GiphyViewH
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle : io/getstream/chat/android/ui/helper/ViewStyle {
-	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;II)V
-	public synthetic fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;IFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;II)V
 	public final fun component1 ()Ljava/lang/Integer;
 	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component11 ()Lio/getstream/chat/android/ui/font/TextStyle;
@@ -1615,10 +1626,10 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun component25 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component26 ()I
 	public final fun component27 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component28 ()I
+	public final fun component28 ()Ljava/lang/Integer;
 	public final fun component29 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component3 ()Ljava/lang/Integer;
-	public final fun component30 ()I
+	public final fun component30 ()Ljava/lang/Integer;
 	public final fun component31 ()I
 	public final fun component32 ()F
 	public final fun component33 ()I
@@ -1643,8 +1654,8 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun component7 ()I
 	public final fun component8 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component9 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;II)Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
+	public final fun copy (Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;IFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;II)Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;IIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/view/ViewReactionsViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;Lio/getstream/chat/android/ui/font/TextStyle;Ljava/lang/Integer;IFIFLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;IIIFFZLandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDateSeparatorBackgroundColor ()I
 	public final fun getEditReactionsViewStyle ()Lio/getstream/chat/android/ui/feature/messages/list/reactions/edit/EditReactionsViewStyle;
@@ -1659,8 +1670,8 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun getMessageBackgroundColorMine ()Ljava/lang/Integer;
 	public final fun getMessageBackgroundColorTheirs ()Ljava/lang/Integer;
 	public final fun getMessageDeletedBackground ()I
-	public final fun getMessageDeletedBackgroundMine ()I
-	public final fun getMessageDeletedBackgroundTheirs ()I
+	public final fun getMessageDeletedBackgroundMine ()Ljava/lang/Integer;
+	public final fun getMessageDeletedBackgroundTheirs ()Ljava/lang/Integer;
 	public final fun getMessageEndMargin ()I
 	public final fun getMessageLinkBackgroundColorMine ()I
 	public final fun getMessageLinkBackgroundColorTheirs ()I
@@ -2926,6 +2937,8 @@ public final class io/getstream/chat/android/ui/font/TextStyle$Builder {
 	public final fun color (II)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
 	public final fun font (II)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
 	public final fun font (IILandroid/graphics/Typeface;)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
+	public final fun fontAssetsPath (ILjava/lang/String;)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
+	public final fun fontResource (II)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
 	public final fun hint (ILjava/lang/String;)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
 	public final fun hintColor (II)Lio/getstream/chat/android/ui/font/TextStyle$Builder;
 	public final fun size (I)Lio/getstream/chat/android/ui/font/TextStyle$Builder;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
@@ -98,6 +98,11 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param audioRecordingButtonEnabled If the button to record audio is enabled.
  * @param audioRecordingButtonPreferred If the button to record audio is displayed over send button while input is
  * empty.
+ * @param audioRecordingButtonIconDrawable The icon for the button to record audio.
+ * @param audioRecordingButtonIconTintList The tint list for the button to record audio.
+ * @param audioRecordingButtonWidth The width of the button to record audio.
+ * @param audioRecordingButtonHeight The height of the button to record audio.
+ * @param audioRecordingButtonPadding The padding of the button to record audio.
  * @param audioRecordingHoldToRecordText The info text that will be shown if touch event on audio button was too short.
  * @param audioRecordingHoldToRecordTextStyle The text style that will be used for the "hold to record" text.
  * @param audioRecordingHoldToRecordBackgroundDrawable The drawable will be used as a background for the "hold to

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.ui.feature.messages.composer
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.content.res.TypedArray
 import android.graphics.Typeface
 import android.graphics.drawable.Drawable
@@ -53,12 +54,16 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param commandSuggestionsTitleText The text for the title at the top of the command suggestions dialog.
  * @param commandSuggestionsTitleTextStyle The text style for the title at the top of the command suggestions dialog.
  * @param commandSuggestionsTitleIconDrawable The icon for the title at the top of the command suggestions dialog.
+ * @param commandSuggestionsTitleIconDrawableTintColor The tint applied to the icon for the title at the top
+ * of the command suggestions dialog.
  * @param commandSuggestionsBackgroundColor The background color of the command suggestions dialog.
  * @param commandSuggestionItemCommandNameTextStyle The text style for the command name.
  * @param commandSuggestionItemCommandDescriptionText The command description template with two placeholders.
  * @param commandSuggestionItemCommandDescriptionTextStyle The text style for the command description.
  * @param mentionSuggestionsBackgroundColor The background color of the mention suggestions dialog.
  * @param mentionSuggestionItemIconDrawable The icon for each command icon in the suggestion list.
+ * @param mentionSuggestionItemIconDrawableTintColor The tint applied to the icon for each command icon
+ * in the suggestion list.
  * @param mentionSuggestionItemUsernameTextStyle The text style that will be used for the user name.
  * @param mentionSuggestionItemMentionText The mention template that will be used for the mention preview.
  * @param mentionSuggestionItemMentionTextStyle The text style that will be used for the mention preview.
@@ -121,9 +126,11 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param audioRecordingFloatingLockedIconDrawableTint The tint color that will be used for the the locked icon.
  * @param attachmentsButtonVisible If the button to pick attachments is displayed.
  * @param attachmentsButtonIconDrawable The icon for the attachments button.
+ * @param attachmentsButtonIconTintList The tint list for the attachments button.
  * @param attachmentsButtonRippleColor Ripple color of the attachments button.
  * @param commandsButtonVisible If the button to select commands is displayed.
  * @param commandsButtonIconDrawable The icon for the commands button.
+ * @param commandsButtonIconTintList The tint list for the commands button.
  * @param commandsButtonRippleColor Ripple color of the commands button.
  * @param alsoSendToChannelCheckboxVisible If the checkbox to send a message to the channel is displayed.
  * @param alsoSendToChannelCheckboxDrawable The drawable that will be used for the checkbox.
@@ -136,6 +143,7 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @param dismissModeIconDrawable The icon for the button that dismisses edit or reply mode.
  * @param sendMessageButtonEnabled If the button to send message is enabled.
  * @param sendMessageButtonIconDrawable The icon for the button to send message.
+ * @param sendMessageButtonIconTintList The tint list for the button to send message.
  * @param cooldownTimerTextStyle The text style that will be used for cooldown timer.
  * @param cooldownTimerBackgroundDrawable Background drawable for cooldown timer.
  * @param messageReplyBackgroundColor Sets the background color of the quoted message bubble visible in the composer
@@ -157,12 +165,24 @@ import io.getstream.chat.android.ui.utils.extensions.use
  */
 public data class MessageComposerViewStyle(
     @ColorInt public val backgroundColor: Int,
+    @Deprecated(
+        message = "Use the " +
+            "commandSuggestionsTitleIconDrawableTintColor" +
+            "/mentionSuggestionItemIconDrawableTintColor " +
+            "/attachmentsButtonIconTintList " +
+            "/commandsButtonIconTintList " +
+            "/sendMessageButtonIconTintList " +
+            "property instead.",
+        replaceWith = ReplaceWith("proper button tint property"),
+        level = DeprecationLevel.WARNING,
+    )
     @ColorInt public val buttonIconDrawableTintColor: Int?,
     public val dividerBackgroundDrawable: Drawable,
     // Command suggestions content
     public val commandSuggestionsTitleText: String,
     public val commandSuggestionsTitleTextStyle: TextStyle,
     public val commandSuggestionsTitleIconDrawable: Drawable,
+    public val commandSuggestionsTitleIconDrawableTintColor: Int?,
     @ColorInt public val commandSuggestionsBackgroundColor: Int,
     public val commandSuggestionItemCommandNameTextStyle: TextStyle,
     public val commandSuggestionItemCommandDescriptionText: String,
@@ -170,6 +190,7 @@ public data class MessageComposerViewStyle(
     // Mention suggestions content
     @ColorInt public val mentionSuggestionsBackgroundColor: Int,
     public val mentionSuggestionItemIconDrawable: Drawable,
+    public val mentionSuggestionItemIconDrawableTintColor: Int?,
     public val mentionSuggestionItemUsernameTextStyle: TextStyle,
     public val mentionSuggestionItemMentionText: String,
     public val mentionSuggestionItemMentionTextStyle: TextStyle,
@@ -214,9 +235,11 @@ public data class MessageComposerViewStyle(
     // Leading content
     public val attachmentsButtonVisible: Boolean,
     public val attachmentsButtonIconDrawable: Drawable,
+    public val attachmentsButtonIconTintList: ColorStateList?,
     @ColorInt public val attachmentsButtonRippleColor: Int?,
     public val commandsButtonVisible: Boolean,
     public val commandsButtonIconDrawable: Drawable,
+    public val commandsButtonIconTintList: ColorStateList?,
     @ColorInt public val commandsButtonRippleColor: Int?,
     // Footer content
     public val alsoSendToChannelCheckboxVisible: Boolean,
@@ -232,6 +255,7 @@ public data class MessageComposerViewStyle(
     // Trailing content
     public val sendMessageButtonEnabled: Boolean,
     public val sendMessageButtonIconDrawable: Drawable,
+    public val sendMessageButtonIconTintList: ColorStateList?,
     @Px public val sendMessageButtonWidth: Int,
     @Px public val sendMessageButtonHeight: Int,
     @Px public val sendMessageButtonPadding: Int,
@@ -239,6 +263,7 @@ public data class MessageComposerViewStyle(
     public val audioRecordingButtonEnabled: Boolean,
     public val audioRecordingButtonPreferred: Boolean,
     public val audioRecordingButtonIconDrawable: Drawable,
+    public val audioRecordingButtonIconTintList: ColorStateList?,
     @Px public val audioRecordingButtonWidth: Int,
     @Px public val audioRecordingButtonHeight: Int,
     @Px public val audioRecordingButtonPadding: Int,
@@ -328,6 +353,10 @@ public data class MessageComposerViewStyle(
                     R.styleable.MessageComposerView_streamUiMessageComposerCommandSuggestionsTitleIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_command_blue)!!
 
+                val commandSuggestionsTitleIconDrawableTintColor = a.getColorOrNull(
+                    R.styleable.MessageComposerView_streamUiMessageComposerMentionSuggestionItemIconDrawableTintColor,
+                )
+
                 val commandSuggestionsBackgroundColor = a.getColor(
                     R.styleable.MessageComposerView_streamUiMessageComposerCommandSuggestionsBackgroundColor,
                     context.getColorCompat(R.color.stream_ui_white),
@@ -386,6 +415,10 @@ public data class MessageComposerViewStyle(
                 val mentionSuggestionItemIconDrawable: Drawable = a.getDrawable(
                     R.styleable.MessageComposerView_streamUiMessageComposerMentionSuggestionItemIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_mention)!!
+
+                val mentionSuggestionItemIconDrawableTintColor = a.getColorOrNull(
+                    R.styleable.MessageComposerView_streamUiMessageComposerMentionSuggestionItemIconDrawableTintColor,
+                )
 
                 val mentionSuggestionItemUsernameTextStyle = TextStyle.Builder(a)
                     .size(
@@ -603,6 +636,11 @@ public data class MessageComposerViewStyle(
                     R.styleable.MessageComposerView_streamUiMessageComposerAttachmentsButtonIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_attach)!!
 
+                val attachmentsButtonIconTintList = a.getColorStateListCompat(
+                    context,
+                    R.styleable.MessageComposerView_streamUiMessageComposerAttachmentsButtonIconTintList,
+                )
+
                 val attachmentsButtonRippleColor = a.getColorOrNull(
                     R.styleable.MessageComposerView_streamUiMessageComposerAttachmentsButtonRippleColor,
                 )
@@ -616,6 +654,11 @@ public data class MessageComposerViewStyle(
                     context,
                     R.styleable.MessageComposerView_streamUiMessageComposerCommandsButtonIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_command)!!
+
+                val commandsButtonIconTintList = a.getColorStateListCompat(
+                    context,
+                    R.styleable.MessageComposerView_streamUiMessageComposerCommandsButtonIconTintList,
+                )
 
                 val commandsButtonRippleColor = a.getColorOrNull(
                     R.styleable.MessageComposerView_streamUiMessageComposerCommandsButtonRippleColor,
@@ -692,6 +735,11 @@ public data class MessageComposerViewStyle(
                     R.styleable.MessageComposerView_streamUiMessageComposerSendMessageButtonIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_send_message)!!
 
+                val sendMessageButtonIconTintList = a.getColorStateListCompat(
+                    context,
+                    R.styleable.MessageComposerView_streamUiMessageComposerSendMessageButtonIconTintList,
+                )
+
                 val sendMessageButtonWidth: Int =
                     a.getDimensionPixelSize(
                         R.styleable.MessageComposerView_streamUiMessageComposerSendMessageButtonWidth,
@@ -724,6 +772,11 @@ public data class MessageComposerViewStyle(
                     context,
                     R.styleable.MessageComposerView_streamUiMessageComposerAudioRecordingButtonIconDrawable,
                 ) ?: context.getDrawableCompat(R.drawable.stream_ui_ic_mic)!!
+
+                val audioRecordingButtonIconTintList = a.getColorStateListCompat(
+                    context,
+                    R.styleable.MessageComposerView_streamUiMessageComposerAudioRecordingButtonIconTintList,
+                )
 
                 val audioRecordingButtonWidth: Int =
                     a.getDimensionPixelSize(
@@ -908,6 +961,7 @@ public data class MessageComposerViewStyle(
                     commandSuggestionsTitleText = commandSuggestionsTitleText,
                     commandSuggestionsTitleTextStyle = commandSuggestionsTitleTextStyle,
                     commandSuggestionsTitleIconDrawable = commandSuggestionsTitleIconDrawable,
+                    commandSuggestionsTitleIconDrawableTintColor = commandSuggestionsTitleIconDrawableTintColor,
                     commandSuggestionsBackgroundColor = commandSuggestionsBackgroundColor,
                     commandSuggestionItemCommandNameTextStyle = commandSuggestionItemCommandNameTextStyle,
                     commandSuggestionItemCommandDescriptionText = commandSuggestionItemCommandDescriptionText,
@@ -915,6 +969,7 @@ public data class MessageComposerViewStyle(
                     // Mention suggestions content
                     mentionSuggestionsBackgroundColor = mentionSuggestionsBackgroundColor,
                     mentionSuggestionItemIconDrawable = mentionSuggestionItemIconDrawable,
+                    mentionSuggestionItemIconDrawableTintColor = mentionSuggestionItemIconDrawableTintColor,
                     mentionSuggestionItemUsernameTextStyle = mentionSuggestionItemUsernameTextStyle,
                     mentionSuggestionItemMentionText = mentionSuggestionItemMentionText,
                     mentionSuggestionItemMentionTextStyle = mentionSuggestionItemMentionTextStyle,
@@ -963,9 +1018,11 @@ public data class MessageComposerViewStyle(
                     // Leading content
                     attachmentsButtonVisible = attachmentsButtonVisible,
                     attachmentsButtonIconDrawable = attachmentsButtonIconDrawable,
+                    attachmentsButtonIconTintList = attachmentsButtonIconTintList,
                     attachmentsButtonRippleColor = attachmentsButtonRippleColor,
                     commandsButtonVisible = commandsButtonVisible,
                     commandsButtonIconDrawable = commandsButtonIconDrawable,
+                    commandsButtonIconTintList = commandsButtonIconTintList,
                     commandsButtonRippleColor = commandsButtonRippleColor,
                     // Footer content
                     alsoSendToChannelCheckboxVisible = alsoSendToChannelCheckboxVisible,
@@ -981,6 +1038,7 @@ public data class MessageComposerViewStyle(
                     // Trailing content
                     sendMessageButtonEnabled = sendMessageButtonEnabled,
                     sendMessageButtonIconDrawable = sendMessageButtonIconDrawable,
+                    sendMessageButtonIconTintList = sendMessageButtonIconTintList,
                     sendMessageButtonWidth = sendMessageButtonWidth,
                     sendMessageButtonHeight = sendMessageButtonHeight,
                     sendMessageButtonPadding = sendMessageButtonPadding,
@@ -988,6 +1046,7 @@ public data class MessageComposerViewStyle(
                     audioRecordingButtonVisible = audioRecordingButtonVisible,
                     audioRecordingButtonPreferred = audioRecordingButtonPreferred,
                     audioRecordingButtonIconDrawable = audioRecordingButtonIconDrawable,
+                    audioRecordingButtonIconTintList = audioRecordingButtonIconTintList,
                     audioRecordingButtonWidth = audioRecordingButtonWidth,
                     audioRecordingButtonHeight = audioRecordingButtonHeight,
                     audioRecordingButtonPadding = audioRecordingButtonPadding,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerCommandSuggestionsContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerCommandSuggestionsContent.kt
@@ -96,7 +96,9 @@ public class DefaultMessageComposerCommandSuggestionsContent : FrameLayout, Mess
         binding.commandsTitleTextView.text = style.commandSuggestionsTitleText
         binding.commandsTitleTextView.setTextStyle(style.commandSuggestionsTitleTextStyle)
         binding.commandsTitleTextView.setStartDrawable(
-            style.commandSuggestionsTitleIconDrawable.applyTint(style.buttonIconDrawableTintColor),
+            style.commandSuggestionsTitleIconDrawable.applyTint(
+                tintColor = style.commandSuggestionsTitleIconDrawableTintColor ?: style.buttonIconDrawableTintColor,
+            ),
         )
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerLeadingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerLeadingContent.kt
@@ -96,14 +96,24 @@ public class DefaultMessageComposerLeadingContent : FrameLayout, MessageComposer
         binding.commandsButton.setImageDrawable(style.commandsButtonIconDrawable)
         binding.commandsButton.setBorderlessRipple(style.commandsButtonRippleColor)
 
-        style.buttonIconDrawableTintColor?.let { tintColor ->
-            val colorStateList = getColorList(
+        val getStateListColor = { tintColor: Int ->
+            getColorList(
                 normalColor = context.getColorCompat(R.color.stream_ui_grey),
                 selectedColor = tintColor,
                 disabledColor = context.getColorCompat(R.color.stream_ui_grey_gainsboro),
             )
-            binding.attachmentsButton.imageTintList = colorStateList
-            binding.commandsButton.imageTintList = colorStateList
+        }
+
+        style.attachmentsButtonIconTintList?.also { tintList ->
+            binding.attachmentsButton.imageTintList = tintList
+        } ?: style.buttonIconDrawableTintColor?.let { tintColor ->
+            binding.attachmentsButton.imageTintList = getStateListColor(tintColor)
+        }
+
+        style.commandsButtonIconTintList?.also { tintList ->
+            binding.commandsButton.imageTintList = tintList
+        } ?: style.buttonIconDrawableTintColor?.let { tintColor ->
+            binding.commandsButton.imageTintList = getStateListColor(tintColor)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerMentionSuggestionsContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerMentionSuggestionsContent.kt
@@ -154,7 +154,9 @@ private class MentionsViewHolder(
         binding.usernameTextView.setTextStyle(style.mentionSuggestionItemUsernameTextStyle)
         binding.mentionNameTextView.setTextStyle(style.mentionSuggestionItemMentionTextStyle)
         binding.mentionsIcon.setImageDrawable(
-            style.mentionSuggestionItemIconDrawable.applyTint(style.buttonIconDrawableTintColor),
+            style.mentionSuggestionItemIconDrawable.applyTint(
+                tintColor = style.mentionSuggestionItemIconDrawableTintColor ?: style.buttonIconDrawableTintColor,
+            ),
         )
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerTrailingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerTrailingContent.kt
@@ -97,6 +97,14 @@ public class DefaultMessageComposerTrailingContent : FrameLayout, MessageCompose
     override fun attachContext(messageComposerContext: MessageComposerContext) {
         this.style = messageComposerContext.style
 
+        val getStateListColor = { tintColor: Int ->
+            getColorList(
+                normalColor = tintColor,
+                selectedColor = tintColor,
+                disabledColor = context.getColorCompat(R.color.stream_ui_grey_gainsboro),
+            )
+        }
+
         binding.sendMessageButton.setImageDrawable(style.sendMessageButtonIconDrawable)
         binding.sendMessageButton.updateLayoutParams {
             width = style.sendMessageButtonWidth
@@ -108,20 +116,17 @@ public class DefaultMessageComposerTrailingContent : FrameLayout, MessageCompose
             style.sendMessageButtonPadding,
             style.sendMessageButtonPadding,
         )
-        style.buttonIconDrawableTintColor?.let { tintColor ->
-            binding.sendMessageButton.imageTintList = getColorList(
-                normalColor = tintColor,
-                selectedColor = tintColor,
-                disabledColor = context.getColorCompat(R.color.stream_ui_grey_gainsboro),
-            )
+        style.sendMessageButtonIconTintList?.also { tintList ->
+            binding.sendMessageButton.imageTintList = tintList
+        } ?: style.buttonIconDrawableTintColor?.let { tintColor ->
+            binding.sendMessageButton.imageTintList = getStateListColor(tintColor)
         }
+
         binding.recordAudioButton.setImageDrawable(style.audioRecordingButtonIconDrawable)
-        style.buttonIconDrawableTintColor?.let { tintColor ->
-            binding.recordAudioButton.imageTintList = getColorList(
-                normalColor = tintColor,
-                selectedColor = tintColor,
-                disabledColor = context.getColorCompat(R.color.stream_ui_grey_gainsboro),
-            )
+        style.audioRecordingButtonIconTintList?.also { tintList ->
+            binding.recordAudioButton.imageTintList = tintList
+        } ?: style.buttonIconDrawableTintColor?.let { tintColor ->
+            binding.recordAudioButton.imageTintList = getStateListColor(tintColor)
         }
         binding.recordAudioButton.updateLayoutParams {
             width = style.audioRecordingButtonWidth

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle.kt
@@ -118,12 +118,22 @@ public data class MessageListItemStyle(
     public val iconIndicatorRead: Drawable,
     public val iconIndicatorPendingSync: Drawable,
     public val iconOnlyVisibleToYou: Drawable,
+    @Deprecated(
+        message = "Use textStyleMessageDeletedMine and textStyleMessageDeletedTheirs instead.",
+        replaceWith = ReplaceWith("textStyleMessageDeletedMine and textStyleMessageDeletedTheirs"),
+        level = DeprecationLevel.WARNING,
+    )
     public val textStyleMessageDeleted: TextStyle,
+    @Deprecated(
+        message = "Use messageDeletedBackgroundMine and messageDeletedBackgroundTheirs instead.",
+        replaceWith = ReplaceWith("messageDeletedBackgroundMine and messageDeletedBackgroundTheirs"),
+        level = DeprecationLevel.WARNING,
+    )
     @ColorInt public val messageDeletedBackground: Int,
-    public val textStyleMessageDeletedMine: TextStyle = textStyleMessageDeleted,
-    @ColorInt public val messageDeletedBackgroundMine: Int = messageDeletedBackground,
-    public val textStyleMessageDeletedTheirs: TextStyle = textStyleMessageDeleted,
-    @ColorInt public val messageDeletedBackgroundTheirs: Int = messageDeletedBackground,
+    public val textStyleMessageDeletedMine: TextStyle?,
+    @ColorInt public val messageDeletedBackgroundMine: Int?,
+    public val textStyleMessageDeletedTheirs: TextStyle?,
+    @ColorInt public val messageDeletedBackgroundTheirs: Int?,
     @ColorInt public val messageStrokeColorMine: Int,
     @Px public val messageStrokeWidthMine: Float,
     @ColorInt public val messageStrokeColorTheirs: Int,
@@ -498,6 +508,64 @@ public data class MessageListItemStyle(
                 .style(R.styleable.MessageListView_streamUiMessageTextStyleMessageDeleted, Typeface.ITALIC)
                 .build()
 
+            val messageDeletedBackgroundMine =
+                attributes.getColor(
+                    R.styleable.MessageListView_streamUiDeletedMessageBackgroundColorMine,
+                    VALUE_NOT_SET,
+                )
+
+            val textStyleMessageDeletedMine = TextStyle.Builder(attributes)
+                .size(
+                    R.styleable.MessageListView_streamUiMessageTextSizeMessageDeletedMine,
+                    textStyleMessageDeleted.size,
+                )
+                .color(
+                    R.styleable.MessageListView_streamUiMessageTextColorMessageDeletedMine,
+                    textStyleMessageDeleted.color,
+                )
+                .fontAssetsPath(
+                    R.styleable.MessageListView_streamUiMessageTextFontAssetsMessageDeletedMine,
+                    textStyleMessageDeleted.fontAssetsPath,
+                )
+                .fontResource(
+                    R.styleable.MessageListView_streamUiMessageTextFontMessageDeletedMine,
+                    textStyleMessageDeleted.fontResource,
+                )
+                .style(
+                    R.styleable.MessageListView_streamUiMessageTextStyleMessageDeletedMine,
+                    textStyleMessageDeleted.style,
+                )
+                .build()
+
+            val messageDeletedBackgroundTheirs =
+                attributes.getColor(
+                    R.styleable.MessageListView_streamUiDeletedMessageBackgroundColorTheirs,
+                    VALUE_NOT_SET,
+                )
+
+            val textStyleMessageDeletedTheirs = TextStyle.Builder(attributes)
+                .size(
+                    R.styleable.MessageListView_streamUiMessageTextSizeMessageDeletedTheirs,
+                    textStyleMessageDeleted.size,
+                )
+                .color(
+                    R.styleable.MessageListView_streamUiMessageTextColorMessageDeletedTheirs,
+                    textStyleMessageDeleted.color,
+                )
+                .fontAssetsPath(
+                    R.styleable.MessageListView_streamUiMessageTextFontAssetsMessageDeletedTheirs,
+                    textStyleMessageDeleted.fontAssetsPath,
+                )
+                .fontResource(
+                    R.styleable.MessageListView_streamUiMessageTextFontMessageDeletedTheirs,
+                    textStyleMessageDeleted.fontResource,
+                )
+                .style(
+                    R.styleable.MessageListView_streamUiMessageTextStyleMessageDeletedTheirs,
+                    textStyleMessageDeleted.style,
+                )
+                .build()
+
             val messageStrokeColorMine = attributes.getColor(
                 R.styleable.MessageListView_streamUiMessageStrokeColorMine,
                 context.getColorCompat(MESSAGE_STROKE_COLOR_MINE),
@@ -638,6 +706,10 @@ public data class MessageListItemStyle(
                 iconOnlyVisibleToYou = iconOnlyVisibleToYou,
                 messageDeletedBackground = messageDeletedBackground,
                 textStyleMessageDeleted = textStyleMessageDeleted,
+                messageDeletedBackgroundMine = messageDeletedBackgroundMine.nullIfNotSet(),
+                textStyleMessageDeletedMine = textStyleMessageDeletedMine.nullIfEqualsTo(textStyleMessageDeleted),
+                messageDeletedBackgroundTheirs = messageDeletedBackgroundTheirs.nullIfNotSet(),
+                textStyleMessageDeletedTheirs = textStyleMessageDeletedTheirs.nullIfEqualsTo(textStyleMessageDeleted),
                 messageStrokeColorMine = messageStrokeColorMine,
                 messageStrokeWidthMine = messageStrokeWidthMine,
                 messageStrokeColorTheirs = messageStrokeColorTheirs,
@@ -662,6 +734,10 @@ public data class MessageListItemStyle(
 
         private fun Int.nullIfNotSet(): Int? {
             return if (this == VALUE_NOT_SET) null else this
+        }
+
+        private fun TextStyle.nullIfEqualsTo(defaultValue: TextStyle): TextStyle? {
+            return if (this == defaultValue) null else this
         }
 
         private fun MessageListItemStyle.checkMessageMaxWidthFactorsRange() {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/internal/MessageDeletedViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/internal/MessageDeletedViewHolder.kt
@@ -48,7 +48,7 @@ internal class MessageDeletedViewHolder(
             when (data.isTheirs) {
                 true -> style.textStyleMessageDeletedTheirs
                 else -> style.textStyleMessageDeletedMine
-            },
+            } ?: style.textStyleMessageDeleted,
         )
 
         binding.messageContainer.updateLayoutParams<ConstraintLayout.LayoutParams> {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/background/MessageBackgroundFactoryImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/background/MessageBackgroundFactoryImpl.kt
@@ -69,7 +69,7 @@ public open class MessageBackgroundFactoryImpl(private val style: MessageListIte
                     when (data.isTheirs) {
                         true -> style.messageDeletedBackgroundTheirs
                         else -> style.messageDeletedBackgroundMine
-                    },
+                    } ?: style.messageDeletedBackground,
                 )
             }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/font/TextStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/font/TextStyle.kt
@@ -96,6 +96,14 @@ public data class TextStyle(
             this.fontResource = array.getResourceId(resId, -1)
         }
 
+        public fun fontAssetsPath(@StyleableRes assetsPath: Int, defValue: String?): Builder = apply {
+            this.fontAssetsPath = array.getString(assetsPath) ?: defValue
+        }
+
+        public fun fontResource(@StyleableRes resId: Int, defValue: Int): Builder = apply {
+            this.fontResource = array.getResourceId(resId, defValue)
+        }
+
         public fun font(
             @StyleableRes assetsPath: Int,
             @StyleableRes resId: Int,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/TypedArray.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/TypedArray.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.ui.utils.extensions
 
 import android.content.Context
+import android.content.res.ColorStateList
 import android.content.res.TypedArray
 import android.graphics.drawable.Drawable
 import androidx.annotation.ColorInt
@@ -41,6 +42,21 @@ internal fun TypedArray.getDrawableCompat(context: Context, @StyleableRes id: In
     val resource = getResourceId(id, 0)
     if (resource != 0) {
         return AppCompatResources.getDrawable(context, resource)
+    }
+    return null
+}
+
+/**
+ * Retrieves the ColorStateList for the attribute.
+ *
+ * @param context The context to inflate against.
+ * @param id The index of attribute to retrieve.
+ * @return An object that can be used to draw this resource.
+ */
+internal fun TypedArray.getColorStateListCompat(context: Context, @StyleableRes id: Int): ColorStateList? {
+    val resource = getResourceId(id, 0)
+    if (resource != 0) {
+        return AppCompatResources.getColorStateList(context, resource)
     }
     return null
 }

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_composer_view.xml
@@ -33,6 +33,7 @@
         </attr>
 
         <attr name="streamUiMessageComposerCommandSuggestionsTitleIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerCommandSuggestionsTitleIconDrawableTintColor" format="reference|color" />
         <attr name="streamUiMessageComposerCommandSuggestionsBackgroundColor" format="reference|color" />
 
         <attr name="streamUiMessageComposerCommandSuggestionItemCommandNameTextSize" format="dimension" />
@@ -59,6 +60,7 @@
         <!-- Mention suggestions content -->
         <attr name="streamUiMessageComposerMentionSuggestionsBackgroundColor" format="reference|color" />
         <attr name="streamUiMessageComposerMentionSuggestionItemIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerMentionSuggestionItemIconDrawableTintColor" format="reference|color" />
 
         <attr name="streamUiMessageComposerMentionSuggestionItemUsernameTextSize" format="dimension" />
         <attr name="streamUiMessageComposerMentionSuggestionItemUsernameTextColor" format="reference|color" />
@@ -166,9 +168,11 @@
         <!-- Leading content -->
         <attr name="streamUiMessageComposerAttachmentsButtonVisible" format="boolean" />
         <attr name="streamUiMessageComposerAttachmentsButtonIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerAttachmentsButtonIconTintList" format="reference" />
         <attr name="streamUiMessageComposerAttachmentsButtonRippleColor" format="color|reference" />
         <attr name="streamUiMessageComposerCommandsButtonVisible" format="boolean" />
         <attr name="streamUiMessageComposerCommandsButtonIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerCommandsButtonIconTintList" format="reference" />
         <attr name="streamUiMessageComposerCommandsButtonRippleColor" format="color|reference" />
 
         <!-- Footer content -->
@@ -196,6 +200,7 @@
         <!-- Trailing content -->
         <attr name="streamUiMessageComposerSendMessageButtonEnabled" format="boolean" />
         <attr name="streamUiMessageComposerSendMessageButtonIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerSendMessageButtonIconTintList" format="reference" />
         <attr name="streamUiMessageComposerSendMessageButtonWidth" format="dimension|reference" />
         <attr name="streamUiMessageComposerSendMessageButtonHeight" format="dimension|reference" />
         <attr name="streamUiMessageComposerSendMessageButtonPadding" format="dimension|reference" />
@@ -203,6 +208,7 @@
         <attr name="streamUiMessageComposerAudioRecordingButtonVisible" format="boolean" />
         <attr name="streamUiMessageComposerAudioRecordingButtonPreferred" format="boolean" />
         <attr name="streamUiMessageComposerAudioRecordingButtonIconDrawable" format="reference" />
+        <attr name="streamUiMessageComposerAudioRecordingButtonIconTintList" format="reference" />
         <attr name="streamUiMessageComposerAudioRecordingButtonWidth" format="dimension|reference" />
         <attr name="streamUiMessageComposerAudioRecordingButtonHeight" format="dimension|reference" />
         <attr name="streamUiMessageComposerAudioRecordingButtonPadding" format="dimension|reference" />

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -290,6 +290,30 @@
             <flag name="italic" value="2" />
         </attr>
 
+        <!-- Message deleted style mine -->
+        <attr name="streamUiDeletedMessageBackgroundColorMine" format="color" />
+        <attr name="streamUiMessageTextSizeMessageDeletedMine" format="dimension|reference" />
+        <attr name="streamUiMessageTextColorMessageDeletedMine" format="color" />
+        <attr name="streamUiMessageTextFontMessageDeletedMine" format="reference" />
+        <attr name="streamUiMessageTextFontAssetsMessageDeletedMine" format="string" />
+        <attr name="streamUiMessageTextStyleMessageDeletedMine">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <!-- Message deleted style theirs -->
+        <attr name="streamUiDeletedMessageBackgroundColorTheirs" format="color" />
+        <attr name="streamUiMessageTextSizeMessageDeletedTheirs" format="dimension|reference" />
+        <attr name="streamUiMessageTextColorMessageDeletedTheirs" format="color" />
+        <attr name="streamUiMessageTextFontMessageDeletedTheirs" format="reference" />
+        <attr name="streamUiMessageTextFontAssetsMessageDeletedTheirs" format="string" />
+        <attr name="streamUiMessageTextStyleMessageDeletedTheirs">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
         <!-- System message style -->
         <attr name="streamUiSystemMessageTextSize" format="dimension|reference" />
         <attr name="streamUiSystemMessageTextColor" format="color" />

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -1023,6 +1023,7 @@
         <item name="streamUiMessageComposerCommandSuggestionsTitleTextSize">@dimen/stream_ui_text_medium</item>
         <item name="streamUiMessageComposerCommandSuggestionsTitleTextColor">@color/stream_ui_text_color_secondary</item>
         <item name="streamUiMessageComposerCommandSuggestionsTitleIconDrawable">@drawable/stream_ui_ic_command_blue</item>
+        <item name="streamUiMessageComposerCommandSuggestionsTitleIconDrawableTintColor">@null</item>
         <item name="streamUiMessageComposerCommandSuggestionsBackgroundColor">@color/stream_ui_white</item>
         <item name="streamUiMessageComposerCommandSuggestionItemCommandNameTextSize">@dimen/stream_ui_text_medium</item>
         <item name="streamUiMessageComposerCommandSuggestionItemCommandNameTextColor">@color/stream_ui_text_color_primary</item>
@@ -1033,6 +1034,7 @@
         <!-- Mention suggestions content -->
         <item name="streamUiMessageComposerMentionSuggestionsBackgroundColor">@color/stream_ui_white</item>
         <item name="streamUiMessageComposerMentionSuggestionItemIconDrawable">@drawable/stream_ui_ic_mention</item>
+        <item name="streamUiMessageComposerMentionSuggestionItemIconDrawableTintColor">@null</item>
         <item name="streamUiMessageComposerMentionSuggestionItemUsernameTextSize">@dimen/stream_ui_text_medium</item>
         <item name="streamUiMessageComposerMentionSuggestionItemUsernameTextColor">@color/stream_ui_text_color_primary</item>
         <item name="streamUiMessageComposerMentionSuggestionItemMentionText">@string/stream_ui_message_composer_mention_template</item>
@@ -1085,9 +1087,11 @@
         <!-- Leading content -->
         <item name="streamUiMessageComposerAttachmentsButtonVisible">true</item>
         <item name="streamUiMessageComposerAttachmentsButtonIconDrawable">@drawable/stream_ui_ic_attach</item>
+        <item name="streamUiMessageComposerAttachmentsButtonIconTintList">@null</item>
         <item name="streamUiMessageComposerAttachmentsButtonRippleColor">@null</item>
         <item name="streamUiMessageComposerCommandsButtonVisible">true</item>
         <item name="streamUiMessageComposerCommandsButtonIconDrawable">@drawable/stream_ui_ic_command</item>
+        <item name="streamUiMessageComposerCommandsButtonIconTintList">@null</item>
         <item name="streamUiMessageComposerCommandsButtonRippleColor">@null</item>
 
         <!-- Footer content -->
@@ -1107,6 +1111,7 @@
         <!-- Trailing content -->
         <item name="streamUiMessageComposerSendMessageButtonEnabled">true</item>
         <item name="streamUiMessageComposerSendMessageButtonIconDrawable">@drawable/stream_ui_ic_send_message</item>
+        <item name="streamUiMessageComposerSendMessageButtonIconTintList">@null</item>
         <item name="streamUiMessageComposerSendMessageButtonWidth">@dimen/stream_ui_message_composer_trailing_content_button_send_message_width</item>
         <item name="streamUiMessageComposerSendMessageButtonHeight">@dimen/stream_ui_message_composer_trailing_content_button_send_message_height</item>
         <item name="streamUiMessageComposerSendMessageButtonPadding">@dimen/stream_ui_message_composer_trailing_content_button_send_message_padding</item>
@@ -1114,6 +1119,7 @@
         <item name="streamUiMessageComposerAudioRecordingButtonEnabled">true</item>
         <item name="streamUiMessageComposerAudioRecordingButtonPreferred">false</item>
         <item name="streamUiMessageComposerAudioRecordingButtonIconDrawable">@drawable/stream_ui_ic_mic</item>
+        <item name="streamUiMessageComposerAudioRecordingButtonIconTintList">@null</item>
         <item name="streamUiMessageComposerAudioRecordingButtonWidth">@dimen/stream_ui_message_composer_trailing_content_button_record_audio_width</item>
         <item name="streamUiMessageComposerAudioRecordingButtonHeight">@dimen/stream_ui_message_composer_trailing_content_button_record_audio_height</item>
         <item name="streamUiMessageComposerAudioRecordingButtonPadding">@dimen/stream_ui_message_composer_trailing_content_button_record_audio_padding</item>


### PR DESCRIPTION
### 🎯 Goal

Closes: https://github.com/GetStream/android-internal-board/issues/212

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
