### PR TITLE
Upgrade Kotlin Coroutines to version 1.8.1

### DIFF
--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -29,7 +29,7 @@ object Versions {
     internal const val COMPOSE_ACCOMPANIST = "0.32.0"
     internal const val COMPOSE_STABLE_MARKER = "1.0.2"
     internal const val CONSTRAINT_LAYOUT = "2.1.4"
-    internal const val COROUTINES = "1.7.3"
+    internal const val COROUTINES = "1.8.1"
     internal const val DETEKT_PLUGIN = "1.23.1"
     internal const val DOKKA = "1.9.0"
     internal const val DOKKASAURUS = "0.1.10"


### PR DESCRIPTION
### 🎯 Goal
Upgrade Kotlin Coroutines to version 1.8.1

This version fix an internal error happening on Android devices with version 12, 13 and/or 14 as was described [here](https://github.com/GetStream/stream-chat-android/issues/5202#issuecomment-1988644160). 
Fix: #5202 

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2htZnRpcXY2emludTRkamhzbTl3cmh1dHo3a2Q3aGhkMXYwMnVkMSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/5lMOLc2HztwcM/giphy-downsized.gif)
