### PR TITLE
Remove KotlinJsonAdapterFactory dependency

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -183,7 +183,6 @@ object Dependencies {
     const val mockitoKotlin = "org.mockito.kotlin:mockito-kotlin:${Versions.MOCKITO_KOTLIN}"
     const val moshi = "com.squareup.moshi:moshi:${Versions.MOSHI}"
     const val moshiCodegen = "com.squareup.moshi:moshi-kotlin-codegen:${Versions.MOSHI}"
-    const val moshiKotlin = "com.squareup.moshi:moshi-kotlin:${Versions.MOSHI}"
     const val moshiAdapters = "com.squareup.moshi:moshi-adapters:${Versions.MOSHI}"
     const val navigationFragmentKTX = "androidx.navigation:navigation-fragment-ktx:${Versions.ANDROIDX_NAVIGATION}"
     const val navigationSafeArgsGradlePlugin =

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/command/utils/Json.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/command/utils/Json.kt
@@ -1,8 +1,0 @@
-package io.getstream.chat.android.command.utils
-
-import com.squareup.moshi.Moshi
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
-
-fun moshi(): Moshi = Moshi.Builder()
-    .addLast(KotlinJsonAdapterFactory())
-    .build()

--- a/stream-chat-android-client-test/build.gradle
+++ b/stream-chat-android-client-test/build.gradle
@@ -37,7 +37,6 @@ dependencies {
     implementation Dependencies.workRuntimeKtx
 
     // Tests
-    testImplementation Dependencies.moshiKotlin
     testImplementation Dependencies.junitJupiterApi
     testImplementation Dependencies.junitJupiterParams
     testRuntimeOnly Dependencies.junitJupiterEngine

--- a/stream-chat-android-offline/build.gradle
+++ b/stream-chat-android-offline/build.gradle
@@ -84,7 +84,6 @@ dependencies {
 
     // Serialization
     implementation Dependencies.moshi
-    implementation Dependencies.moshiKotlin
     implementation Dependencies.moshiAdapters
     ksp Dependencies.moshiCodegen
 
@@ -93,7 +92,6 @@ dependencies {
     testImplementation project(":stream-chat-android-client-test")
     testImplementation testFixtures(project(":stream-chat-android-core"))
     testImplementation Dependencies.streamResult
-    testImplementation Dependencies.moshiKotlin
 
     testImplementation Dependencies.junitJupiterApi
     testImplementation Dependencies.junitJupiterParams

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/converter/internal/ConverterMoshiInstance.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/converter/internal/ConverterMoshiInstance.kt
@@ -19,12 +19,10 @@ package io.getstream.chat.android.offline.repository.database.converter.internal
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.MultiMapJsonAdapter
 import com.squareup.moshi.addAdapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.getstream.chat.android.client.parser2.adapters.DateAdapter
 
 @OptIn(ExperimentalStdlibApi::class)
 internal val moshi: Moshi = Moshi.Builder()
     .addAdapter(DateAdapter())
-    .add(KotlinJsonAdapterFactory())
     .add(MultiMapJsonAdapter.FACTORY)
     .build()

--- a/stream-chat-android-state/build.gradle
+++ b/stream-chat-android-state/build.gradle
@@ -80,7 +80,7 @@ dependencies {
     testImplementation project(":stream-chat-android-test")
     testImplementation project(":stream-chat-android-client-test")
     testImplementation testFixtures(project(":stream-chat-android-core"))
-    testImplementation Dependencies.moshiKotlin
+    testImplementation Dependencies.moshi
 
     testImplementation Dependencies.junitJupiterApi
     testImplementation Dependencies.junitJupiterParams

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/extensions/ChannelExtensionsTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/extensions/ChannelExtensionsTest.kt
@@ -21,7 +21,6 @@ import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.adapter
-import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import io.getstream.chat.android.client.extensions.internal.applyPagination
 import io.getstream.chat.android.client.parser2.adapters.DateAdapter
 import io.getstream.chat.android.models.Attachment
@@ -61,7 +60,6 @@ internal class ChannelExtensionsTest {
                     override fun toJson(writer: JsonWriter, value: Attachment.UploadState?) = TODO("Not implemented")
                 },
             )
-            .add(KotlinJsonAdapterFactory())
             .build()
         val adapter = moshi.adapter<List<Channel>>()
         val channels = requireNotNull(adapter.fromJson(JsonReader.of(channelsFile.source().buffer())))


### PR DESCRIPTION
We don't need the reflection based Moshi support - I think for all classes we rely on code-gen instead (all of them are annotated with annotations). Application compiles and runs without it.

Docs: https://github.com/square/moshi#reflection