### PR TITLE
Remove autobackup from Compose sample 

### DIFF
--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -21,7 +21,7 @@
 
     <application
         android:name="io.getstream.chat.android.compose.sample.ChatApp"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:networkSecurityConfig="@xml/network_security_config"


### PR DESCRIPTION
Automatic backups break the login in our compose sample (autobackup is already disabled in the XML sample).