### PR TITLE
Headers providers Interfaces to fetch image/video URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,8 +51,10 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Created `VideoHeadersProvider` interface to provide headers for video requests. [#5265](https://github.com/GetStream/stream-chat-android/pull/5265)
 
 ### ⚠️ Changed
+- The `ImageHeadersProvider.getImageRequestHeaders()` method use the url as a parameter. [#5265](https://github.com/GetStream/stream-chat-android/pull/5265)
 
 ### ❌ Removed
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/general/Configuration.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/general/Configuration.java
@@ -102,7 +102,7 @@ public class Configuration {
      * [Customizing Image Headers](https://getstream.io/chat/docs/sdk/android/ui/general-customization/chatui/#adding-extra-headers-to-image-requests)
      */
     public void customizingImageHeaders() {
-        ChatUI.setImageHeadersProvider(() -> {
+        ChatUI.setImageHeadersProvider((url) -> {
             Map<String, String> headers = new HashMap<>();
             headers.put("token", "12345");
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/Configuration.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/Configuration.kt
@@ -94,7 +94,7 @@ private class ChatUiSnippets {
      */
     fun customizingImageHeaders() {
         ChatUI.imageHeadersProvider = object : ImageHeadersProvider {
-            override fun getImageRequestHeaders(): Map<String, String> {
+            override fun getImageRequestHeaders(url: String): Map<String, String> {
                 return mapOf("token" to "12345")
             }
         }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -353,7 +353,7 @@ public final class io/getstream/chat/android/ui/common/helper/DateFormatter$Comp
 }
 
 public abstract interface class io/getstream/chat/android/ui/common/helper/ImageHeadersProvider {
-	public abstract fun getImageRequestHeaders ()Ljava/util/Map;
+	public abstract fun getImageRequestHeaders (Ljava/lang/String;)Ljava/util/Map;
 }
 
 public final class io/getstream/chat/android/ui/common/helper/internal/StorageHelper$Companion {

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -356,6 +356,10 @@ public abstract interface class io/getstream/chat/android/ui/common/helper/Image
 	public abstract fun getImageRequestHeaders (Ljava/lang/String;)Ljava/util/Map;
 }
 
+public abstract interface class io/getstream/chat/android/ui/common/helper/VideoHeadersProvider {
+	public abstract fun getVideoRequestHeaders (Ljava/lang/String;)Ljava/util/Map;
+}
+
 public final class io/getstream/chat/android/ui/common/helper/internal/StorageHelper$Companion {
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/ImageHeadersProvider.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/ImageHeadersProvider.kt
@@ -20,9 +20,16 @@ package io.getstream.chat.android.ui.common.helper
  * Provides HTTP headers for image loading requests.
  */
 public interface ImageHeadersProvider {
-    public fun getImageRequestHeaders(): Map<String, String>
+
+    /**
+     * Returns a map of headers to be used for the image loading request.
+     *
+     * @param url The URL of the image to load.
+     * @return A map of headers to be used for the image loading request.
+     */
+    public fun getImageRequestHeaders(url: String): Map<String, String>
 }
 
 internal object DefaultImageHeadersProvider : ImageHeadersProvider {
-    override fun getImageRequestHeaders(): Map<String, String> = emptyMap()
+    override fun getImageRequestHeaders(url: String): Map<String, String> = emptyMap<String, String>()
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/VideoHeadersProvider.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/VideoHeadersProvider.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.helper
+
+/**
+ * Provides HTTP headers for video loading requests.
+ */
+public interface VideoHeadersProvider {
+
+    /**
+     * Returns a map of headers to be used for the video loading request.
+     *
+     * @param url The URL of the video to load.
+     * @return A map of headers to be used for the video loading request.
+     */
+    public fun getVideoRequestHeaders(url: String): Map<String, String>
+}
+
+internal object DefaultVideoHeadersProvider : VideoHeadersProvider {
+    override fun getVideoRequestHeaders(url: String): Map<String, String> = emptyMap<String, String>()
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/VideoHeadersProvider.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/VideoHeadersProvider.kt
@@ -16,6 +16,8 @@
 
 package io.getstream.chat.android.ui.common.helper
 
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
 /**
  * Provides HTTP headers for video loading requests.
  */
@@ -30,6 +32,7 @@ public interface VideoHeadersProvider {
     public fun getVideoRequestHeaders(url: String): Map<String, String>
 }
 
-internal object DefaultVideoHeadersProvider : VideoHeadersProvider {
+@InternalStreamChatApi
+public object DefaultVideoHeadersProvider : VideoHeadersProvider {
     override fun getVideoRequestHeaders(url: String): Map<String, String> = emptyMap<String, String>()
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/CoilStreamImageLoader.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/CoilStreamImageLoader.kt
@@ -51,7 +51,7 @@ internal object CoilStreamImageLoader : StreamImageLoader {
             ?.let { url ->
                 val imageResult = context.streamImageLoader.execute(
                     ImageRequest.Builder(context)
-                        .headers(imageHeadersProvider.getImageRequestHeaders().toHeaders())
+                        .headers(imageHeadersProvider.getImageRequestHeaders(url).toHeaders())
                         .data(url)
                         .applyTransformation(transformation)
                         .build(),
@@ -70,7 +70,9 @@ internal object CoilStreamImageLoader : StreamImageLoader {
     ): Disposable {
         val context = target.context
         val disposable = target.load(data, context.streamImageLoader) {
-            headers(imageHeadersProvider.getImageRequestHeaders().toHeaders())
+            data?.toString()?.let { url ->
+                headers(imageHeadersProvider.getImageRequestHeaders(url).toHeaders())
+            }
 
             if (placeholderResId != null) {
                 placeholder(placeholderResId)
@@ -100,7 +102,9 @@ internal object CoilStreamImageLoader : StreamImageLoader {
     ): Disposable {
         val context = target.context
         val disposable = target.load(data, context.streamImageLoader) {
-            headers(imageHeadersProvider.getImageRequestHeaders().toHeaders())
+            data?.toString()?.let { url ->
+                headers(imageHeadersProvider.getImageRequestHeaders(url).toHeaders())
+            }
 
             if (placeholderDrawable != null) {
                 placeholder(placeholderDrawable)
@@ -142,9 +146,12 @@ internal object CoilStreamImageLoader : StreamImageLoader {
         val context = target.context
 
         val drawable = withContext(DispatcherProvider.IO) {
+            val headersMap = data?.toString()?.let { url ->
+                imageHeadersProvider.getImageRequestHeaders(url)
+            } ?: emptyMap()
             val result = context.streamImageLoader.execute(
                 ImageRequest.Builder(context)
-                    .headers(imageHeadersProvider.getImageRequestHeaders().toHeaders())
+                    .headers(headersMap.toHeaders())
                     .placeholder(placeholderDrawable)
                     .fallback(placeholderDrawable)
                     .error(placeholderDrawable)
@@ -183,7 +190,9 @@ internal object CoilStreamImageLoader : StreamImageLoader {
     ): Disposable {
         val context = target.context
         val disposable = target.load(uri, context.streamImageLoader) {
-            headers(imageHeadersProvider.getImageRequestHeaders().toHeaders())
+            uri?.toString()?.let { url ->
+                headers(imageHeadersProvider.getImageRequestHeaders(url).toHeaders())
+            }
 
             if (placeholderResId != null) {
                 placeholder(placeholderResId)

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -19,6 +19,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun getStyle ()Lio/getstream/chat/android/ui/font/ChatStyle;
 	public static final fun getSupportedReactions ()Lio/getstream/chat/android/ui/helper/SupportedReactions;
 	public static final fun getUserAvatarRenderer ()Lio/getstream/chat/android/ui/widgets/avatar/UserAvatarRenderer;
+	public static final fun getVideoHeadersProvider ()Lio/getstream/chat/android/ui/common/helper/VideoHeadersProvider;
 	public static final fun getVideoThumbnailsEnabled ()Z
 	public static final fun setAttachmentFactoryManager (Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/AttachmentFactoryManager;)V
 	public static final fun setAttachmentPreviewFactoryManager (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/preview/AttachmentPreviewFactoryManager;)V
@@ -39,6 +40,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun setStyle (Lio/getstream/chat/android/ui/font/ChatStyle;)V
 	public static final fun setSupportedReactions (Lio/getstream/chat/android/ui/helper/SupportedReactions;)V
 	public static final fun setUserAvatarRenderer (Lio/getstream/chat/android/ui/widgets/avatar/UserAvatarRenderer;)V
+	public static final fun setVideoHeadersProvider (Lio/getstream/chat/android/ui/common/helper/VideoHeadersProvider;)V
 	public static final fun setVideoThumbnailsEnabled (Z)V
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -18,7 +18,9 @@ package io.getstream.chat.android.ui
 
 import android.content.Context
 import io.getstream.chat.android.ui.common.helper.DateFormatter
+import io.getstream.chat.android.ui.common.helper.DefaultVideoHeadersProvider
 import io.getstream.chat.android.ui.common.helper.ImageHeadersProvider
+import io.getstream.chat.android.ui.common.helper.VideoHeadersProvider
 import io.getstream.chat.android.ui.common.images.internal.StreamImageLoader
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.utils.ChannelNameFormatter
@@ -68,6 +70,12 @@ public object ChatUI {
      */
     @JvmStatic
     public var imageHeadersProvider: ImageHeadersProvider by StreamImageLoader.instance()::imageHeadersProvider
+
+    /**
+     * Provides HTTP headers for video loading requests.
+     */
+    @JvmStatic
+    public var videoHeadersProvider: VideoHeadersProvider = DefaultVideoHeadersProvider
 
     /**
      * Allows setting default fonts used by UI components.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/internal/AttachmentGalleryVideoPageFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/internal/AttachmentGalleryVideoPageFragment.kt
@@ -213,7 +213,7 @@ internal class AttachmentGalleryVideoPageFragment : Fragment() {
 
     private fun loadVideo() {
         binding.videoView.apply {
-            setVideoURI(Uri.parse(assetUrl))
+            setVideoURI(Uri.parse(assetUrl), ChatUI.videoHeadersProvider.getVideoRequestHeaders(assetUrl ?: ""))
             this.setMediaController(mediaController)
             setOnErrorListener { _, _, _ ->
                 Toast.makeText(


### PR DESCRIPTION
### 🎯 Goal
The SDK already provided the `ImageHeadersProvider` interface to inject custom headers whenever an image URL wanted to be loaded. This interface has been updated to receive as a parameter the URL that will be fetched to be able to inject different headers depending on the URL.

In the same way, the `VideoHeadersProvider` interface has been created to use custom headers when video URLs are fetched.

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcGJ2YTNxZngxNDJhdXptaHo5NHZhZzQ0dmM3em5uZmZueTJ1YWFuNSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/jRwKzj28kaAxbfH5fC/giphy.gif)