### PR TITLE
Ensure the link builder always uses lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fix annotated messages not being building proper links. [#5163](https://github.com/GetStream/stream-chat-android/pull/5163)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.core.util.PatternsCompat
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import java.util.Locale
 import java.util.regex.Pattern
 
 /**
@@ -112,13 +113,15 @@ private fun AnnotatedString.Builder.linkify(
     }
 }
 
-private fun String.fixPrefix(schemes: List<String>): String {
-    return if (schemes.none { scheme -> startsWith(scheme) }) {
-        schemes[0] + this
-    } else {
-        this
-    }
-}
+private fun String.fixPrefix(schemes: List<String>): String =
+    lowercase(Locale.getDefault())
+        .let {
+            if (schemes.none { scheme -> it.startsWith(scheme) }) {
+                schemes[0] + it
+            } else {
+                it
+            }
+        }
 
 private val URL_SCHEMES = listOf("http://", "https://")
 private val EMAIL_SCHEMES = listOf("mailto:")


### PR DESCRIPTION
### 🎯 Goal
Link should be always used in lowercase.
Fix: #5162 

### 🎉 GIF
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExc3U2MW5lODY5NmhqZGpheDV1M25qbnBsZWxsd2Vkc255Z2x6YzRwYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/V5l5ZucxUc7kNTaXWK/giphy.gif)
