### PR TITLE
[PBE-5969] UnreadLabel shouldn't appear when only deleted messages are unread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- UnreadLabel is not added on the case all unread messages are deleted. [#5403](https://github.com/GetStream/stream-chat-android/pull/5403)
 
 ### ⬆️ Improved
 


### PR DESCRIPTION
### 🎯 Goal

Currently, when a message is deleted, the read are updated removing them from the deleted message and adding them to the previous message. It causes that a deleted message on the last possition is always marked as unread.

Only non-deleted messages should be elegible to be marked as unread

### 🛠 Implementation details
UnreadLabel is not added on the case that only deleted messages are after the last read message

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/3bb0cbee-79c5-45a3-97e7-166b5ea8657e" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/b38b2725-9397-4f71-b484-7a24ca4e48c3" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGVmYWd5ODJ4ZHRzZnl1dmd2dXJpaXQ5ODJiMzh0Yjg5OXM4ejloYyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l0HlMSVVw9zqmClLq/giphy.gif)