### PR TITLE
[PBE-5181] filter out expired pinned messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ## stream-chat-android-state
 ### 🐞 Fixed
+- Fixed expired pinned messages being exposed in the pinned message list. [#5343](https://github.com/GetStream/stream-chat-android/pull/5343)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableStateTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableStateTests.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.state.plugin.state.channel.internal
 
 import io.getstream.chat.android.models.User
@@ -23,7 +39,6 @@ internal class ChannelMutableStateTests {
 
     private lateinit var channelState: ChannelMutableState
 
-
     @BeforeEach
     fun setUp() {
         channelState = ChannelMutableState(
@@ -33,7 +48,7 @@ internal class ChannelMutableStateTests {
             MutableStateFlow(
                 mapOf(currentUser.id to currentUser),
             ),
-            ChannelMutableStateTests::currentTime
+            ChannelMutableStateTests::currentTime,
         )
     }
 
@@ -51,11 +66,11 @@ internal class ChannelMutableStateTests {
             deletedAt = null,
             pinned = true,
             pinnedAt = Date(now),
-            pinExpires = Date(now + 1.minutes.inWholeMilliseconds)
+            pinExpires = Date(now + 1.minutes.inWholeMilliseconds),
         )
         val expiresIn1h = alreadyExpired.copy(
             id = randomString(),
-            pinExpires = Date(now + 1.hours.inWholeMilliseconds)
+            pinExpires = Date(now + 1.hours.inWholeMilliseconds),
         )
         val pinnedMessages = listOf(alreadyExpired, expiresIn1h)
 


### PR DESCRIPTION
### 🎯 Goal

Related Ticket:
- https://stream-io.atlassian.net/browse/PBE-5181

Related PR:
- https://github.com/GetStream/stream-chat-android/pull/5321
- https://github.com/GetStream/stream-chat-android/pull/5329

### 🛠 Implementation details

Ensure all expired pinned messages are filtered out from exposure.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
