### PR TITLE
Add jitpack repository to resolve GitVersioners dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,22 +40,18 @@ buildscript {
             }
         }
 
-        // fetch dagger plugin only
-        mavenCentral() {
+        maven {
+            url "https://jitpack.io"
             content {
-                includeGroup("com.google.dagger")
-                includeGroup("com.google.dagger.hilt.android")
-            }
-            mavenContent {
-                releasesOnly()
+                includeModule("com.github.passsy", "gradle-gitVersioner-plugin")
             }
         }
 
         // fetch plugins from gradle plugin portal (https://plugins.gradle.org)
         gradlePluginPortal()
 
-        // fetch plugins from gradle maven publication
-        maven { url "https://plugins.gradle.org/m2/" }
+        // Fallback for the rest of the dependencies
+        mavenCentral()
     }
 
     dependencies {

--- a/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/io/getstream/chat/android/Dependencies.kt
@@ -155,7 +155,7 @@ object Dependencies {
     const val flipper = "com.facebook.flipper:flipper:${Versions.FLIPPER}"
     const val flipperNetwork = "com.facebook.flipper:flipper-network-plugin:${Versions.FLIPPER}"
     const val flipperLoader = "com.facebook.soloader:soloader:${Versions.FLIPPER_SO_LOADER}"
-    const val gitversionerPlugin = "com.pascalwelsch.gitversioner:gitversioner:${Versions.GITVERSIONER}"
+    const val gitversionerPlugin = "com.github.passsy:gradle-gitVersioner-plugin:${Versions.GITVERSIONER}"
     const val googleServicesPlugin = "com.google.gms:google-services:${Versions.GOOGLE_SERVICES}"
     const val gradleNexusPublishPlugin = "io.github.gradle-nexus:publish-plugin:${Versions.GRADLE_NEXUS_PUBLISH_PLUGIN}"
     const val gradleVersionsPlugin = "com.github.ben-manes:gradle-versions-plugin:${Versions.GRADLE_VERSIONS_PLUGIN}"


### PR DESCRIPTION
### 🎯 Goal
After jCenter was shut down, GitVersioners was not available by any maven repository. It looks like it was working on our CI because of the cache system we have implemented, but it started to fail recently, maybe because of any cache expiration.

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZHZpeHZjd3dnM2Y4YnI0bXl5OWdmbGRtN3Y2ZDFsanpsN2J6MGp2NSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/nnHSPHMDx9OdGlsZuP/giphy.gif)
