### PR TITLE
Fix skip slow mode capability not handled

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2665,6 +2665,7 @@ public final class io/getstream/chat/android/client/models/ChannelCapabilities {
 	public static final field SEND_REPLY Ljava/lang/String;
 	public static final field SEND_TYPING_EVENTS Ljava/lang/String;
 	public static final field SET_CHANNEL_COOLDOWN Ljava/lang/String;
+	public static final field SKIP_SLOW_MODE Ljava/lang/String;
 	public static final field SLOW_MODE Ljava/lang/String;
 	public static final field TYPING_EVENTS Ljava/lang/String;
 	public static final field UPDATE_ANY_MESSAGE Ljava/lang/String;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/ChannelCapabilities.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/models/ChannelCapabilities.kt
@@ -83,6 +83,8 @@ public object ChannelCapabilities {
     public const val TYPING_EVENTS: String = "typing-events"
     /** Indicates that channel slow mode is active. */
     public const val SLOW_MODE: String = "slow-mode"
+    /** Indicates that slow-mode should be skipped. */
+    public const val SKIP_SLOW_MODE: String = "skip-slow-mode"
     /** Ability to join a call. */
     public const val JOIN_CALL: String = "join-call"
     /** "Ability to create a call. */

--- a/stream-chat-android-ui-common/detekt-baseline.xml
+++ b/stream-chat-android-ui-common/detekt-baseline.xml
@@ -2,6 +2,7 @@
 <SmellBaseline>
   <ManuallySuppressedIssues/>
   <CurrentIssues>
+    <ID>ComplexCondition:MessageComposerController.kt$MessageComposerController$cooldownInterval > 0 &amp;&amp; isSlowModeActive.value &amp;&amp; !isInEditMode &amp;&amp; !isSlowModeDisabled.value</ID>
     <ID>MaxLineLength:MessageComposerController.kt$MessageComposerController$val</ID>
   </CurrentIssues>
 </SmellBaseline>


### PR DESCRIPTION
Same implementation as https://github.com/GetStream/stream-chat-swiftui/pull/402/files.
We need to handle the `skip-slow-mode` flag which completely disables slow mode on the client.