### PR TITLE
[PBE-0] use user.id for mentions if user.name is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 
 ### ⬆️ Improved
 - `MessageOptionsDialogFragment` now uses `MessageListItemViewHolderFactory` to get item view type. [#5369](https://github.com/GetStream/stream-chat-android/pull/5369)
+- Default `MentionsViewHolder` uses `user.id` if `user.name` is empty. [#5384](https://github.com/GetStream/stream-chat-android/pull/5384)
 
 ### ✅ Added
 - Create a new UI for the poll message. [#5285](https://github.com/GetStream/stream-chat-android/pull/5285)
@@ -86,6 +87,7 @@
 - Expose `topBarContent` and `bottomBarContent` in `MessageScreen`. [#5377](https://github.com/GetStream/stream-chat-android/pull/5377)
 
 ### ⬆️ Improved
+- `DefaultMentionSuggestionItemCenterContent` component uses `user.id` if `user.name` is empty. [#5384](https://github.com/GetStream/stream-chat-android/pull/5384)
 
 ### ✅ Added
 - Add `PollDialogs` component used to show poll dialogs. [#5370](https://github.com/GetStream/stream-chat-android/pull/5370)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/mentions/MentionSuggestionItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/suggestions/mentions/MentionSuggestionItem.kt
@@ -114,22 +114,26 @@ internal fun RowScope.DefaultMentionSuggestionItemCenterContent(user: User) {
     Column(
         modifier = Modifier
             .weight(1f)
-            .wrapContentHeight(),
+            .wrapContentHeight()
+            .align(Alignment.CenterVertically),
     ) {
+        val username = "@${user.id}"
         Text(
-            text = user.name,
+            text = user.name.ifEmpty { username },
             style = ChatTheme.typography.bodyBold,
             color = ChatTheme.colors.textHighEmphasis,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
         )
-        Text(
-            text = "@${user.id}",
-            style = ChatTheme.typography.footnote,
-            color = ChatTheme.colors.textLowEmphasis,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-        )
+        if (user.name.isNotEmpty()) {
+            Text(
+                text = username,
+                style = ChatTheme.typography.body,
+                color = ChatTheme.colors.textLowEmphasis,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
     }
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -726,7 +726,7 @@ public class MessageComposerController(
      */
     public fun selectMention(user: User) {
         val username = user.name.ifEmpty { user.id }
-        val augmentedMessageText = "${messageText.substringBeforeLast("@")}@${username} "
+        val augmentedMessageText = "${messageText.substringBeforeLast("@")}@$username "
 
         setMessageInputInternal(augmentedMessageText, MessageInput.Source.MentionSelected)
         selectedMentions += user

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -725,7 +725,8 @@ public class MessageComposerController(
      * @param user The user that is used to autocomplete the mention.
      */
     public fun selectMention(user: User) {
-        val augmentedMessageText = "${messageText.substringBeforeLast("@")}@${user.name} "
+        val username = user.name.ifEmpty { user.id }
+        val augmentedMessageText = "${messageText.substringBeforeLast("@")}@${username} "
 
         setMessageInputInternal(augmentedMessageText, MessageInput.Source.MentionSelected)
         selectedMentions += user

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerMentionSuggestionsContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerMentionSuggestionsContent.kt
@@ -206,7 +206,9 @@ private class MentionsViewHolder(
         binding.userAvatarView.doOnLayout {
             binding.userAvatarView.setUser(item)
         }
-        binding.usernameTextView.text = item.name
-        binding.mentionNameTextView.text = String.format(mentionTemplateText, item.name.lowercase())
+        val username = String.format(mentionTemplateText, item.id.lowercase())
+        binding.usernameTextView.text = item.name.ifEmpty { username }
+        binding.mentionNameTextView.isVisible = item.name.isNotEmpty()
+        binding.mentionNameTextView.text = username
     }
 }


### PR DESCRIPTION
### 🎯 Goal

When `user.name` is empty we have to use `user.id` in Mentions UI component to align with other SDKs.

**Related ticket**:
- https://stream-io.atlassian.net/browse/PBE-5751

**Slack**:
- https://getstream.slack.com/archives/C07EV8DFMRN/p1724790876176129?thread_ts=1724696447.660409&cid=C07EV8DFMRN

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
