### PR TITLE
[PBE-4081] clear cache on channel.hidden event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 ### 🐞 Fixed
 - Fixed channel cache not being updated when a message is soft deleted. [#5321](https://github.com/GetStream/stream-chat-android/pull/5321)
 - Expired/deleted pinned messages are filtered out. [#5321](https://github.com/GetStream/stream-chat-android/pull/5321)
+- Clear channels' cache on `channel.hidden` event. [#5324](https://github.com/GetStream/stream-chat-android/pull/5324)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -710,6 +710,12 @@ internal class EventHandlerSequential(
                     repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
                     repos.setChannelDeletedAt(event.cid, event.createdAt)
                 }
+                is ChannelHiddenEvent -> {
+                    repos.evictChannel(event.cid)
+                    if (event.clearHistory) {
+                        repos.deleteChannelMessagesBefore(event.cid, event.createdAt)
+                    }
+                }
                 is MessageDeletedEvent -> {
                     if (event.hardDelete) {
                         repos.deleteChannelMessage(event.message)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
@@ -597,6 +597,9 @@ internal class ChannelLogic(
             }
             is ChannelHiddenEvent -> {
                 channelStateLogic.toggleHidden(true)
+                if (event.clearHistory) {
+                    removeMessagesBefore(event.createdAt)
+                }
             }
             is ChannelVisibleEvent -> {
                 channelStateLogic.toggleHidden(false)


### PR DESCRIPTION
### 🎯 Goal

Clean up cache on `channel.hidden` event

Relates to:
- https://stream-io.atlassian.net/browse/PBE-4081
- https://github.com/GetStream/stream-chat-android/pull/5281

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
