### PR TITLE
Fix Message.ownReactions incorrect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 
 ## stream-chat-android-state
 ### 🐞 Fixed
+- Fix wrong Message.ownReactions. [#5106](https://github.com/GetStream/stream-chat-android/pull/5106)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/thread/internal/ThreadLogic.kt
@@ -89,12 +89,16 @@ internal class ThreadLogic(
     internal fun handleEvents(events: List<HasMessage>) {
         val messages = events
             .map { event ->
+                val ownReactions = getMessage(event.message.id)?.ownReactions ?: event.message.ownReactions
                 if (event is MessageUpdatedEvent) {
                     event.message.copy(
                         replyTo = mutableState.messages.value.firstOrNull { it.id == event.message.replyMessageId },
+                        ownReactions = ownReactions,
                     )
                 } else {
-                    event.message
+                    event.message.copy(
+                        ownReactions = ownReactions,
+                    )
                 }
             }
         upsertMessages(messages)


### PR DESCRIPTION
This fixes an issue where in threads where the root message list of `ownReactions` was incorrect (empty).