### PR TITLE
Fix delete messages with attachment

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
@@ -152,8 +152,6 @@ public class UploadAttachmentsWorker(
                 } ?: SyncStatus.FAILED_PERMANENTLY,
         )
         channelStateLogic?.upsertMessage(updatedMessage)
-        // RepositoryFacade::insertMessage is implemented as upsert, therefore we need to delete the message first
-        messageRepository.deleteChannelMessage(updatedMessage)
         messageRepository.insertMessage(updatedMessage)
         AttachmentsUploadStates.updateMessageAttachments(updatedMessage)
     }


### PR DESCRIPTION
### 🎯 Goal
Our `UploadAttachmentsWorker` was deleting the message after all attachment was uploaded. It was done on that way to ensure any nested data related with the message was removed from the DB. It is not needed anymore because the internal implementation of our respository already cover this case, replacing the full message in our cache, and updating the DB removing any outdate data for the nested objects.

With this PR, the user can delete their own attachments sent to a channels.

### 🎨 UI Changes

_Add relevant screenshots_
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/92289afa-736a-4bc8-a777-2147fed7f19d" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/6c5c3de9-0401-43c0-a113-e228f9c7acdd" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
