### PR TITLE
[PBE-4155] Ensure last preview message is not a deleted one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Message list is cleared when the channel remove all its messages. [#5360](https://github.com/GetStream/stream-chat-android/pull/5360)
+- Ensure channels list doesn't show deleted messages on the last message preview. [#5367](https://github.com/GetStream/stream-chat-android/pull/5367)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/extensions/internal/Channel.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.extensions.internal
 
 import io.getstream.chat.android.client.extensions.syncUnreadCountWithReads
 import io.getstream.chat.android.client.query.pagination.AnyChannelPaginationRequest
+import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelUserRead
@@ -44,7 +45,9 @@ public fun Channel.users(): List<User> {
 
 @InternalStreamChatApi
 public val Channel.lastMessage: Message?
-    get() = messages.maxByOrNull { it.createdAt ?: it.createdLocallyAt ?: Date(0) }
+    get() = messages
+        .filterNot { it.isDeleted() }
+        .maxByOrNull { it.createdAt ?: it.createdLocallyAt ?: Date(0) }
 
 @InternalStreamChatApi
 public fun Channel.updateLastMessage(
@@ -60,6 +63,7 @@ public fun Channel.updateLastMessage(
             .associateBy { it.id } + (message.id to message)
         )
         .values
+        .filterNot { it.isDeleted() }
         .sortedBy { it.createdAt ?: it.createdLocallyAt }
 
     val newReads = read.map { read ->

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -154,7 +154,7 @@ public fun randomMessage(
     createdAt: Date? = randomDate(),
     updatedAt: Date? = randomDate(),
     messageTextUpdatedAt: Date? = randomDate(),
-    deletedAt: Date? = randomDate(),
+    deletedAt: Date? = randomDateOrNull(),
     updatedLocallyAt: Date? = randomDate(),
     createdLocallyAt: Date? = randomDate(),
     user: User = randomUser(),

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
@@ -68,7 +68,11 @@ internal class ChannelRepositoryImplTest {
     @Test
     fun `Given channel without messages in DB, Should insert channel with updated last message`() = runTest {
         val channel = randomChannel(messages = emptyList())
-        val lastMessage = randomMessage(createdAt = Date(), parentId = null)
+        val lastMessage = randomMessage(
+            createdAt = Date(),
+            deletedAt = null,
+            parentId = null,
+        )
         whenever(channelDao.select("cid")) doReturn channel.toEntity()
 
         channelRepository.updateLastMessageForChannel("cid", lastMessage)
@@ -89,8 +93,18 @@ internal class ChannelRepositoryImplTest {
     fun `Given channel with outdated lastMessage in DB, Should insert channel with updated last message`() = runTest {
         val before = Date(1000)
         val after = Date(2000)
-        val outdatedMessage = randomMessage(id = "messageId1", createdAt = before, parentId = null)
-        val newLastMessage = randomMessage(id = "messageId2", createdAt = after, parentId = null)
+        val outdatedMessage = randomMessage(
+            id = "messageId1",
+            createdAt = before,
+            parentId = null,
+            deletedAt = null,
+        )
+        val newLastMessage = randomMessage(
+            id = "messageId2",
+            createdAt = after,
+            parentId = null,
+            deletedAt = null,
+        )
         val channel = randomChannel(messages = listOf(outdatedMessage), lastMessageAt = before)
         whenever(channelDao.select(cid = "cid")) doReturn channel.toEntity()
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
@@ -142,8 +142,11 @@ internal class QueryChannelsStateLogic(
      */
     internal suspend fun addChannelsState(channels: List<Channel>) {
         mutableState.queryChannelsSpec.cids += channels.map { it.cid }
-        val existingChannels = mutableState.rawChannels
-        mutableState.setChannels((existingChannels ?: emptyMap()) + channels.map { it.cid to it })
+        val existingChannels = mutableState.rawChannels ?: emptyMap()
+        mutableState.setChannels(
+            existingChannels +
+                channels.map { it.cid to it.joinMessages(existingChannels[it.cid]) },
+        )
         channels.map { channel ->
             coroutineScope.async {
                 logicRegistry.channelState(channel.type, channel.id).updateDataForChannel(
@@ -156,6 +159,12 @@ internal class QueryChannelsStateLogic(
             it.await()
         }
     }
+
+    private fun Channel.joinMessages(existingChannel: Channel?): Channel =
+        copy(
+            messages = ((existingChannel?.messages ?: emptyList()) + messages)
+                .distinctBy { it.id },
+        )
 
     /**
      * Remove channels to state.

--- a/stream-chat-android-ui-utils/src/main/kotlin/io/getstream/chat/android/uiutils/extension/Channel.kt
+++ b/stream-chat-android-ui-utils/src/main/kotlin/io/getstream/chat/android/uiutils/extension/Channel.kt
@@ -21,6 +21,7 @@ import androidx.annotation.PluralsRes
 import androidx.annotation.StringRes
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.getUsersExcludingCurrent
+import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.client.utils.message.isRegular
 import io.getstream.chat.android.client.utils.message.isSystem
 import io.getstream.chat.android.models.Channel
@@ -41,7 +42,7 @@ public fun Channel.getPreviewMessage(currentUser: User?): Message? =
         messages
     }.asSequence()
         .filter { it.createdAt != null || it.createdLocallyAt != null }
-        .filter { it.deletedAt == null }
+        .filterNot { it.isDeleted() }
         .filter { !it.silent }
         .filter { it.user.id == currentUser?.id || !it.shadowed }
         .filter { it.isRegular() || it.isSystem() }


### PR DESCRIPTION
### 🎯 Goal
When the last message is a deleted one, there isn't any preview available for the channels list.
On the DB we are filtering deleted messages when the channel is stored to ensure the last message is a non-delated one.
On the state plugin we are merging offline messages with the new ones we are receiving querying channels.

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeDRxc2RlOG5uc3dvdWx6dTd3M3pvaHNlNnh6MzY3cmkwNHF6NXdxdSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EzjQ3pr8xozjT7Hk2P/giphy.gif)