### PR TITLE
Cache dateformat used by UI

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/DateFormatter.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/DateFormatter.kt
@@ -238,6 +238,11 @@ internal class DefaultDateFormatter(
         private val context: Context,
         private val locale: Locale,
     ) : DateContext {
+
+        private val dateTimePatternLazy by lazy {
+            DateFormat.getBestDateTimePattern(locale, "yy MM dd")
+        }
+
         override fun now(): Date = Date()
 
         override fun yesterdayString(): String {
@@ -251,7 +256,7 @@ internal class DefaultDateFormatter(
         override fun dateTimePattern(): String {
             // Gets a localized pattern that contains 2 digit representations of
             // the year, month, and day of month
-            return DateFormat.getBestDateTimePattern(locale, "yy MM dd")
+            return dateTimePatternLazy
         }
     }
 }


### PR DESCRIPTION
This line is executed on every channel item drawn and causes a small delay - but this small stuff quickly adds up and contributes to the janky channel list in Compose.