### PR TITLE
[PBE-5213] After a message is properly sent from the message composer, it is marked as read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Sent messages from the MessageComposer are marked as read. [#5322](https://github.com/GetStream/stream-chat-android/pull/5322)
 
 ### ✅ Added
 
@@ -73,6 +74,7 @@
 - Fixed quoted message styling. [#5316](https://github.com/GetStream/stream-chat-android/pull/5316)
 
 ### ⬆️ Improved
+- Sent messages from the MessageComposer are marked as read. [#5322](https://github.com/GetStream/stream-chat-android/pull/5322)
 
 ### ✅ Added
 - Added `ChatTheme.timeProvider` to provide the current time. [#5321](https://github.com/GetStream/stream-chat-android/pull/5321)

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -427,6 +427,7 @@ internal class MessageComposerViewModelTest {
 
         fun givenSendMessage(message: Message = Message()) = apply {
             whenever(chatClient.sendMessage(any(), any(), any(), any())) doReturn message.asCall()
+            whenever(chatClient.markMessageRead(any(), any(), any())) doReturn Unit.asCall()
         }
 
         fun get(): MessageComposerViewModel {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -428,6 +428,7 @@ internal class MessageComposerViewModelTest {
 
         fun givenSendMessage(message: Message = Message()) = apply {
             whenever(chatClient.sendMessage(any(), any(), any(), any())) doReturn message.asCall()
+            whenever(chatClient.markMessageRead(any(), any(), any())) doReturn Unit.asCall()
         }
 
         fun get(): MessageComposerViewModel {


### PR DESCRIPTION
### 🎯 Goal
After a message is properly sent from the message composer, it is marked as read

Fix: https://stream-io.atlassian.net/browse/PBE-5213

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExcmxjb2xwYnRoMDVpb3VpMjFjNjlreWo3NHpsaWtlcnE1aGZ0MDU1ZiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/khzcoxbwTKv00IeW2L/giphy-downsized.gif)
