### PR TITLE
[PBE-4795] add missing ChannelState.pinnedMessages

### DIFF
--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -726,6 +726,7 @@ public abstract interface class io/getstream/chat/android/client/channel/state/C
 	public abstract fun getMessagesState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMuted ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getOldMessages ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getPinnedMessages ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getQuotedMessagesMap ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getRead ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getReads ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-chat-android-client/detekt-baseline.xml
+++ b/stream-chat-android-client/detekt-baseline.xml
@@ -26,6 +26,7 @@
     <ID>MagicNumber:WaveformExtractor.kt$WaveformExtractor.&lt;no name provided>$8</ID>
     <ID>MaxLineLength:BaseChatModule.kt$BaseChatModule$NetworkStateProvider(userScope, appContext.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager)</ID>
     <ID>MaxLineLength:Message.kt$*</ID>
+    <ID>MaxLineLength:MoshiChatApi.kt$MoshiChatApi$pinnedMessages = response.pinned_messages.map { it.toDomain(currentUserIdProvider()).enrichWithCid(channel.cid) }</ID>
     <ID>MaxLineLength:Reaction.kt$*</ID>
     <ID>MaxLineLength:StringExtensionsKtTest.kt$StringExtensionsKtTest.Companion$"https://us-east.stream-io-cdn.com/1/images/IMAGE_NAME.jpg?Key-Pair-Id=SODHGWNRLG&amp;Policy=akIjUneI9Kmbds2&amp;Signature=dsnIjJ8-gfdgihih8-GkhdfgfdGFG32--KHJDFj349sfsdf~SFDf2~Fsdfgrg3~kjnooi23Jig-Kjoih34iW~k7Jbe2~Jnk33j-Fsiniiz2~Sfj23iJihn-Jinfnsiw2kS"</ID>
     <ID>MaxLineLength:StringExtensionsKtTest.kt$StringExtensionsKtTest.Companion$"https://us-east.stream-io-cdn.com/1/images/IMAGE_NAME.jpg?Key-Pair-Id=SODHGWNRLG&amp;Policy=akIjUneI9Kmbds2&amp;Signature=dsnIjJ8-gfdgihih8-GkhdfgfdGFG32--KHJDFj349sfsdf~SFDf2~Fsdfgrg3~kjnooi23Jig-Kjoih34iW~k7Jbe2~Jnk33j-Fsiniiz2~Sfj23iJihn-Jinfnsiw2kS&amp;oh=$originalHeight&amp;ow=$originalWidth"</ID>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -767,6 +767,7 @@ constructor(
                 members = response.members.map { it.toDomain(currentUserIdProvider()) },
                 membership = response.membership?.toDomain(currentUserIdProvider()),
                 messages = response.messages.map { it.toDomain(currentUserIdProvider()).enrichWithCid(channel.cid) },
+                pinnedMessages = response.pinned_messages.map { it.toDomain(currentUserIdProvider()).enrichWithCid(channel.cid) },
                 watchers = response.watchers.map { it.toDomain(currentUserIdProvider()) },
                 hidden = response.hidden,
                 hiddenMessagesBefore = response.hide_messages_before,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/ChannelResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/ChannelResponse.kt
@@ -28,6 +28,7 @@ import java.util.Date
 internal data class ChannelResponse(
     val channel: DownstreamChannelDto,
     val messages: List<DownstreamMessageDto> = emptyList(),
+    val pinned_messages: List<DownstreamMessageDto> = emptyList(),
     val members: List<DownstreamMemberDto> = emptyList(),
     val membership: DownstreamMemberDto?,
     val watchers: List<DownstreamUserDto> = emptyList(),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelMessagesUpdateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelMessagesUpdateLogic.kt
@@ -23,13 +23,16 @@ import io.getstream.chat.android.models.Message
 @InternalStreamChatApi
 public interface ChannelMessagesUpdateLogic {
 
-    public fun upsertMessage(message: Message, updateCount: Boolean = true)
+    public fun upsertMessage(message: Message)
 
     public fun upsertMessages(
         messages: List<Message>,
-        shouldRefreshMessages: Boolean = false,
-        updateCount: Boolean = true,
+        shouldRefreshMessages: Boolean = false
     )
+
+    public fun upsertPinnedMessages(messages: List<Message>, shouldRefreshMessages: Boolean)
+
+    public fun delsertPinnedMessage(message: Message)
 
     public fun listenForChannelState(): ChannelState
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelMessagesUpdateLogic.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelMessagesUpdateLogic.kt
@@ -27,7 +27,7 @@ public interface ChannelMessagesUpdateLogic {
 
     public fun upsertMessages(
         messages: List<Message>,
-        shouldRefreshMessages: Boolean = false
+        shouldRefreshMessages: Boolean = false,
     )
 
     public fun upsertPinnedMessages(messages: List<Message>, shouldRefreshMessages: Boolean)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
@@ -52,6 +52,9 @@ public interface ChannelState {
     /** The message collection of this channel. */
     public val messages: StateFlow<List<Message>>
 
+    /** The pinned message collection of this channel. */
+    public val pinnedMessages: StateFlow<List<Message>>
+
     /** Strong typed state of message collection of this channel. See [MessagesState] for more details.*/
     public val messagesState: StateFlow<MessagesState>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Message.kt
@@ -28,6 +28,12 @@ import java.util.Date
 @InternalStreamChatApi
 public fun Collection<Message>.updateUsers(users: Map<String, User>): List<Message> = map { it.updateUsers(users) }
 
+/** Updates collection of messages with more recent data of [users]. */
+@InternalStreamChatApi
+public fun Map<String, Message>.updateUsers(users: Map<String, User>): Map<String, Message> = mapValues { (_, value) ->
+    value.updateUsers(users)
+}
+
 /**
  * Updates a message with more recent data of [users]. It updates author user, latestReactions, replyTo message,
  * mentionedUsers, threadParticipants and pinnedBy user of this instance.

--- a/stream-chat-android-compose-sample/detekt-baseline.xml
+++ b/stream-chat-android-compose-sample/detekt-baseline.xml
@@ -11,6 +11,7 @@
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG1pdHJpaSJ9._j7pM2kqj46ztls0tG1DiUMl45l54VOLvl8jp5VCmZU"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZmlsaXAifQ.WKqTjU6fHHjtFej-sUqS2ml3Rvdqn4Ptrf7jfKqzFgU"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw"</ID>
+    <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXRfbmluamEifQ.s6We-MRy0ZXraiyLz8kShEPPIxXfqwUOOClfJgpTk8c"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamFld29vbmcifQ.d-7AREGaSirn7TjxwLyAUvOU-nz2_LL5oMTycZvcnQc"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ.2_5Hae3LKjVSfA0gQxXlZn54Bq6xDlhjPx2J7azUNB4"</ID>
     <ID>MaxLineLength:PredefinedUserCredentials.kt$PredefinedUserCredentials$token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2xlZyJ9.ZucjlxjiNewCORdCLwpKwZw2nNtRC_Bv17TjHlitdLU"</ID>

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.android.compose.sample.data
 
+import io.getstream.chat.android.PrivacySettings
+import io.getstream.chat.android.ReadReceipts
+import io.getstream.chat.android.TypingIndicators
 import io.getstream.chat.android.models.User
 
 /**
@@ -173,6 +176,16 @@ object PredefinedUserCredentials {
                 language = "fr",
             ),
             token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw",
+        ),
+        UserCredentials(
+            apiKey = API_KEY,
+            user = User(
+                id = "kanat_ninja",
+                name = "Kanat Ninja",
+                image = "https://getstream.io/static/a4ba18b7dc1eedfa3ea4edbac74ce5e4/a3911/kanat-kiialbaev.webp",
+            ),
+
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXRfbmluamEifQ.s6We-MRy0ZXraiyLz8kShEPPIxXfqwUOOClfJgpTk8c",
         ),
         UserCredentials(
             apiKey = API_KEY,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
@@ -16,9 +16,6 @@
 
 package io.getstream.chat.android.compose.sample.data
 
-import io.getstream.chat.android.PrivacySettings
-import io.getstream.chat.android.ReadReceipts
-import io.getstream.chat.android.TypingIndicators
 import io.getstream.chat.android.models.User
 
 /**

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModelTest.kt
@@ -163,6 +163,7 @@ internal class MessageListViewModelTest {
                 whenever(it.membersCount) doReturn MutableStateFlow(randomInt())
                 whenever(it.watcherCount) doReturn MutableStateFlow(randomInt())
                 whenever(it.messagesState) doReturn MutableStateFlow(messageState)
+                whenever(it.pinnedMessages) doReturn MutableStateFlow(emptyList())
                 whenever(it.typing) doReturn MutableStateFlow(TypingEvent(channelId, emptyList()))
                 whenever(it.reads) doReturn MutableStateFlow(listOf())
                 whenever(it.read) doReturn MutableStateFlow(randomChannelUserRead(lastReadMessageId = null))

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
@@ -471,10 +471,9 @@ internal class ChannelLogic(
     }
 
     private fun upsertEventMessage(message: Message) {
-        channelStateLogic.upsertMessage(
-            message.copy(ownReactions = getMessage(message.id)?.ownReactions ?: message.ownReactions),
-            updateCount = false,
-        )
+        val ownReactions = getMessage(message.id)?.ownReactions ?: message.ownReactions
+        channelStateLogic.upsertMessage(message.copy(ownReactions = ownReactions))
+        channelStateLogic.delsertPinnedMessage(message.copy(ownReactions = ownReactions))
     }
 
     /**

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -232,8 +232,10 @@ internal class ChannelStateLogic(
     }
 
     override fun delsertPinnedMessage(message: Message) {
-        logger.d { "[delsertPinnedMessage] pinned: ${message.pinned}, message.id: ${message.id}" +
-            ", message.text: ${message.text}" }
+        logger.d {
+            "[delsertPinnedMessage] pinned: ${message.pinned}, message.id: ${message.id}" +
+                ", message.text: ${message.text}"
+        }
         if (message.pinned) {
             upsertPinnedMessages(listOf(message), false)
         } else {

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/WhenHandleEvent.kt
@@ -116,7 +116,7 @@ internal class WhenHandleEvent : SynchronizedCoroutineTest {
 
         channelLogic.handleEvent(userStartWatchingEvent)
 
-        verify(channelStateLogic).upsertMessage(newMessage, false)
+        verify(channelStateLogic).upsertMessage(newMessage)
         verify(channelStateLogic).updateCurrentUserRead(userStartWatchingEvent.createdAt, userStartWatchingEvent.message)
         verify(channelStateLogic).toggleHidden(false)
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/EditMessageListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/EditMessageListenerStateTest.kt
@@ -66,7 +66,6 @@ internal class EditMessageListenerStateTest {
             argThat { message ->
                 message.id == testMessage.id
             },
-            any(),
         )
         verify(threadStateLogic).upsertMessage(
             argThat { message ->
@@ -98,7 +97,6 @@ internal class EditMessageListenerStateTest {
             argThat { message ->
                 message.id == testMessage.id && message.syncStatus == SyncStatus.IN_PROGRESS
             },
-            any(),
         )
         verify(threadStateLogic).upsertMessage(
             argThat { message ->
@@ -130,7 +128,6 @@ internal class EditMessageListenerStateTest {
             argThat { message ->
                 message.id == testMessage.id && message.syncStatus == SyncStatus.SYNC_NEEDED
             },
-            any(),
         )
         verify(threadStateLogic).upsertMessage(
             argThat { message ->
@@ -162,7 +159,6 @@ internal class EditMessageListenerStateTest {
             argThat { message ->
                 message.id == testMessage.id && message.syncStatus == SyncStatus.COMPLETED
             },
-            any(),
         )
         verify(threadStateLogic).upsertMessage(
             argThat { message ->
@@ -194,7 +190,6 @@ internal class EditMessageListenerStateTest {
             argThat { message ->
                 message.id == testMessage.id && message.syncStatus == SyncStatus.SYNC_NEEDED
             },
-            any(),
         )
         verify(threadStateLogic).upsertMessage(
             argThat { message ->

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogicTest.kt
@@ -229,7 +229,7 @@ internal class ChannelStateLogicTest {
         channelStateLogic.propagateChannelQuery(channel, request)
 
         verify(mutableState, times(0)).updateCachedLatestMessages(any())
-        verify(mutableState, times(0)).upsertMessages(any(), any())
+        verify(mutableState, times(0)).upsertMessages(any())
     }
 
     @Test
@@ -246,7 +246,7 @@ internal class ChannelStateLogicTest {
             messageLimit = 30,
         )
 
-        verify(mutableState, times(0)).upsertMessages(any(), any())
+        verify(mutableState, times(0)).upsertMessages(any())
     }
 
     @Test
@@ -259,7 +259,7 @@ internal class ChannelStateLogicTest {
             .withMessages(Pagination.GREATER_THAN, randomString(), 1)
 
         channelStateLogic.propagateChannelQuery(channel, filteringRequest)
-        verify(mutableState).upsertMessages(any(), any())
+        verify(mutableState).upsertMessages(any())
     }
 
     @Test
@@ -271,7 +271,7 @@ internal class ChannelStateLogicTest {
         val request = QueryChannelRequest().apply { isNotificationUpdate = true }.withMessages(1)
         channelStateLogic.propagateChannelQuery(channel, request)
 
-        verify(mutableState, times(0)).upsertMessages(any(), any())
+        verify(mutableState, times(0)).upsertMessages(any())
     }
 
     @Test
@@ -309,6 +309,6 @@ internal class ChannelStateLogicTest {
 
         channelStateLogic.upsertMessage(updatedMessage, false)
 
-        verify(mutableState).upsertMessages(eq(listOf(updatedMessage)), any())
+        verify(mutableState).upsertMessages(eq(listOf(updatedMessage)))
     }
 }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogicTest.kt
@@ -307,7 +307,7 @@ internal class ChannelStateLogicTest {
             updatedLocallyAt = randomDateAfter((message.updatedLocallyAt ?: message.updatedAt ?: NEVER).time),
         )
 
-        channelStateLogic.upsertMessage(updatedMessage, false)
+        channelStateLogic.upsertMessage(updatedMessage)
 
         verify(mutableState).upsertMessages(eq(listOf(updatedMessage)))
     }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -130,6 +130,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Date
+import kotlin.math.log
 import io.getstream.chat.android.ui.common.state.messages.Flag as FlagMessage
 
 /**
@@ -234,7 +235,8 @@ public class MessageListController(
                 state.channelData,
                 state.membersCount,
                 state.watcherCount,
-            ) { _, _, _ ->
+                state.pinnedMessages,
+            ) { _, _, _, _ ->
                 state.toChannel()
             }
         }
@@ -1473,6 +1475,7 @@ public class MessageListController(
      * Resets the [MessagesState]s, to remove the message overlay, by setting 'selectedMessageState' to null.
      */
     public fun removeOverlay() {
+        logger.v { "[removeOverlay] no args" }
         _threadListState.value = _threadListState.value.copy(selectedMessageState = null)
         setMessageListState(_messageListState.value.copy(selectedMessageState = null))
     }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -130,7 +130,6 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import java.util.Date
-import kotlin.math.log
 import io.getstream.chat.android.ui.common.state.messages.Flag as FlagMessage
 
 /**

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -534,6 +534,7 @@ internal class MessageListControllerTests {
                 ),
             ),
             messagesState: StateFlow<List<Message>> = MutableStateFlow(emptyList()),
+            pinnedMessagesState: StateFlow<List<Message>> = MutableStateFlow(emptyList()),
             membersState: StateFlow<List<Member>> = MutableStateFlow(emptyList()),
             membersCountState: StateFlow<Int> = MutableStateFlow(0),
             watchersState: StateFlow<List<User>> = MutableStateFlow(emptyList()),
@@ -549,6 +550,7 @@ internal class MessageListControllerTests {
                 whenever(channelState.watchers) doReturn watchersState
                 whenever(channelState.watcherCount) doReturn watchersCountState
                 whenever(channelState.messages) doReturn messagesState
+                whenever(channelState.pinnedMessages) doReturn pinnedMessagesState
                 whenever(channelState.messagesState) doReturn messagesState.map { messages ->
                     MessagesState.Result(messages)
                 }.stateIn(testCoroutines.scope, SharingStarted.Eagerly, MessagesState.Result(emptyList()))

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -298,12 +298,14 @@ internal class MessageListViewModelTest {
                 messages = emptyList(),
             ),
             messages: List<Message> = listOf(),
+            pinnedMessages: List<Message> = listOf(),
         ) = apply {
             val channelState: ChannelState = mock {
                 whenever(it.cid) doReturn CID
                 whenever(it.channelId) doReturn CHANNEL_ID
                 whenever(it.channelType) doReturn CHANNEL_TYPE
                 whenever(it.messages) doReturn MutableStateFlow(messages)
+                whenever(it.pinnedMessages) doReturn MutableStateFlow(pinnedMessages)
                 whenever(it.channelData) doReturn MutableStateFlow(channelData)
                 whenever(it.channelConfig) doReturn MutableStateFlow(Config())
                 whenever(it.members) doReturn MutableStateFlow(listOf())


### PR DESCRIPTION
### 🎯 Goal

Closes:
- https://stream-io.atlassian.net/browse/PBE-4795

### 🛠 Implementation details

Expose `pinnedMessages` in `ChannelState`

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
