### PR TITLE
Asynchronously create ChannelMutableState()

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/offline/plugin/logic/internal/LogicRegistry.kt
@@ -68,7 +68,8 @@ internal class LogicRegistry internal constructor(
             val queryChannelsStateLogic = QueryChannelsStateLogic(
                 stateRegistry.queryChannels(filter, sort).toMutableState(),
                 stateRegistry,
-                this
+                this,
+                coroutineScope,
             )
 
             val queryChannelsDatabaseLogic = QueryChannelsDatabaseLogic(

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/offline/plugin/logic/querychannels/internal/QueryChannelsStateLogicTest.kt
@@ -25,8 +25,11 @@ import io.getstream.chat.android.offline.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.offline.plugin.state.StateRegistry
 import io.getstream.chat.android.offline.plugin.state.channel.ChannelState
 import io.getstream.chat.android.offline.plugin.state.querychannels.internal.QueryChannelsMutableState
+import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.randomCID
+import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.`should contain same`
+import org.junit.Rule
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -36,6 +39,9 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 
 internal class QueryChannelsStateLogicTest {
+
+    @get:Rule
+    val testCoroutines = TestCoroutineRule()
 
     private val testCid = randomCID()
 
@@ -54,7 +60,8 @@ internal class QueryChannelsStateLogicTest {
         on(it.channelState(any(), any())) doReturn mock()
     }
 
-    private val queryChannelsStateLogic = QueryChannelsStateLogic(mutableState, stateRegistry, logicRegistry)
+    private val queryChannelsStateLogic =
+        QueryChannelsStateLogic(mutableState, stateRegistry, logicRegistry, testCoroutines.scope)
 
     @Test
     fun `when a channel is inside the query spec and it is refreshed, it should be added`() {
@@ -110,7 +117,7 @@ internal class QueryChannelsStateLogicTest {
     }
 
     @Test
-    fun `when adding channel state both specs and channels should be added`() {
+    fun `when adding channel state both specs and channels should be added`() = runTest {
         val channel1 = randomChannel()
         val channel2 = randomChannel()
         val channels = listOf(channel1, channel2)


### PR DESCRIPTION
The `ChannelMutableState()` is rather slow to create (many `StateFlows` with `SharingStarted.Eagerly`) - we need to investigate this closer but for now we can prepare the channels in parallel. In my measurements this approach is always faster - it seems to save about 500ms on 30 channels (in the sample app).