### PR TITLE
bug fix for "Unable to set audio speed after pausing"

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/audio/StreamAudioPlayer.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/audio/StreamAudioPlayer.kt
@@ -146,7 +146,9 @@ internal class StreamMediaPlayer(
                 currentSpeed + SPEED_INCREMENT
             }
 
-            if (playerState == PlayerState.PLAYING && mediaPlayer.isSpeedSettable()) {
+            if ((playerState == PlayerState.PLAYING || playerState == PlayerState.PAUSE) &&
+                mediaPlayer.isSpeedSettable()
+            ) {
                 playingSpeed = newSpeed
                 mediaPlayer.speed = newSpeed
                 publishSpeed(currentAudioHash, newSpeed)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/audio/StreamAudioPlayer.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/audio/StreamAudioPlayer.kt
@@ -150,7 +150,9 @@ internal class StreamMediaPlayer(
                 mediaPlayer.isSpeedSettable()
             ) {
                 playingSpeed = newSpeed
-                mediaPlayer.speed = newSpeed
+                if (playerState == PlayerState.PLAYING) {
+                    mediaPlayer.speed = newSpeed
+                }
                 publishSpeed(currentAudioHash, newSpeed)
             }
         }


### PR DESCRIPTION
### 🎯 Goal

fix issue causing users to not be able to set speed after pausing audio #5450 

### 🛠 Implementation details

allow setting speed when audio is paused

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/c8e7428d-fafa-4d31-8ba7-6d3a5f27cf69" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/ea0f3821-ddf4-4421-a582-c05e7dcc6c69" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Play audio recording
- pause audio recording
- Set speed

### 🎉 GIF

![](https://media.giphy.com/media/EwLd3SdEt9eZOxzVGR/giphy.gif?cid=ecf05e47js3lmpufhrxpxql1rvpnn7zd3py0xk9hp7bavjt5&ep=v1_gifs_search&rid=giphy.gif&ct=g)
