### PR TITLE
Push to staging on docusaurus dir changes

### DIFF
--- a/.github/workflows/docusaurus-staging.yml
+++ b/.github/workflows/docusaurus-staging.yml
@@ -2,8 +2,8 @@ name: Publish Docusaurus to staging
 
 on:
   push:
-    branches:
-      - develop
+    paths:
+      - 'docusaurus/**'
 
 jobs:
   push_docusaurus:


### PR DESCRIPTION
### 🎯 Goal

Change docs staging push trigger from `when branch is merged into develop` to `docusaurus folder has changes`.

### 🛠 Implementation details

Change from
```
on:
  push:
    branches:
      - develop
```
to
```
on:
  push:
    paths:
      - 'docusaurus/**'
```

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] PR targets the `develop` branch

### ☑️Reviewer Checklist
- [ ] New feature tested and works