### PR TITLE
Do not load more channels if the total number of channels equals the visible items count

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
@@ -29,6 +29,24 @@ object PredefinedUserCredentials {
         UserCredentials(
             apiKey = API_KEY,
             user = User(
+                "aapostol",
+                name = "Aleksandar Apostolov",
+                image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72"
+            ),
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A"
+        ),
+        UserCredentials(
+            apiKey = API_KEY,
+            user = User(
+                "dnovak",
+                name = "Daniel Novak",
+                image = "https://ca.slack-edge.com/T02RM6X6B-U05DKELFBB8-a8641b819de8-192"
+            ),
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8"
+        ),
+        UserCredentials(
+            apiKey = API_KEY,
+            user = User(
                 id = "jc",
                 name = "Jc Miñarro",
                 image = "https://ca.slack-edge.com/T02RM6X6B-U011KEXDPB2-891dbb8df64f-128",

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
@@ -31,18 +31,18 @@ object PredefinedUserCredentials {
             user = User(
                 "aapostol",
                 name = "Aleksandar Apostolov",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72"
+                image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72",
             ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A"
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A",
         ),
         UserCredentials(
             apiKey = API_KEY,
             user = User(
                 "dnovak",
                 name = "Daniel Novak",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U05DKELFBB8-a8641b819de8-192"
+                image = "https://ca.slack-edge.com/T02RM6X6B-U05DKELFBB8-a8641b819de8-192",
             ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8"
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8",
         ),
         UserCredentials(
             apiKey = API_KEY,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/handlers/LoadMoreHandler.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/handlers/LoadMoreHandler.kt
@@ -31,12 +31,14 @@ import kotlinx.coroutines.flow.filter
  *
  * @param listState The state of the list used to control scrolling.
  * @param loadMoreThreshold The number if items before the end of the list.
+ * @param channelCount Total channel count (optional). If provided taken into account when considering if more items should be loaded.
  * @param loadMore Handler for load more action.
  */
 @Composable
 public fun LoadMoreHandler(
     listState: LazyListState,
     loadMoreThreshold: Int = 3,
+    channelCount: Int? = null,
     loadMore: () -> Unit,
 ) {
     val shouldLoadMore = remember {
@@ -45,7 +47,19 @@ public fun LoadMoreHandler(
             val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
                 ?: return@derivedStateOf false
 
-            lastVisibleItem.index > (totalItemsCount - loadMoreThreshold - 1)
+            val result = lastVisibleItem.index > (totalItemsCount - loadMoreThreshold - 1)
+
+            if (channelCount == null) {
+                // Return the result, there is no channel count provided
+                return@derivedStateOf result
+            }
+
+            val visibleItemsCount = listState.layoutInfo.visibleItemsInfo.size
+            if (channelCount <= visibleItemsCount) {
+                false
+            } else {
+                result
+            }
         }
     }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/Channels.kt
@@ -95,7 +95,10 @@ public fun Channels(
         }
 
         if (!endOfChannels && channelItems.isNotEmpty()) {
-            LoadMoreHandler(lazyListState) {
+            LoadMoreHandler(
+                listState = lazyListState,
+                channelCount = channelItems.size,
+            ) {
                 onLastItemReached()
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
@@ -248,6 +248,7 @@ public class ChannelListViewModel(
                         ChannelsStateData.Loading,
                         -> channelsState.copy(
                             isLoading = true,
+                            isLoadingMore = false,
                             searchQuery = searchQuery,
                         ).also {
                             logger.d { "Loading state for query" }
@@ -256,6 +257,7 @@ public class ChannelListViewModel(
                             logger.d { "No offline results. Channels are empty" }
                             channelsState.copy(
                                 isLoading = false,
+                                isLoadingMore = false,
                                 channelItems = emptyList(),
                                 searchQuery = searchQuery,
                             )

--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.ui.sample.application
 
-import io.getstream.chat.android.models.User
 import io.getstream.chat.ui.sample.data.user.SampleUser
 
 object AppConfig {
@@ -28,17 +27,17 @@ object AppConfig {
     val availableUsers: List<SampleUser> = listOf(
         SampleUser(
             apiKey = apiKey,
-            id ="aapostol",
+            id = "aapostol",
             name = "Aleksandar Apostolov",
             image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72",
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A"
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A",
         ),
         SampleUser(
             apiKey = apiKey,
             id = "dnovak",
             name = "Daniel Novak",
             image = "https://ca.slack-edge.com/T02RM6X6B-U05DKELFBB8-a8641b819de8-192",
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8"
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8",
         ),
         SampleUser(
             apiKey = apiKey,

--- a/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
+++ b/stream-chat-android-ui-components-sample/src/demo/kotlin/io/getstream/chat/ui/sample/application/AppConfig.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.ui.sample.application
 
+import io.getstream.chat.android.models.User
 import io.getstream.chat.ui.sample.data.user.SampleUser
 
 object AppConfig {
@@ -25,6 +26,20 @@ object AppConfig {
     const val cndTimeout: Int = 30000
 
     val availableUsers: List<SampleUser> = listOf(
+        SampleUser(
+            apiKey = apiKey,
+            id ="aapostol",
+            name = "Aleksandar Apostolov",
+            image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A"
+        ),
+        SampleUser(
+            apiKey = apiKey,
+            id = "dnovak",
+            name = "Daniel Novak",
+            image = "https://ca.slack-edge.com/T02RM6X6B-U05DKELFBB8-a8641b819de8-192",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8"
+        ),
         SampleUser(
             apiKey = apiKey,
             id = "jc",


### PR DESCRIPTION
For the ChannelList composable, avoid invoking the LoadMoreHandler if the channel state items count is the same as the visible items in the lazy column. In this case we know there are no more channels and no need to invoke the handler.