### PR TITLE
bug fix for Clicking on Certain Areas of Audio Recording in Message List Displays "Invalid URL" Error

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/navigation/destinations/AttachmentDestination.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/navigation/destinations/AttachmentDestination.kt
@@ -87,11 +87,13 @@ public open class AttachmentDestination(
 
         if (url.isNullOrEmpty()) {
             logger.e { "Wrong URL for attachment. Attachment: $attachment" }
-            Toast.makeText(
-                context,
-                context.getString(R.string.stream_ui_message_list_attachment_invalid_url),
-                Toast.LENGTH_SHORT,
-            ).show()
+            if (attachment.type == AttachmentType.UNKNOWN) {
+                Toast.makeText(
+                    context,
+                    context.getString(R.string.stream_ui_message_list_attachment_invalid_url),
+                    Toast.LENGTH_SHORT,
+                ).show()
+            }
             return
         }
 


### PR DESCRIPTION
Clicking on Certain Areas of Audio Recording in Message List Displays "Invalid URL" Error

### 🎯 Goal

fix for this issue #5446 

### 🛠 Implementation details

basically check to make sure the attachment is unsupported before showing error message

### 🧪 Testing
Try tapping random places in the message bubble try to avoid buttons and the slider the toast should not appear



### 🎉 GIF

![](https://media.giphy.com/media/QsnQsvAkrkKGiHZuo8/giphy.gif?cid=790b76113abdan384llwu7rlwdm6n9k9bwo8trm8w2z4zwnx&ep=v1_gifs_search&rid=giphy.gif&ct=g)
