### PR TITLE
[PBE-3749] Implement ChatClient::markThreadUnread operation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `ChatClient::markThreadUnread` to mark a given thread as unread. [#5457](https://github.com/GetStream/stream-chat-android/pull/5457)
+- Add `ChannelClient::markThreadUnread` to mark a given thread as unread. [#5457](https://github.com/GetStream/stream-chat-android/pull/5457)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -99,6 +99,7 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun markMessageRead (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markRead (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markThreadRead (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun markThreadUnread (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markUnread (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun muteChannel (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)Lio/getstream/result/call/Call;
@@ -649,6 +650,7 @@ public final class io/getstream/chat/android/client/channel/ChannelClient {
 	public final fun markMessageRead (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markRead ()Lio/getstream/result/call/Call;
 	public final fun markThreadRead (Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun markThreadUnread (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun markUnread (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun mute ()Lio/getstream/result/call/Call;
 	public final fun mute (Ljava/lang/Integer;)Lio/getstream/result/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2485,6 +2485,24 @@ internal constructor(
             }
     }
 
+    /**
+     * Marks a given thread starting from the given message as unread.
+     *
+     * @param channelType Type of the channel.
+     * @param channelId Id of the channel.
+     * @param threadId Id of the thread to mark as unread.
+     * @param messageId Id of the message from where the thread should be marked as unread.
+     */
+    @CheckResult
+    public fun markThreadUnread(
+        channelType: String,
+        channelId: String,
+        threadId: String,
+        messageId: String,
+    ): Call<Unit> {
+        return api.markThreadUnread(channelType, channelId, threadId = threadId, messageId = messageId)
+    }
+
     @CheckResult
     public fun updateUsers(users: List<User>): Call<List<User>> {
         return api.updateUsers(users)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -290,6 +290,14 @@ internal interface ChatApi {
     ): Call<Unit>
 
     @CheckResult
+    fun markThreadUnread(
+        channelType: String,
+        channelId: String,
+        threadId: String,
+        messageId: String,
+    ): Call<Unit>
+
+    @CheckResult
     fun showChannel(channelType: String, channelId: String): Call<Unit>
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -721,6 +721,22 @@ constructor(
         ).toUnitCall()
     }
 
+    override fun markThreadUnread(
+        channelType: String,
+        channelId: String,
+        threadId: String,
+        messageId: String,
+    ): Call<Unit> {
+        return channelApi.markUnread(
+            channelType = channelType,
+            channelId = channelId,
+            request = MarkUnreadRequest(
+                thread_id = threadId,
+                message_id = messageId,
+            ),
+        ).toUnitCall()
+    }
+
     override fun markAllRead(): Call<Unit> {
         return channelApi.markAllRead().toUnitCall()
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MarkUnreadRequest.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/requests/MarkUnreadRequest.kt
@@ -21,4 +21,5 @@ import com.squareup.moshi.JsonClass
 @JsonClass(generateAdapter = true)
 internal data class MarkUnreadRequest(
     val message_id: String,
+    val thread_id: String? = null,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/ChannelClient.kt
@@ -420,6 +420,17 @@ public class ChannelClient internal constructor(
         return client.markUnread(channelType, channelId, messageId)
     }
 
+    /**
+     * Marks a given thread in the channel starting from the given message as unread.
+     *
+     * @param messageId Id of the message from where the thread should be marked as unread.
+     * @param threadId Id of the thread to mark as unread.
+     */
+    @CheckResult
+    public fun markThreadUnread(threadId: String, messageId: String): Call<Unit> {
+        return client.markThreadUnread(channelType, channelId, threadId = threadId, messageId = messageId)
+    }
+
     @CheckResult
     public fun markRead(): Call<Unit> {
         return client.markRead(channelType, channelId)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenMarkUnreadThread.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenMarkUnreadThread.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.chatclient
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.test.TestCall
+import io.getstream.chat.android.test.callFrom
+import io.getstream.result.Error
+import io.getstream.result.Result
+import io.getstream.result.call.Call
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+
+internal class WhenMarkUnreadThread : BaseChatClientTest() {
+
+    @Test
+    fun `Given markUnread api call successful ChatClient should return success result`() = runTest {
+        val apiResult = callFrom { }
+        val sut = Fixture().givenMarkUnreadApiResult(apiResult).get()
+
+        val result = sut.markThreadUnread("channelType", "channelId", "threadId", "messageId").await()
+
+        result shouldBeInstanceOf Result.Success::class
+    }
+
+    @Test
+    fun `Given markUnread api call fails ChatClient should return error result`() = runTest {
+        val apiResult = TestCall<Unit>(Result.Failure(Error.GenericError("Error")))
+        val sut = Fixture().givenMarkUnreadApiResult(apiResult).get()
+
+        val result = sut.markThreadUnread("channelType", "channelId", "threadId", "messageId").await()
+
+        result shouldBeInstanceOf Result.Failure::class
+    }
+
+    private inner class Fixture {
+
+        fun givenMarkUnreadApiResult(result: Call<Unit>) = apply {
+            whenever(api.markThreadUnread(any(), any(), any(), any())) doReturn result
+        }
+
+        fun get(): ChatClient = chatClient
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Implement the ChatClient.markThreadUnread operation. It will be used as part of the whole Threads V2 implementation.

### 🛠 Implementation details
- Extend the MarkUnreadRequest with thread_id filed (as per the api documentation)
- Implement new markThreadUnread (similar to markUnread) methods on ChatClient and ChannelClient

### 🎨 UI Changes

_NA_

### 🧪 Testing

_Currently not used_


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
