### PR TITLE
Hide unread messages button on the case the list of messages is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 - Fixed `MessageListController.channel.members` not being updated when a member is banned. [#5368](https://github.com/GetStream/stream-chat-android/pull/5368)
 
 ### ⬆️ Improved
+- Hide "Unread Messages" button when there are no messages on the messages list. [#5376](https://github.com/GetStream/stream-chat-android/pull/5376)
 
 ### ✅ Added
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -543,10 +543,9 @@ public class MessageListController(
             }
             .onFirst { channelUserRead ->
                 unreadLabelState.value = channelUserRead.lastReadMessageId
+                    ?.takeUnless { channelState.value?.messages?.value.isNullOrEmpty() }
                     ?.takeUnless { channelState.value?.messages?.value?.lastOrNull()?.id == it }
-                    ?.let {
-                        UnreadLabel(channelUserRead.unreadMessages, it, shouldShowButton)
-                    }
+                    ?.let { UnreadLabel(channelUserRead.unreadMessages, it, shouldShowButton) }
             }.launchIn(scope)
     }
 


### PR DESCRIPTION
### 🎯 Goal
Hide unread messages button on the case the list of messages is empty

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| ![Screenshot_20240827_141542](https://github.com/user-attachments/assets/700b1c5f-3ce3-419d-99a6-e35d6c8b191d) | ![Screenshot_20240827_141432](https://github.com/user-attachments/assets/836ae365-7ebb-4b2b-89a5-7deb6b11afda) |

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExNzZlNzViM3pqeHJyc2p5d3NqcDdqZzU4amtnOG14YmE4ZjE4M2dtZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/4xWGyVKoXqg2eVCiq9/giphy.gif)