### PR TITLE
[PBE-3738] Ensure message has id before starting the send process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fix crash when parsing users from query user endpoint. [#5257](https://github.com/GetStream/stream-chat-android/pull/5257)
+- Fix `ChatClient.sendMessage()` method to be able to send multiple message in parallel. [#5266](https://github.com/GetStream/stream-chat-android/pull/5266)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -136,6 +136,7 @@ import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.TokenUtils
 import io.getstream.chat.android.client.utils.internal.toggle.ToggleService
 import io.getstream.chat.android.client.utils.mergePartially
+import io.getstream.chat.android.client.utils.message.ensureId
 import io.getstream.chat.android.client.utils.observable.ChatEventsObservable
 import io.getstream.chat.android.client.utils.observable.Disposable
 import io.getstream.chat.android.client.utils.retry.NoRetryPolicy
@@ -1721,6 +1722,7 @@ internal constructor(
         isRetrying: Boolean = false,
     ): Call<Message> {
         return message.copy(createdLocallyAt = message.createdLocallyAt ?: Date())
+            .ensureId(getCurrentUser() ?: getStoredUser())
             .let { processedMessage ->
                 CoroutineCall(userScope) {
                     val debugger = clientDebugger.debugSendMessage(channelType, channelId, processedMessage, isRetrying)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/interceptor/message/internal/PrepareMessageLogicImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/interceptor/message/internal/PrepareMessageLogicImpl.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.client.interceptor.message.PrepareMessageLogic
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.client.utils.internal.getMessageType
+import io.getstream.chat.android.client.utils.message.ensureId
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
@@ -61,8 +62,7 @@ internal class PrepareMessageLogicImpl(
                 )
             }
         }
-        return message.copy(
-            id = message.id.takeIf { it.isNotBlank() } ?: generateMessageId(user.id),
+        return message.ensureId(user).copy(
             user = user,
             attachments = attachments,
             type = getMessageType(message),
@@ -90,13 +90,6 @@ internal class PrepareMessageLogicImpl(
                     channel?.replyMessage(null)
                 }
             }
-    }
-
-    /**
-     * Returns a unique message id prefixed with user id.
-     */
-    private fun generateMessageId(userId: String): String {
-        return "$userId-${UUID.randomUUID()}"
     }
 
     private fun generateUploadId(): String {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+@file:Suppress("TooManyFunctions")
 @file:JvmName("MessageUtils")
 
 package io.getstream.chat.android.client.utils.message
@@ -25,6 +26,8 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageModerationAction
 import io.getstream.chat.android.models.MessageType
 import io.getstream.chat.android.models.SyncStatus
+import io.getstream.chat.android.models.User
+import java.util.UUID
 
 private const val ITEM_COUNT_OF_TWO: Int = 2
 
@@ -146,3 +149,18 @@ public fun Message.isModerationFlag(): Boolean = moderationDetails?.action == Me
  */
 public fun Message.isModerationError(currentUserId: String?): Boolean = isMine(currentUserId) &&
     (isError() && isModerationBounce())
+
+/**
+ * Ensures the message has an id.
+ * If the message doesn't have an id, a unique message id is generated.
+ * @return the message with an id.
+ */
+internal fun Message.ensureId(currentUser: User?): Message =
+    copy(id = id.takeIf { it.isNotBlank() } ?: generateMessageId(currentUser))
+
+/**
+ * Returns a unique message id prefixed with user id.
+ */
+private fun generateMessageId(user: User?): String {
+    return "${user?.id}-${UUID.randomUUID()}"
+}


### PR DESCRIPTION
### 🎯 Goal
The LLC SDK has a preventive mechanism to not send the same message twice.
The mechanism is based on the message id, but the message id wasn't initialized in time which caused some messages to be dropped in the case multiple messages are sent at the same time.
 
Fix https://stream-io.atlassian.net/browse/PBE-3738

### 🎉 GIF

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2FqMXYxMnhqNTF2c2RvYzFtaXluZ2ZycnN0M2V3M2JjanB5Y2FlcCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/KCe1XIj29KxN2aQWYg/giphy.gif)