### PR TITLE
[PBE-5890] Deprecate `NotInFilterObject`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### ✅ Added
 
 ### ⚠️ Changed
+- Deprecate `NotInFilterObject` because it is not supported backend-side anymore. [#5393](https://github.com/GetStream/stream-chat-android/pull/5393)
 
 ### ❌ Removed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,6 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
+| `NotInFilterObject` | 2024.09.03 <br/>6.5.1 | 2024.10.17 ⌛| 2024.10.03 ⌛| This filter is not supported backend-side anymore, if you are using it and need help with your integration, contact us and we will provide you an alternative. |
 | `AttachmentSelectionListener` | 2024.02.21 <br/>6.0.15 | 2024.03.21 ⌛ | 2024.04.21 ⌛ | Use `AttachmentsPickerDialogFragment.AttachmentsSelectionListener` instead. |
 | `ImageAttachmentQuotedContent` | 2022.09.13 <br/>5.9.1 | 2022.09.27<br/>5.9.1 | 2023.08.29<br/>6.0.0 | Deprecated in favor of `MediaAttachmentQuotedContent`. The new function has the ability to preview videos as well as images. |
 | `StreamDimens` constructor containing parameter `attachmentsContentImageGridSpacing`  | 2022.09.13 <br/>5.9.1 | 2022.09.27<br/>5.9.1 | 2023.08.29<br/>6.0.0 | This constructor has been deprecated. Use the constructor that does not contain the parameter `attachmentsContentImageGridSpacing`. |

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/FilterObject.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/FilterObject.kt
@@ -20,6 +20,13 @@ package io.getstream.chat.android.models
  * Filter object that specifies requests for backend queries.
  */
 public sealed class FilterObject
+
+@Deprecated(
+    message = "This filter will stop to be supported in the future.",
+    level = DeprecationLevel.WARNING,
+)
+public data class NotInFilterObject internal constructor(val fieldName: String, val values: Set<Any>) : FilterObject()
+
 public data class AndFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()
 public data class OrFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()
 public data class NorFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()
@@ -46,6 +53,5 @@ public data class LessThanOrEqualsFilterObject internal constructor(
     val value: Any,
 ) : FilterObject()
 public data class InFilterObject internal constructor(val fieldName: String, val values: Set<Any>) : FilterObject()
-public data class NotInFilterObject internal constructor(val fieldName: String, val values: Set<Any>) : FilterObject()
 public data class DistinctFilterObject internal constructor(val memberIds: Set<String>) : FilterObject()
 public object NeutralFilterObject : FilterObject()

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Filters.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Filters.kt
@@ -84,13 +84,25 @@ public object Filters {
     public fun `in`(fieldName: String, vararg values: Number): FilterObject = InFilterObject(fieldName, values.toSet())
 
     @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
     public fun nin(fieldName: String, vararg values: String): FilterObject =
         NotInFilterObject(fieldName, values.toSet())
 
     @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
     public fun nin(fieldName: String, values: List<Any>): FilterObject = NotInFilterObject(fieldName, values.toSet())
 
     @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
     public fun nin(fieldName: String, vararg values: Number): FilterObject =
         NotInFilterObject(fieldName, values.toSet())
 


### PR DESCRIPTION
### 🎯 Goal
Deprecate `NotInFilterObject` because it is no longer supported on the backend side.
This class will be removed soon on a future release.

### 🎉 GIF
![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExbjV4enRleGsyMm9xOHJvZ29nanFsOHpkY3ZwZG84OG9tbnFhdnZqcyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/cUelQ4WixZJEBZEVKS/giphy.gif)
