### PR TITLE
Fix Gzip compression (v5)

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptor.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptor.kt
@@ -27,7 +27,6 @@ internal class HeadersInterceptor(private val isAnonymous: () -> Boolean) : Inte
             .newBuilder()
             .addHeader("Content-Type", "application/json")
             .addHeader("stream-auth-type", authType)
-            .addHeader("Accept-Encoding", "application/gzip")
             .addHeader("X-Stream-Client", ChatClient.buildSdkTrackingHeaders())
             .addHeader("Cache-Control", "no-cache")
             .build()


### PR DESCRIPTION
GZIP configuration was wrong. We were adding `application/gzip` instead of `gzip` into `Accept-Encoding`. But the best solution is to not specify this at all - because if you do, then you have to handle it on your own. OkHttp handles this transparently - we don’t need to specify it.
This is best explained by Jake Wharton here: https://github.com/square/okhttp/issues/2132 

I verified this by placing breakpoints into `GzipSource.read`  in OkHttp and also in `BridgeInterceptor` . The read function is not getting called on the `GzipSource` in develop - only if I delete our accept-encoding header it works correctly.