### PR TITLE
#5327 Enable Multiple Channel List ViewModels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,7 +76,7 @@
 
 ### ✅ Added
 - Exposed user avatar click listener in MessagesScreen.kt
-
+- Added ability to create multiple instance of ChannelListViewModel with differing parameters
 ### ⚠️ Changed
 
 ### ❌ Removed

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -650,7 +650,7 @@ public final class io/getstream/chat/android/compose/ui/attachments/preview/hand
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/ChannelsScreenKt {
-	public static final fun ChannelsScreen (Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Ljava/lang/String;ZLio/getstream/chat/android/compose/ui/channels/SearchMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ChannelsScreen (Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/compose/ui/channels/SearchMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/SearchMode : java/lang/Enum {
@@ -2298,10 +2298,9 @@ public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelL
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Ljava/lang/String;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
-	public final fun getViewModelKey ()Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/compose/viewmodel/mediapreview/MediaGalleryPreviewViewModel : androidx/lifecycle/ViewModel {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2298,9 +2298,10 @@ public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelL
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Ljava/lang/String;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
+	public final fun getViewModelKey ()Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/compose/viewmodel/mediapreview/MediaGalleryPreviewViewModel : androidx/lifecycle/ViewModel {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
@@ -73,6 +73,7 @@ import io.getstream.chat.android.ui.common.state.channels.actions.ViewInfo
  * @param viewModelFactory The factory used to build the ViewModels and power the behavior.
  * You can use the default implementation by not passing in an instance yourself, or you
  * can customize the behavior using its parameters.
+ * @param viewModelKey Key to differentiate between instances of [ChannelListViewModel].
  * @param title Header title.
  * @param isShowingHeader If we show the header or hide it.
  * @param searchMode The search mode for the screen.
@@ -87,6 +88,7 @@ import io.getstream.chat.android.ui.common.state.channels.actions.ViewInfo
 @Suppress("LongMethod")
 public fun ChannelsScreen(
     viewModelFactory: ChannelViewModelFactory = ChannelViewModelFactory(),
+    viewModelKey: String? = null,
     title: String = "Stream Chat",
     isShowingHeader: Boolean = true,
     searchMode: SearchMode = SearchMode.None,
@@ -99,7 +101,7 @@ public fun ChannelsScreen(
 ) {
     val listViewModel: ChannelListViewModel = viewModel(
         ChannelListViewModel::class.java,
-        key = viewModelFactory.viewModelKey,
+        key = viewModelKey,
         factory = viewModelFactory,
     )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
@@ -99,6 +99,7 @@ public fun ChannelsScreen(
 ) {
     val listViewModel: ChannelListViewModel = viewModel(
         ChannelListViewModel::class.java,
+        key = viewModelFactory.viewModelKey,
         factory = viewModelFactory,
     )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandl
  * @param memberLimit How many members are fetched for each channel item when loading channels.
  * @param messageLimit How many messages are fetched for each channel item when loading channels.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
+ * @param viewModelKey Optional key for for cases where the app needs multiple instances with varying parameters.
  */
 public class ChannelViewModelFactory(
     private val chatClient: ChatClient = ChatClient.instance(),
@@ -46,6 +47,7 @@ public class ChannelViewModelFactory(
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
+    public val viewModelKey: String? = null,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -37,7 +37,6 @@ import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandl
  * @param memberLimit How many members are fetched for each channel item when loading channels.
  * @param messageLimit How many messages are fetched for each channel item when loading channels.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
- * @param viewModelKey Optional key for for cases where the app needs multiple instances with varying parameters.
  */
 public class ChannelViewModelFactory(
     private val chatClient: ChatClient = ChatClient.instance(),
@@ -47,7 +46,6 @@ public class ChannelViewModelFactory(
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
-    public val viewModelKey: String? = null,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(


### PR DESCRIPTION
### 🎯 Goal

Enable multiple instances of `ChannelsListViewModel` to be cached with varying parameters.

https://github.com/GetStream/stream-chat-android/issues/5327

### 🛠 Implementation details

Added an optinonal viewmodel key to `ChannelViewModelFactory` that is used by `ChannelsScreen`.

Behaviour is the same when viewmodel key is not set so its backwards compatible with previous releases.

### 🎨 UI Changes

N/A

### 🧪 Testing

Patch contains changes to `ChannelsActivity` inside `stream-chat-android-compose-sample`, adding a horizontal pager with two tabs where each tab has a slightly different sort on the list.

In the companion object there is a boolean `UseKeys` which is currently set to false, run with false to see the issue occur and run with true to see the fix.

<details>

<summary>Provide the patch summary here</summary>

```
Subject: [PATCH] #5327 Add key to ChannelViewModelFactory.kt and use in ChannelsScreen.kt
---
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(revision 2d81264ebe311e31f921fc0a3e007555f63dad0c)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(date 1721678685714)
@@ -21,6 +21,7 @@
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -31,14 +32,19 @@
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Scaffold
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -68,17 +74,27 @@
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalFoundationApi::class)
 class ChannelsActivity : BaseConnectedActivity() {
 
-    private val factory by lazy {
+    private val defaultFactory by lazy {
         ChannelViewModelFactory(
             ChatClient.instance(),
             QuerySortByField.descByName("last_updated"),
+            viewModelKey = if (UseKeys) "default" else null,
+        )
+    }
+
+    private val lastUpdatedFactory by lazy {
+        ChannelViewModelFactory(
+            ChatClient.instance(),
+            QuerySortByField.ascByName("last_updated"),
             null,
+            viewModelKey = if (UseKeys) "last-updated" else null,
         )
     }
 
-    private val listViewModel: ChannelListViewModel by viewModels { factory }
+    private val listViewModel: ChannelListViewModel by viewModels { lastUpdatedFactory }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -96,21 +112,60 @@
                 autoTranslationEnabled = ChatApp.autoTranslationEnabled,
                 allowUIAutomationTest = true,
             ) {
-                ChannelsScreen(
-                    viewModelFactory = factory,
-                    title = stringResource(id = R.string.app_name),
-                    isShowingHeader = true,
-                    searchMode = SearchMode.Messages,
-                    onChannelClick = ::openMessages,
-                    onSearchMessageItemClick = ::openMessages,
-                    onBackPressed = ::finish,
-                    onHeaderAvatarClick = {
-                        listViewModel.viewModelScope.launch {
-                            ChatHelper.disconnectUser()
-                            openUserLogin()
-                        }
-                    },
-                )
+                val coroutineScope = rememberCoroutineScope()
+
+                val tabs = listOf("Default", "Last updated")
+
+                val pagerState = rememberPagerState(
+                    pageCount = { tabs.size },
+                )
+
+                Column {
+                    TabRow(
+                        selectedTabIndex = pagerState.currentPage,
+                    ) {
+                        tabs.forEachIndexed { index, title ->
+                            Tab(
+                                selected = pagerState.currentPage == index,
+                                text = {
+                                    Text(title)
+                                },
+                                onClick = {
+                                    coroutineScope.launch {
+                                        pagerState.scrollToPage(index)
+                                    }
+                                },
+                            )
+                        }
+                    }
+
+                    HorizontalPager(
+                        state = pagerState,
+                    ) { page ->
+
+                        val factory = when (page) {
+                            0 -> defaultFactory
+                            1 -> lastUpdatedFactory
+                            else -> error("")
+                        }
+
+                        ChannelsScreen(
+                            viewModelFactory = factory,
+                            title = stringResource(id = R.string.app_name),
+                            isShowingHeader = true,
+                            searchMode = SearchMode.Messages,
+                            onChannelClick = ::openMessages,
+                            onSearchMessageItemClick = ::openMessages,
+                            onBackPressed = ::finish,
+                            onHeaderAvatarClick = {
+                                listViewModel.viewModelScope.launch {
+                                    ChatHelper.disconnectUser()
+                                    openUserLogin()
+                                }
+                            },
+                        )
+                    }
+                }
 
 //                MyCustomUiSimplified()
 //                MyCustomUi()
@@ -271,6 +326,10 @@
     }
 
     companion object {
+
+        /*  toggle this to see fix */
+        private const val UseKeys = false
+
         fun createIntent(context: Context): Intent {
             return Intent(context, ChannelsActivity::class.java).apply {
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK

```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] ~New code is covered by unit tests~
- [ ] ~Comparison screenshots added for visual changes~
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![key](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExbnB6dm84M3ZrNm1qaHJybnFjbXNpbjhjbHJ5OWsybmh1MDlmejNkdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EmkBfdGYTCwmXMnf3A/giphy.webp)
