### PR TITLE
Fix "Unread Label" behavior

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -527,9 +527,11 @@ public class MessageListController(
                     }
             }
             .onFirst { channelUserRead ->
-                unreadLabelState.value = channelUserRead.lastReadMessageId?.let {
-                    UnreadLabel(channelUserRead.unreadMessages, it)
-                }
+                unreadLabelState.value = channelUserRead.lastReadMessageId
+                    ?.takeUnless { channelState.value?.messages?.value?.lastOrNull()?.id == it }
+                    ?.let {
+                        UnreadLabel(channelUserRead.unreadMessages, it)
+                    }
             }.launchIn(scope)
     }
 


### PR DESCRIPTION
### 🎯 Goal
Fix weird behavior when a new message is sent to a channel and the "Unread Label" appears.
Fix: #5206 

### 🛠 Implementation details
Unread label should never be shown on the case last message is read, even if new messages are sent

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
