### PR TITLE
[PBE-3852] fix crash on gallery screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fixed crash on `AttachmentGalleryActivity`. [#5284](https://github.com/GetStream/stream-chat-android/pull/5284)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentGalleryActivity.kt
@@ -117,13 +117,13 @@ public class AttachmentGalleryActivity : AppCompatActivity() {
         binding = StreamUiActivityAttachmentGalleryBinding.inflate(streamThemeInflater)
         setContentView(binding.root)
         setupGalleryOverviewButton()
-        binding.closeButton.setOnClickListener { onBackPressed() }
+        binding.closeButton.setOnClickListener { finish() }
         viewModel.attachmentGalleryItemsLiveData.observe(this, ::setupGallery)
     }
 
     private fun setupGallery(attachmentGalleryItems: List<AttachmentGalleryItem>) {
         if (attachmentGalleryItems.isEmpty()) {
-            onBackPressed()
+            finish()
         } else {
             this.attachmentGalleryItems = attachmentGalleryItems
             setupGalleryAdapter()

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/overview/MediaAttachmentGridView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/overview/MediaAttachmentGridView.kt
@@ -121,9 +121,12 @@ public class MediaAttachmentGridView : FrameLayout {
     }
 
     private fun setDateText(attachmentGalleryItems: List<AttachmentGalleryItem>) {
-        val createdAt = attachmentGalleryItems[dateScrollListener.lastVisibleItemPosition].createdAt
-        binding.dateContainer.isVisible = true
-        binding.dateTextView.text = dateFormat.format(createdAt)
+        val createdAt = when (attachmentGalleryItems.isNotEmpty()) {
+            true -> attachmentGalleryItems[dateScrollListener.lastVisibleItemPosition].createdAt
+            else -> null
+        }
+        binding.dateContainer.isVisible = attachmentGalleryItems.isNotEmpty()
+        binding.dateTextView.text = createdAt?.let { dateFormat.format(it) }
     }
 
     private class MediaDateScrollListener(


### PR DESCRIPTION
### 🎯 Goal

#### Closes
- https://stream-io.atlassian.net/browse/PBE-3852

#### Related PR
- https://github.com/GetStream/stream-chat-android/pull/1960

### 🛠 Implementation details

Most likely the `AttachmentGalleryActivity` gets killed in background. Then when the activity gets restored, `setupGallery` is being called with empty items list, which triggers `onBackPressed`, which internally calls `popBackStackImmediate` and it crashes due other ongoing transaction.

####  Possible scenario might be:
- user backgrounds the app on gallery screen
- then activity gets killed in the background either due to doze mode or resources draining

I forced this scenario on my end with activity being killed in the background (can see empty list coming), however, I was unable to replicate the crash (gallery just gets closed)


#### Another crash

I also noticed another crash while investigating [PBE-3852](https://stream-io.atlassian.net/browse/PBE-3852)
```
  FATAL EXCEPTION: main
  Process: io.getstream.chat.ui.sample.debug, PID: 12445
  java.lang.IndexOutOfBoundsException: Empty list doesn't contain element at index 0.
    at kotlin.collections.EmptyList.get(Collections.kt:37)
    at kotlin.collections.EmptyList.get(Collections.kt:25)
    at io.getstream.chat.android.ui.feature.gallery.overview.MediaAttachmentGridView.setDateText(MediaAttachmentGridView.kt:124)
    at io.getstream.chat.android.ui.feature.gallery.overview.MediaAttachmentGridView.setAttachments(MediaAttachmentGridView.kt:100)
    at io.getstream.chat.android.ui.feature.gallery.overview.internal.MediaAttachmentDialogFragment$onViewCreated$1$3.invoke(MediaAttachmentDialogFragment.kt:53)
    at io.getstream.chat.android.ui.feature.gallery.overview.internal.MediaAttachmentDialogFragment$onViewCreated$1$3.invoke(MediaAttachmentDialogFragment.kt:53)
    at io.getstream.chat.android.ui.feature.gallery.overview.internal.MediaAttachmentDialogFragment$sam$androidx_lifecycle_Observer$0.onChanged(Unknown Source:2)
    at androidx.lifecycle.LiveData.considerNotify(LiveData.java:133)
    at androidx.lifecycle.LiveData.dispatchingValue(LiveData.java:146)
    at androidx.lifecycle.LiveData$ObserverWrapper.activeStateChanged(LiveData.java:483)
    at androidx.lifecycle.LiveData$LifecycleBoundObserver.onStateChanged(LiveData.java:440)
    at androidx.lifecycle.LifecycleRegistry$ObserverWithState.dispatchEvent(LifecycleRegistry.kt:314)
    at androidx.lifecycle.LifecycleRegistry.forwardPass(LifecycleRegistry.kt:251)
    at androidx.lifecycle.LifecycleRegistry.sync(LifecycleRegistry.kt:287)
    at androidx.lifecycle.LifecycleRegistry.moveToState(LifecycleRegistry.kt:136)
    at androidx.lifecycle.LifecycleRegistry.handleLifecycleEvent(LifecycleRegistry.kt:119)
    at androidx.fragment.app.FragmentViewLifecycleOwner.handleLifecycleEvent(FragmentViewLifecycleOwner.java:100)
    at androidx.fragment.app.Fragment.performStart(Fragment.java:3194)
    at androidx.fragment.app.FragmentStateManager.start(FragmentStateManager.java:628)
    at androidx.fragment.app.FragmentStateManager.moveToExpectedState(FragmentStateManager.java:290)
    at androidx.fragment.app.FragmentStore.moveToExpectedState(FragmentStore.java:114)
    at androidx.fragment.app.FragmentManager.moveToState(FragmentManager.java:1455)
    at androidx.fragment.app.FragmentManager.dispatchStateChange(FragmentManager.java:3034)
    at androidx.fragment.app.FragmentManager.dispatchStart(FragmentManager.java:2959)
    at androidx.fragment.app.FragmentController.dispatchStart(FragmentController.java:274)
    at androidx.fragment.app.FragmentActivity.onStart(FragmentActivity.java:358)
    at androidx.appcompat.app.AppCompatActivity.onStart(AppCompatActivity.java:251)
    at android.app.Instrumentation.callActivityOnStart(Instrumentation.java:1543)
    at android.app.Activity.performStart(Activity.java:8330)
    at android.app.ActivityThread.handleStartActivity(ActivityThread.java:3670)
    at android.app.servertransaction.TransactionExecutor.performLifecycleSequence(TransactionExecutor.java:221)
    at android.app.servertransaction.TransactionExecutor.cycleToPath(TransactionExecutor.java:201)
    at android.app.servertransaction.TransactionExecutor.executeLifecycleState(TransactionExecutor.java:173)
    at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:97)
    at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2307)
    at android.os.Handler.dispatchMessage(Handler.java:106)
    at android.os.Looper.loopOnce(Looper.java:201)
    at android.os.Looper.loop(Looper.java:288)
    at android.app.ActivityThread.main(ActivityThread.java:7872)
    at java.lang.reflect.Method.invoke(Native Method)
    at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
    at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:936)
```

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_


[PBE-3852]: https://stream-io.atlassian.net/browse/PBE-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ