### PR TITLE
[PBE-4081]  hidden channel messages are shown up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 
 ## stream-chat-android-offline
 ### 🐞 Fixed
+- Fixed messages from hidden channels being shown up. [#5281](https://github.com/GetStream/stream-chat-android/pull/5281)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2283,6 +2283,7 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun deleteChannelMessage (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteChannelMessages (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun evictMessages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessage (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessages (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -120,6 +120,8 @@ public interface MessageRepository {
      */
     public suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message>
 
+    public suspend fun evictMessages()
+
     /**
      * Clear messages of this repository.
      */

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -168,6 +168,16 @@ public class RepositoryFacade private constructor(
         messageRepository.deleteChannelMessages(cid)
     }
 
+    override suspend fun setHiddenForChannel(cid: String, hidden: Boolean, hideMessagesBefore: Date) {
+        channelsRepository.setHiddenForChannel(cid, hidden, hideMessagesBefore)
+        messageRepository.evictMessages()
+    }
+
+    override suspend fun setHiddenForChannel(cid: String, hidden: Boolean) {
+        channelsRepository.setHiddenForChannel(cid, hidden)
+        messageRepository.evictMessages()
+    }
+
     public suspend fun storeStateForChannel(channel: Channel) {
         storeStateForChannels(listOf(channel))
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -37,6 +37,8 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun deleteChannelMessage(message: Message) { /* No-Op */ }
     override suspend fun selectMessageIdsBySyncState(syncStatus: SyncStatus): List<String> = emptyList()
     override suspend fun selectMessageBySyncState(syncStatus: SyncStatus): List<Message> = emptyList()
+    override suspend fun evictMessages() { /* No-Op */ }
+
     override suspend fun clear() { /* No-Op */ }
     override suspend fun selectMessagesForChannel(
         cid: String,

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/DatabaseChannelRepository.kt
@@ -153,9 +153,7 @@ internal class DatabaseChannelRepository(
      * @param deletedAt Date.
      */
     override suspend fun setChannelDeletedAt(cid: String, deletedAt: Date) {
-        channelCache[cid]?.let { cachedChannel ->
-            cacheChannel(listOf(cachedChannel.copy(deletedAt = deletedAt)))
-        }
+        channelCache.remove(cid)
         scope.launchWithMutex(dbMutex) { channelDao.setDeletedAt(cid, deletedAt) }
     }
 
@@ -167,14 +165,7 @@ internal class DatabaseChannelRepository(
      * @param hideMessagesBefore Date.
      */
     override suspend fun setHiddenForChannel(cid: String, hidden: Boolean, hideMessagesBefore: Date) {
-        channelCache[cid]?.let { cachedChannel ->
-            cacheChannel(
-                cachedChannel.copy(
-                    hidden = hidden,
-                    hiddenMessagesBefore = hideMessagesBefore,
-                ),
-            )
-        }
+        channelCache.remove(cid)
         scope.launchWithMutex(dbMutex) { channelDao.setHidden(cid, hidden, hideMessagesBefore) }
     }
 
@@ -185,9 +176,7 @@ internal class DatabaseChannelRepository(
      * @param hidden Date.
      */
     override suspend fun setHiddenForChannel(cid: String, hidden: Boolean) {
-        channelCache[cid]?.let { cachedChannel ->
-            cacheChannel(listOf(cachedChannel.copy(hidden = hidden)))
-        }
+        channelCache.remove(cid)
         scope.launchWithMutex(dbMutex) { channelDao.setHidden(cid, hidden) }
     }
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -185,6 +185,11 @@ internal class DatabaseMessageRepository(
         return messageDao.selectBySyncStatus(syncStatus).map { it.toModel(getUser, ::selectRepliedMessage) }
     }
 
+    override suspend fun evictMessages() {
+        messageCache.evictAll()
+        replyMessageCache.evictAll()
+    }
+
     override suspend fun clear() {
         messageCache.evictAll()
         replyMessageCache.evictAll()

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -262,6 +262,10 @@ internal class MockMessageRepository : MessageRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun evictMessages() {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun clear() {
         messages.clear()
     }


### PR DESCRIPTION
### 🎯 Goal

We have to clear cache layer when channel becomes `hidden` to avoid messages from that channel to be accessible.

Closes:
- https://stream-io.atlassian.net/browse/PBE-4081

Related PR:
- https://github.com/GetStream/stream-chat-android/pull/5189

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
