### PR TITLE
[PBE-5896] Fix/async voice compose render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- `Attachment.uploadId` is only used locally and removed whenever the attachments are uploaded. [#5395](https://github.com/GetStream/stream-chat-android/pull/5395)
 
 ### ✅ Added
 
@@ -67,6 +68,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fix condition to show async-voice attachments on MessageList. [#5395](https://github.com/GetStream/stream-chat-android/pull/5395)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/AttachmentUploader.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.client.attachment
 
 import android.webkit.MimeTypeMap
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.extensions.EXTRA_UPLOAD_ID
 import io.getstream.chat.android.client.extensions.uploadId
 import io.getstream.chat.android.client.uploader.StreamCdnImageMimeTypes
 import io.getstream.chat.android.client.utils.ProgressCallback
@@ -266,7 +267,7 @@ public class AttachmentUploader(private val client: ChatClient = ChatClient.inst
                 else -> imageUrl
             },
             assetUrl = uploadedFile.file,
-            extraData = extraData + uploadedFile.extraData,
+            extraData = (extraData + uploadedFile.extraData) - EXTRA_UPLOAD_ID,
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/attachment/AttachmentUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/attachment/AttachmentUploaderTests.kt
@@ -125,6 +125,7 @@ internal class AttachmentUploaderTests {
                 name = attachment.upload!!.name,
                 title = attachment.upload!!.name,
                 uploadState = Attachment.UploadState.Success,
+                extraData = attachment.extraData - EXTRA_UPLOAD_ID,
             )
             val result = sut.uploadAttachment(channelType, channelId, attachment)
             result.shouldBeInstanceOf(Result.Success::class)
@@ -150,6 +151,7 @@ internal class AttachmentUploaderTests {
                 name = attachment.upload!!.name,
                 title = attachment.upload!!.name,
                 uploadState = Attachment.UploadState.Success,
+                extraData = attachment.extraData - EXTRA_UPLOAD_ID,
             )
             val result = sut.uploadAttachment(
                 channelType,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -107,6 +107,7 @@ public object StreamAttachmentFactories {
         UploadAttachmentFactory(
             onContentItemClick = onUploadContentItemClick,
         ),
+        AudioRecordAttachmentFactory(),
         LinkAttachmentFactory(
             linkDescriptionMaxLines = linkDescriptionMaxLines,
             onContentItemClick = onLinkContentItemClick,
@@ -125,7 +126,6 @@ public object StreamAttachmentFactories {
             showFileSize = showFileSize,
             onContentItemClick = onFileContentItemClick,
         ),
-        AudioRecordAttachmentFactory(),
         UnsupportedAttachmentFactory(),
     )
 


### PR DESCRIPTION
### 🎯 Goal
Async-Voice attachments weren't rendered properly on Compose SDK on some situations.
Some internal properties caused it, which we use in our attachments to track the upload process.
Apart of that, the attachments factories has been reordered to ensure Async-Voice attachments use the proper factory

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOTJsajk4M2l3YTBhenRvdGV6MjhnemV4d28zeTZqa290b2VhanJ2cSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/kxhfWP2Bk2cBnrHZhK/giphy.gif)