### PR TITLE
Fix Regex not escaped in getOccurrenceRanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fix: Regex was not correctly escaped in getOccurrenceRanges [#5108](https://github.com/GetStream/stream-chat-android/pull/5108)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/String.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/common/extensions/internal/String.kt
@@ -35,7 +35,7 @@ internal val String.Companion.EMPTY: String
 internal fun String.getOccurrenceRanges(items: List<String>? = null, ignoreCase: Boolean = false): List<IntRange> {
     val regexOptions: Set<RegexOption> = setOfNotNull(RegexOption.IGNORE_CASE.takeIf { ignoreCase })
     return items?.flatMap { item ->
-        Regex(item, regexOptions).findAll(this).map { it.range }
+        Regex(Regex.escape(item), regexOptions).findAll(this).map { it.range }
     } ?: listOf(0 until length)
 }
 

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/common/extensions/StringTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/common/extensions/StringTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.extensions
+
+import io.getstream.chat.android.ui.common.extensions.internal.getOccurrenceRanges
+import org.junit.jupiter.api.Test
+
+internal class StringTest {
+
+    @Test
+    fun `getOccurrenceRanges works with invalid regex expressions`() {
+        "test".getOccurrenceRanges(listOf("Ryan :)"))
+        assert(true)
+    }
+
+    @Test
+    fun `getOccurrenceRanges returns no position`() {
+        val result = "test".getOccurrenceRanges(listOf("Ryan"))
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `getOccurrenceRanges returns correct position`() {
+        val result = "Ryan".getOccurrenceRanges(listOf("Ryan"))
+        assert(result.size == 1)
+        assert(result[0].first == 0)
+        assert(result[0].last == 3)
+    }
+
+    @Test
+    fun `getOccurrenceRanges returns correct positions`() {
+        val result = "Ryan Ryan".getOccurrenceRanges(listOf("Ryan"))
+        assert(result.size == 2)
+        assert(result[0].first == 0)
+        assert(result[0].last == 3)
+        assert(result[1].first == 5)
+        assert(result[1].last == 8)
+    }
+
+    @Test
+    fun `getOccurrenceRanges returns no position if empty list`() {
+        val result = "Ryan".getOccurrenceRanges(emptyList())
+        assert(result.isEmpty())
+    }
+
+    @Test
+    fun `getOccurrenceRanges returns no position if empty text`() {
+        val result = "".getOccurrenceRanges(emptyList())
+        assert(result.isEmpty())
+    }
+}


### PR DESCRIPTION
This function can lead to a crash if the items contain invalid Regex strings (e.g. "Ryan :)")