### PR TITLE
[PBE-4110] fix quoted message styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fixed crash on `AttachmentGalleryActivity`. [#5284](https://github.com/GetStream/stream-chat-android/pull/5284)
+- Fixed quoted message styling to be consistent with `isMine` property. [#5287](https://github.com/GetStream/stream-chat-android/pull/5287)
+  * 🚨If you are overriding `TransformStyle.messageReplyStyleTransformer`, please ensure you validate your UI after this change. 
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.ui.sample.application
 
 import android.content.Context
 import android.graphics.Color
+import androidx.core.content.ContextCompat
 import com.google.firebase.FirebaseApp
 import io.getstream.android.push.firebase.FirebasePushDeviceGenerator
 import io.getstream.android.push.huawei.HuaweiPushDeviceGenerator
@@ -40,6 +41,7 @@ import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.dec
 import io.getstream.chat.android.ui.helper.StyleTransformer
 import io.getstream.chat.android.ui.helper.TransformStyle
 import io.getstream.chat.ui.sample.BuildConfig
+import io.getstream.chat.ui.sample.R
 import io.getstream.chat.ui.sample.debugger.CustomChatClientDebugger
 import io.getstream.chat.ui.sample.feature.HostActivity
 import io.getstream.chat.ui.sample.feature.chat.messagelist.decorator.CustomDecoratorProviderFactory
@@ -161,6 +163,33 @@ class ChatInitializer(
                 reactionSorting = ReactionSortingByLastReactionAt,
             )
         }
+
+        /*val lightGray = ContextCompat.getColor(context, R.color.stream_ui_grey_whisper)
+        TransformStyle.messageListItemStyleTransformer = StyleTransformer { defaultStyle ->
+            defaultStyle.copy(
+                messageBackgroundColorMine = Color.BLACK,
+                messageBackgroundColorTheirs = lightGray,
+                textStyleMine = defaultStyle.textStyleMine.copy(
+                    color = Color.WHITE,
+                ),
+                textStyleTheirs = defaultStyle.textStyleTheirs.copy(
+                    color = Color.BLACK,
+                ),
+            )
+        }
+
+        TransformStyle.messageReplyStyleTransformer = StyleTransformer { defaultStyle ->
+            defaultStyle.copy(
+                messageBackgroundColorMine = lightGray,
+                messageBackgroundColorTheirs = Color.BLACK,
+                textStyleMine = defaultStyle.textStyleMine.copy(
+                    color = Color.BLACK,
+                ),
+                textStyleTheirs = defaultStyle.textStyleTheirs.copy(
+                    color = Color.WHITE,
+                ),
+            )
+        }*/
 
         ChatUI.decoratorProviderFactory = CustomDecoratorProviderFactory() + DecoratorProviderFactory.defaultFactory()
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.ui.sample.application
 
 import android.content.Context
 import android.graphics.Color
-import androidx.core.content.ContextCompat
 import com.google.firebase.FirebaseApp
 import io.getstream.android.push.firebase.FirebasePushDeviceGenerator
 import io.getstream.android.push.huawei.HuaweiPushDeviceGenerator
@@ -41,7 +40,6 @@ import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.dec
 import io.getstream.chat.android.ui.helper.StyleTransformer
 import io.getstream.chat.android.ui.helper.TransformStyle
 import io.getstream.chat.ui.sample.BuildConfig
-import io.getstream.chat.ui.sample.R
 import io.getstream.chat.ui.sample.debugger.CustomChatClientDebugger
 import io.getstream.chat.ui.sample.feature.HostActivity
 import io.getstream.chat.ui.sample.feature.chat.messagelist.decorator.CustomDecoratorProviderFactory

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/MessageReplyView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/MessageReplyView.kt
@@ -153,27 +153,25 @@ public class MessageReplyView : FrameLayout {
                     }
                     setTint(color)
                 }
-                quotedMessage.isMine(ChatClient.instance().getCurrentUser()) -> {
+                isMine -> {
                     paintStyle = Paint.Style.FILL_AND_STROKE
-                    val color = if (isMine) {
-                        style?.messageBackgroundColorTheirs ?: context.getColorCompat(R.color.stream_ui_white)
-                    } else {
-                        style?.messageBackgroundColorMine ?: context.getColorCompat(R.color.stream_ui_grey_whisper)
-                    }
-                    setTint(color)
-                    style?.messageStrokeColorMine?.let(::setStrokeTint)
+                    setStrokeTint(
+                        style?.messageStrokeColorMine
+                            ?: context.getColorCompat(R.color.stream_ui_literal_transparent),
+                    )
                     strokeWidth = style?.messageStrokeWidthMine ?: DEFAULT_STROKE_WIDTH
+                    setTint(style?.messageBackgroundColorMine
+                        ?: context.getColorCompat(R.color.stream_ui_white))
                 }
                 else -> {
                     paintStyle = Paint.Style.FILL_AND_STROKE
                     setStrokeTint(
                         style?.messageStrokeColorTheirs
-                            ?: context.getColorCompat(R.color.stream_ui_grey_whisper),
+                            ?: context.getColorCompat(R.color.stream_ui_grey_gainsboro),
                     )
                     strokeWidth = style?.messageStrokeWidthTheirs ?: DEFAULT_STROKE_WIDTH
-                    val tintColor =
-                        style?.messageBackgroundColorTheirs ?: context.getColorCompat(R.color.stream_ui_white)
-                    setTint(tintColor)
+                    setTint(style?.messageBackgroundColorTheirs
+                        ?: context.getColorCompat(R.color.stream_ui_grey_whisper))
                 }
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/MessageReplyView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/MessageReplyView.kt
@@ -160,8 +160,10 @@ public class MessageReplyView : FrameLayout {
                             ?: context.getColorCompat(R.color.stream_ui_literal_transparent),
                     )
                     strokeWidth = style?.messageStrokeWidthMine ?: DEFAULT_STROKE_WIDTH
-                    setTint(style?.messageBackgroundColorMine
-                        ?: context.getColorCompat(R.color.stream_ui_white))
+                    setTint(
+                        style?.messageBackgroundColorMine
+                            ?: context.getColorCompat(R.color.stream_ui_white),
+                    )
                 }
                 else -> {
                     paintStyle = Paint.Style.FILL_AND_STROKE
@@ -170,8 +172,10 @@ public class MessageReplyView : FrameLayout {
                             ?: context.getColorCompat(R.color.stream_ui_grey_gainsboro),
                     )
                     strokeWidth = style?.messageStrokeWidthTheirs ?: DEFAULT_STROKE_WIDTH
-                    setTint(style?.messageBackgroundColorTheirs
-                        ?: context.getColorCompat(R.color.stream_ui_grey_whisper))
+                    setTint(
+                        style?.messageBackgroundColorTheirs
+                            ?: context.getColorCompat(R.color.stream_ui_grey_whisper),
+                    )
                 }
             }
         }

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -364,8 +364,8 @@
         <item name="streamUiMessageTextStyleThreadSeparator">normal</item>
 
         <!-- Message Reply background color -->
-        <item name="streamUiMessageReplyBackgroundColorMine">@color/stream_ui_grey_gainsboro</item>
-        <item name="streamUiMessageReplyBackgroundColorTheirs">@color/stream_ui_bars_background</item>
+        <item name="streamUiMessageReplyBackgroundColorMine">@color/stream_ui_bars_background</item>
+        <item name="streamUiMessageReplyBackgroundColorTheirs">@color/stream_ui_grey_gainsboro</item>
 
         <!-- Message Reply text style mine -->
         <item name="streamUiMessageReplyTextSizeMine">@dimen/stream_ui_text_medium</item>


### PR DESCRIPTION
### 🎯 Goal

Closes: 
- https://stream-io.atlassian.net/browse/PBE-4110

### 🛠 Implementation details

We should **not** apply styling depending on both `quotedMessage.isMine` and `containerMessage.isMine` combined. 
It brings complexity in understanding and expectations on UI customizations


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
