### PR TITLE
[AND-13] Add channel info when searching for messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add support for moderation V2. Add `moderation` field in `Message` model to support the new version of moderation. [#5493](https://github.com/GetStream/stream-chat-android/pull/5493)
 
 ### ⚠️ Changed
+- 🚨 Breaking change: ViewModels related with "searching messages" feature provide a `List<MessageResult>` instead of a `List<Message>`. [#5500](https://github.com/GetStream/stream-chat-android/pull/5500)
 
 ### ❌ Removed
 
@@ -83,8 +84,10 @@
 - Add `ChatTheme.keyboardBehaviour` property to customize different keyboard behaviours. [#5506](https://github.com/GetStream/stream-chat-android/pull/5506)
 - Add `MessageOptionItemVisibility.isBlockUserVisible` property to show/hide the block user option. [#5512](https://github.com/GetStream/stream-chat-android/pull/5512)
 - Add `ChatTheme.channelOptionsTheme` property to customize the channel options. [#5513](https://github.com/GetStream/stream-chat-android/pull/5513) 
+- Add `SearchResultItemState.channel` property containing the cached info of the channel where the message was sent. [#5500](https://github.com/GetStream/stream-chat-android/pull/5500)
 
 ### ⚠️ Changed
+- 🚨 Breaking change: The `SearchResultNameFormatter.formatMessageTitle` method receives a `SearchResultItemState` instead of a `Message`. [#5500](https://github.com/GetStream/stream-chat-android/pull/5500)
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -3422,7 +3422,7 @@ public final class io/getstream/chat/android/compose/ui/util/ReactionIconFactory
 
 public abstract interface class io/getstream/chat/android/compose/ui/util/SearchResultNameFormatter {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/util/SearchResultNameFormatter$Companion;
-	public abstract fun formatMessageTitle (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;)Landroidx/compose/ui/text/AnnotatedString;
+	public abstract fun formatMessageTitle (Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;Lio/getstream/chat/android/models/User;Landroidx/compose/runtime/Composer;I)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class io/getstream/chat/android/compose/ui/util/SearchResultNameFormatter$Companion {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -745,10 +745,8 @@ public final class io/getstream/chat/android/compose/ui/channels/list/Composable
 public final class io/getstream/chat/android/compose/ui/channels/list/ComposableSingletons$SearchResultItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channels/list/ComposableSingletons$SearchResultItemKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function4;
-	public static field lambda-2 Lkotlin/jvm/functions/Function4;
 	public fun <init> ()V
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/list/SearchResultItemKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -104,11 +104,13 @@ public final class io/getstream/chat/android/compose/state/channels/list/ItemSta
 
 public final class io/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState : io/getstream/chat/android/compose/state/channels/list/ItemState {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/models/Message;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
-	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;
+	public final fun component2 ()Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
 	public fun getKey ()Ljava/lang/String;
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public fun hashCode ()I

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
@@ -45,9 +45,12 @@ public sealed class ItemState {
      * Represents each search result item we show in the list of channels.
      *
      * @param message The message to show.
+     * @param channel The channel where the message was sent.
+     * It can be null if the channel was not found on the local cache.
      */
     public data class SearchResultItemState(
         val message: Message,
+        val channel: Channel?,
     ) : ItemState() {
         override val key: String = message.id
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/SearchResultItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/SearchResultItem.kt
@@ -145,7 +145,7 @@ internal fun RowScope.DefaultSearchResultItemCenterContent(
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = ChatTheme.searchResultNameFormatter.formatMessageTitle(searchResultItemState.message, currentUser),
+            text = ChatTheme.searchResultNameFormatter.formatMessageTitle(searchResultItemState, currentUser),
             style = ChatTheme.typography.bodyBold,
             fontSize = 16.sp,
             maxLines = 1,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/SearchResultItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/SearchResultItem.kt
@@ -67,6 +67,7 @@ public fun SearchResultItem(
     leadingContent: @Composable RowScope.(ItemState.SearchResultItemState) -> Unit = {
         DefaultSearchResultItemLeadingContent(
             searchResultItemState = it,
+            currentUser = currentUser,
         )
     },
     centerContent: @Composable RowScope.(ItemState.SearchResultItemState) -> Unit = {
@@ -107,22 +108,33 @@ public fun SearchResultItem(
  * the message.
  *
  * @param searchResultItemState The state of the search result item.
+ * @param currentUser The currently logged in user.
  */
 @Composable
 internal fun DefaultSearchResultItemLeadingContent(
     searchResultItemState: ItemState.SearchResultItemState,
+    currentUser: User?,
 ) {
-    UserAvatar(
-        user = searchResultItemState.message.user,
-        modifier = Modifier
-            .padding(
-                start = ChatTheme.dimens.channelItemHorizontalPadding,
-                end = 4.dp,
-                top = ChatTheme.dimens.channelItemVerticalPadding,
-                bottom = ChatTheme.dimens.channelItemVerticalPadding,
+    (
+        searchResultItemState
+            .channel
+            ?.takeIf { it.members.size == 2 }
+            ?.let { it.members.firstOrNull { it.getUserId() != currentUser?.id }?.user }
+            ?: searchResultItemState.message.user
+        )
+        .let { user ->
+            UserAvatar(
+                user = user,
+                modifier = Modifier
+                    .padding(
+                        start = ChatTheme.dimens.channelItemHorizontalPadding,
+                        end = 4.dp,
+                        top = ChatTheme.dimens.channelItemVerticalPadding,
+                        bottom = ChatTheme.dimens.channelItemVerticalPadding,
+                    )
+                    .size(ChatTheme.dimens.channelAvatarSize),
             )
-            .size(ChatTheme.dimens.channelAvatarSize),
-    )
+        }
 }
 
 /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
@@ -108,7 +108,7 @@ public fun PinnedMessageList(
         state.results.isEmpty() && state.isLoading -> loadingContent()
         state.results.isEmpty() && !state.isLoading -> emptyContent()
         else -> PinnedMessages(
-            messages = state.results,
+            messages = state.results.map { it.message },
             modifier = modifier,
             itemContent = itemContent,
             itemDivider = itemDivider,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/SearchResultNameFormatter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/SearchResultNameFormatter.kt
@@ -17,11 +17,13 @@
 package io.getstream.chat.android.compose.ui.util
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.withStyle
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.channels.list.ItemState
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.User
@@ -78,7 +80,7 @@ private object DefaultSearchResultNameFormatter : SearchResultNameFormatter {
                         ?: searchResultItem.message.channelInfo?.name
                     )
                     ?.let { channelName ->
-                        append(" in ")
+                        append(stringResource(R.string.stream_compose_in))
                         withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
                             append(channelName)
                         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
@@ -256,12 +256,19 @@ public class ChannelListViewModel(
         logger.d { "[observeSearchMessages] query: '$query'" }
         searchMessageState.filterNotNull().collectLatest {
             logger.v { "[observeSearchMessages] state: ${it.stringify()}" }
+            val channels = chatClient.repositoryFacade.selectChannels(it.messages.map { message -> message.cid })
             channelsState = channelsState.copy(
                 searchQuery = searchQuery.value,
                 isLoading = it.isLoading,
                 isLoadingMore = it.isLoadingMore,
                 endOfChannels = !it.canLoadMore,
-                channelItems = it.messages.map(ItemState::SearchResultItemState),
+                channelItems = it.messages.map {
+                    val channel = channels.firstOrNull { channel -> channel.cid == it.cid }
+                    ItemState.SearchResultItemState(
+                        message = it,
+                        channel = channel,
+                    )
+                },
             )
         }
     }.onFailure {

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -242,6 +242,7 @@
 
     <!--  Threads  -->
     <string name="stream_compose_thread_list_empty_title">No threads here yet...</string>
+    <string name="stream_compose_in">" in "</string>
     <plurals name="stream_compose_thread_list_new_threads">
         <item quantity="one">%d new thread</item>
         <item quantity="other">%d new threads</item>

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -558,6 +558,20 @@ public final class io/getstream/chat/android/ui/common/images/resizing/StreamCdn
 	public final fun defaultStreamCdnImageResizing ()Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;
 }
 
+public final class io/getstream/chat/android/ui/common/model/MessageResult {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Message;
+	public final fun component2 ()Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;)Lio/getstream/chat/android/ui/common/model/MessageResult;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/model/MessageResult;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/model/MessageResult;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
+	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/common/notifications/StreamCoilUserIconBuilder : io/getstream/chat/android/client/notifications/handler/UserIconBuilder {
 	public static final field $stable I
 	public fun <init> (Landroid/content/Context;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/pinned/PinnedMessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/pinned/PinnedMessageListController.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.querysort.QuerySortByField
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.common.state.pinned.PinnedMessageListState
 import io.getstream.log.TaggedLogger
 import io.getstream.log.taggedLogger
@@ -97,7 +98,7 @@ public class PinnedMessageListController(
             _state.update { current ->
                 current.copy(
                     isLoading = true,
-                    results = current.results + Message(),
+                    results = current.results + MessageResult(Message(), null),
                 )
             }
             loadPinnedMessages()
@@ -118,7 +119,14 @@ public class PinnedMessageListController(
                 logger.d { "Loaded ${messages.size} pinned messages" }
                 _state.update { current ->
                     current.copy(
-                        results = (current.results + messages).filter { it.id.isNotEmpty() },
+                        results = (
+                            current.results + messages.map { message ->
+                                MessageResult(
+                                    message,
+                                    null,
+                                )
+                            }
+                            ).filter { it.message.id.isNotEmpty() },
                         isLoading = false,
                         canLoadMore = messages.size == QUERY_LIMIT,
                         nextDate = messages.lastOrNull()?.pinnedAt ?: nextDate,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/model/MessageResult.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/model/MessageResult.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.model
+
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.Message
+
+public data class MessageResult(
+    val message: Message,
+    val channel: Channel?,
+)

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/pinned/PinnedMessageListControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/pinned/PinnedMessageListControllerTest.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.test.TestCall
 import io.getstream.chat.android.test.TestCoroutineRule
 import io.getstream.chat.android.test.callFrom
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.result.Error
 import io.getstream.result.Result
 import io.getstream.result.call.Call
@@ -80,6 +81,7 @@ internal class PinnedMessageListControllerTest {
         // given
         val pinnedMessages = generatePinnedMessages(count = 1)
         val returnValue = callFrom { pinnedMessages }
+        val expectedResult = pinnedMessages.map { MessageResult(it, null) }
         val controller = PinnedMessageListController(cid, mockChannelClient(returnValue))
         // when
         val loadingState = controller.state.value
@@ -93,7 +95,7 @@ internal class PinnedMessageListControllerTest {
         // verify loaded state
         loadedState.canLoadMore `should be equal to` false
         loadedState.isLoading `should be equal to` false
-        loadedState.results `should be equal to` pinnedMessages
+        loadedState.results `should be equal to` expectedResult
     }
 
     @Test
@@ -101,6 +103,7 @@ internal class PinnedMessageListControllerTest {
         // given
         val pinnedMessages = generatePinnedMessages(count = 30)
         val returnValue = callFrom { pinnedMessages }
+        val expectedResult = pinnedMessages.map { MessageResult(it, null) }
         val controller = PinnedMessageListController(cid, mockChannelClient(returnValue))
         // when
         val loadingState = controller.state.value
@@ -114,7 +117,7 @@ internal class PinnedMessageListControllerTest {
         // verify loaded state
         loadedState.canLoadMore `should be equal to` true
         loadedState.isLoading `should be equal to` false
-        loadedState.results `should be equal to` pinnedMessages
+        loadedState.results `should be equal to` expectedResult
     }
 
     @Test
@@ -122,6 +125,7 @@ internal class PinnedMessageListControllerTest {
         // given
         val pinnedMessages = generatePinnedMessages(count = 1)
         val returnValue = callFrom { pinnedMessages }
+        val expectedResult = pinnedMessages.map { MessageResult(it, null) }
         val channelClient = mockChannelClient(returnValue)
         val controller = PinnedMessageListController(cid, channelClient)
         // when
@@ -132,7 +136,7 @@ internal class PinnedMessageListControllerTest {
         // verify loaded state
         loadedState.canLoadMore `should be equal to` false
         loadedState.isLoading `should be equal to` false
-        loadedState.results `should be equal to` pinnedMessages
+        loadedState.results `should be equal to` expectedResult
         // verify channelClient.getPinnedMessages was called only twice
         verify(channelClient, times(1)).getPinnedMessages(any(), any(), any())
     }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4232,6 +4232,8 @@ public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListVi
 
 public final class io/getstream/chat/android/ui/viewmodel/mentions/MentionListViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> ()V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getErrorEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getState ()Landroidx/lifecycle/LiveData;
 	public final fun loadMore ()V
@@ -4904,6 +4906,8 @@ public final class io/getstream/chat/android/ui/viewmodel/pinned/PinnedMessageLi
 
 public final class io/getstream/chat/android/ui/viewmodel/search/SearchViewModel : androidx/lifecycle/ViewModel {
 	public fun <init> ()V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getErrorEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getState ()Landroidx/lifecycle/LiveData;
 	public final fun loadMore ()V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/internal/MessageResultDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/internal/MessageResultDiffCallback.kt
@@ -14,22 +14,19 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.ui.common.state.pinned
+package io.getstream.chat.android.ui.feature.internal
 
+import androidx.recyclerview.widget.DiffUtil
 import io.getstream.chat.android.ui.common.model.MessageResult
-import java.util.Date
 
-/**
- * Represents the pinned message list state, used to render the required UI.
- *
- * @param canLoadMore Indicator if we've reached the end of messages, to stop triggering pagination.
- * @param results The messages to render.
- * @param isLoading Indicator if we're currently loading data (initial load).
- * @param nextDate Date used to fetch next page of the messages.
- */
-public data class PinnedMessageListState(
-    val canLoadMore: Boolean,
-    val results: List<MessageResult>,
-    val isLoading: Boolean,
-    val nextDate: Date,
-)
+internal object MessageResultDiffCallback : DiffUtil.ItemCallback<MessageResult>() {
+    override fun areItemsTheSame(
+        oldItem: MessageResult,
+        newItem: MessageResult,
+    ): Boolean = oldItem.message.id == newItem.message.id
+
+    override fun areContentsTheSame(
+        oldItem: MessageResult,
+        newItem: MessageResult,
+    ): Boolean = oldItem == newItem
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/mentions/list/MentionListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/mentions/list/MentionListView.kt
@@ -25,6 +25,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiMentionListViewBinding
 import io.getstream.chat.android.ui.feature.mentions.list.internal.MentionListAdapter
 import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
@@ -85,7 +86,7 @@ public class MentionListView : ViewFlipper {
         }
     }
 
-    public fun showMessages(messages: List<Message>) {
+    public fun showMessages(messages: List<MessageResult>) {
         val isEmpty = messages.isEmpty()
 
         displayedChild = if (isEmpty) Flipper.EMPTY else Flipper.RESULTS

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/mentions/list/internal/MentionListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/mentions/list/internal/MentionListAdapter.kt
@@ -17,21 +17,19 @@
 package io.getstream.chat.android.ui.feature.mentions.list.internal
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.ChatUI
-import io.getstream.chat.android.ui.common.extensions.internal.context
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionListBinding
+import io.getstream.chat.android.ui.feature.internal.MessageResultDiffCallback
 import io.getstream.chat.android.ui.feature.mentions.list.MentionListView.MentionSelectedListener
 import io.getstream.chat.android.ui.feature.mentions.list.internal.MentionListAdapter.MessagePreviewViewHolder
 import io.getstream.chat.android.ui.feature.messages.preview.MessagePreviewStyle
 import io.getstream.chat.android.ui.feature.messages.preview.internal.MessagePreviewView
-import io.getstream.chat.android.ui.utils.extensions.asMention
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
-internal class MentionListAdapter : ListAdapter<Message, MessagePreviewViewHolder>(MessageDiffCallback) {
+internal class MentionListAdapter : ListAdapter<MessageResult, MessagePreviewViewHolder>(MessageResultDiffCallback) {
 
     private var mentionSelectedListener: MentionSelectedListener? = null
 
@@ -66,24 +64,9 @@ internal class MentionListAdapter : ListAdapter<Message, MessagePreviewViewHolde
             }
         }
 
-        internal fun bind(message: Message) {
-            this.message = message
-            view.setMessage(message, ChatUI.currentUserProvider.getCurrentUser()?.asMention(context))
-        }
-    }
-
-    private object MessageDiffCallback : DiffUtil.ItemCallback<Message>() {
-        override fun areItemsTheSame(oldItem: Message, newItem: Message): Boolean {
-            return oldItem.id == newItem.id
-        }
-
-        override fun areContentsTheSame(oldItem: Message, newItem: Message): Boolean {
-            // Comparing only properties used by the ViewHolder
-            return oldItem.id == newItem.id &&
-                oldItem.createdAt == newItem.createdAt &&
-                oldItem.createdLocallyAt == newItem.createdLocallyAt &&
-                oldItem.text == newItem.text &&
-                oldItem.user == newItem.user
+        internal fun bind(messageResult: MessageResult) {
+            this.message = messageResult.message
+            view.renderMessageResult(messageResult)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/PinnedMessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/PinnedMessageListView.kt
@@ -26,6 +26,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiPinnedMessageListViewBinding
 import io.getstream.chat.android.ui.feature.pinned.list.internal.PinnedMessageListAdapter
 import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
@@ -90,12 +91,12 @@ public class PinnedMessageListView : ViewFlipper {
         )
     }
 
-    public fun showMessages(messages: List<Message>) {
-        val isEmpty = messages.isEmpty()
+    public fun showMessages(messageResults: List<MessageResult>) {
+        val isEmpty = messageResults.isEmpty()
 
         displayedChild = if (isEmpty) Flipper.EMPTY else Flipper.RESULTS
 
-        adapter.submitList(messages)
+        adapter.submitList(messageResults)
         scrollListener.enablePagination()
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/internal/PinnedMessageListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/internal/PinnedMessageListAdapter.kt
@@ -28,7 +28,8 @@ import io.getstream.chat.android.ui.feature.messages.preview.MessagePreviewStyle
 import io.getstream.chat.android.ui.feature.pinned.list.PinnedMessageListView.PinnedMessageSelectedListener
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
-internal class PinnedMessageListAdapter : ListAdapter<MessageResult, RecyclerView.ViewHolder>(MessageResultDiffCallback) {
+internal class PinnedMessageListAdapter :
+    ListAdapter<MessageResult, RecyclerView.ViewHolder>(MessageResultDiffCallback) {
 
     private var pinnedMessageSelectedListener: PinnedMessageSelectedListener? = null
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/internal/PinnedMessageListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/pinned/list/internal/PinnedMessageListAdapter.kt
@@ -17,20 +17,18 @@
 package io.getstream.chat.android.ui.feature.pinned.list.internal
 
 import android.view.ViewGroup
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.ChatUI
-import io.getstream.chat.android.ui.common.extensions.internal.context
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionListBinding
 import io.getstream.chat.android.ui.databinding.StreamUiPinnedMessageListLoadingMoreViewBinding
+import io.getstream.chat.android.ui.feature.internal.MessageResultDiffCallback
 import io.getstream.chat.android.ui.feature.messages.preview.MessagePreviewStyle
 import io.getstream.chat.android.ui.feature.pinned.list.PinnedMessageListView.PinnedMessageSelectedListener
-import io.getstream.chat.android.ui.utils.extensions.asMention
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
-internal class PinnedMessageListAdapter : ListAdapter<Message, RecyclerView.ViewHolder>(MessageDiffCallback) {
+internal class PinnedMessageListAdapter : ListAdapter<MessageResult, RecyclerView.ViewHolder>(MessageResultDiffCallback) {
 
     private var pinnedMessageSelectedListener: PinnedMessageSelectedListener? = null
 
@@ -60,7 +58,7 @@ internal class PinnedMessageListAdapter : ListAdapter<Message, RecyclerView.View
     }
 
     override fun getItemViewType(position: Int): Int {
-        return if (getItem(position).id.isNotEmpty()) {
+        return if (getItem(position).message.id.isNotEmpty()) {
             ITEM_MESSAGE
         } else {
             ITEM_LOADING_MORE
@@ -77,7 +75,7 @@ internal class PinnedMessageListAdapter : ListAdapter<Message, RecyclerView.View
     }
 
     inner class PinnedMessageLoadingMoreView(
-        private val binding: StreamUiPinnedMessageListLoadingMoreViewBinding,
+        binding: StreamUiPinnedMessageListLoadingMoreViewBinding,
     ) : RecyclerView.ViewHolder(binding.root)
 
     inner class MessagePreviewViewHolder(
@@ -92,24 +90,9 @@ internal class PinnedMessageListAdapter : ListAdapter<Message, RecyclerView.View
             }
         }
 
-        internal fun bind(message: Message) {
-            this.message = message
-            binding.root.setMessage(message, ChatUI.currentUserProvider.getCurrentUser()?.asMention(context))
-        }
-    }
-
-    private object MessageDiffCallback : DiffUtil.ItemCallback<Message>() {
-        override fun areItemsTheSame(oldItem: Message, newItem: Message): Boolean {
-            return oldItem.id == newItem.id
-        }
-
-        override fun areContentsTheSame(oldItem: Message, newItem: Message): Boolean {
-            // Comparing only properties used by the ViewHolder
-            return oldItem.id == newItem.id &&
-                oldItem.createdAt == newItem.createdAt &&
-                oldItem.createdLocallyAt == newItem.createdLocallyAt &&
-                oldItem.text == newItem.text &&
-                oldItem.user == newItem.user
+        internal fun bind(messageResult: MessageResult) {
+            this.message = messageResult.message
+            binding.root.renderMessageResult(messageResult)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/search/internal/SearchResultListAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/search/internal/SearchResultListAdapter.kt
@@ -18,22 +18,20 @@ package io.getstream.chat.android.ui.feature.search.internal
 
 import android.view.ViewGroup
 import androidx.core.view.updateLayoutParams
-import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.ui.ChatUI
-import io.getstream.chat.android.ui.common.extensions.internal.context
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiItemMentionListBinding
+import io.getstream.chat.android.ui.feature.internal.MessageResultDiffCallback
 import io.getstream.chat.android.ui.feature.search.internal.SearchResultListAdapter.MessagePreviewViewHolder
 import io.getstream.chat.android.ui.feature.search.list.SearchResultListView.SearchResultSelectedListener
 import io.getstream.chat.android.ui.feature.search.list.SearchResultListViewStyle
-import io.getstream.chat.android.ui.utils.extensions.asMention
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
 internal class SearchResultListAdapter(
     private val style: SearchResultListViewStyle,
-) : ListAdapter<Message, MessagePreviewViewHolder>(MessageDiffCallback) {
+) : ListAdapter<MessageResult, MessagePreviewViewHolder>(MessageResultDiffCallback) {
 
     private var searchResultSelectedListener: SearchResultSelectedListener? = null
 
@@ -84,24 +82,9 @@ internal class SearchResultListAdapter(
             }
         }
 
-        internal fun bind(message: Message) {
-            this.message = message
-            binding.root.setMessage(message, ChatUI.currentUserProvider.getCurrentUser()?.asMention(context))
-        }
-    }
-
-    private object MessageDiffCallback : DiffUtil.ItemCallback<Message>() {
-        override fun areItemsTheSame(oldItem: Message, newItem: Message): Boolean {
-            return oldItem.id == newItem.id
-        }
-
-        override fun areContentsTheSame(oldItem: Message, newItem: Message): Boolean {
-            // Comparing only properties used by the ViewHolder
-            return oldItem.id == newItem.id &&
-                oldItem.createdAt == newItem.createdAt &&
-                oldItem.createdLocallyAt == newItem.createdLocallyAt &&
-                oldItem.text == newItem.text &&
-                oldItem.user == newItem.user
+        internal fun bind(messageResult: MessageResult) {
+            this.message = messageResult.message
+            binding.root.renderMessageResult(messageResult)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/search/list/SearchResultListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/search/list/SearchResultListView.kt
@@ -24,6 +24,7 @@ import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.databinding.StreamUiSearchResultListViewBinding
 import io.getstream.chat.android.ui.feature.search.internal.SearchResultListAdapter
 import io.getstream.chat.android.ui.font.setTextStyle
@@ -86,7 +87,7 @@ public class SearchResultListView : ViewFlipper {
     /**
      * Shows the list of search results.
      */
-    public fun showMessages(query: String, messages: List<Message>) {
+    public fun showMessages(query: String, messages: List<MessageResult>) {
         val isEmpty = messages.isEmpty()
 
         displayedChild = if (isEmpty) Flipper.EMPTY else Flipper.RESULTS

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/pinned/PinnedMessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/pinned/PinnedMessageListViewModelBinding.kt
@@ -32,7 +32,7 @@ import io.getstream.chat.android.ui.feature.pinned.list.PinnedMessageListView
 @JvmName("bind")
 public fun PinnedMessageListViewModel.bindView(view: PinnedMessageListView, lifecycleOwner: LifecycleOwner) {
     state.observe(lifecycleOwner) { state ->
-        val isLoadingMore = state.results.isNotEmpty() && state.results.last().id == ""
+        val isLoadingMore = state.results.isNotEmpty() && state.results.last().message.id == ""
 
         when {
             isLoadingMore -> {


### PR DESCRIPTION
### 🎯 Goal
When searching for messages, our customers couldn't know the channel data in which this message was posted. It was a bit problematic for 1:1 channel where the data rendered on the screen could be a bit confusing for the user searching for messages.

The list of messages has been pre-processed, recovering the channel data from our internal DB before it is provided to the view.
### 🎉 GIF
 ![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExMXZrNG40MjA2aDFqaXl0Mzc0a2Y0bzl5ZzdheXhqeDA0MHg3N2tvZCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l6Qw59NgxFcLNUk2p6/giphy.gif)
