### PR TITLE
[i252] Add isInThread to MessagePositionHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,8 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- 🚨Breaking change: Changed `MessagePositionHandler.handleMessagePosition` signature. [#5168](https://github.com/GetStream/stream-chat-android/pull/5168)
+  * Added `isInThread: Boolean` parameter. 
 
 ### ❌ Removed
 

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -211,11 +211,10 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 
 public abstract interface class io/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler {
 	public static final field Companion Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler$Companion;
-	public abstract fun handleMessagePosition (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Message;Z)Ljava/util/List;
+	public abstract fun handleMessagePosition (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Message;ZZ)Ljava/util/List;
 }
 
 public final class io/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler$Companion {
-	public final fun defaultHandler ()Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;
 }
 
 public abstract interface class io/getstream/chat/android/ui/common/helper/ClipboardHandler {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -783,6 +783,7 @@ public class MessageListController(
                 message = message,
                 nextMessage = nextMessage,
                 isAfterDateSeparator = shouldAddDateSeparator,
+                isInThread = isInThread,
             )
 
             val isLastMessageInGroup =

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.ui.common.feature.messages.list
 
 import io.getstream.chat.android.client.utils.message.isError
 import io.getstream.chat.android.client.utils.message.isSystem
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.state.messages.list.MessagePosition
 
@@ -32,6 +33,7 @@ public fun interface MessagePositionHandler {
      * @param message The current [Message] in the list.
      * @param nextMessage The next [Message] in the list.
      * @param isAfterDateSeparator If a date separator was added before the current [Message].
+     * @param isInThread If the current [Message] is in a thread.
      *
      * @return The position of the current message inside the group.
      */
@@ -40,6 +42,7 @@ public fun interface MessagePositionHandler {
         message: Message,
         nextMessage: Message?,
         isAfterDateSeparator: Boolean,
+        isInThread: Boolean,
     ): List<MessagePosition>
 
     public companion object {
@@ -49,6 +52,7 @@ public fun interface MessagePositionHandler {
          *
          * @return The default implementation of [MessagePositionHandler].
          */
+        @InternalStreamChatApi
         @Suppress("ComplexCondition")
         public fun defaultHandler(): MessagePositionHandler {
             return MessagePositionHandler {
@@ -56,6 +60,7 @@ public fun interface MessagePositionHandler {
                     message: Message,
                     nextMessage: Message?,
                     isAfterDateSeparator: Boolean,
+                    _: Boolean,
                 ->
                 val previousUser = previousMessage?.user
                 val user = message.user


### PR DESCRIPTION
### 🎯 Goal

Closes:
- https://github.com/GetStream/android-internal-board/issues/252


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
