### PR TITLE
[i244] fix crash in ChatEventsObservable.onNext

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fixed crash in `ChatEventsObservable.onNext`. [#5165](https://github.com/GetStream/stream-chat-android/pull/5165)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/observable/Subscriptions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/observable/Subscriptions.kt
@@ -35,8 +35,10 @@ internal open class SubscriptionImpl(
     listener: ChatEventListener<ChatEvent>,
 ) : EventSubscription {
 
+    @Volatile
     private var listener: ChatEventListener<ChatEvent>? = listener
 
+    @Volatile
     override var isDisposed: Boolean = false
 
     var afterEventDelivered: () -> Unit = {}
@@ -64,8 +66,10 @@ internal class SuspendSubscription(
     private val filter: (ChatEvent) -> Boolean,
     listener: ChatEventsObservable.ChatEventSuspendListener<ChatEvent>,
 ) : EventSubscription {
+    @Volatile
     private var listener: ChatEventsObservable.ChatEventSuspendListener<ChatEvent>? = listener
 
+    @Volatile
     override var isDisposed: Boolean = false
 
     override fun dispose() {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
@@ -19,10 +19,13 @@ package io.getstream.chat.android.client
 import io.getstream.chat.android.client.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
+import io.getstream.chat.android.client.scope.ClientTestScope
+import io.getstream.chat.android.client.scope.UserTestScope
 import io.getstream.chat.android.client.setup.state.internal.MutableClientState
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.InitializationState
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.TestResult
 import kotlinx.coroutines.test.runTest
@@ -31,6 +34,7 @@ import org.amshove.kluent.`should be`
 import org.amshove.kluent.`should throw`
 import org.amshove.kluent.`with message`
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -123,6 +127,10 @@ public class DependencyResolverTest {
 
     public companion object {
 
+        @JvmField
+        @RegisterExtension
+        public val testCoroutines: TestCoroutineExtension = TestCoroutineExtension()
+
         @JvmStatic
         public fun initializationStatesArguments(): List<Arguments> =
             InitializationState.values()
@@ -134,6 +142,8 @@ public class DependencyResolverTest {
         var plugins: MutableList<Plugin> = arrayListOf()
         var pluginFactories: MutableList<PluginFactory> = arrayListOf()
         val mutableClientState: MutableClientState = mock()
+        val clientScope = ClientTestScope(testCoroutines.scope)
+        val userScope = UserTestScope(clientScope)
 
         fun with(plugin: Plugin) = apply {
             plugins.add(plugin)
@@ -155,8 +165,8 @@ public class DependencyResolverTest {
             userCredentialStorage = mock(),
             userStateService = mock(),
             tokenUtils = mock(),
-            clientScope = mock(),
-            userScope = mock(),
+            clientScope = clientScope,
+            userScope = userScope,
             retryPolicy = mock(),
             appSettingsManager = mock(),
             chatSocket = mock(),


### PR DESCRIPTION
### 🎯 Goal

Closes:
- https://github.com/GetStream/android-internal-board/issues/244

Fix: #5149 

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
