### PR TITLE
Fix crash on ChatInfo due to wrong thread used to update the livedata

### DIFF
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/ChatInfoViewModel.kt
@@ -126,7 +126,9 @@ class ChatInfoViewModel(
     }
 
     private fun updateChannelMuteStatus(channelMutes: List<ChannelMute>) {
-        _state.value = _state.value!!.copy(channelMuted = channelMutes.any { it.channel?.cid == cid })
+        _state.value?.let { state ->
+            _state.postValue(state.copy(channelMuted = channelMutes.any { it.channel?.cid == cid }))
+        }
     }
 
     private fun switchChannelMute(isEnabled: Boolean) {


### PR DESCRIPTION
### 🎯 Goal

Fix crash on ChatInfo due to wrong thread used to update the livedata 

```
FATAL EXCEPTION: DefaultDispatcher-worker-7
Process: io.getstream.chat.ui.sample.debug, PID: 12497
java.lang.IllegalStateException: Cannot invoke setValue on a background thread
at androidx.lifecycle.LiveData.assertMainThread(LiveData.java:502)
at androidx.lifecycle.LiveData.setValue(LiveData.java:306)
at androidx.lifecycle.MutableLiveData.setValue(MutableLiveData.java:50)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoViewModel.updateChannelMuteStatus(ChatInfoViewModel.kt:129)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoViewModel.onAction(ChatInfoViewModel.kt:123)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoFragment.subscribeForChannelMutesUpdatedEvents$lambda$9(ChatInfoFragment.kt:173)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoFragment.$r8$lambda$uucVadR1I2ukfp6ERqdeL84SviA(Unknown Source:0)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoFragment$$ExternalSyntheticLambda0.onEvent(D8$$SyntheticClass:0)
at io.getstream.chat.ui.sample.feature.chat.info.ChatInfoFragment$subscribeForChannelMutesUpdatedEvents$$inlined$subscribeFor$1.onEvent(ClientExtensions.kt:48)
at io.getstream.chat.android.client.ChatClient.subscribeFor$lambda$49(ChatClient.kt:1239)
at io.getstream.chat.android.client.ChatClient.$r8$lambda$eNSrh-ZiTcLD0IQAXL_6JLOpJcU(Unknown Source:0)
at io.getstream.chat.android.client.ChatClient$$ExternalSyntheticLambda29.onEvent(D8$$SyntheticClass:0)
at io.getstream.chat.android.client.utils.observable.SubscriptionImpl.onNext(Subscriptions.kt:56)
at io.getstream.chat.android.client.utils.observable.ChatEventsObservable$notifySubscriptions$1.invokeSuspend(ChatEventsObservable.kt:103)
at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(ContinuationImpl.kt:33)
at kotlinx.coroutines.DispatchedTask.run(DispatchedTask.kt:101)
at kotlinx.coroutines.internal.LimitedDispatcher$Worker.run(LimitedDispatcher.kt:113)
at kotlinx.coroutines.scheduling.TaskImpl.run(Tasks.kt:89)
at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely(CoroutineScheduler.kt:589)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask(CoroutineScheduler.kt:823)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker(CoroutineScheduler.kt:720)
at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run(CoroutineScheduler.kt:707)
Suppressed: kotlinx.coroutines.internal.DiagnosticCoroutineContextException: [io.getstream.result.call.SharedCalls@2af6468, UserIdentifier(dnovak), StandaloneCoroutine{Cancelling}@5b5a081, Dispatchers.IO]
```

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOGZkNXI1NDZ2bTN0ZTUwdDg1cHNlZGhkeGxrMmo3bjQwc2drZ3ExMyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/EHtxY9W5udG8Dty7a6/giphy.gif)