### PR TITLE
[PBE-0] Fix moderation action FLAG literal.

### DIFF
--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MessageModerationDetails.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MessageModerationDetails.kt
@@ -48,7 +48,7 @@ public data class MessageModerationAction(
          * A flagged message means it was sent for review in the dashboard but the message was still published.
          */
         public val flag: MessageModerationAction = MessageModerationAction(
-            rawValue = "MESSAGE_RESPONSE_ACTION_BOUNCE",
+            rawValue = "MESSAGE_RESPONSE_ACTION_FLAG",
         )
 
         /**


### PR DESCRIPTION
### 🎯 Goal

A wrong literal was used for the moderation action FLAG in the code: `MESSAGE_RESPONSE_ACTION_BOUNCE` instead of `MESSAGE_RESPONSE_ACTION_FLAG`.

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
