### PR TITLE
Add reason to flag endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - `Channel.lastMessageAt` is not updated when there is a new message within a thread. [#5245](https://github.com/GetStream/stream-chat-android/pull/5245)
 
 ### ✅ Added
+- Added `reason` and `custom` fields to flag message endpoint.[#5242](https://github.com/GetStream/stream-chat-android/pull/5242)
+- Added `reason` and `custom` fields to flag user endpoint.[#5242](https://github.com/GetStream/stream-chat-android/pull/5242)
 
 ### ⚠️ Changed
 

--- a/docusaurus/docs/Android/client/moderation-tools.mdx
+++ b/docusaurus/docs/Android/client/moderation-tools.mdx
@@ -42,22 +42,38 @@ If a message was moderated, `moderationDetails` will have the following values:
 Any user is allowed to flag a message or a user. Flagging does not perform any particular action on the chat. The API will only trigger the related webhook event and make the message appear on your _Dashboard Chat Moderation_ view.
 
 ```kotlin
-client.flagMessage("message-id").enqueue { result -> 
-    if (result.isSuccess) { 
-        // Message was flagged 
-        val flag: Flag = result.data() 
-    } else { 
-        // Handle result.error() 
-    } 
-} 
+client.flagMessage(
+    messageId = "message-id",
+    reason = "This message is inappropriate",
+    customData = mapOf("extra_info" to "more details"),
+).enqueue { result ->
+    when (result) {
+        is Result.Success -> {
+            // Message was flagged
+            val flag = result.value
+        }
+
+        is Result.Failure -> {
+            // Handler error
+        }
+    }
+}
  
-client.flagUser("user-id").enqueue { result -> 
-    if (result.isSuccess) { 
-        // User was flagged 
-        val flag: Flag = result.data() 
-    } else { 
-        // Handle result.error() 
-    } 
+client.flagUser(
+    userId = "user-id",
+    reason = "This user is a spammer",
+    customData = mapOf("extra_info" to "more details"),
+).enqueue { result ->
+    when (result) {
+        is Result.Success -> {
+            // User was flagged
+            val flag = result.value
+        }
+
+        is Result.Failure -> {
+            // Handler error
+        }
+    }
 }
 ```
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -50,8 +50,8 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun enableSlowMode (Ljava/lang/String;Ljava/lang/String;I)Lio/getstream/result/call/Call;
 	public final fun enrichUrl (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun fetchCurrentUser ()Lio/getstream/result/call/Call;
-	public final fun flagMessage (Ljava/lang/String;)Lio/getstream/result/call/Call;
-	public final fun flagUser (Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun flagMessage (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/result/call/Call;
+	public final fun flagUser (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/result/call/Call;
 	public final fun getAppSettings ()Lio/getstream/chat/android/models/AppSettings;
 	public final fun getChannel (Ljava/lang/String;IIZ)Lio/getstream/result/call/Call;
 	public final fun getChannel (Ljava/lang/String;Ljava/lang/String;IIZ)Lio/getstream/result/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2545,13 +2545,29 @@ internal constructor(
     public fun muteCurrentUser(): Call<Mute> = api.muteCurrentUser()
 
     @CheckResult
-    public fun flagUser(userId: String): Call<Flag> = api.flagUser(userId)
+    public fun flagUser(
+        userId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag> = api.flagUser(
+        userId,
+        reason,
+        customData,
+    )
 
     @CheckResult
     public fun unflagUser(userId: String): Call<Flag> = api.unflagUser(userId)
 
     @CheckResult
-    public fun flagMessage(messageId: String): Call<Flag> = api.flagMessage(messageId)
+    public fun flagMessage(
+        messageId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag> = api.flagMessage(
+        messageId,
+        reason,
+        customData,
+    )
 
     @CheckResult
     public fun unflagMessage(messageId: String): Call<Flag> = api.unflagMessage(messageId)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -354,13 +354,21 @@ internal interface ChatApi {
     ): Call<Unit>
 
     @CheckResult
-    fun flagUser(userId: String): Call<Flag>
+    fun flagUser(
+        userId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag>
 
     @CheckResult
     fun unflagUser(userId: String): Call<Flag>
 
     @CheckResult
-    fun flagMessage(messageId: String): Call<Flag>
+    fun flagMessage(
+        messageId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag>
 
     @CheckResult
     fun unflagMessage(messageId: String): Call<Flag>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/FlagRequestAdapterFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/FlagRequestAdapterFactory.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api2
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import com.squareup.moshi.Moshi
+import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
+import java.lang.reflect.Type
+
+/**
+ * A [JsonAdapter.Factory] which provide [JsonAdapter] to serialize/deserialize [FlagRequest] entities.
+ */
+internal object FlagRequestAdapterFactory : JsonAdapter.Factory {
+    override fun create(type: Type, annotations: MutableSet<out Annotation>, moshi: Moshi): JsonAdapter<*>? =
+        when (type) {
+            FlagRequest::class.java -> FlagRequestAdapter(moshi)
+            else -> null
+        }
+
+    /**
+     * A [JsonAdapter] to serialize/deserialize [FlagRequest] entities.
+     */
+    private class FlagRequestAdapter(private val moshi: Moshi) : JsonAdapter<FlagRequest>() {
+        override fun fromJson(reader: JsonReader): FlagRequest? {
+            reader.readJsonValue()
+            return null
+        }
+
+        override fun toJson(writer: JsonWriter, value: FlagRequest?) {
+            when (value) {
+                is FlagMessageRequest -> moshi.adapter(FlagMessageRequest::class.java).toJson(writer, value)
+                is FlagUserRequest -> moshi.adapter(FlagUserRequest::class.java).toJson(writer, value)
+                else -> {}
+            }
+        }
+    }
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -47,6 +47,9 @@ import io.getstream.chat.android.client.api2.model.requests.AcceptInviteRequest
 import io.getstream.chat.android.client.api2.model.requests.AddDeviceRequest
 import io.getstream.chat.android.client.api2.model.requests.AddMembersRequest
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagMessageRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagUserRequest
 import io.getstream.chat.android.client.api2.model.requests.GuestUserRequest
 import io.getstream.chat.android.client.api2.model.requests.HideChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.InviteMembersRequest
@@ -426,23 +429,43 @@ constructor(
         }
     }
 
-    override fun flagUser(userId: String): Call<Flag> =
-        flag(mutableMapOf("target_user_id" to userId))
+    override fun flagUser(
+        userId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag> =
+        flag(
+            FlagUserRequest(
+                targetUserId = userId,
+                reason = reason,
+                custom = customData,
+            ),
+        )
 
     override fun unflagUser(userId: String): Call<Flag> =
         unflag(mutableMapOf("target_user_id" to userId))
 
-    override fun flagMessage(messageId: String): Call<Flag> =
-        flag(mutableMapOf("target_message_id" to messageId))
+    override fun flagMessage(
+        messageId: String,
+        reason: String?,
+        customData: Map<String, String>,
+    ): Call<Flag> =
+        flag(
+            FlagMessageRequest(
+                targetMessageId = messageId,
+                reason = reason,
+                custom = customData,
+            ),
+        )
 
     override fun unflagMessage(messageId: String): Call<Flag> =
         unflag(mutableMapOf("target_message_id" to messageId))
 
-    private fun flag(body: MutableMap<String, String>): Call<Flag> {
+    private fun flag(body: FlagRequest): Call<Flag> {
         return moderationApi.flag(body = body).map { response -> response.flag.toDomain() }
     }
 
-    private fun unflag(body: MutableMap<String, String>): Call<Flag> {
+    private fun unflag(body: Map<String, String>): Call<Flag> {
         return moderationApi.unflag(body = body).map { response -> response.flag.toDomain() }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ModerationApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/ModerationApi.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.client.api2.endpoint
 import io.getstream.chat.android.client.api.AuthenticatedApi
 import io.getstream.chat.android.client.api2.UrlQueryPayload
 import io.getstream.chat.android.client.api2.model.requests.BanUserRequest
+import io.getstream.chat.android.client.api2.model.requests.FlagRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteChannelRequest
 import io.getstream.chat.android.client.api2.model.requests.MuteUserRequest
 import io.getstream.chat.android.client.api2.model.requests.QueryBannedUsersRequest
@@ -49,7 +50,7 @@ internal interface ModerationApi {
     fun unmuteChannel(@Body body: MuteChannelRequest): RetrofitCall<CompletableResponse>
 
     @POST("/moderation/flag")
-    fun flag(@Body body: Map<String, String>): RetrofitCall<FlagResponse>
+    fun flag(@Body body: FlagRequest): RetrofitCall<FlagResponse>
 
     @POST("/moderation/unflag")
     fun unflag(@Body body: Map<String, String>): RetrofitCall<FlagResponse>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/FlagRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/FlagRequest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api2.model.requests
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+
+internal sealed class FlagRequest {
+    abstract val reason: String?
+    abstract val custom: Map<String, String>
+}
+
+@JsonClass(generateAdapter = true)
+internal data class FlagMessageRequest(
+    @Json(name = "target_message_id") val targetMessageId: String,
+    @Json(name = "reason") override val reason: String?,
+    @Json(name = "custom") override val custom: Map<String, String>,
+) : FlagRequest()
+
+@JsonClass(generateAdapter = true)
+internal data class FlagUserRequest(
+    @Json(name = "target_user_id") val targetUserId: String,
+    @Json(name = "reason") override val reason: String?,
+    @Json(name = "custom") override val custom: Map<String, String>,
+) : FlagRequest()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/MoshiChatParser.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.parser2
 
 import com.squareup.moshi.JsonAdapter
 import com.squareup.moshi.Moshi
+import io.getstream.chat.android.client.api2.FlagRequestAdapterFactory
 import io.getstream.chat.android.client.api2.MoshiUrlQueryPayloadFactory
 import io.getstream.chat.android.client.api2.mapping.toDomain
 import io.getstream.chat.android.client.api2.mapping.toDto
@@ -63,6 +64,7 @@ internal class MoshiChatParser : ChatParser {
             .add(UpstreamReactionDtoAdapter)
             .add(DownstreamUserDtoAdapter)
             .add(UpstreamUserDtoAdapter)
+            .add(FlagRequestAdapterFactory)
             .build()
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/UsersApiCallsTests.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.Flag
 import io.getstream.chat.android.models.Mute
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomString
 import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -123,12 +124,22 @@ internal class UsersApiCallsTests {
             date,
             date,
         )
+        val reason = randomString()
+        val customData = mapOf(randomString() to randomString())
 
         Mockito.`when`(
-            mock.api.flagUser(targetUserId),
+            mock.api.flagUser(
+                userId = targetUserId,
+                reason = reason,
+                customData = customData,
+            ),
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagUser(targetUserId).await()
+        val result = client.flagUser(
+            userId = targetUserId,
+            reason = reason,
+            customData = customData,
+        ).await()
 
         verifySuccess(result, flag)
     }
@@ -151,12 +162,22 @@ internal class UsersApiCallsTests {
             date,
             date,
         )
+        val reason = randomString()
+        val customData = mapOf(randomString() to randomString())
 
         Mockito.`when`(
-            mock.api.flagUser(targetUserId),
+            mock.api.flagUser(
+                userId = targetUserId,
+                reason = reason,
+                customData = customData,
+            ),
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagUser(targetUserId).await()
+        val result = client.flagUser(
+            userId = targetUserId,
+            reason = reason,
+            customData = customData,
+        ).await()
 
         verifySuccess(result, flag)
     }
@@ -178,12 +199,22 @@ internal class UsersApiCallsTests {
             date,
             date,
         )
+        val reason = randomString()
+        val customData = mapOf(randomString() to randomString())
 
         Mockito.`when`(
-            mock.api.flagMessage(targetMessageId),
+            mock.api.flagMessage(
+                messageId = targetMessageId,
+                reason = reason,
+                customData = customData,
+            ),
         ).thenReturn(RetroSuccess(flag).toRetrofitCall())
 
-        val result = client.flagMessage(targetMessageId).await()
+        val result = client.flagMessage(
+            messageId = targetMessageId,
+            reason = reason,
+            customData = customData,
+        ).await()
 
         verifySuccess(result, flag)
     }

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2279,7 +2279,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Lio/getstream/chat/android/models/Message;ZILjava/lang/Object;)V
 	public final fun dismissAllMessageActions ()V
 	public final fun dismissMessageAction (Lio/getstream/chat/android/ui/common/state/messages/MessageAction;)V
-	public final fun flagMessage (Lio/getstream/chat/android/models/Message;)V
+	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;)V
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getCurrentMessagesState ()Lio/getstream/chat/android/ui/common/state/messages/list/MessageListState;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -672,7 +672,15 @@ private fun MessageDialogs(listViewModel: MessageListViewModel) {
             modifier = Modifier.padding(16.dp),
             title = stringResource(id = R.string.stream_compose_flag_message_title),
             message = stringResource(id = R.string.stream_compose_flag_message_text),
-            onPositiveAction = remember(listViewModel) { { listViewModel.flagMessage(flagAction.message) } },
+            onPositiveAction = remember(listViewModel) {
+                {
+                    listViewModel.flagMessage(
+                        flagAction.message,
+                        reason = null,
+                        customData = emptyMap(),
+                    )
+                }
+            },
             onDismiss = remember(listViewModel) { { listViewModel.dismissMessageAction(flagAction) } },
         )
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -267,8 +267,16 @@ public class MessageListViewModel(
      * @param message Message to delete.
      */
     @Suppress("ConvertArgumentToSet")
-    public fun flagMessage(message: Message) {
-        messageListController.flagMessage(message)
+    public fun flagMessage(
+        message: Message,
+        reason: String?,
+        customData: Map<String, String>,
+    ) {
+        messageListController.flagMessage(
+            message,
+            reason,
+            customData,
+        )
     }
 
     /**

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/cms/Moderation.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/cms/Moderation.java
@@ -2,19 +2,20 @@ package io.getstream.chat.docs.java.client.cms;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import io.getstream.chat.android.client.ChatClient;
-import io.getstream.chat.android.models.FilterObject;
 import io.getstream.chat.android.client.api.models.QueryUsersRequest;
-import io.getstream.chat.android.models.querysort.QuerySortByField;
-import io.getstream.chat.android.models.querysort.QuerySorter;
 import io.getstream.chat.android.client.channel.ChannelClient;
 import io.getstream.chat.android.models.BannedUser;
 import io.getstream.chat.android.models.BannedUsersSort;
+import io.getstream.chat.android.models.FilterObject;
 import io.getstream.chat.android.models.Filters;
 import io.getstream.chat.android.models.Flag;
 import io.getstream.chat.android.models.Mute;
 import io.getstream.chat.android.models.User;
+import io.getstream.chat.android.models.querysort.QuerySortByField;
+import io.getstream.chat.android.models.querysort.QuerySorter;
 
 public class Moderation {
     private ChatClient client;
@@ -28,7 +29,11 @@ public class Moderation {
         class Flags {
 
             public void flag() {
-                client.flagMessage("message-id").enqueue(result -> {
+                client.flagMessage(
+                        "message-id",
+                        "This message is inappropriate",
+                        Map.of("extra_info", "more details")
+                ).enqueue(result -> {
                     if (result.isSuccess()) {
                         // Message was flagged
                         Flag flag = result.getOrNull();
@@ -37,7 +42,11 @@ public class Moderation {
                     }
                 });
 
-                client.flagUser("user-id").enqueue(result -> {
+                client.flagUser(
+                        "user-id",
+                        "This user is a spammer",
+                        Map.of("extra_info", "more details")
+                ).enqueue(result -> {
                     if (result.isSuccess()) {
                         // User was flagged
                         Flag flag = result.getOrNull();

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/cms/Moderation.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/cms/Moderation.kt
@@ -18,24 +18,34 @@ class Moderation(val client: ChatClient, val channelClient: ChannelClient) {
         inner class Flags {
 
             fun flag() {
-                client.flagMessage("message-id").enqueue { result ->
+                client.flagMessage(
+                    messageId = "message-id",
+                    reason = "This message is inappropriate",
+                    customData = mapOf("extra_info" to "more details"),
+                ).enqueue { result ->
                     when (result) {
                         is Result.Success -> {
                             // Message was flagged
                             val flag = result.value
                         }
+
                         is Result.Failure -> {
                             // Handler error
                         }
                     }
                 }
 
-                client.flagUser("user-id").enqueue { result ->
+                client.flagUser(
+                    userId = "user-id",
+                    reason = "This user is a spammer",
+                    customData = mapOf("extra_info" to "more details"),
+                ).enqueue { result ->
                     when (result) {
                         is Result.Success -> {
                             // User was flagged
                             val flag = result.value
                         }
+
                         is Result.Failure -> {
                             // Handler error
                         }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -141,8 +141,8 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun enterNormalMode ()V
 	public final fun enterThreadMode (Lio/getstream/chat/android/models/Message;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun enterThreadMode$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;)V
-	public static synthetic fun flagMessage$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public static synthetic fun flagMessage$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public final fun getChannel ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getChannelState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -1522,11 +1522,23 @@ public class MessageListController(
     /**
      * Flags the selected message.
      *
-     * @param message Message to delete.
+     * @param message Message to be flagged.
+     * @param reason The reason for flagging the message.
+     * @param customData Additional data to send with the flag.
+     * @param onResult Handler that notifies the result of the flag action.
      */
-    public fun flagMessage(message: Message, onResult: (Result<Flag>) -> Unit = {}) {
+    public fun flagMessage(
+        message: Message,
+        reason: String?,
+        customData: Map<String, String>,
+        onResult: (Result<Flag>) -> Unit = {},
+    ) {
         _messageActions.value = _messageActions.value - _messageActions.value.filterIsInstance<FlagMessage>().toSet()
-        chatClient.flagMessage(message.id).enqueue { response ->
+        chatClient.flagMessage(
+            message.id,
+            reason,
+            customData,
+        ).enqueue { response ->
             onResult(response)
             if (response is Result.Failure) {
                 val error = response.value

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4286,14 +4286,18 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 }
 
 public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
-	public fun <init> (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
-	public final fun component2 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun component4 ()Lkotlin/jvm/functions/Function1;
+	public final fun copy (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagMessage;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomData ()Ljava/util/Map;
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public final fun getReason ()Ljava/lang/String;
 	public final fun getResultHandler ()Lkotlin/jvm/functions/Function1;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -229,7 +229,11 @@ public class MessageListViewModel(
             is Event.ShadowBanUser -> messageListController.shadowBanUser(event.user.id)
             is Event.RemoveShadowBanFromUser -> messageListController.removeShadowBanFromUser(event.user.id)
             is Event.RemoveAttachment -> messageListController.removeAttachment(event.messageId, event.attachment)
-            is Event.FlagMessage -> messageListController.flagMessage(event.message) { result ->
+            is Event.FlagMessage -> messageListController.flagMessage(
+                event.message,
+                event.reason,
+                event.customData,
+            ) { result ->
                 event.resultHandler(result)
             }
             is Event.BanUser -> messageListController.banUser(
@@ -524,7 +528,12 @@ public class MessageListViewModel(
          * @param resultHandler Lambda function that handles the result of the operation.
          * e.g. if the message was successfully flagged or not.
          */
-        public data class FlagMessage(val message: Message, val resultHandler: ((Result<Flag>) -> Unit) = { }) : Event()
+        public data class FlagMessage(
+            val message: Message,
+            val reason: String?,
+            val customData: Map<String, String>,
+            val resultHandler: ((Result<Flag>) -> Unit) = { },
+        ) : Event()
 
         /**
          * When the user pins a message.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
@@ -63,7 +63,16 @@ public fun MessageListViewModel.bindView(
     view.setLastMessageReadHandler { onEvent(LastMessageRead) }
     view.setMessageDeleteHandler { onEvent(DeleteMessage(it, hard = false)) }
     view.setThreadStartHandler { onEvent(ThreadModeEntered(it)) }
-    view.setMessageFlagHandler { onEvent(FlagMessage(it, view::handleFlagMessageResult)) }
+    view.setMessageFlagHandler {
+        onEvent(
+            FlagMessage(
+                it,
+                reason = null,
+                customData = emptyMap(),
+                view::handleFlagMessageResult,
+            ),
+        )
+    }
     view.setMessagePinHandler { onEvent(MessageListViewModel.Event.PinMessage(it)) }
     view.setMessageUnpinHandler { onEvent(MessageListViewModel.Event.UnpinMessage(it)) }
     view.setMessageMarkAsUnreadHandler { onEvent(MessageListViewModel.Event.MarkAsUnreadMessage(it)) }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.randomChannelUserRead
 import io.getstream.chat.android.randomInt
+import io.getstream.chat.android.randomString
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
@@ -157,17 +158,32 @@ internal class MessageListViewModelTest {
         val messages = listOf(messageToFlag, message2)
         val messageState = MessagesState.Result(messages)
         val chatClient = MockChatClientBuilder().build()
+        val reason = randomString()
+        val customData = mapOf(randomString() to randomString())
 
         val viewModel = Fixture(chatClient = chatClient)
             .givenCurrentUser()
             .givenChannelQuery()
             .givenChannelState(messageState = messageState, messages = messages)
-            .givenFlagMessage(message = messageToFlag)
-            .get()
+            .givenFlagMessage(
+                message = messageToFlag,
+                reason = reason,
+                customData = customData,
+            ).get()
 
-        viewModel.onEvent(MessageListViewModel.Event.FlagMessage(messageToFlag))
+        viewModel.onEvent(
+            MessageListViewModel.Event.FlagMessage(
+                message = messageToFlag,
+                reason = reason,
+                customData = customData,
+            ),
+        )
 
-        verify(chatClient).flagMessage(messageId = messageToFlag.id)
+        verify(chatClient).flagMessage(
+            messageId = messageToFlag.id,
+            reason = reason,
+            customData = customData,
+        )
     }
 
     @Test
@@ -251,8 +267,14 @@ internal class MessageListViewModelTest {
             whenever(chatClient.queryChannel(any(), any(), any(), any())) doReturn channel.asCall()
         }
 
-        fun givenFlagMessage(message: Message) = apply {
-            whenever(chatClient.flagMessage(message.id)) doReturn mock()
+        fun givenFlagMessage(message: Message, reason: String, customData: Map<String, String>) = apply {
+            whenever(
+                chatClient.flagMessage(
+                    messageId = message.id,
+                    reason = reason,
+                    customData = customData,
+                ),
+            ) doReturn mock()
         }
 
         fun givenDeleteMessage() = apply {


### PR DESCRIPTION
### 🎯 Goal
The API allows send `reason` and `custom` data whenever a message/user is flagged, but the SDK didn't provide a way to add it.
New `reason` and `custom` fields have been added 
close: https://github.com/GetStream/android-internal-board/issues/286

### 🎉 GIF
![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGtvZzJhaDdkdnBjOHoyZTJzdnFybjhjZzRrNmczbW1oZ3dxcHYwciZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/tv0a5CfYyHKExsJ1Tc/giphy.gif)
