### PR TITLE
Use a Sealed Class for VersionPrefixHeader (V5)

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2319,6 +2319,21 @@ public final class io/getstream/chat/android/client/extensions/internal/Reaction
 public final class io/getstream/chat/android/client/extensions/internal/UserKt {
 }
 
+public final class io/getstream/chat/android/client/header/VersionPrefixHeader$Compose : io/getstream/chat/android/client/header/VersionPrefixHeader {
+	public static final field INSTANCE Lio/getstream/chat/android/client/header/VersionPrefixHeader$Compose;
+	public fun getPrefix ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/header/VersionPrefixHeader$Default : io/getstream/chat/android/client/header/VersionPrefixHeader {
+	public static final field INSTANCE Lio/getstream/chat/android/client/header/VersionPrefixHeader$Default;
+	public fun getPrefix ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/client/header/VersionPrefixHeader$UiComponents : io/getstream/chat/android/client/header/VersionPrefixHeader {
+	public static final field INSTANCE Lio/getstream/chat/android/client/header/VersionPrefixHeader$UiComponents;
+	public fun getPrefix ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/client/interceptor/SendMessageInterceptor$DefaultImpls {
 	public static synthetic fun interceptMessage$default (Lio/getstream/chat/android/client/interceptor/SendMessageInterceptor;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -3246,7 +3246,7 @@ internal constructor(
          */
         @InternalStreamChatApi
         @JvmStatic
-        public var VERSION_PREFIX_HEADER: VersionPrefixHeader = VersionPrefixHeader.DEFAULT
+        public var VERSION_PREFIX_HEADER: VersionPrefixHeader = VersionPrefixHeader.Default
 
         /**
          * Flag used to track whether offline support is enabled.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/header/VersionPrefixHeader.kt
@@ -24,19 +24,27 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
  * @param prefix Header for particular SDK.
  */
 @InternalStreamChatApi
-public enum class VersionPrefixHeader(public val prefix: String) {
+public sealed class VersionPrefixHeader {
+    public abstract val prefix: String
+
     /**
      * Low-level client.
      */
-    DEFAULT("stream-chat-android-"),
+    public object Default : VersionPrefixHeader() {
+        override val prefix: String = "stream-chat-android-"
+    }
 
     /**
      * XML based UI components.
      */
-    UI_COMPONENTS("stream-chat-android-ui-components-"),
+    public object UiComponents : VersionPrefixHeader() {
+        override val prefix: String = "stream-chat-android-ui-components-"
+    }
 
     /**
      * Compose UI components.
      */
-    COMPOSE("stream-chat-android-compose-")
+    public object Compose : VersionPrefixHeader() {
+        override val prefix: String = "stream-chat-android-compose-"
+    }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -176,7 +176,7 @@ public fun ChatTheme(
     content: @Composable () -> Unit,
 ) {
     LaunchedEffect(Unit) {
-        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.COMPOSE
+        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.Compose
     }
 
     CompositionLocalProvider(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/ChatUIInitializer.kt
@@ -38,7 +38,7 @@ import kotlinx.coroutines.runBlocking
 public class ChatUIInitializer : Initializer<Unit> {
 
     override fun create(context: Context): Unit = runBlocking(DispatcherProvider.IO) {
-        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.UI_COMPONENTS
+        ChatClient.VERSION_PREFIX_HEADER = VersionPrefixHeader.UiComponents
         ChatUI.appContext = context
 
         setImageLoader(context)


### PR DESCRIPTION
### 🎯 Goal
Use sealed class instead of enum v5