### PR TITLE
Catch only `UnsupportedEncodingException` while building Websocket URL

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -63,7 +63,7 @@ internal class SocketFactory(
                     "$baseWsUrl&authorization=$token&stream-auth-type=jwt"
                 }
             }
-        } catch (_: Throwable) {
+        } catch (_: UnsupportedEncodingException) {
             throw UnsupportedEncodingException("Unable to encode user details json: $json")
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Catch only `UnsupportedEncodingException` while building Websocket URL

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExdHIwNXgxZGdobDk3Ym03MXIybGxxN3YxcmhtcjNnMXkzeXR2MmxiMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/Jrnm3vFIEA5KE/giphy.gif)