### PR TITLE
[i281] fix crash with custom message view holder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,12 +58,15 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed crash when providing a custom message view holder. [#5232](https://github.com/GetStream/stream-chat-android/pull/5232)
 
 ### ⬆️ Improved
 
 ### ✅ Added
 
 ### ⚠️ Changed
+- 🚨Breaking change: Exposed `MessageListItemViewHolderFactory.getItemViewType` which returns the view type for the given view holder. [#5232](https://github.com/GetStream/stream-chat-android/pull/5232)
+  * You have to implement this method in your custom `MessageListItemViewHolderFactory` implementation along with another `getItemViewType` method, which returns the view type for the given message item.
 
 ### ❌ Removed
 

--- a/docusaurus/android_versioned_docs/version-6.x.x-before-refactoring/04-ui/04-message-components/02-message-list.mdx
+++ b/docusaurus/android_versioned_docs/version-6.x.x-before-refactoring/04-ui/04-message-components/02-message-list.mdx
@@ -626,6 +626,13 @@ class CustomMessageViewHolderFactory : MessageListItemViewHolderFactory() {
         }
     }
 
+    override fun getItemViewType(viewHolder: BaseMessageItemViewHolder<out MessageListItem>): Int {
+        if (viewHolder is TodayViewHolder) {
+            return TODAY_VIEW_HOLDER_TYPE
+        }
+        return super.getItemViewType(viewHolder)
+    }
+
     private fun Date?.isLessThenDayAgo(): Boolean {
         if (this == null) {
             return false
@@ -669,9 +676,16 @@ class CustomMessageViewHolderFactory extends MessageListItemViewHolderFactory {
                 return TODAY_VIEW_HOLDER_TYPE;
             }
         }
-
         return super.getItemViewType(item);
 
+    }
+
+    @Override
+    public int getItemViewType(@NonNull BaseMessageItemViewHolder<? extends MessageListItem> viewHolder) {
+        if (viewHolder instanceof TodayViewHolder) {
+            return TODAY_VIEW_HOLDER_TYPE;
+        }
+        return super.getItemViewType(viewHolder);
     }
 
     private boolean isLessThanDayAgo(Date date) {

--- a/docusaurus/docs/Android/ui/message-components/message-list.mdx
+++ b/docusaurus/docs/Android/ui/message-components/message-list.mdx
@@ -599,6 +599,13 @@ class CustomMessageViewHolderFactory : MessageListItemViewHolderFactory() {
         }
     }
 
+    override fun getItemViewType(viewHolder: BaseMessageItemViewHolder<out MessageListItem>): Int {
+        if (viewHolder is TodayViewHolder) {
+            return TODAY_VIEW_HOLDER_TYPE
+        }
+        return super.getItemViewType(viewHolder)
+    }
+
     private fun Date?.isLessThenDayAgo(): Boolean {
         if (this == null) {
             return false
@@ -642,9 +649,16 @@ class CustomMessageViewHolderFactory extends MessageListItemViewHolderFactory {
                 return TODAY_VIEW_HOLDER_TYPE;
             }
         }
-
         return super.getItemViewType(item);
 
+    }
+
+    @Override
+    public int getItemViewType(@NonNull BaseMessageItemViewHolder<? extends MessageListItem> viewHolder) {
+        if (viewHolder instanceof TodayViewHolder) {
+            return TODAY_VIEW_HOLDER_TYPE;
+        }
+        return super.getItemViewType(viewHolder);
     }
 
     private boolean isLessThanDayAgo(Date date) {

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/messages/MessageList.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/messages/MessageList.java
@@ -220,6 +220,14 @@ public class MessageList extends Fragment {
 
             }
 
+            @Override
+            public int getItemViewType(@NonNull BaseMessageItemViewHolder<? extends MessageListItem> viewHolder) {
+                if (viewHolder instanceof TodayViewHolder) {
+                    return TODAY_VIEW_HOLDER_TYPE;
+                }
+                return super.getItemViewType(viewHolder);
+            }
+
             private boolean isLessThanDayAgo(Date date) {
                 if (date == null) return false;
                 long dayInMillis = TimeUnit.DAYS.toMillis(1);

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
@@ -234,6 +234,13 @@ class MessageListViewSnippets : Fragment() {
                 }
             }
 
+            override fun getItemViewType(viewHolder: BaseMessageItemViewHolder<out MessageListItem>): Int {
+                if (viewHolder is TodayViewHolder) {
+                    return TODAY_VIEW_HOLDER_TYPE
+                }
+                return super.getItemViewType(viewHolder)
+            }
+
             private fun Date?.isLessThenDayAgo(): Boolean {
                 if (this == null) {
                     return false

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2755,6 +2755,7 @@ public class io/getstream/chat/android/ui/feature/messages/list/adapter/MessageL
 	public fun <init> ()V
 	public fun createViewHolder (Landroid/view/ViewGroup;I)Lio/getstream/chat/android/ui/feature/messages/list/adapter/BaseMessageItemViewHolder;
 	protected final fun getAttachmentFactoryManager ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/AttachmentFactoryManager;
+	public fun getItemViewType (Lio/getstream/chat/android/ui/feature/messages/list/adapter/BaseMessageItemViewHolder;)I
 	public fun getItemViewType (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem;)I
 	protected final fun getListenerContainer ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainer;
 	protected final fun getListeners ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListeners;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemViewHolderFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemViewHolderFactory.kt
@@ -40,6 +40,7 @@ import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListIte
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItemViewType.THREAD_SEPARATOR
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItemViewType.TYPING_INDICATOR
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItemViewType.UNREAD_SEPARATOR
+import io.getstream.chat.android.ui.feature.messages.list.adapter.internal.MessageListItemAdapter
 import io.getstream.chat.android.ui.feature.messages.list.adapter.internal.MessageListItemViewTypeMapper
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.AttachmentFactoryManager
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.decorator.DecoratorProvider
@@ -174,7 +175,14 @@ public open class MessageListItemViewHolderFactory {
         return MessageListItemViewTypeMapper.getViewTypeValue(item, attachmentFactoryManager)
     }
 
-    internal fun getItemViewType(viewHolder: BaseMessageItemViewHolder<out MessageListItem>): Int {
+    /**
+     * Returns a view type value based on the type of the given [viewHolder].
+     * The view type returned here will be used in [MessageListItemAdapter.onBindViewHolder]
+     * to check if the ViewHolder is of the correct type before binding the item.
+     *
+     * For built-in view types, see [MessageListItemViewType] and its constants.
+     */
+    public open fun getItemViewType(viewHolder: BaseMessageItemViewHolder<out MessageListItem>): Int {
         return when (viewHolder) {
             is DateDividerViewHolder -> DATE_DIVIDER
             is MessageDeletedViewHolder -> MESSAGE_DELETED

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemAdapter.kt
@@ -88,7 +88,7 @@ internal class MessageListItemAdapter(
         val holderViewType = viewHolderFactory.getItemViewType(holder)
         if (itemViewType != holderViewType) {
             logger.w {
-                "[onBindViewHolder] #paylods; viewType mismatch; " +
+                "[onBindViewHolder] #payloads; viewType mismatch; " +
                     "item: ${MessageListItemViewType.toString(itemViewType)}, " +
                     "viewHolder: ${MessageListItemViewType.toString(holderViewType)}"
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemAdapter.kt
@@ -56,6 +56,16 @@ internal class MessageListItemAdapter(
 
     override fun onBindViewHolder(holder: BaseMessageItemViewHolder<out MessageListItem>, position: Int) {
         val item = getItem(position)
+        val itemViewType = viewHolderFactory.getItemViewType(item)
+        val holderViewType = viewHolderFactory.getItemViewType(holder)
+        if (itemViewType != holderViewType) {
+            logger.w {
+                "[onBindViewHolder] #regular; viewType mismatch; " +
+                    "item: ${MessageListItemViewType.toString(itemViewType)}, " +
+                    "viewHolder: ${MessageListItemViewType.toString(holderViewType)}"
+            }
+            return
+        }
         holder.bindListItem(item, FULL_MESSAGE_LIST_ITEM_PAYLOAD_DIFF)
     }
 
@@ -78,8 +88,9 @@ internal class MessageListItemAdapter(
         val holderViewType = viewHolderFactory.getItemViewType(holder)
         if (itemViewType != holderViewType) {
             logger.w {
-                "[onBindViewHolder] viewType mismatch; item: ${MessageListItemViewType.toString(itemViewType)}" +
-                    ", viewHolder: ${MessageListItemViewType.toString(holderViewType)}"
+                "[onBindViewHolder] #paylods; viewType mismatch; " +
+                    "item: ${MessageListItemViewType.toString(itemViewType)}, " +
+                    "viewHolder: ${MessageListItemViewType.toString(holderViewType)}"
             }
             return
         }


### PR DESCRIPTION
### 🎯 Goal

#### Closes: 
- https://github.com/GetStream/android-internal-board/issues/281

####  Related PR:
- #5219

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
