### PR TITLE
[PBE-2806] Thread replies are scrolled to bottom on any event

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -33,7 +33,6 @@ import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
@@ -265,10 +264,6 @@ internal fun BoxScope.DefaultMessagesHelperContent(
 
     val offset = messagesLazyListState.focusedMessageOffset
 
-    val hasLoadedThread by derivedStateOf {
-        messagesState.messageItems.size > 1 && messagesState.parentMessageId != null
-    }
-
     LaunchedEffect(newMessageState, focusedItemIndex, offset) {
         if (focusedItemIndex != -1 &&
             !lazyListState.isScrollInProgress
@@ -284,7 +279,7 @@ internal fun BoxScope.DefaultMessagesHelperContent(
             newMessageState,
             areNewestMessagesLoaded,
             lazyListState.isScrollInProgress,
-        ) || hasLoadedThread
+        )
 
         if (shouldScrollToBottom) {
             coroutineScope.launch {


### PR DESCRIPTION
### 🎯 Goal

Closes:
- https://stream-io.atlassian.net/browse/PBE-2806


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
