### PR TITLE
[AND-11] Expose flagUser/unflagUser on MessageListController and MessageListViewModels.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessageListController.flagUser()` and `MessageListController.unflagUser()` methods for flagging/un-flagging users. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
+- Add `MessageListController.ErrorEvent`s - `FlagUserError` and `UnflagUserError` representing errors which occurred during the execution of the corresponding operations. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
 
 ### ⚠️ Changed
 - 🚨 Breaking change: The `MessagePositionHandler.handleMessagePosition` function now includes a new parameter, `isBeforeDateSeparator`, to handle message positioning more precisely within a group of messages. [#5466](https://github.com/GetStream/stream-chat-android/pull/5466)
@@ -64,6 +66,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessageListViewModel.flagUser()` and `MessageListViewModel.unflagUser()` methods for flagging/un-flagging users. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
 
 ### ⚠️ Changed
 
@@ -75,6 +78,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessageListViewModel.flagUser()` and `MessageListViewModel.unflagUser()` methods for flagging/un-flagging users. [#5478](https://github.com/GetStream/stream-chat-android/pull/5478)
 
 ### ⚠️ Changed
 - 🚨 Breaking change: Replace usage of `RippleTheme` with `StreamRippleConfiguration` for customizing ripples via `ChatTheme`. [#5475](https://github.com/GetStream/stream-chat-android/pull/5475)

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -3570,6 +3570,8 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public final fun dismissMessageAction (Lio/getstream/chat/android/ui/common/state/messages/MessageAction;)V
 	public final fun displayPollMoreOptions (Lio/getstream/chat/android/ui/common/state/messages/poll/SelectedPoll;)V
 	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;)V
+	public final fun flagUser (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun flagUser$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getCurrentMessagesState ()Lio/getstream/chat/android/ui/common/state/messages/list/MessageListState;
@@ -3614,6 +3616,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public static synthetic fun shadowBanUser$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
 	public final fun unbanUser (Ljava/lang/String;)V
+	public final fun unflagUser (Ljava/lang/String;)V
 	public final fun unmuteUser (Ljava/lang/String;)V
 	public final fun updateLastSeenMessage (Lio/getstream/chat/android/models/Message;)V
 	public final fun updatePollState (Lio/getstream/chat/android/models/Poll;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/ui/common/state/messages/poll/PollSelectionType;)V

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -291,7 +291,6 @@ public class MessageListViewModel(
      * @param message Message to delete.
      */
     @JvmOverloads
-    @Suppress("ConvertArgumentToSet")
     public fun deleteMessage(message: Message, hard: Boolean = false) {
         messageListController.deleteMessage(message, hard)
     }
@@ -302,7 +301,6 @@ public class MessageListViewModel(
      *
      * @param message Message to delete.
      */
-    @Suppress("ConvertArgumentToSet")
     public fun flagMessage(
         message: Message,
         reason: String?,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -391,6 +391,30 @@ public class MessageListViewModel(
     }
 
     /**
+     * Flags a user identified by the provided ID.
+     *
+     * @param userId The ID of the user to flag.
+     * @param reason The reason for flagging the user.
+     * @param customData Additional key-value data submitted with the request.
+     */
+    public fun flagUser(
+        userId: String,
+        reason: String? = null,
+        customData: Map<String, String> = emptyMap(),
+    ) {
+        messageListController.flagUser(userId = userId, reason = reason, customData = customData)
+    }
+
+    /**
+     * Un-flags a user identified by the provided ID.
+     *
+     * @param userId The ID of the user to un-flag.
+     */
+    public fun unflagUser(userId: String) {
+        messageListController.unflagUser(userId)
+    }
+
+    /**
      * Leaves the thread we're in and resets the state of the [messageMode] and both of the [MessageListState]s.
      */
     public fun leaveThread() {

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -148,6 +148,8 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public static synthetic fun enterThreadMode$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public final fun flagMessage (Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun flagMessage$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
+	public final fun flagUser (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public static synthetic fun flagUser$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public final fun getChannel ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getChannelState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun getConnectionState ()Lkotlinx/coroutines/flow/StateFlow;
@@ -213,6 +215,7 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public static synthetic fun shadowBanUser$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
 	public final fun unbanUser (Ljava/lang/String;)V
 	public final fun unblockUser (Ljava/lang/String;)V
+	public final fun unflagUser (Ljava/lang/String;)V
 	public final fun unmuteUser (Lio/getstream/chat/android/models/User;)V
 	public final fun unmuteUser (Ljava/lang/String;)V
 	public final fun unpinMessage (Lio/getstream/chat/android/models/Message;)V
@@ -250,6 +253,18 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun component1 ()Lio/getstream/result/Error;
 	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagMessageError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getStreamError ()Lio/getstream/result/Error;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagUserError : io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/result/Error;)V
+	public final fun component1 ()Lio/getstream/result/Error;
+	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagUserError;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagUserError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$FlagUserError;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getStreamError ()Lio/getstream/result/Error;
 	public fun hashCode ()I
@@ -334,6 +349,18 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun component1 ()Lio/getstream/result/Error;
 	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$PollRemovingVoteError;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$PollRemovingVoteError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$PollRemovingVoteError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getStreamError ()Lio/getstream/result/Error;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnflagUserError : io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/result/Error;)V
+	public final fun component1 ()Lio/getstream/result/Error;
+	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnflagUserError;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnflagUserError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnflagUserError;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getStreamError ()Lio/getstream/result/Error;
 	public fun hashCode ()I

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -2030,6 +2030,38 @@ public class MessageListController(
     }
 
     /**
+     * Flags a user identified by the provided ID.
+     *
+     * @param userId The ID of the user to flag.
+     * @param reason The reason for flagging the user.
+     * @param customData Additional key-value data submitted with the request.
+     */
+    public fun flagUser(
+        userId: String,
+        reason: String? = null,
+        customData: Map<String, String> = emptyMap(),
+    ) {
+        chatClient
+            .flagUser(userId = userId, reason = reason, customData = customData)
+            .enqueue(onError = { error ->
+                onActionResult(error) { ErrorEvent.FlagUserError(it) }
+            })
+    }
+
+    /**
+     * Un-flags a user identified by the provided ID.
+     *
+     * @param userId The ID of the user to un-flag.
+     */
+    public fun unflagUser(userId: String) {
+        chatClient
+            .unflagUser(userId = userId)
+            .enqueue(onError = { error ->
+                onActionResult(error) { ErrorEvent.UnflagUserError(it) }
+            })
+    }
+
+    /**
      * Block a user. Unlike ban the block is not channel related but rather directly to the user.
      *
      * @param userId the id of the user that will be blocked.
@@ -2321,6 +2353,20 @@ public class MessageListController(
          * @param streamError Contains the original [Throwable] along with a message.
          */
         public data class BlockUserError(override val streamError: Error) : ErrorEvent(streamError)
+
+        /**
+         * Error occurring during the operation of flagging a user.
+         *
+         * @param streamError Contains the original [Throwable] along with a message.
+         */
+        public data class FlagUserError(override val streamError: Error) : ErrorEvent(streamError)
+
+        /**
+         * Error occurring during the operation of un-flagging a user.
+         *
+         * @param streamError Contains the original [Throwable] along with a message.
+         */
+        public data class UnflagUserError(override val streamError: Error) : ErrorEvent(streamError)
 
         /**
          * When an error occurs while pinning a message.

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4500,6 +4500,22 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagUser : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagUser;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagUser;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$FlagUser;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCustomData ()Ljava/util/Map;
+	public final fun getReason ()Ljava/lang/String;
+	public final fun getUserId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$GiphyActionSelected : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
 	public fun <init> (Lio/getstream/chat/android/ui/common/state/messages/list/GiphyAction;)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/common/state/messages/list/GiphyAction;
@@ -4720,6 +4736,17 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnbanUser;Lio/getstream/chat/android/models/User;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnbanUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getUser ()Lio/getstream/chat/android/models/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnflagUser : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnflagUser;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnflagUser;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnflagUser;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -309,6 +309,8 @@ public class MessageListView : ConstraintLayout {
             is MessageListController.ErrorEvent.MuteUserError -> R.string.stream_ui_message_list_error_mute_user
             is MessageListController.ErrorEvent.UnmuteUserError -> R.string.stream_ui_message_list_error_unmute_user
             is MessageListController.ErrorEvent.BlockUserError -> R.string.stream_ui_message_list_error_block_user
+            is MessageListController.ErrorEvent.FlagUserError -> R.string.stream_ui_message_list_error_flag_user
+            is MessageListController.ErrorEvent.UnflagUserError -> R.string.stream_ui_message_list_error_unflag_user
             is MessageListController.ErrorEvent.FlagMessageError -> R.string.stream_ui_message_list_error_flag_message
             is MessageListController.ErrorEvent.PinMessageError -> R.string.stream_ui_message_list_error_pin_message
             is MessageListController.ErrorEvent.UnpinMessageError -> R.string.stream_ui_message_list_error_unpin_message

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -242,6 +242,8 @@ public class MessageListViewModel(
             is Event.UnbanUser -> messageListController.unbanUser(event.user.id)
             is Event.ShadowBanUser -> messageListController.shadowBanUser(event.user.id)
             is Event.RemoveShadowBanFromUser -> messageListController.removeShadowBanFromUser(event.user.id)
+            is Event.FlagUser -> messageListController.flagUser(event.userId, event.reason, event.customData)
+            is Event.UnflagUser -> messageListController.unflagUser(event.userId)
             is Event.RemoveAttachment -> messageListController.removeAttachment(event.messageId, event.attachment)
             is Event.FlagMessage -> messageListController.flagMessage(
                 event.message,
@@ -673,6 +675,26 @@ public class MessageListViewModel(
          * @param user The user to be blocked.
          */
         public data class RemoveShadowBanFromUser(val user: User) : Event()
+
+        /**
+         * Event for flagging a user.
+         *
+         * @param userId The ID of the user to flag.
+         * @param reason The reason for flagging the user.
+         * @param customData Additional key-value data submitted with the request.
+         */
+        public data class FlagUser(
+            val userId: String,
+            val reason: String? = null,
+            val customData: Map<String, String> = emptyMap(),
+        ) : Event()
+
+        /**
+         * Event for flagging a user.
+         *
+         * @param userId The ID of the user to un-flag.
+         */
+        public data class UnflagUser(val userId: String) : Event()
 
         /**
          * When the user replies to a message.

--- a/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
@@ -88,6 +88,8 @@
     <string name="stream_ui_message_list_error_mute_user">Failed to mute user</string>
     <string name="stream_ui_message_list_error_unmute_user">Failed to unmute user</string>
     <string name="stream_ui_message_list_error_block_user">Failed to block user</string>
+    <string name="stream_ui_message_list_error_flag_user">Failed to flag user</string>
+    <string name="stream_ui_message_list_error_unflag_user">Failed to un-flag user</string>
     <string name="stream_ui_message_list_error_flag_message">Failed to flag message</string>
     <string name="stream_ui_message_list_error_pin_message">Failed to pin message</string>
     <string name="stream_ui_message_list_error_mark_as_unread_message">Failed to mark as unread message</string>


### PR DESCRIPTION
### 🎯 Goal
Exposes the `flagUser()` and `unflagUser()` methods on the `MessageListController` and `MessageListViewModel (xml and compose)` so that they can be invoked from the UI components, without accessing the `ChatClient` directly.

Linear: https://linear.app/stream/issue/AND-11/expose-flaguserunflaguser-on-messagelistcontrollermessagelistviewmodel

### 🛠 Implementation details
- Expose `flagUser()`/`unflagUser()` on the `MessageListController` (delegates the call to the `ChatClient`)
- Create new `ErrorEvent.FlagUserError` and `ErrorEvent.UnflagUserError` for handling errors which occurred while performing the corresponding operation
- Expose `flagUser()`/`unflagUser()` on the `MessageListViewModel(compose)`
- Create new `Event.FlagUser` and `Event.UnflagUser` for triggering the corresponding operations from the `xml` SDK.

### 🎨 UI Changes
_NA_

### 🧪 Testing

- Not really testable, as we don't provide a UI for the `flagUser` operations.


### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR targets the `develop` branch
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
