### PR TITLE
Add menu option to mark a conversation as unread from a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Create new feature to mark a channel as unread. [#5103](https://github.com/GetStream/stream-chat-android/pull/5103)
+- Add a new `NotificationMarkUnreadEvent` event type. [#5103](https://github.com/GetStream/stream-chat-android/pull/5103)
 
 ### ⚠️ Changed
 
@@ -60,6 +62,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add a new menu option to mark a channel as unread. [#5103](https://github.com/GetStream/stream-chat-android/pull/5103)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1583,6 +1583,42 @@ public final class io/getstream/chat/android/client/events/NotificationMarkReadE
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/client/events/NotificationMarkUnreadEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasUnreadCounts, io/getstream/chat/android/client/events/UserEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()I
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/util/Date;
+	public final fun component13 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Date;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Lio/getstream/chat/android/models/User;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/lang/String;
+	public final fun component7 ()Ljava/lang/String;
+	public final fun component8 ()I
+	public final fun component9 ()I
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;Ljava/lang/String;)Lio/getstream/chat/android/client/events/NotificationMarkUnreadEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/NotificationMarkUnreadEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/String;Ljava/util/Date;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/NotificationMarkUnreadEvent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getChannelId ()Ljava/lang/String;
+	public fun getChannelType ()Ljava/lang/String;
+	public fun getCid ()Ljava/lang/String;
+	public fun getCreatedAt ()Ljava/util/Date;
+	public final fun getFirstUnreadMessageId ()Ljava/lang/String;
+	public final fun getLastReadMessageAt ()Ljava/util/Date;
+	public final fun getLastReadMessageId ()Ljava/lang/String;
+	public fun getRawCreatedAt ()Ljava/lang/String;
+	public fun getTotalUnreadCount ()I
+	public fun getType ()Ljava/lang/String;
+	public fun getUnreadChannels ()I
+	public final fun getUnreadMessages ()I
+	public fun getUser ()Lio/getstream/chat/android/models/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/client/events/NotificationMessageNewEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasChannel, io/getstream/chat/android/client/events/HasMessage, io/getstream/chat/android/client/events/HasUnreadCounts {
 	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Channel;Lio/getstream/chat/android/models/Message;II)V
 	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Channel;Lio/getstream/chat/android/models/Message;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -85,6 +85,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun markAllRead ()Lio/getstream/result/call/Call;
 	public final fun markMessageRead (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markRead (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun markUnread (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/result/call/Call;
 	public static synthetic fun muteChannel$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/result/call/Call;
@@ -584,6 +585,7 @@ public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public static synthetic fun keystroke$default (Lio/getstream/chat/android/client/channel/ChannelClient;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 	public final fun markMessageRead (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markRead ()Lio/getstream/result/call/Call;
+	public final fun markUnread (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun mute ()Lio/getstream/result/call/Call;
 	public final fun mute (Ljava/lang/Integer;)Lio/getstream/result/call/Call;
 	public static synthetic fun mute$default (Lio/getstream/chat/android/client/channel/ChannelClient;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/result/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2219,6 +2219,28 @@ internal constructor(
             .share(userScope) { MarkReadIdentifier(channelType, channelId) }
     }
 
+    /**
+     * Marks the specified channel as unread.
+     *
+     * @param channelType Type of the channel.
+     * @param channelId Id of the channel.
+     * @param messageId Id of the message.
+     */
+    @CheckResult
+    public fun markUnread(
+        channelType: String,
+        channelId: String,
+        messageId: String,
+    ): Call<Unit> {
+        return api.markUnread(channelType, channelId, messageId)
+            .doOnStart(userScope) {
+                logger.d { "[markUnread] #doOnStart; cid: $channelType:$channelId, msgId: $messageId" }
+            }
+            .doOnResult(userScope) {
+                logger.v { "[markUnread] #doOnResult; completed($channelType:$channelId, $messageId): $it" }
+            }
+    }
+
     @CheckResult
     public fun updateUsers(users: List<User>): Call<List<User>> {
         return api.updateUsers(users)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -252,6 +252,13 @@ internal interface ChatApi {
     ): Call<Unit>
 
     @CheckResult
+    fun markUnread(
+        channelType: String,
+        channelId: String,
+        messageId: String,
+    ): Call<Unit>
+
+    @CheckResult
     fun showChannel(channelType: String, channelId: String): Call<Unit>
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -51,6 +51,7 @@ import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
 import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
+import io.getstream.chat.android.client.api2.model.requests.MarkUnreadRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.PartialUpdateMessageRequest
@@ -652,6 +653,14 @@ constructor(
             channelType = channelType,
             channelId = channelId,
             request = MarkReadRequest(messageId),
+        ).toUnitCall()
+    }
+
+    override fun markUnread(channelType: String, channelId: String, messageId: String): Call<Unit> {
+        return channelApi.markUnread(
+            channelType = channelType,
+            channelId = channelId,
+            request = MarkUnreadRequest(messageId),
         ).toUnitCall()
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ChannelApi.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.MarkReadRequest
+import io.getstream.chat.android.client.api2.model.requests.MarkUnreadRequest
 import io.getstream.chat.android.client.api2.model.requests.PinnedMessagesRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryChannelsRequest
@@ -168,6 +169,13 @@ internal interface ChannelApi {
         @Path("type") channelType: String,
         @Path("id") channelId: String,
         @Body request: MarkReadRequest,
+    ): RetrofitCall<CompletableResponse>
+
+    @POST("/channels/{type}/{id}/unread")
+    fun markUnread(
+        @Path("type") channelType: String,
+        @Path("id") channelId: String,
+        @Body request: MarkUnreadRequest,
     ): RetrofitCall<CompletableResponse>
 
     @POST("/channels/{type}/{id}/show")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -50,6 +50,7 @@ import io.getstream.chat.android.client.api2.model.dto.NotificationInviteAccepte
 import io.getstream.chat.android.client.api2.model.dto.NotificationInviteRejectedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationInvitedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMarkReadEventDto
+import io.getstream.chat.android.client.api2.model.dto.NotificationMarkUnreadEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMessageNewEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMutesUpdatedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationRemovedFromChannelEventDto
@@ -97,6 +98,7 @@ import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
 import io.getstream.chat.android.client.events.NotificationInviteRejectedEvent
 import io.getstream.chat.android.client.events.NotificationInvitedEvent
 import io.getstream.chat.android.client.events.NotificationMarkReadEvent
+import io.getstream.chat.android.client.events.NotificationMarkUnreadEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
@@ -155,6 +157,7 @@ internal fun ChatEventDto.toDomain(): ChatEvent {
         is NotificationInviteRejectedEventDto -> toDomain()
         is NotificationInvitedEventDto -> toDomain()
         is NotificationMarkReadEventDto -> toDomain()
+        is NotificationMarkUnreadEventDto -> toDomain()
         is NotificationMessageNewEventDto -> toDomain()
         is NotificationMutesUpdatedEventDto -> toDomain()
         is NotificationRemovedFromChannelEventDto -> toDomain()
@@ -459,6 +462,24 @@ private fun NotificationMarkReadEventDto.toDomain(): NotificationMarkReadEvent {
         channelId = channel_id,
         totalUnreadCount = total_unread_count,
         unreadChannels = unread_channels,
+    )
+}
+
+private fun NotificationMarkUnreadEventDto.toDomain(): NotificationMarkUnreadEvent {
+    return NotificationMarkUnreadEvent(
+        type = type,
+        createdAt = created_at.date,
+        rawCreatedAt = created_at.rawDate,
+        user = user.toDomain(),
+        cid = cid,
+        channelType = channel_type,
+        channelId = channel_id,
+        totalUnreadCount = total_unread_count,
+        unreadChannels = unread_channels,
+        firstUnreadMessageId = first_unread_message_id,
+        lastReadMessageId = last_read_message_id,
+        lastReadMessageAt = last_read_at.date,
+        unreadMessages = unread_messages,
     )
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -269,6 +269,22 @@ internal data class NotificationMarkReadEventDto(
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)
+internal data class NotificationMarkUnreadEventDto(
+    val type: String,
+    val created_at: ExactDate,
+    val user: DownstreamUserDto,
+    val cid: String,
+    val channel_type: String,
+    val channel_id: String,
+    val first_unread_message_id: String,
+    val last_read_message_id: String,
+    val last_read_at: ExactDate,
+    val unread_messages: Int,
+    val total_unread_count: Int,
+    val unread_channels: Int,
+) : ChatEventDto()
+
+@JsonClass(generateAdapter = true)
 internal data class MarkAllReadEventDto(
     val type: String,
     val created_at: ExactDate,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MarkUnreadRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MarkUnreadRequest.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api2.model.requests
+
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
+internal data class MarkUnreadRequest(
+    val message_id: String,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -369,6 +369,11 @@ public class ChannelClient internal constructor(
     }
 
     @CheckResult
+    public fun markUnread(messageId: String): Call<Unit> {
+        return client.markUnread(channelType, channelId, messageId)
+    }
+
+    @CheckResult
     public fun markRead(): Call<Unit> {
         return client.markRead(channelType, channelId)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -56,6 +56,7 @@ import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
 import io.getstream.chat.android.client.events.NotificationInviteRejectedEvent
 import io.getstream.chat.android.client.events.NotificationInvitedEvent
 import io.getstream.chat.android.client.events.NotificationMarkReadEvent
+import io.getstream.chat.android.client.events.NotificationMarkUnreadEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
@@ -212,6 +213,7 @@ public class ChannelClient internal constructor(
             is NotificationInviteRejectedEvent -> event.cid == cid
             is NotificationInvitedEvent -> event.cid == cid
             is NotificationMarkReadEvent -> event.cid == cid
+            is NotificationMarkUnreadEvent -> event.cid == cid
             is NotificationMessageNewEvent -> event.cid == cid
             is NotificationRemovedFromChannelEvent -> event.cid == cid
             is ReactionDeletedEvent -> event.cid == cid

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -408,6 +408,25 @@ public data class NotificationMarkReadEvent(
 ) : CidEvent(), UserEvent, HasUnreadCounts
 
 /**
+ * Triggered when the the user mark as unread a conversation from a particular message
+ */
+public data class NotificationMarkUnreadEvent(
+    override val type: String,
+    override val createdAt: Date,
+    override val rawCreatedAt: String,
+    override val user: User,
+    override val cid: String,
+    override val channelType: String,
+    override val channelId: String,
+    override val totalUnreadCount: Int = 0,
+    override val unreadChannels: Int = 0,
+    val unreadMessages: Int,
+    val firstUnreadMessageId: String,
+    val lastReadMessageAt: Date,
+    val lastReadMessageId: String,
+) : CidEvent(), UserEvent, HasUnreadCounts
+
+/**
  * Triggered when the total count of unread messages (across all channels the user is a member) changes
  */
 public data class MarkAllReadEvent(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
@@ -171,7 +171,7 @@ public fun Channel.removeMembership(currentUserId: String?): Channel =
 
 @InternalStreamChatApi
 public fun Channel.updateReads(newRead: ChannelUserRead): Channel {
-    val oldRead = read.firstOrNull { it.user == newRead.user }
+    val oldRead = read.firstOrNull { it.user.id == newRead.user.id }
     return copy(
         read = if (oldRead != null) {
             read - oldRead + newRead

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/EventAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/adapters/EventAdapter.kt
@@ -52,6 +52,7 @@ import io.getstream.chat.android.client.api2.model.dto.NotificationInviteAccepte
 import io.getstream.chat.android.client.api2.model.dto.NotificationInviteRejectedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationInvitedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMarkReadEventDto
+import io.getstream.chat.android.client.api2.model.dto.NotificationMarkUnreadEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMessageNewEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationMutesUpdatedEventDto
 import io.getstream.chat.android.client.api2.model.dto.NotificationRemovedFromChannelEventDto
@@ -110,6 +111,7 @@ internal class EventDtoAdapter(
     private val userStopWatchingEventAdapter = moshi.adapter(UserStopWatchingEventDto::class.java)
     private val notificationAddedToChannelEventAdapter = moshi.adapter(NotificationAddedToChannelEventDto::class.java)
     private val notificationMarkReadEventAdapter = moshi.adapter(NotificationMarkReadEventDto::class.java)
+    private val notificationMarkUnreadEventAdapter = moshi.adapter(NotificationMarkUnreadEventDto::class.java)
     private val markAllReadEventAdapter = moshi.adapter(MarkAllReadEventDto::class.java)
     private val notificationMessageNewEventAdapter = moshi.adapter(NotificationMessageNewEventDto::class.java)
     private val notificationInvitedEventAdapter = moshi.adapter(NotificationInvitedEventDto::class.java)
@@ -175,6 +177,7 @@ internal class EventDtoAdapter(
                 map.containsKey("cid") -> notificationMarkReadEventAdapter
                 else -> markAllReadEventAdapter
             }
+            EventType.NOTIFICATION_MARK_UNREAD -> notificationMarkUnreadEventAdapter
             EventType.NOTIFICATION_MESSAGE_NEW -> notificationMessageNewEventAdapter
             EventType.NOTIFICATION_INVITED -> notificationInvitedEventAdapter
             EventType.NOTIFICATION_INVITE_ACCEPTED -> notificationInviteAcceptedEventAdapter

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -277,6 +277,24 @@ internal fun createNotificationMarkReadEventStringJson() =
         """.trimIndent(),
     )
 
+internal fun createNotificationMarkUnreadEventStringJson() =
+    createChatEventStringJson(
+        "notification.mark_unread",
+        """
+            "channel_type": "channelType",
+            "channel_id": "channelId",
+            "cid": "channelType:channelId",
+            "user": ${createUserJsonString()},
+            "watcher_count": 3,
+            "total_unread_count": 4,
+            "unread_channels": 5,
+            "unread_messages": 1,
+            "first_unread_message_id": "09afcd85-9dbb-4da8-8d85-5a6b4268d755",
+            "last_read_at": "2020-06-29T06:14:28.000Z",
+            "last_read_message_id": "parentMessageId"
+        """.trimIndent(),
+    )
+
 internal fun createNotificationMessageNewEventStringJson() =
     createChatEventStringJson(
         "notification.message_new",

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -47,6 +47,7 @@ import io.getstream.chat.android.client.createNotificationInviteAcceptedEventStr
 import io.getstream.chat.android.client.createNotificationInviteRejectedEventStringJson
 import io.getstream.chat.android.client.createNotificationInvitedEventStringJson
 import io.getstream.chat.android.client.createNotificationMarkReadEventStringJson
+import io.getstream.chat.android.client.createNotificationMarkUnreadEventStringJson
 import io.getstream.chat.android.client.createNotificationMessageNewEventStringJson
 import io.getstream.chat.android.client.createNotificationMutesUpdatedEventStringJson
 import io.getstream.chat.android.client.createNotificationRemovedFromChannelEventStringJson
@@ -90,6 +91,7 @@ import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
 import io.getstream.chat.android.client.events.NotificationInviteRejectedEvent
 import io.getstream.chat.android.client.events.NotificationInvitedEvent
 import io.getstream.chat.android.client.events.NotificationMarkReadEvent
+import io.getstream.chat.android.client.events.NotificationMarkUnreadEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
@@ -129,6 +131,7 @@ internal object EventArguments {
     private const val parentMessageId = "parentMessageId"
     private const val watcherCount = 3
     private const val unreadChannels = 5
+    private const val unreadMessages = 1
     private const val totalUnreadCount = 4
     private val user = User(
         id = "bender",
@@ -431,6 +434,21 @@ internal object EventArguments {
         totalUnreadCount = totalUnreadCount,
         unreadChannels = unreadChannels,
     )
+    private val notificationMarkUnreadEvent = NotificationMarkUnreadEvent(
+        type = EventType.NOTIFICATION_MARK_UNREAD,
+        createdAt = date,
+        rawCreatedAt = streamDateFormatter.format(date),
+        user = user,
+        cid = cid,
+        channelType = channelType,
+        channelId = channelId,
+        totalUnreadCount = totalUnreadCount,
+        unreadChannels = unreadChannels,
+        unreadMessages = unreadMessages,
+        firstUnreadMessageId = message.id,
+        lastReadMessageAt = date,
+        lastReadMessageId = parentMessageId,
+    )
     private val notificationMessageNewEvent = NotificationMessageNewEvent(
         type = EventType.NOTIFICATION_MESSAGE_NEW,
         createdAt = date,
@@ -667,6 +685,7 @@ internal object EventArguments {
         notificationInviteRejectedEvent,
         notificationInvitedEvent,
         notificationMarkReadEvent,
+        notificationMarkUnreadEvent,
         notificationMessageNewEvent,
         notificationRemovedFromChannelEvent,
         reactionDeletedEvent,
@@ -712,6 +731,7 @@ internal object EventArguments {
         Arguments.of(createNotificationInviteRejectedEventStringJson(), notificationInviteRejectedEvent),
         Arguments.of(createNotificationInvitedEventStringJson(), notificationInvitedEvent),
         Arguments.of(createNotificationMarkReadEventStringJson(), notificationMarkReadEvent),
+        Arguments.of(createNotificationMarkUnreadEventStringJson(), notificationMarkUnreadEvent),
         Arguments.of(createNotificationMessageNewEventStringJson(), notificationMessageNewEvent),
         Arguments.of(createNotificationRemovedFromChannelEventStringJson(), notificationRemovedFromChannelEvent),
         Arguments.of(createReactionDeletedEventStringJson(), reactionDeletedEvent),

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -757,6 +757,7 @@ public final class io/getstream/chat/android/models/EventType {
 	public static final field NOTIFICATION_INVITE_ACCEPTED Ljava/lang/String;
 	public static final field NOTIFICATION_INVITE_REJECTED Ljava/lang/String;
 	public static final field NOTIFICATION_MARK_READ Ljava/lang/String;
+	public static final field NOTIFICATION_MARK_UNREAD Ljava/lang/String;
 	public static final field NOTIFICATION_MESSAGE_NEW Ljava/lang/String;
 	public static final field NOTIFICATION_MUTES_UPDATED Ljava/lang/String;
 	public static final field NOTIFICATION_REMOVED_FROM_CHANNEL Ljava/lang/String;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/EventType.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/EventType.kt
@@ -53,6 +53,7 @@ public object EventType {
     public const val NOTIFICATION_CHANNEL_TRUNCATED: String = "notification.channel_truncated"
     public const val NOTIFICATION_CHANNEL_DELETED: String = "notification.channel_deleted"
     public const val NOTIFICATION_MARK_READ: String = "notification.mark_read"
+    public const val NOTIFICATION_MARK_UNREAD: String = "notification.mark_unread"
     public const val NOTIFICATION_INVITED: String = "notification.invited"
     public const val NOTIFICATION_INVITE_ACCEPTED: String = "notification.invite_accepted"
     public const val NOTIFICATION_INVITE_REJECTED: String = "notification.invite_rejected"

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
@@ -79,6 +79,9 @@ class MessageListViewSnippets : Fragment() {
         messageListView.setMessageUnpinHandler { message: Message ->
             // Handle when message is going to be unpinned
         }
+        messageListView.setMessageMarkAsUnreadHandler() { message: Message ->
+            // Handle when message is going to be marked as unread
+        }
         messageListView.setGiphySendHandler { giphyAction: GiphyAction ->
             // Handle when some giphyAction is going to be performed
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
@@ -53,6 +53,7 @@ import io.getstream.chat.android.client.events.NotificationInviteAcceptedEvent
 import io.getstream.chat.android.client.events.NotificationInviteRejectedEvent
 import io.getstream.chat.android.client.events.NotificationInvitedEvent
 import io.getstream.chat.android.client.events.NotificationMarkReadEvent
+import io.getstream.chat.android.client.events.NotificationMarkUnreadEvent
 import io.getstream.chat.android.client.events.NotificationMessageNewEvent
 import io.getstream.chat.android.client.events.NotificationMutesUpdatedEvent
 import io.getstream.chat.android.client.events.NotificationRemovedFromChannelEvent
@@ -74,6 +75,7 @@ import io.getstream.chat.android.client.extensions.internal.applyPagination
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.model.querychannels.pagination.internal.QueryChannelPaginationRequest
@@ -627,6 +629,16 @@ internal class ChannelLogic(
             }
             is MarkAllReadEvent -> {
                 channelStateLogic.enqueueUpdateRead(event)
+            }
+            is NotificationMarkUnreadEvent -> {
+                channelStateLogic.updateRead(
+                    ChannelUserRead(
+                        user = event.user,
+                        lastRead = event.lastReadMessageAt,
+                        unreadMessages = event.unreadMessages,
+                        event.createdAt,
+                    ),
+                )
             }
             is NotificationInviteAcceptedEvent -> {
                 channelStateLogic.addMember(event.member)

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -79,6 +79,8 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun loadOlderMessages (I)V
 	public static synthetic fun loadOlderMessages$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;IILjava/lang/Object;)V
 	public final fun markLastMessageRead ()V
+	public final fun markUnread (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun markUnread$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun muteUser (Lio/getstream/chat/android/models/User;)V
 	public final fun muteUser (Ljava/lang/String;Ljava/lang/Integer;)V
 	public static synthetic fun muteUser$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
@@ -141,6 +143,18 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun component1 ()Lio/getstream/result/Error;
 	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getStreamError ()Lio/getstream/result/Error;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$MarkUnreadError : io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/result/Error;)V
+	public final fun component1 ()Lio/getstream/result/Error;
+	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$MarkUnreadError;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$MarkUnreadError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$MarkUnreadError;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getStreamError ()Lio/getstream/result/Error;
 	public fun hashCode ()I
@@ -446,6 +460,18 @@ public final class io/getstream/chat/android/ui/common/state/messages/Flag : io/
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
 	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/common/state/messages/Flag;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/Flag;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/Flag;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/state/messages/MarkAsUnread : io/getstream/chat/android/ui/common/state/messages/MessageAction {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/models/Message;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Message;
+	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/common/state/messages/MarkAsUnread;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/MarkAsUnread;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/MarkAsUnread;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public fun hashCode ()I

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1405,6 +1405,25 @@ public class MessageListController(
     }
 
     /**
+     * Marks the selected message as unread.
+     *
+     * @param message Message to mark as unread.
+     * @param onResult Handler that notifies the result of the mark as unread action.
+     */
+    public fun markUnread(message: Message, onResult: (Result<Unit>) -> Unit = {}) {
+        cid.cidToTypeAndId().let { (channelType, channelId) ->
+            chatClient.markUnread(channelType, channelId, message.id).enqueue { response ->
+                onResult(response)
+                if (response is Result.Failure) {
+                    onActionResult(response.value) {
+                        ErrorEvent.MarkUnreadError(it)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
      * Pins or unpins the message from the current channel based on its state.
      *
      * @param message The message to update the pin state of.
@@ -1848,6 +1867,13 @@ public class MessageListController(
          * @param streamError Contains the original [Throwable] along with a message.
          */
         public data class FlagMessageError(override val streamError: Error) : ErrorEvent(streamError)
+
+        /**
+         * When an error occurs while marking a message as read.
+         *
+         * @param streamError Contains the original [Throwable] along with a message.
+         */
+        public data class MarkUnreadError(override val streamError: Error) : ErrorEvent(streamError)
 
         /**
          * When an error occurs while blocking a user.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageAction.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageAction.kt
@@ -66,6 +66,10 @@ public data class Copy(
     override val message: Message,
 ) : MessageAction()
 
+public data class MarkAsUnread(
+    override val message: Message,
+) : MessageAction()
+
 /**
  * Start editing an owned message.
  */
@@ -111,6 +115,7 @@ public fun MessageAction.updateMessage(message: Message): MessageAction {
         is Reply -> copy(message = message)
         is ThreadReply -> copy(message = message)
         is Copy -> copy(message = message)
+        is MarkAsUnread -> copy(message = message)
         is Edit -> copy(message = message)
         is Pin -> copy(message = message)
         is Delete -> copy(message = message)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2183,44 +2183,44 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 
 public final class io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)V
+	public fun <init> (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIIZIIZIIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;
 	public final fun component10 ()I
 	public final fun component11 ()Z
 	public final fun component12 ()I
 	public final fun component13 ()I
-	public final fun component14 ()Z
-	public final fun component15 ()I
+	public final fun component14 ()I
+	public final fun component15 ()Z
 	public final fun component16 ()I
-	public final fun component17 ()Z
-	public final fun component18 ()I
+	public final fun component17 ()I
+	public final fun component18 ()Z
 	public final fun component19 ()I
 	public final fun component2 ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;
-	public final fun component20 ()Z
-	public final fun component21 ()I
-	public final fun component22 ()Z
+	public final fun component20 ()I
+	public final fun component21 ()Z
+	public final fun component22 ()I
 	public final fun component23 ()Z
 	public final fun component24 ()Z
 	public final fun component25 ()Z
 	public final fun component26 ()Z
-	public final fun component27 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component28 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component29 ()I
+	public final fun component27 ()Z
+	public final fun component28 ()Z
+	public final fun component29 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component3 ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
-	public final fun component30 ()I
-	public final fun component31 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component30 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component31 ()I
 	public final fun component32 ()I
 	public final fun component33 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component34 ()I
-	public final fun component35 ()I
+	public final fun component35 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component36 ()I
 	public final fun component37 ()I
 	public final fun component38 ()I
 	public final fun component39 ()I
 	public final fun component4 ()Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;
-	public final fun component40 ()Z
+	public final fun component40 ()I
 	public final fun component41 ()I
-	public final fun component42 ()I
+	public final fun component42 ()Z
 	public final fun component43 ()I
 	public final fun component44 ()I
 	public final fun component45 ()I
@@ -2232,14 +2232,16 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun component50 ()I
 	public final fun component51 ()I
 	public final fun component52 ()I
-	public final fun component53 ()Z
-	public final fun component54 ()Z
+	public final fun component53 ()I
+	public final fun component54 ()I
+	public final fun component55 ()Z
+	public final fun component56 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()I
 	public final fun component8 ()I
 	public final fun component9 ()Z
-	public final fun copy (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIZIIZIIZIZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIIZIIZIIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;ZIIZIZIIIZIIZIIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getCopyIcon ()I
@@ -2257,6 +2259,8 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun getGiphyViewHolderStyle ()Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;
 	public final fun getItemStyle ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
 	public final fun getLoadingView ()I
+	public final fun getMarkAsUnreadEnabled ()Z
+	public final fun getMarkAsUnreadIcon ()I
 	public final fun getMessageOptionsBackgroundColor ()I
 	public final fun getMessageOptionsText ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getMessageOptionsUserReactionAlignment ()I

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -1975,6 +1975,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun setMessageItemTransformer (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageListItemTransformer;)V
 	public final fun setMessageListItemPredicate (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageListItemPredicate;)V
 	public final fun setMessageLongClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageLongClickListener;)V
+	public final fun setMessageMarkAsUnreadHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageMarkAsUnreadHandler;)V
 	public final fun setMessageOptionItemsFactory (Lio/getstream/chat/android/ui/feature/messages/list/options/message/MessageOptionItemsFactory;)V
 	public final fun setMessagePinHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessagePinHandler;)V
 	public final fun setMessageReactionHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageReactionHandler;)V
@@ -2094,6 +2095,10 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageLongClickListener {
 	public abstract fun onMessageLongClick (Lio/getstream/chat/android/models/Message;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageMarkAsUnreadHandler {
+	public abstract fun onMessageMarkAsUnread (Lio/getstream/chat/android/models/Message;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$MessagePinHandler {
@@ -3811,6 +3816,17 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 
 public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$LastMessageRead : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
 	public static final field INSTANCE Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$LastMessageRead;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$MarkAsUnreadMessage : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Lio/getstream/chat/android/models/Message;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Message;
+	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$MarkAsUnreadMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$MarkAsUnreadMessage;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$MarkAsUnreadMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -55,6 +55,7 @@ import io.getstream.chat.android.ui.common.state.messages.Copy
 import io.getstream.chat.android.ui.common.state.messages.CustomAction
 import io.getstream.chat.android.ui.common.state.messages.Delete
 import io.getstream.chat.android.ui.common.state.messages.Edit
+import io.getstream.chat.android.ui.common.state.messages.MarkAsUnread
 import io.getstream.chat.android.ui.common.state.messages.MessageAction
 import io.getstream.chat.android.ui.common.state.messages.Pin
 import io.getstream.chat.android.ui.common.state.messages.React
@@ -218,6 +219,9 @@ public class MessageListView : ConstraintLayout {
     private var messagePinHandler = MessagePinHandler {
         throw IllegalStateException("onMessagePinHandler must be set.")
     }
+    private var messageMarkAsUnreadHandler = MessageMarkAsUnreadHandler {
+        throw IllegalStateException("onMessageMarkAsUnreadHandler must be set.")
+    }
     private var messageUnpinHandler = MessageUnpinHandler {
         throw IllegalStateException("onMessageUnpinHandler must be set.")
     }
@@ -310,6 +314,8 @@ public class MessageListView : ConstraintLayout {
             is MessageListController.ErrorEvent.FlagMessageError -> R.string.stream_ui_message_list_error_flag_message
             is MessageListController.ErrorEvent.PinMessageError -> R.string.stream_ui_message_list_error_pin_message
             is MessageListController.ErrorEvent.UnpinMessageError -> R.string.stream_ui_message_list_error_unpin_message
+            is MessageListController.ErrorEvent.MarkUnreadError ->
+                R.string.stream_ui_message_list_error_mark_as_unread_message
         }.let(::showToast)
     }
 
@@ -1428,6 +1434,15 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
+     * Sets the handler used to handle when the message is going to be marked as read.
+     *
+     * @param MessageMarkAsUnreadHandler The handler to use.
+     */
+    public fun setMessageMarkAsUnreadHandler(messageMarkAsUnreadHandler: MessageMarkAsUnreadHandler) {
+        this.messageMarkAsUnreadHandler = messageMarkAsUnreadHandler
+    }
+
+    /**
      * Sets the handler used to handle when the message is going to be unpinned.
      *
      * @param messageUnpinHandler The handler to use.
@@ -1632,6 +1647,7 @@ public class MessageListView : ConstraintLayout {
                     messagePinHandler.onMessagePin(message)
                 }
             }
+            is MarkAsUnread -> messageMarkAsUnreadHandler.onMessageMarkAsUnread(message)
             is Delete -> {
                 if (style.deleteConfirmationEnabled) {
                     confirmDeleteMessageHandler.onConfirmDeleteMessage(message) {
@@ -1759,6 +1775,10 @@ public class MessageListView : ConstraintLayout {
 
     public fun interface MessagePinHandler {
         public fun onMessagePin(message: Message)
+    }
+
+    public fun interface MessageMarkAsUnreadHandler {
+        public fun onMessageMarkAsUnread(message: Message)
     }
 
     public fun interface MessageUnpinHandler {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
@@ -335,7 +335,7 @@ public data class MessageListViewStyle(
                     attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
 
                 val markAsUnreadEnabled =
-                    attributes.getBoolean(R.styleable.MessageListView_streamUiMarkAsUnreadEnabled, true)
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiMarkAsUnreadEnabled, false)
 
                 val retryMessageEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageEnabled, true)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
@@ -109,6 +109,7 @@ public data class MessageListViewStyle(
     val threadsEnabled: Boolean,
     val retryIcon: Int,
     val copyIcon: Int,
+    val markAsUnreadIcon: Int,
     val editMessageEnabled: Boolean,
     val editIcon: Int,
     val flagIcon: Int,
@@ -119,6 +120,7 @@ public data class MessageListViewStyle(
     val deleteIcon: Int,
     val deleteMessageEnabled: Boolean,
     val copyTextEnabled: Boolean,
+    val markAsUnreadEnabled: Boolean,
     val retryMessageEnabled: Boolean,
     val deleteConfirmationEnabled: Boolean,
     val flagMessageConfirmationEnabled: Boolean,
@@ -294,6 +296,11 @@ public data class MessageListViewStyle(
                     R.drawable.stream_ui_ic_copy,
                 )
 
+                val markAsUnreadIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiMarkAsUnreadOptionIcon,
+                    R.drawable.stream_ui_ic_mark_as_unread,
+                )
+
                 val editIcon = attributes.getResourceId(
                     R.styleable.MessageListView_streamUiEditOptionIcon,
                     R.drawable.stream_ui_ic_edit,
@@ -326,6 +333,9 @@ public data class MessageListViewStyle(
 
                 val copyTextEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
+
+                val markAsUnreadEnabled =
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiMarkAsUnreadEnabled, true)
 
                 val retryMessageEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageEnabled, true)
@@ -539,6 +549,7 @@ public data class MessageListViewStyle(
                     threadReplyIcon = threadReplyIcon,
                     retryIcon = retryIcon,
                     copyIcon = copyIcon,
+                    markAsUnreadIcon = markAsUnreadIcon,
                     editIcon = editIcon,
                     flagIcon = flagIcon,
                     flagEnabled = flagEnabled,
@@ -547,6 +558,7 @@ public data class MessageListViewStyle(
                     pinMessageEnabled = pinMessageEnabled,
                     deleteIcon = deleteIcon,
                     copyTextEnabled = copyTextEnabled,
+                    markAsUnreadEnabled = markAsUnreadEnabled,
                     retryMessageEnabled = retryMessageEnabled,
                     deleteConfirmationEnabled = deleteConfirmationEnabled,
                     flagMessageConfirmationEnabled = flagMessageConfirmationEnabled,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/options/message/MessageOptionItemsFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/options/message/MessageOptionItemsFactory.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.ui.common.state.messages.Copy
 import io.getstream.chat.android.ui.common.state.messages.Delete
 import io.getstream.chat.android.ui.common.state.messages.Edit
 import io.getstream.chat.android.ui.common.state.messages.Flag
+import io.getstream.chat.android.ui.common.state.messages.MarkAsUnread
 import io.getstream.chat.android.ui.common.state.messages.Pin
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.Resend
@@ -117,6 +118,7 @@ public open class DefaultMessageOptionItemsFactory(
         val canDeleteAnyMessage = ownCapabilities.contains(ChannelCapabilities.DELETE_ANY_MESSAGE)
         val canEditOwnMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_OWN_MESSAGE)
         val canEditAnyMessage = ownCapabilities.contains(ChannelCapabilities.UPDATE_ANY_MESSAGE)
+        val canMarkAsUnread = ownCapabilities.contains(ChannelCapabilities.READ_EVENTS)
 
         return listOfNotNull(
             if (style.retryMessageEnabled && isOwnMessage && isMessageFailed) {
@@ -142,6 +144,15 @@ public open class DefaultMessageOptionItemsFactory(
                     optionText = context.getString(R.string.stream_ui_message_list_thread_reply),
                     optionIcon = context.getDrawableCompat(style.threadReplyIcon)!!,
                     messageAction = ThreadReply(selectedMessage),
+                )
+            } else {
+                null
+            },
+            if (style.markAsUnreadEnabled && canMarkAsUnread) {
+                MessageOptionItem(
+                    optionText = context.getString(R.string.stream_ui_message_list_mark_as_unread),
+                    optionIcon = context.getDrawableCompat(style.markAsUnreadIcon)!!,
+                    messageAction = MarkAsUnread(selectedMessage),
                 )
             } else {
                 null

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -222,6 +222,9 @@ public class MessageListViewModel(
             is Event.BackButtonPressed -> {
                 onBackButtonPressed()
             }
+            is Event.MarkAsUnreadMessage -> {
+                messageListController.markUnread(event.message)
+            }
             is Event.DeleteMessage -> {
                 messageListController.deleteMessage(event.message, event.hard)
             }
@@ -584,6 +587,13 @@ public class MessageListViewModel(
          * @param message The message to be unpinned.
          */
         public data class UnpinMessage(val message: Message) : Event()
+
+        /**
+         * When the user marks a message as unread.
+         *
+         * @param message The message to be marked as unread.
+         */
+        public data class MarkAsUnreadMessage(val message: Message) : Event()
 
         /**
          * When the user selects a Giphy message.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
@@ -65,6 +65,7 @@ public fun MessageListViewModel.bindView(
     view.setMessageFlagHandler { onEvent(FlagMessage(it, view::handleFlagMessageResult)) }
     view.setMessagePinHandler { onEvent(MessageListViewModel.Event.PinMessage(it)) }
     view.setMessageUnpinHandler { onEvent(MessageListViewModel.Event.UnpinMessage(it)) }
+    view.setMessageMarkAsUnreadHandler { onEvent(MessageListViewModel.Event.MarkAsUnreadMessage(it)) }
     view.setGiphySendHandler { giphyAction ->
         onEvent(GiphyActionSelected(giphyAction))
     }

--- a/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_mark_as_unread.xml
+++ b/stream-chat-android-ui-components/src/main/res/drawable/stream_ui_ic_mark_as_unread.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    >
+    <path
+        android:fillColor="@color/stream_ui_grey"
+        android:fillType="evenOdd"
+        android:pathData="M22 7.98V17C22 18.1 21.1 19 20 19H6L2 23V5C2 3.9 2.9 3 4 3H14.1C14.04 3.32 14 3.66 14 4C14 4.34 14.04 4.68 14.1 5H4V17H20V8.9C20.74 8.75 21.42 8.42 22 7.98ZM16 4C16 5.66 17.34 7 19 7C20.66 7 22 5.66 22 4C22 2.34 20.66 1 19 1C17.34 1 16 2.34 16 4Z"
+        />
+</vector>

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -359,8 +359,10 @@
         <attr name="streamUiReplyOptionIcon" format="reference" />
         <attr name="streamUiReplyEnabled" format="boolean" />
         <attr name="streamUiCopyMessageActionEnabled" format="boolean" />
+        <attr name="streamUiMarkAsUnreadEnabled" format="boolean" />
         <attr name="streamUiRetryMessageEnabled" format="boolean" />
         <attr name="streamUiCopyOptionIcon" format="reference" />
+        <attr name="streamUiMarkAsUnreadOptionIcon" format="reference" />
         <attr name="streamUiEditOptionIcon" format="reference" />
         <attr name="streamUiEditMessageEnabled" format="boolean" />
         <attr name="streamUiFlagOptionIcon" format="reference" />

--- a/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
@@ -46,6 +46,7 @@
     <string name="stream_ui_message_list_thread_reply">Thread reply</string>
     <string name="stream_ui_message_list_resend_message">Resend</string>
     <string name="stream_ui_message_list_copy_message">Copy Message</string>
+    <string name="stream_ui_message_list_mark_as_unread">Mark as Unread</string>
     <string name="stream_ui_message_list_edit_message">Edit Message</string>
     <string name="stream_ui_message_list_flag_message">Flag Message</string>
     <string name="stream_ui_message_list_pin_message">Pin to Conversation</string>

--- a/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
@@ -81,6 +81,7 @@
     <string name="stream_ui_message_list_error_block_user">Failed to block user</string>
     <string name="stream_ui_message_list_error_flag_message">Failed to flag message</string>
     <string name="stream_ui_message_list_error_pin_message">Failed to pin message</string>
+    <string name="stream_ui_message_list_error_mark_as_unread_message">Failed to mark as unread message</string>
     <string name="stream_ui_message_list_error_unpin_message">Failed to unpin message</string>
     <string name="stream_ui_message_list_error_delete_message">Failed to delete message</string>
 </resources>


### PR DESCRIPTION
### 🎯 Goal
This PR implement all the low level code to mark a conversation unread from a message and handle any new events is received regarding this feature.
An UI option to invoke this feature is added to the UI-Components but it is disabled by default until we allow to show an "unread label" within the conversation list.

### 🎨 UI Changes
![Screenshot_20231205_102756](https://github.com/GetStream/stream-chat-android/assets/4047514/286c7ee9-0b1e-4b87-9e4e-b2aef93c57e1)

### 🧪 Testing
To test it you will need to apply the following patch

<details>

<summary>Patch to enable "Mark as Unread" by default</summary>

```
Subject: [PATCH] Patch code to automatically jump to message `50` when go into conversation with "Daren"
---
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt	(revision 373e7e221faa102b398e9be2de10bb19ff437d99)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt	(date 1702476467699)
@@ -335,7 +335,7 @@
                     attributes.getBoolean(R.styleable.MessageListView_streamUiCopyMessageActionEnabled, true)
 
                 val markAsUnreadEnabled =
-                    attributes.getBoolean(R.styleable.MessageListView_streamUiMarkAsUnreadEnabled, false)
+                    attributes.getBoolean(R.styleable.MessageListView_streamUiMarkAsUnreadEnabled, true)
 
                 val retryMessageEnabled =
                     attributes.getBoolean(R.styleable.MessageListView_streamUiRetryMessageEnabled, true)
```

</details>

### 🎉 GIF
![](https://media.giphy.com/media/Oo1MAs4PmdkJO/giphy.gif)
