### PR TITLE
Open `ChatClient.getMessageUsingCache()` extension method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Open `ChatClient.getMessageUsingCache()` extension method. [#5153](https://github.com/GetStream/stream-chat-android/pull/5153
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -72,6 +72,7 @@ public final class io/getstream/chat/android/state/extensions/ChatClientExtensio
 	public static final fun cancelEphemeralMessage (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/Message;)Lio/getstream/result/call/Call;
 	public static final fun downloadAttachment (Lio/getstream/chat/android/client/ChatClient;Landroid/content/Context;Lio/getstream/chat/android/models/Attachment;)Lio/getstream/result/call/Call;
 	public static final fun getGlobalState (Lio/getstream/chat/android/client/ChatClient;)Lio/getstream/chat/android/state/plugin/state/global/GlobalState;
+	public static final fun getMessageUsingCache (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun getRepliesAsState (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun getRepliesAsState$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ILkotlinx/coroutines/CoroutineScope;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/extensions/ChatClient.kt
@@ -347,7 +347,6 @@ public fun ChatClient.cancelEphemeralMessage(message: Message): Call<Boolean> {
  *
  * @return The message with the corresponding iID wrapped inside a [Call].
  */
-@InternalStreamChatApi
 @CheckResult
 public fun ChatClient.getMessageUsingCache(
     messageId: String,


### PR DESCRIPTION
### 🎯 Goal
Open `ChatClient.getMessageUsingCache()` extension method
fix: https://github.com/GetStream/android-internal-board/issues/238

### 🎉 GIF

![](https://media.giphy.com/media/WcR5pKdtznPculqt2D/giphy-downsized-large.gif)