### PR TITLE
Fix edge to edge extra padding and overlapping content

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -36,7 +36,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.MaterialTheme
@@ -203,7 +203,7 @@ public fun MessagesScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .systemBarsPadding()
+            .safeDrawingPadding()
             .testTag("Stream_MessagesScreen"),
     ) {
         Scaffold(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -204,6 +205,8 @@ public fun MessagesScreen(
         modifier = Modifier
             .fillMaxSize()
             .safeDrawingPadding()
+            // Explicitly consume IME inset (even if not needed), to avoid children applying it again on some devices.
+            .consumeWindowInsets(WindowInsets.ime)
             .testTag("Stream_MessagesScreen"),
     ) {
         Scaffold(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentsPicker.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Card
 import androidx.compose.material.Icon
@@ -92,8 +93,9 @@ public fun AttachmentsPicker(
 
     Box(
         modifier = Modifier
-            .fillMaxSize()
             .background(ChatTheme.attachmentPickerTheme.backgroundOverlay)
+            .safeDrawingPadding()
+            .fillMaxSize()
             .clickable(
                 onClick = onDismiss,
                 indication = null,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -30,8 +30,8 @@ import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.Checkbox
@@ -218,7 +218,7 @@ public fun MessageComposer(
     val messageComposerState by viewModel.messageComposerState.collectAsState()
 
     MessageComposer(
-        modifier = modifier.imePadding(),
+        modifier = modifier.safeDrawingPadding(),
         onSendMessage = { text, attachments ->
             val messageWithData = viewModel.buildNewMessage(text, attachments)
 


### PR DESCRIPTION
### 🎯 Goal

Fix unnecessary padding and overlapping content in `edge-to-edge` scenario.

### 🛠 Implementation details

- Use `safeDrawingPadding` instead of existing inset padding modifiers:
  - `MessagesScreen`: existing `systemBarsPadding` only accounts for the system bar, but not for the keyboard & navigation bar, leading to attachments picker being obscured.
  - `MessageComposer`: existing `imePadding` only accoungs for the keyboard, so if used as a standalone component, other insets are not taken into account.
  - `AttachmentsPicker`: has no inset padding, needed if used as standalone.
- Explicitly consume ime inset in `MessagesScreen` with `consumeWindowInsets(WindowInsets.ime)`, even if normally it's not needed, as a potential fix for reported cases when the `MessageComposer` has too much bottom padding (roughly the size of 2 keyboards).
- By using `safeDrawingPadding`, cut-outs is also supported for these components.

### 🧪 Testing

Use `MessagesScreen` in an edge-to-edge app.
Use `MessageComposer` and `AttachmentsPicker` as standalone components.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
