### PR TITLE
[PBE-5781] Reorder how ThreadState Properties are updated when new messages arrieve

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/ThreadQueryListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/ThreadQueryListenerState.kt
@@ -91,21 +91,19 @@ internal class ThreadQueryListenerState(
     ) {
         val threadLogic = logic.thread(parentId)
         result.onSuccess { messages ->
-            threadLogic.upsertMessages(messages)
-            threadLogic.setEndOfNewerMessages(messages.size < limit)
             threadLogic.updateNewestMessageInThread(messages)
+            threadLogic.setEndOfNewerMessages(messages.size < limit)
+            threadLogic.upsertMessages(messages)
         }
         threadLogic.setLoading(false)
     }
 
-    private fun onResult(threadLogic: ThreadLogic?, result: Result<List<Message>>, limit: Int) {
+    private fun onResult(threadLogic: ThreadLogic, result: Result<List<Message>>, limit: Int) {
         if (result is Result.Success) {
             val newMessages = result.value
-            threadLogic?.run {
-                upsertMessages(newMessages)
-                setEndOfOlderMessages(newMessages.size < limit)
-                updateOldestMessageInThread(newMessages)
-            }
+            threadLogic.updateOldestMessageInThread(newMessages)
+            threadLogic.setEndOfOlderMessages(newMessages.size < limit)
+            threadLogic.upsertMessages(newMessages)
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Fix race-condition when the endOfOlderMessage/endOfNewerMessage flag was updated after the messageList is updated

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMW5wYmpqOG5mMGo3MnV1eDBkNXFwdWZicDNxbWNzbWY3c3g4MWZoYSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/12tu4pkMqVKJ1K/giphy.gif)