### PR TITLE
[AND-6] Add edge-to-edge support for apps targeting Android 15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@
 
 ### ✅ Added
 - Add `MessageListViewModel.flagUser()` and `MessageListViewModel.unflagUser()` methods for flagging/un-flagging users. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
+- Add edge-to-edge support for apps targeting Android 15. [#5469](https://github.com/GetStream/stream-chat-android/pull/5469)
 
 ### ⚠️ Changed
 
@@ -123,6 +124,7 @@
 
 ### ✅ Added
 - Add `MessageListViewModel.flagUser()` and `MessageListViewModel.unflagUser()` methods for flagging/un-flagging users. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
+- Add edge-to-edge support for apps targeting Android 15. [#5469](https://github.com/GetStream/stream-chat-android/pull/5469)
 
 ### ⚠️ Changed
 - 🚨 Breaking change: Replace usage of `RippleTheme` with `StreamRippleConfiguration` for customizing ripples via `ChatTheme`. [#5475](https://github.com/GetStream/stream-chat-android/pull/5475)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
@@ -28,7 +28,9 @@ import android.widget.FrameLayout
 import android.widget.MediaController
 import android.widget.Toast
 import android.widget.VideoView
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.animation.AnimatedVisibility
@@ -53,13 +55,16 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -75,8 +80,8 @@ import androidx.compose.material.Text
 import androidx.compose.material.rememberScaffoldState
 import androidx.compose.material.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -93,6 +98,7 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.ContentScale
@@ -112,7 +118,6 @@ import com.google.accompanist.pager.PagerState
 import com.google.accompanist.pager.rememberPagerState
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.skydoves.landscapist.ImageOptions
 import com.skydoves.landscapist.coil.CoilImageState
 import com.skydoves.landscapist.coil.rememberCoilImageState
@@ -250,7 +255,7 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
                 videoThumbnailsEnabled = videoThumbnailsEnabled,
                 streamCdnImageResizing = streamCdnImageResizing,
             ) {
-                SetupSystemUI()
+                SetupEdgeToEdge()
 
                 val message = mediaGalleryPreviewViewModel.message
 
@@ -271,21 +276,17 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
         }
     }
 
-    /**
-     * Responsible for updating the system UI.
-     */
     @Composable
-    private fun SetupSystemUI() {
-        val systemUiController = rememberSystemUiController()
-        val useDarkIcons = !isSystemInDarkTheme()
-
-        val systemBarsColor = ChatTheme.colors.barsBackground
-
-        SideEffect {
-            systemUiController.setSystemBarsColor(
-                color = systemBarsColor,
-                darkIcons = useDarkIcons,
-            )
+    private fun SetupEdgeToEdge() {
+        val nightMode = isSystemInDarkTheme()
+        val systemBarsColor = ChatTheme.colors.barsBackground.toArgb()
+        LaunchedEffect(nightMode) {
+            val style = if (nightMode) {
+                SystemBarStyle.dark(systemBarsColor)
+            } else {
+                SystemBarStyle.light(systemBarsColor, systemBarsColor)
+            }
+            enableEdgeToEdge(statusBarStyle = style, navigationBarStyle = style)
         }
     }
 
@@ -317,7 +318,12 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
         val pagerState = rememberPagerState(initialPage = startingPosition)
         val coroutineScope = rememberCoroutineScope()
 
-        Box(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(ChatTheme.colors.barsBackground)
+                .windowInsetsPadding(WindowInsets.systemBars),
+        ) {
             Scaffold(
                 modifier = Modifier.fillMaxSize(),
                 scaffoldState = scaffoldState,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
@@ -28,22 +28,27 @@ import android.widget.MediaController
 import android.widget.ProgressBar
 import android.widget.Toast
 import android.widget.VideoView
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.systemBars
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
@@ -51,7 +56,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
-import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.mirrorRtl
@@ -62,6 +66,7 @@ import io.getstream.chat.android.compose.ui.util.mirrorRtl
 public class MediaPreviewActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        setupEdgeToEdge()
         super.onCreate(savedInstanceState)
         val url = intent.getStringExtra(KEY_URL)
         val title = intent.getStringExtra(KEY_TITLE) ?: ""
@@ -73,8 +78,11 @@ public class MediaPreviewActivity : AppCompatActivity() {
 
         setContent {
             ChatTheme {
-                SetupSystemUI()
                 MediaPreviewScreen(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black)
+                        .windowInsetsPadding(WindowInsets.systemBars),
                     url = url,
                     title = title,
                     onPlaybackError = {
@@ -101,6 +109,7 @@ public class MediaPreviewActivity : AppCompatActivity() {
      */
     @Composable
     private fun MediaPreviewScreen(
+        modifier: Modifier = Modifier,
         url: String,
         title: String,
         onPlaybackError: () -> Unit,
@@ -109,33 +118,19 @@ public class MediaPreviewActivity : AppCompatActivity() {
         BackHandler(enabled = true, onBack = onBackPressed)
 
         Scaffold(
-            modifier = Modifier.fillMaxSize(),
+            modifier = modifier,
             backgroundColor = Color.Black,
             topBar = { MediaPreviewToolbar(title, onBackPressed) },
             content = { MediaPreviewContent(url, onBackPressed, onPlaybackError) },
         )
     }
 
-    /**
-     * Responsible for updating the system UI.
-     */
-    @Composable
-    private fun SetupSystemUI() {
-        val systemUiController = rememberSystemUiController()
-
-        val statusBarColor = Color.Black
-        val navigationBarColor = Color.Black
-
-        SideEffect {
-            systemUiController.setStatusBarColor(
-                color = statusBarColor,
-                darkIcons = false,
-            )
-            systemUiController.setNavigationBarColor(
-                color = navigationBarColor,
-                darkIcons = false,
-            )
-        }
+    private fun setupEdgeToEdge() {
+        val barsColor = Color.Black.toArgb()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(barsColor),
+            navigationBarStyle = SystemBarStyle.dark(barsColor),
+        )
     }
 
     /**

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/documents/AttachmentDocumentActivity.java
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/documents/AttachmentDocumentActivity.java
@@ -12,7 +12,12 @@ import android.webkit.WebViewClient;
 import android.widget.ProgressBar;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.OnApplyWindowInsetsListener;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -30,6 +35,7 @@ public class AttachmentDocumentActivity extends AppCompatActivity {
 
     private static final String KEY_URL = "url";
 
+    View rootView;
     WebView webView;
     ProgressBar progressBar;
 
@@ -42,8 +48,10 @@ public class AttachmentDocumentActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.stream_activity_attachment_document);
+        rootView = findViewById(R.id.rootView);
         webView = findViewById(R.id.webView);
         progressBar = findViewById(R.id.progressBar);
+        setupEdgeToEdge();
         configUIs();
         init();
     }
@@ -52,6 +60,18 @@ public class AttachmentDocumentActivity extends AppCompatActivity {
         Intent intent = getIntent();
         String filePath = intent.getStringExtra(KEY_URL);
         loadDocument(filePath);
+    }
+
+    private void setupEdgeToEdge() {
+        ViewCompat.setOnApplyWindowInsetsListener(rootView, new OnApplyWindowInsetsListener() {
+            @NonNull
+            @Override
+            public WindowInsetsCompat onApplyWindowInsets(@NonNull View v, @NonNull WindowInsetsCompat insets) {
+                Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                v.setPadding(systemBarInsets.left, systemBarInsets.top, systemBarInsets.right, systemBarInsets.bottom);
+                return WindowInsetsCompat.CONSUMED;
+            }
+        });
     }
 
     private void configUIs() {

--- a/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment_document.xml
+++ b/stream-chat-android-ui-common/src/main/res/layout/stream_activity_attachment_document.xml
@@ -17,6 +17,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/rootView"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/stream_gray_dark"

--- a/stream-chat-android-ui-components/src/main/AndroidManifest.xml
+++ b/stream-chat-android-ui-components/src/main/AndroidManifest.xml
@@ -58,6 +58,7 @@
 
         <activity
             android:name=".feature.messages.MessageListActivity"
+            android:windowSoftInputMode="adjustResize"
             android:exported="false"
             />
     </application>

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/ChannelListActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/ChannelListActivity.kt
@@ -20,6 +20,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiFragmentContainerBinding
 
@@ -34,6 +37,7 @@ public open class ChannelListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = StreamUiFragmentContainerBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setupEdgeToEdge()
 
         if (savedInstanceState == null) {
             supportFragmentManager.beginTransaction()
@@ -54,6 +58,14 @@ public open class ChannelListActivity : AppCompatActivity() {
             showSearch(true)
             showHeader(true)
             headerTitle(getString(R.string.stream_ui_channel_list_header_connected))
+        }
+    }
+
+    private fun setupEdgeToEdge() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { root, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            root.updatePadding(left = insets.left, top = insets.top, right = insets.right, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentActivity.kt
@@ -24,7 +24,10 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiActivityAttachmentBinding
@@ -46,6 +49,7 @@ public class AttachmentActivity : AppCompatActivity() {
         binding = StreamUiActivityAttachmentBinding.inflate(streamThemeInflater)
         setContentView(binding.root)
 
+        setupEdgeToEdge()
         configUIs()
 
         val type = intent.getStringExtra("type")
@@ -72,6 +76,14 @@ public class AttachmentActivity : AppCompatActivity() {
                 pluginState = WebSettings.PluginState.ON
             }
             webViewClient = AppWebViewClients()
+        }
+    }
+
+    private fun setupEdgeToEdge() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { root, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            root.updatePadding(top = insets.top, left = insets.left, right = insets.right, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentGalleryActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentGalleryActivity.kt
@@ -28,7 +28,10 @@ import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import androidx.viewpager2.widget.ViewPager2
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
@@ -116,9 +119,18 @@ public class AttachmentGalleryActivity : AppCompatActivity() {
 
         binding = StreamUiActivityAttachmentGalleryBinding.inflate(streamThemeInflater)
         setContentView(binding.root)
+        setupEdgeToEdge()
         setupGalleryOverviewButton()
         binding.closeButton.setOnClickListener { finish() }
         viewModel.attachmentGalleryItemsLiveData.observe(this, ::setupGallery)
+    }
+
+    private fun setupEdgeToEdge() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(top = insets.top, left = insets.left, right = insets.right, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
     }
 
     private fun setupGallery(attachmentGalleryItems: List<AttachmentGalleryItem>) {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentMediaActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/AttachmentMediaActivity.kt
@@ -24,8 +24,13 @@ import android.view.KeyEvent
 import android.widget.MediaController
 import android.widget.Toast
 import android.widget.VideoView
+import androidx.activity.SystemBarStyle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiActivityAttachmentMediaBinding
 import io.getstream.chat.android.ui.utils.extensions.getColorCompat
@@ -56,7 +61,7 @@ public class AttachmentMediaActivity : AppCompatActivity() {
             return
         }
 
-        setupSystemUi()
+        setupEdgeToEdge()
         setupViews()
         setupVideoView()
     }
@@ -73,9 +78,17 @@ public class AttachmentMediaActivity : AppCompatActivity() {
     /**
      * Responsible for updating the system UI.
      */
-    private fun setupSystemUi() {
-        window.navigationBarColor = getColorCompat(R.color.stream_ui_literal_black)
-        window.statusBarColor = getColorCompat(R.color.stream_ui_literal_black)
+    private fun setupEdgeToEdge() {
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(getColorCompat(R.color.stream_ui_literal_black)),
+            navigationBarStyle = SystemBarStyle.dark(getColorCompat(R.color.stream_ui_literal_black)),
+        )
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(top = insets.top, left = insets.left, right = insets.right, bottom = insets.bottom)
+
+            WindowInsetsCompat.CONSUMED
+        }
     }
 
     /**

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/MessageListActivity.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/MessageListActivity.kt
@@ -20,6 +20,9 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiFragmentContainerBinding
 
@@ -34,6 +37,7 @@ public open class MessageListActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         binding = StreamUiFragmentContainerBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        setupEdgeToEdge()
 
         if (savedInstanceState == null) {
             val cid = requireNotNull(intent.getStringExtra(EXTRA_CID)) {
@@ -56,6 +60,14 @@ public open class MessageListActivity : AppCompatActivity() {
             setFragment(MessageListFragment())
             showHeader(true)
             messageId(messageId)
+        }
+    }
+
+    private fun setupEdgeToEdge() {
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { root, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.ime())
+            root.updatePadding(left = insets.left, top = insets.top, right = insets.right, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_gallery.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_gallery.xml
@@ -17,6 +17,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    android:background="@color/stream_ui_white"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     >

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_media.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_activity_attachment_media.xml
@@ -19,6 +19,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/stream_ui_literal_black"
     >
 
     <androidx.constraintlayout.widget.ConstraintLayout


### PR DESCRIPTION
### 🎯 Goal

Any apps targeting Android 15 (`targetSdk=35`) have edge-to-edge enabled by default. This means that some screens/components could be obstructed by the system bars / keyboard, making it impossible to interact with. Therefore, we must ensure that the screens we provide from the SDK are supporting edge-to-edge, otherwise integrator apps targeting Android 15 could have issues.

**Note 1: This PR DOESN'T change the SDK / sample apps `targetSdk` value, as that might require other updates. It just makes sure that the affected screens are properly shown in apps targeting Android 15.**

**Note 2: This PR DOESN'T explicitly introduce edge-to-edge for all screens (for Android version < 15). The only screens where edge-to-edge is explicitly requested are screens which are already simulating such experience by colouring the system/navigation bars (which is now deprecated). In all other cases we try to preserve the current behaviour for Android < 15, and ensure the screens are still shown properly for Android >= 15.**

Linear: https://linear.app/stream/issue/AND-6/implement-edge-to-edge-support-for-android-15
GitHub issue: https://github.com/GetStream/stream-chat-android/issues/5458

### 🛠 Implementation details

#### `ui-common`:
- `AttachmentDocumentActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` to ensure the content is not obstructed by status bar / navigation bar.

#### `compose` SDK:
- `MediaGalleryPreviewActivity` - apply content padding based on `WindowInsets.systemBars` to ensure the content is not obstructed by status bar / navigation bar + explicitly request `enableEdgeToEdge(statusBarStyle, navigationBarStyle)` to ensure the system bars are coloured properly (previously we used `SystemUiController` for that purpose)
- `MediaPreviewActivity` - apply content padding based on `WindowInsets.systemBars` to ensure the content is not obstructed by status bar / navigation bar + explicitly request `enableEdgeToEdge(statusBarStyle, navigationBarStyle)` to ensure the system bars are coloured properly (previously we used `SystemUiController` for that purpose). Here, both the background and the system bars are always shown as `Color.Black`, disregarding light/night mode.

#### `xml` SDK:
- `ChannelListActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` to ensure the content is not obstructed by status bar / navigation bar.
-  `AttachmentActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` to ensure the content is not obstructed by status bar / navigation bar.
-  `AttachmentGalleryActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` to ensure the content is not obstructed by status bar / navigation bar.
- `AttachmentMediaActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` to ensure the content is not obstructed by status bar / navigation bar + explicitly request `enableEdgeToEdge(statusBarStyle, navigationBarStyle)` to ensure the system bars are coloured properly (previously we used `window.navigationBarColor/window.statusBarColor` which are now deprecated).
- `MessageListActivity` - apply content padding based on `WindowInsetsCompat.Type.systemBars()` + `WindowInsetsCompat.Type.ime()`. Ensures that the content is not obstructed by status bar / navigation bar, and ensures that the content is not obstructed by the soft keyboard.

### 🎨 UI Changes

#### TargetSdk = 34 (Should look the same before and after the changes)
| Screen | Before (portrait) | Before (landscape) | After (portrait) | After (landscape) |
| --- | --- | --- | --- | --- |
| AttachmentDocumentActivity | ![attachment-document-activity-navbar](https://github.com/user-attachments/assets/b6febe17-486c-4794-bcaa-7589652f2094) |![attachment-document-activity-navbar-lanscape](https://github.com/user-attachments/assets/e125b028-e145-4a53-bbce-9e4d8cb87393) |![attachment-document-activity-navbar](https://github.com/user-attachments/assets/84800ed1-c578-4ca7-a1c2-a9e5a4225a55)|![attachment-document-activity-navbar-landscape](https://github.com/user-attachments/assets/d2c25420-3bc1-4eb8-bece-cdc6fedf0710)|
| MediaGalleryPreviewActivity |![media-gallery-preview-activity-navbar](https://github.com/user-attachments/assets/8cd3d9ee-91ec-4bce-bdc9-7fc02395c79d)|![media-gallery-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/9b82aa3c-fcc6-4b0c-9150-3439c7a4c4fe)|![media-gallery-preview-activity-navbar](https://github.com/user-attachments/assets/7a538852-a66d-4641-a2a5-1d2d62a3ec5b)|![media-gallery-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/c28d2a9c-f437-4720-8344-f87d6b502568)|
| MediaPreviewActivity |![media-preview-activity-navbar](https://github.com/user-attachments/assets/f6c5cea7-ca43-4e3b-b31c-dd4eb7d11b1c)|![media-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/7b2a9faf-948a-4db4-b0eb-f8544875b5f9) |![media-preview-activity-navbar](https://github.com/user-attachments/assets/e5eb0e24-36a8-4459-b9e1-43e39b565006)|![media-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/25a94a58-b68c-4da4-bedd-86e4163ff5b7)|
| ChannelListActivity |![channel-list-activity-navbar](https://github.com/user-attachments/assets/a9afcf9f-ed93-4af6-8819-339ff9329352)|![channel-list-activity-navbar-landscape](https://github.com/user-attachments/assets/282c3d3e-0dc3-4a0d-9cf1-7453eba64d95)|![channel-list-activity-navbar](https://github.com/user-attachments/assets/1c70b3d1-d8d0-46e9-b3ca-40a138540da7)|![channel-list-activity-navbar-landscape](https://github.com/user-attachments/assets/e93264d6-0013-4645-99d6-65d70dc8d886)|
| AttachmentActivity |![attachment-activity-navbar](https://github.com/user-attachments/assets/e1e67c1d-7ca8-421c-ad2b-e760aa2f1103)|![attachment-activity-navbar-landscape](https://github.com/user-attachments/assets/798b25d5-ab8f-41ee-8ac7-1130d177446c) |![attachment-activity-navbar](https://github.com/user-attachments/assets/e4410672-2ed7-4746-94a5-b716c7051c58)|![attachment-activity-navbar-landscape](https://github.com/user-attachments/assets/b68f0836-59a9-4a1d-9248-8584d0238761)|
| AttachmentGalleryActivity |![attachment-gallery-activity-navbar](https://github.com/user-attachments/assets/c1b293d5-bdf6-4080-a206-b8ea7c4ceab5)|![attachment-gallery-activity-navbar-landscape](https://github.com/user-attachments/assets/7776e951-7066-4372-b4e1-229bc7ca5629)|![attachment-gallery-activity-navbar](https://github.com/user-attachments/assets/fe62a436-58ae-41eb-923b-5cc494341b7f)|![attachment-gallery-activity-navbar-landscape](https://github.com/user-attachments/assets/ce595974-9499-4a0a-a9c8-938313504260)|
| AttachmentMediaActivity |![attachment-media-activity-navbar](https://github.com/user-attachments/assets/3662fd36-5ba7-4f8e-89c3-6a841b9747ee)|![attachment-media-activity-navbar-landscape](https://github.com/user-attachments/assets/4ce276a0-8bb0-4f19-8486-f4ae9908b787)|![attachment-media-activity-navbar](https://github.com/user-attachments/assets/5d4826ec-85e4-4174-b617-18c758548e9d)|![attachment-media-activity-navbar-landscape](https://github.com/user-attachments/assets/662369b6-8745-4b06-82ed-2d977af365be)|
| MessageListActivity |![message-list-activity-navbar](https://github.com/user-attachments/assets/eb770672-7237-4614-8df1-7516b1bb2fdc)|![message-list-activity-navbar-landscape](https://github.com/user-attachments/assets/cc5ec13d-6667-4d11-bf75-3b30227bd714)|![message-list-activity-navbar](https://github.com/user-attachments/assets/4baaf15e-6a27-42cd-ab0f-7f8896c81043)|![message-list-activity-navbar-landscape](https://github.com/user-attachments/assets/63e2b345-3cbf-4e4d-ab46-d42b96aed5f0)|


#### TargetSdk = 35 (The components should not be cut-off by the system bars)
| Screen | Before (portrait) | Before (landscape) | After (portrait) | After (landscape) |
| --- | --- | --- | --- | --- |
| AttachmentDocumentActivity |![attachment-document-activity-navbar](https://github.com/user-attachments/assets/b09bf90f-b662-466d-9756-772a0ead0e6a)|![attachment-document-activity-navbar-landscape](https://github.com/user-attachments/assets/10e4ecd3-f38d-4d0d-8715-eff94562667e)|![attachment-document-activity-navbar](https://github.com/user-attachments/assets/f9562346-621d-4eb9-99d0-7f2466568fd1)|![attachment-document-activity-navbar-landscape](https://github.com/user-attachments/assets/c295dbe0-ce46-4142-b05c-47ababc155ab)|
| MediaGalleryPreviewActivity |![media-gallery-preview-activity-navbar](https://github.com/user-attachments/assets/14f192db-cdce-4587-b990-7362affb2d7c)|![media-gallery-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/9bd4d30b-1ffb-4ea0-9dac-a5f09b01b456)|![media-gallery-preview-activity-navbar](https://github.com/user-attachments/assets/723cd601-30dc-41e2-8ca0-c35931863bae)|![media-gallery-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/71c2eed1-813b-4a73-b1b0-25cc4524c3b5)|
| MediaPreviewActivity |![media-preview-activity-navbar](https://github.com/user-attachments/assets/0111b589-9de9-4f8c-9b74-5ed3652dc49b)|![media-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/fbb028ba-ceab-4387-a1ce-e0330f3ecc47)|![media-preview-activity-navbar](https://github.com/user-attachments/assets/0e8d8c04-02f4-40b4-8097-0e79687c6750)|![media-preview-activity-navbar-landscape](https://github.com/user-attachments/assets/9d9d7bd4-53bf-4b84-b377-cfe198606eea)|
| ChannelListActivity |![channel-list-activity-navbar](https://github.com/user-attachments/assets/140ecd9e-97f5-440a-b936-c64a540634c9)|![channel-list-activity-navbar-landscape](https://github.com/user-attachments/assets/7ee98bd8-9165-4799-9610-9576e3a400fd)|![channel-list-activity-navbar](https://github.com/user-attachments/assets/773cb9d9-03e0-4823-8755-ce38c2187472)|![channel-list-activity-navbar-landscape](https://github.com/user-attachments/assets/f3ee7cb9-e866-4ab0-98b0-bd769fd7a369)|
| AttachmentActivity |![attachment-activity-navbar](https://github.com/user-attachments/assets/03db593a-492d-4cea-b314-394f6272fe43)|![attachment-activity-navbar-landscape](https://github.com/user-attachments/assets/e61ec825-1049-4622-a817-5f096c63a863)|![attachment-activity-navbar](https://github.com/user-attachments/assets/af5e47f3-f3c5-4582-a1dd-92eec044de19)|![attachment-activity-navbar-landscape](https://github.com/user-attachments/assets/3664965b-91ba-40fd-a331-0b821c68f114)|
| AttachmentGalleryActivity |![attachment-galley-activity-navbar](https://github.com/user-attachments/assets/8b9c49dd-329c-49df-87a8-e00b14b9308d)|![attachment-galley-activity-navbar-landscape](https://github.com/user-attachments/assets/63820df3-03dd-4ef2-868b-ae1f2e9ed1e2)|![attachment-gallery-activity-navbar](https://github.com/user-attachments/assets/2fa63c9d-2c77-47d6-866c-dfecd02ed78b)|![attachment-gallery-activity-navbar-landscape](https://github.com/user-attachments/assets/1ceebd9f-175e-4e43-9d56-2dcd531f6904)|
| AttachmentMediaActivity |![attachment-media-activity-navbar](https://github.com/user-attachments/assets/420f8a0e-f44c-4abf-ba57-a2830c123584)|![attachment-media-activity-navbar-landscape](https://github.com/user-attachments/assets/3601eea5-4f10-47d8-b36a-fb2a0017258d)|![attachment-media-activity-navbar](https://github.com/user-attachments/assets/97573915-f881-4d58-939a-f47c2e9b24f2)|![attachment-media-activity-navbar-landscape](https://github.com/user-attachments/assets/2aaedd7c-413f-40c8-81a0-51b1fc65cb66)|
| MessageListActivity |![message-list-activity-navbar](https://github.com/user-attachments/assets/4819b9b2-7bc3-4450-aae7-d0524f0b97db)|![message-list-activity-navbar-landscape](https://github.com/user-attachments/assets/871aa3c7-df4d-4d87-b326-f8f0aef291a6)|![messale-list-activity-navbar](https://github.com/user-attachments/assets/8c0b5a21-23ea-4819-96a9-f5865209e973)|![message-list-activity-navbar-landscape](https://github.com/user-attachments/assets/b342664b-c332-4c4c-8562-2f913cb827ac)|

### 🧪 Testing
1. Set `Configuration.sampleTargetSdk = 35`
2. Install either `ui-components-sample` or `compose-sample`
3. Open any of the affected screens (Ex. open Image/Audio/Video/PDF attachment) from a channel


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
