### PR TITLE
Ensure new token is fetch on case reconnecting WS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Fixed crash in `ChatEventsObservable.onNext`. [#5165](https://github.com/GetStream/stream-chat-android/pull/5165)
 
 ### ⬆️ Improved
+- Ensure fresh token is used to establish WS connection. [#5185](https://github.com/GetStream/stream-chat-android/pull/5185)
 
 ### ✅ Added
 - Added `DeleteChannelListener`. [#5164](https://github.com/GetStream/stream-chat-android/pull/5164)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -58,6 +58,8 @@ internal class SocketFactory(
                 is ConnectionConf.AnonymousConnectionConf -> "$baseWsUrl&stream-auth-type=anonymous"
                 is ConnectionConf.UserConnectionConf -> {
                     val token = tokenManager.getToken()
+                        .takeUnless { connectionConf.isReconnection }
+                        ?: tokenManager.loadSync()
                     "$baseWsUrl&authorization=$token&stream-auth-type=jwt"
                 }
             }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
@@ -44,7 +44,7 @@ internal class SocketFactoryTest {
     private val httpClient: OkHttpClient = mock<OkHttpClient>().apply {
         whenever(this.newWebSocket(any(), any())) doReturn mock()
     }
-    private val socketFactory = SocketFactory(chatParser, FakeTokenManager(token), httpClient)
+    private val socketFactory = SocketFactory(chatParser, FakeTokenManager(token, loadSyncToken), httpClient)
 
     /** [arguments] */
     @ParameterizedTest
@@ -65,6 +65,7 @@ internal class SocketFactoryTest {
         private val endpoint = "https://${randomString().lowercase(Locale.getDefault())}/"
         private val apiKey = randomString()
         private val token = randomString()
+        private val loadSyncToken = randomString()
 
         @JvmStatic
         @Suppress("MaxLineLength")
@@ -78,7 +79,7 @@ internal class SocketFactoryTest {
             randomUser().let {
                 Arguments.of(
                     SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
-                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&authorization=$token&stream-auth-type=jwt",
+                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&authorization=$loadSyncToken&stream-auth-type=jwt",
                 )
             },
             User("anon").let {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
@@ -16,11 +16,12 @@
 
 package io.getstream.chat.android.client.token
 
-internal class FakeTokenManager(val tkn: String) : TokenManager {
-
-    override fun loadSync(): String {
-        return tkn
-    }
+internal class FakeTokenManager(
+    private val token: String,
+    private val loadSyncToken: String = token,
+) : TokenManager {
+    override fun loadSync(): String = loadSyncToken
+    override fun getToken(): String = token
 
     override fun ensureTokenLoaded() {
         // empty
@@ -32,10 +33,6 @@ internal class FakeTokenManager(val tkn: String) : TokenManager {
 
     override fun hasTokenProvider(): Boolean {
         return true
-    }
-
-    override fun getToken(): String {
-        return tkn
     }
 
     override fun hasToken(): Boolean {


### PR DESCRIPTION
### 🎯 Goal
Our Socket Factory wasn't fetching a new token in case the reconnection state was achieved. 
Whenever a TokenProvider is used to provide a JWT token with an expiration date, when the token expires and the WS is closed, the token used to establish a new WS Connection isn't refreshed, causing an endless retry process unless the user interacts with our Rest API.

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExNWk5ankxN3pjcmFpZGc2NXc2bTNiZHlyY20zMmxnbGpvYzNpcjAzaSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l36kU80xPf0ojG0Erg/giphy.gif)