### PR TITLE
Not increase unread counter when an shadowed message arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED CHANGELOG
 ## Common changes for all artifacts
 ### 🐞 Fixed
+- Shadowed messages are not increasing the unread count. [#5229](https://github.com/GetStream/stream-chat-android/pull/5229)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
@@ -69,7 +69,8 @@ public fun Channel.updateLastMessage(
                 unreadMessages = read.let {
                     val hasNewUnreadMessage = receivedEventDate.after(it.lastReceivedEventDate) &&
                         newMessages.size > messages.size &&
-                        newMessages.last().id == message.id
+                        newMessages.last().id == message.id &&
+                        !message.shadowed
                     if (hasNewUnreadMessage) it.unreadMessages.inc() else it.unreadMessages
                 },
             )

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -660,6 +660,7 @@ internal class ChannelStateLogic(
                 message.user.id == clientState.user.value?.id ||
                     message.parentId?.takeUnless { message.showInChannel } != null
             }
+            ?.takeUnless { message.shadowed }
             ?.let {
                 updateRead(
                     it.copy(


### PR DESCRIPTION
### 🎯 Goal
Not increase unread counter when an shadowed message arrives
Fix: https://github.com/GetStream/android-internal-board/issues/277

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExamt1ZWw0OHRkZjM1MHp4ZTBhZDZ5eW96bGIxbmoyb3c4djJ5NmtqbCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/7TUaMzjbQDtM4/giphy.gif)
