### PR TITLE
[i267] fix crash on editing message with recording

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed the crash happening while editing a message with a recording attachment. [#5220](https://github.com/GetStream/stream-chat-android/pull/5220)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/AudioRecordAttachmentPreviewFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/AudioRecordAttachmentPreviewFactory.kt
@@ -86,10 +86,12 @@ public class AudioRecordAttachmentPreviewFactory : AttachmentPreviewFactory {
 
         private val logger by taggedLogger("AttachRecordPreviewHolder")
 
-        private lateinit var attachment: Attachment
+        private var attachment: Attachment? = null
 
         init {
-            binding.removeButton.setOnClickListener { attachmentRemovalListener(attachment) }
+            binding.removeButton.setOnClickListener {
+                attachment?.also{ attachmentRemovalListener(it) }
+            }
             style?.audioRecordPlayerViewStyle?.also {
                 binding.playerView.setStyle(it)
             }
@@ -119,6 +121,7 @@ public class AudioRecordAttachmentPreviewFactory : AttachmentPreviewFactory {
         }
 
         override fun unbind() {
+            val attachment = attachment ?: return
             ChatClient.instance().audioPlayer.removeAudios(listOf(attachment.hashCode()))
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/AudioRecordAttachmentPreviewFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/factory/AudioRecordAttachmentPreviewFactory.kt
@@ -90,7 +90,7 @@ public class AudioRecordAttachmentPreviewFactory : AttachmentPreviewFactory {
 
         init {
             binding.removeButton.setOnClickListener {
-                attachment?.also{ attachmentRemovalListener(it) }
+                attachment?.also { attachmentRemovalListener(it) }
             }
             style?.audioRecordPlayerViewStyle?.also {
                 binding.playerView.setStyle(it)


### PR DESCRIPTION
### 🎯 Goal

Closes:
- https://github.com/GetStream/android-internal-board/issues/267

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
