### PR TITLE
Fix ChannelAvatar not clickable

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/Avatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/Avatar.kt
@@ -76,8 +76,15 @@ public fun Avatar(
     }
 
     val cdnImageResizing = ChatTheme.streamCdnImageResizing
+    val clickableModifier = if (onClick != null) {
+        Modifier.clickable { onClick() }
+    } else {
+        Modifier
+    }
     StreamImage(
-        modifier = modifier.clip(shape).clickable { onClick?.invoke() },
+        modifier = modifier
+            .clip(shape)
+            .then(clickableModifier),
         data = { imageUrl.applyStreamCdnImageResizingIfEnabled(cdnImageResizing) },
         loading = {
             if (placeholderPainter != null) {


### PR DESCRIPTION
### 🎯 Goal

The `ChannelAvatar` component wasn't clickable when it shows 2+ user avatars (handled by `GroupAvatar` in the background)

### 🛠 Implementation details

The root cause was in a deeper layer, in the `Avatar` implementation. The `Avatar` always set the `clickable()` modifier on the `StreamImage` component (even if the `onClick` handler was null), which resulted in the `StreamImage` consuming the click events, even if its parent component had a `clickable` modifier set (in this case - `GroupAvatar`).

With this change, the `clickable` modifier is set only when the `onClick` handler is passed.

### 🎨 UI Changes


_Add relevant videos_

<table>
<thead>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
Single user avatar (no changes)
</td>
<td>
<video src="https://github.com/user-attachments/assets/19f209c9-cd0c-4bca-beb7-ac8aba14091b" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/4fd6be5d-dd98-4db1-937f-af88e67e1522" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
Multi user avatar
</td>
<td>
<video src="https://github.com/user-attachments/assets/ffbbfcd8-9ce8-47a2-8629-a905e0f8e939
" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/fe46e378-b34e-42d1-bdda-09ba1fc7141a
" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

1. Open Compose sample app
2. Open a channel with more than 2 users without a channel image
3. Tap on the channel image in the toolbar 


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
