### PR TITLE
Update quoted messages composable to use the quoted text style instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fixed quoted message styling. [#5316](https://github.com/GetStream/stream-chat-android/pull/5316)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageText.kt
@@ -51,8 +51,8 @@ public fun QuotedMessageText(
         message.isSingleEmoji() -> ChatTheme.typography.singleEmoji
         message.isFewEmoji() -> ChatTheme.typography.emojiOnly
         else -> when (replyMessage?.isMine(currentUser) != false) {
-            true -> ChatTheme.ownMessageTheme.textStyle
-            else -> ChatTheme.otherMessageTheme.textStyle
+            true -> ChatTheme.ownMessageTheme.quotedTextStyle
+            else -> ChatTheme.otherMessageTheme.quotedTextStyle
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal
Small PR to fix an issue where the quoted message doesn't have the correct style.

This PR was created initially on #5310 but was merged into `main` branch incorrectly, it should be merged into `develop` branch instead.
