### PR TITLE
Fix empty message list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fixed audio recording not being uploaded [#5066](https://github.com/GetStream/stream-chat-android/pull/5066)
+- All sent messages are initialized with a non-null `createdLocallyAt` property. [#5086](https://github.com/GetStream/stream-chat-android/pull/5086)
 
 ### ⬆️ Improved
 
@@ -39,6 +40,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Fix issue on the pagination process when querying a channel by filling the messages list gap. [#5086](https://github.com/GetStream/stream-chat-android/pull/5086)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1933,6 +1933,9 @@ public final class io/getstream/chat/android/client/extensions/FlowExtensions {
 
 public final class io/getstream/chat/android/client/extensions/MessageExtensionsKt {
 	public static final fun enrichWithCid (Lio/getstream/chat/android/models/Message;Ljava/lang/String;)Lio/getstream/chat/android/models/Message;
+	public static final fun getCreatedAtOrDefault (Lio/getstream/chat/android/models/Message;Ljava/util/Date;)Ljava/util/Date;
+	public static final fun getCreatedAtOrNull (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
+	public static final fun getCreatedAtOrThrow (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
 }
 
 public final class io/getstream/chat/android/client/extensions/SharedPreferencesKt {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/MessageExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/MessageExtensions.kt
@@ -57,3 +57,25 @@ public fun Message.updateMessageOnlineState(isOnline: Boolean): Message {
         updatedLocallyAt = Date(),
     )
 }
+
+/**
+ * @return when the message was created or throw an exception.
+ */
+public fun Message.getCreatedAtOrThrow(): Date {
+    val created = getCreatedAtOrNull()
+    return checkNotNull(created) { "a message needs to have a non null value for either createdAt or createdLocallyAt" }
+}
+
+/**
+ * @return when the message was created or null.
+ */
+public fun Message.getCreatedAtOrNull(): Date? {
+    return createdAt ?: createdLocallyAt
+}
+
+/**
+ * @return when the message was created or `default`.
+ */
+public fun Message.getCreatedAtOrDefault(default: Date): Date {
+    return getCreatedAtOrNull() ?: default
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIcon.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.previewdata.PreviewMessageData
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -34,7 +35,6 @@ import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrThrow
 
 /**
  * Shows a delivery status indicator for a particular message.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -105,6 +105,7 @@ public class MessagesViewModelFactory(
                     mediaRecorder = mediaRecorder,
                     fileToUri = fileToUriConverter,
                     channelId = channelId,
+                    messageLimit = messageLimit,
                     maxAttachmentCount = maxAttachmentCount,
                     maxAttachmentSize = maxAttachmentSize,
                     messageId = messageId,

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -412,6 +412,7 @@ internal class MessageComposerViewModelTest {
                     fileToUri = { it.path },
                     maxAttachmentCount = maxAttachmentCount,
                     maxAttachmentSize = maxAttachmentSize,
+                    messageLimit = 30,
                 ),
             )
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -117,6 +117,7 @@ internal class LogicRegistry internal constructor(
                 repos = repos,
                 userPresence = userPresence,
                 channelStateLogic = stateLogic,
+                coroutineScope = coroutineScope,
             )
         }
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
@@ -92,6 +92,7 @@ internal class WhenHandleEvent : SynchronizedCoroutineTest {
             repos,
             false,
             channelStateLogic,
+            testCoroutines.scope,
         )
     }
 

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1251,6 +1251,7 @@ public final class io/getstream/chat/android/ui/common/utils/extensions/MessageF
 }
 
 public final class io/getstream/chat/android/ui/common/utils/extensions/MessageKt {
+	public static final fun getCreatedAtOrDefault (Lio/getstream/chat/android/models/Message;Ljava/util/Date;)Ljava/util/Date;
 	public static final fun getCreatedAtOrNull (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
 	public static final fun getCreatedAtOrThrow (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
 	public static final fun isModerationFailed (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;)Z

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1251,9 +1251,6 @@ public final class io/getstream/chat/android/ui/common/utils/extensions/MessageF
 }
 
 public final class io/getstream/chat/android/ui/common/utils/extensions/MessageKt {
-	public static final fun getCreatedAtOrDefault (Lio/getstream/chat/android/models/Message;Ljava/util/Date;)Ljava/util/Date;
-	public static final fun getCreatedAtOrNull (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
-	public static final fun getCreatedAtOrThrow (Lio/getstream/chat/android/models/Message;)Ljava/util/Date;
 	public static final fun isModerationFailed (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;)Z
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -96,6 +96,7 @@ public class MessageComposerController(
     private val chatClient: ChatClient = ChatClient.instance(),
     private val mediaRecorder: StreamMediaRecorder,
     private val fileToUri: (File) -> String,
+    private val messageLimit: Int,
     private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
     private val maxAttachmentSize: Long = AttachmentConstants.MAX_UPLOAD_FILE_SIZE,
     private val messageId: String? = null,
@@ -359,7 +360,6 @@ public class MessageComposerController(
     }
 
     private fun observeChannelState(): Flow<ChannelState> {
-        val messageLimit = if (messageId != null) 0 else DefaultMessageLimit
         logger.d { "[observeChannelState] cid: $channelId, messageId: $messageId, messageLimit: $messageLimit" }
         return chatClient.watchChannelAsState(
             cid = channelId,
@@ -967,11 +967,6 @@ public class MessageComposerController(
          * The regex pattern used to check if the message ends with incomplete command.
          */
         private val CommandPattern = Pattern.compile("^/[a-z]*$")
-
-        /**
-         * The default limit for messages count in requests.
-         */
-        private const val DefaultMessageLimit: Int = 30
 
         private const val OneSecond = 1000L
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler.kt
@@ -16,9 +16,10 @@
 
 package io.getstream.chat.android.ui.common.feature.messages.list
 
+import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
+import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.extensions.internal.NEVER
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrThrow
 
 /**
  * A SAM designed to evaluate if a date separator should be added between messages.
@@ -78,7 +79,12 @@ public fun interface DateSeparatorHandler {
             message: Message,
             separatorTimeMillis: Long,
         ): Boolean {
-            return (message.getCreatedAtOrThrow().time - (previousMessage?.getCreatedAtOrThrow()?.time ?: NEVER.time)) >
+            return (
+                message.getCreatedAtOrDefault(NEVER).time - (
+                    previousMessage?.getCreatedAtOrNull()?.time
+                        ?: NEVER.time
+                    )
+                ) >
                 separatorTimeMillis
         }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -385,9 +385,6 @@ public class MessageListController(
     }
 
     private fun observeChannelState(): StateFlow<ChannelState?> {
-        // Using 0 as limit will skip insertion of new messages if we are loading a specific message when
-        // opening the MessageList screen. Prevents race condition where wrong messages might get loaded.
-        val messageLimit = if (messageId != null) 0 else messageLimit
         logger.d { "[observeChannelState] cid: $cid, messageId: $messageId, messageLimit: $messageLimit" }
         return chatClient.watchChannelAsState(
             cid = cid,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -89,7 +89,8 @@ import io.getstream.chat.android.ui.common.state.messages.list.SystemMessageItem
 import io.getstream.chat.android.ui.common.state.messages.list.ThreadDateSeparatorItemState
 import io.getstream.chat.android.ui.common.state.messages.list.TypingItemState
 import io.getstream.chat.android.ui.common.state.messages.list.stringify
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrThrow
+import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrDefault
+import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.ui.common.utils.extensions.onFirst
 import io.getstream.chat.android.ui.common.utils.extensions.shouldShowMessageFooter
 import io.getstream.log.TaggedLogger
@@ -719,7 +720,9 @@ public class MessageListController(
             )
 
             if (shouldAddDateSeparator) {
-                groupedMessages.add(DateSeparatorItemState(message.getCreatedAtOrThrow()))
+                message.getCreatedAtOrNull()?.let { createdAt ->
+                    groupedMessages.add(DateSeparatorItemState(createdAt))
+                }
             }
 
             if (message.isSystem() || (message.isError() && !message.isModerationBounce())) {
@@ -754,7 +757,9 @@ public class MessageListController(
             }
 
             if (shouldAddDateSeparatorInEmptyThread) {
-                groupedMessages.add(DateSeparatorItemState(message.getCreatedAtOrThrow()))
+                message.getCreatedAtOrNull()?.let { createdAt ->
+                    groupedMessages.add(DateSeparatorItemState(createdAt))
+                }
             }
 
             if (isThreadWithNoReplies) {
@@ -764,7 +769,7 @@ public class MessageListController(
             if (index == 0 && isInThread && isThreadWithNoReplies) {
                 groupedMessages.add(
                     ThreadDateSeparatorItemState(
-                        date = message.createdAt ?: message.createdLocallyAt ?: Date(),
+                        date = message.getCreatedAtOrDefault(Date()),
                         replyCount = message.replyCount,
                     ),
                 )

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -20,6 +20,8 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.errors.extractCause
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
+import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.extensions.internal.wasCreatedAfter
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.client.utils.message.isDeleted
@@ -89,8 +91,6 @@ import io.getstream.chat.android.ui.common.state.messages.list.SystemMessageItem
 import io.getstream.chat.android.ui.common.state.messages.list.ThreadDateSeparatorItemState
 import io.getstream.chat.android.ui.common.state.messages.list.TypingItemState
 import io.getstream.chat.android.ui.common.state.messages.list.stringify
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrDefault
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.ui.common.utils.extensions.onFirst
 import io.getstream.chat.android.ui.common.utils.extensions.shouldShowMessageFooter
 import io.getstream.log.TaggedLogger

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Message.kt
@@ -36,7 +36,7 @@ public fun Message.isMine(currentUser: User?): Boolean = currentUser?.id == user
  * @return when the message was created or throw an exception.
  */
 public fun Message.getCreatedAtOrThrow(): Date {
-    val created = createdAt ?: createdLocallyAt
+    val created = getCreatedAtOrNull()
     return checkNotNull(created) { "a message needs to have a non null value for either createdAt or createdLocallyAt" }
 }
 
@@ -45,6 +45,13 @@ public fun Message.getCreatedAtOrThrow(): Date {
  */
 public fun Message.getCreatedAtOrNull(): Date? {
     return createdAt ?: createdLocallyAt
+}
+
+/**
+ * @return when the message was created or `default`.
+ */
+public fun Message.getCreatedAtOrDefault(default: Date): Date {
+    return getCreatedAtOrNull() ?: default
 }
 
 /**

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Message.kt
@@ -21,7 +21,6 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageModerationAction
 import io.getstream.chat.android.models.User
-import java.util.Date
 
 /**
  * @return if the message was sent by current user.
@@ -31,28 +30,6 @@ public fun Message.isMine(chatClient: ChatClient): Boolean = chatClient.clientSt
 
 @InternalStreamChatApi
 public fun Message.isMine(currentUser: User?): Boolean = currentUser?.id == user.id
-
-/**
- * @return when the message was created or throw an exception.
- */
-public fun Message.getCreatedAtOrThrow(): Date {
-    val created = getCreatedAtOrNull()
-    return checkNotNull(created) { "a message needs to have a non null value for either createdAt or createdLocallyAt" }
-}
-
-/**
- * @return when the message was created or null.
- */
-public fun Message.getCreatedAtOrNull(): Date? {
-    return createdAt ?: createdLocallyAt
-}
-
-/**
- * @return when the message was created or `default`.
- */
-public fun Message.getCreatedAtOrDefault(default: Date): Date {
-    return getCreatedAtOrNull() ?: default
-}
 
 /**
  * @return if the message failed at moderation or not.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/MessageFooterVisibility.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/MessageFooterVisibility.kt
@@ -16,6 +16,8 @@
 
 package io.getstream.chat.android.ui.common.utils.extensions
 
+import io.getstream.chat.android.client.extensions.getCreatedAtOrDefault
+import io.getstream.chat.android.client.extensions.internal.NEVER
 import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Message
@@ -70,8 +72,8 @@ private fun isFooterVisibleWithTimeDifference(
         message.isDeleted() -> false
         message.user != nextMessage?.user ||
             nextMessage.isDeleted() ||
-            (nextMessage.getCreatedAtOrNull()?.time ?: 0) -
-            (message.getCreatedAtOrNull()?.time ?: 0) >
+            (nextMessage.getCreatedAtOrDefault(NEVER).time) -
+            (message.getCreatedAtOrDefault(NEVER).time) >
             timeDifferenceMillis -> true
         else -> false
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedAttachmentsViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/ChatInfoSharedAttachmentsViewModel.kt
@@ -22,8 +22,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.common.utils.extensions.getCreatedAtOrThrow
 import io.getstream.result.Result
 import kotlinx.coroutines.launch
 import java.util.Calendar

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
@@ -118,6 +118,7 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
                     maxAttachmentSize = maxAttachmentSize,
                     fileToUri = fileToUri,
                     messageId = messageId,
+                    messageLimit = messageLimit,
                 ),
             )
         },

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -413,6 +413,7 @@ internal class MessageComposerViewModelTest {
                     fileToUri = { it.path },
                     maxAttachmentCount = maxAttachmentCount,
                     maxAttachmentSize = maxAttachmentSize,
+                    messageLimit = 30,
                 ),
             )
         }


### PR DESCRIPTION
### 🎯 Goal
Messages sent ofline weren't initializing the date when the message was created and if we didn't update the message from the one that is returned from backend, we could arrive to condition where it is not updated never causing a crash when the date of all messages is used to sort a conversation.

Apart of that, if we jump to a message in the past, it could cause a gap on the conversation due the pagination was not implemented properly.

I have created a method to be sure any gap on the conversation list is filled when the State module is used.

Fix: #5034

### 🧪 Testing
To test it, you will need to jump to a message in the pass within a conversation.
I have create a channel where there are an indexed list of messages to verify the list of messages is loaded properly.
Open the UI-Component sample app, login with "Jc Miñarro" user and click on the conversation with "Daren".
You will need to apply the following patch to ensure you are jumping to the message `50`


<details>

<summary>Patch code to automatically jump to message `50` when go into conversation with "Daren"</summary>

```
Subject: [PATCH] Patch code to automatically jump to message `50` when go into conversation with "Daren"
---
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(revision 83508a78b3d60740438f4f0589b4c3455ec90bf6)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/channel/list/ChannelListFragment.kt	(date 1700752105892)
@@ -104,7 +104,7 @@
 
             setChannelItemClickListener {
                 requireActivity().findNavController(R.id.hostFragmentContainer)
-                    .navigateSafely(HomeFragmentDirections.actionOpenChat(it.cid))
+                    .navigateSafely(HomeFragmentDirections.actionOpenChat(it.cid, messageId = "jc-a804c3cb-3e9b-4af1-a56a-54419d372b80"))
             }
 
             setChannelDeleteClickListener { channel ->

```

</details>


### 🎉 GIF

![](https://media.giphy.com/media/BGmjoNCsRcKE2twZFa/giphy-downsized.gif)