### PR TITLE
Asynchronously create ChannelMutableState()

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -71,6 +71,7 @@ internal class LogicRegistry internal constructor(
                 stateRegistry.queryChannels(filter, sort).toMutableState(),
                 stateRegistry,
                 this,
+                coroutineScope,
             )
 
             val queryChannelsDatabaseLogic = QueryChannelsDatabaseLogic(

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogicTest.kt
@@ -28,7 +28,10 @@ import io.getstream.chat.android.randomString
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.querychannels.internal.QueryChannelsMutableState
+import io.getstream.chat.android.test.TestCoroutineRule
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should contain same`
+import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -38,6 +41,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 internal class QueryChannelsStateLogicTest {
+
+    @get:Rule
+    val testCoroutines = TestCoroutineRule()
 
     private val type = randomString()
     private val id = randomString()
@@ -58,7 +64,8 @@ internal class QueryChannelsStateLogicTest {
         on(it.channelState(any(), any())) doReturn mock()
     }
 
-    private val queryChannelsStateLogic = QueryChannelsStateLogic(mutableState, stateRegistry, logicRegistry)
+    private val queryChannelsStateLogic =
+        QueryChannelsStateLogic(mutableState, stateRegistry, logicRegistry, testCoroutines.scope)
 
     @Test
     fun `when a channel is inside the query spec and it is refreshed, it should be added`() {
@@ -114,7 +121,7 @@ internal class QueryChannelsStateLogicTest {
     }
 
     @Test
-    fun `when adding channel state both specs and channels should be added`() {
+    fun `when adding channel state both specs and channels should be added`() = runTest {
         val channel1 = randomChannel()
         val channel2 = randomChannel()
         val channels = listOf(channel1, channel2)


### PR DESCRIPTION
The `ChannelMutableState()` is rather slow to create (many `StateFlows` with `SharingStarted.Eagerly`) - we need to investigate this closer but for now we can prepare the channels in parallel. In my measurements this approach is always faster - it seems to save about 500ms on 30 channels (in the sample app).