### PR TITLE
[AND-172] Await Depednecy Resolve process until ChatClient is properly initialized

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Internal "Resolve Dependency" process improvements. [#5514](https://github.com/GetStream/stream-chat-android/pull/5514)
 
 ### ✅ Added
 - Add `Channel.membership.pinnedAt` property notifiying if/when a channel was pinned by the current user. [#5513](https://github.com/GetStream/stream-chat-android/pull/5513)

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -9,6 +9,7 @@ public final class io/getstream/chat/android/client/BuildConfig {
 public final class io/getstream/chat/android/client/ChatClient {
 	public static final field Companion Lio/getstream/chat/android/client/ChatClient$Companion;
 	public static final field DEFAULT_SORT Lio/getstream/chat/android/models/querysort/QuerySorter;
+	public static final field RESOLVE_DEPENDENCY_TIMEOUT J
 	public final fun acceptInvite (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun addDevice (Lio/getstream/chat/android/models/Device;)Lio/getstream/result/call/Call;
 	public final fun addMembers (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/AddMembersParams;)Lio/getstream/result/call/Call;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -376,12 +376,11 @@ internal constructor(
             )
     }
 
-    @PublishedApi
     @InternalStreamChatApi
     @StreamHandsOff(
         "This method is used to avoid race-condition between plugin initialization and dependency resolution.",
     )
-    internal fun awaitInitializationState(timeoutMilliseconds: Long): InitializationState? {
+    public fun awaitInitializationState(timeoutMilliseconds: Long): InitializationState? {
         var initState: InitializationState? = clientState.initializationState.value
         var spendTime = 0L
         inheritScope { Job(it) }.launch {

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -330,6 +330,7 @@ internal class ChannelListViewModelTest {
         fun givenCurrentUser(currentUser: User = User(id = "Jc")) = apply {
             whenever(clientState.user) doReturn MutableStateFlow(currentUser)
             whenever(clientState.initializationState) doReturn MutableStateFlow(InitializationState.COMPLETE)
+            whenever(chatClient.awaitInitializationState(any())) doReturn InitializationState.COMPLETE
         }
 
         fun givenChannelMutes(channelMutes: List<ChannelMute> = emptyList()) = apply {

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -402,6 +402,7 @@ internal class MessageComposerViewModelTest {
             whenever(clientState.user) doReturn MutableStateFlow(currentUser)
             whenever(chatClient.clientState) doReturn clientState
             whenever(clientState.initializationState) doReturn MutableStateFlow(InitializationState.COMPLETE)
+            whenever(chatClient.awaitInitializationState(any())) doReturn InitializationState.COMPLETE
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/extensions/ChatClientExtensionTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/extensions/ChatClientExtensionTests.kt
@@ -46,6 +46,7 @@ import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
@@ -136,6 +137,7 @@ internal class ChatClientExtensionTests {
                 userFlow.value = null
                 Unit.asCall()
             }
+            on(it.awaitInitializationState(any())) doReturn InitializationState.COMPLETE
         }
     }
 

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
@@ -264,6 +264,7 @@ internal class ChannelListViewModelTest {
             whenever(clientState.user) doReturn MutableStateFlow(currentUser)
             whenever(clientState.initializationState) doReturn MutableStateFlow(InitializationState.COMPLETE)
             whenever(chatClient.getCurrentUser()) doReturn currentUser
+            whenever(chatClient.awaitInitializationState(any())) doReturn InitializationState.COMPLETE
         }
 
         fun givenChannelMutes(channelMutes: List<ChannelMute> = emptyList()) = apply {

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -403,6 +403,7 @@ internal class MessageComposerViewModelTest {
             whenever(clientState.user) doReturn MutableStateFlow(currentUser)
             whenever(chatClient.clientState) doReturn clientState
             whenever(clientState.initializationState) doReturn MutableStateFlow(InitializationState.COMPLETE)
+            whenever(chatClient.awaitInitializationState(any())) doReturn InitializationState.COMPLETE
         }
 
         fun givenChannelQuery(channel: Channel = Channel()) = apply {


### PR DESCRIPTION
### 🎯 Goal
Await Depednecy Resolve process until ChatClient is properly initialized or timeout is over to avoid race-conditions in situations where the Chat Components are initialized without waiting the user is connected.

### 🧪 Testing

Using the following patch we can verify the `GlobalState` can be resolved requesting it even before the `connectUser()` method is invoked.

<details>

<summary>Patch</summary>

```
Subject: [PATCH] crash investigation
---
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(revision bbeee84dd2a16f5fa8f22cdd6d2b3399fd6bbe3f)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(date 1734007345405)
@@ -30,10 +30,13 @@
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.UploadAttachmentsNetworkType
 import io.getstream.chat.android.offline.plugin.factory.StreamOfflinePluginFactory
+import io.getstream.chat.android.state.extensions.globalState
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 import io.getstream.result.Error
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.launch
 
 /**
  * A helper class that is responsible for initializing the SDK and connecting/disconnecting
@@ -100,6 +103,10 @@
         onSuccess: () -> Unit = {},
         onError: (Error) -> Unit = {},
     ) {
+        GlobalScope.launch {
+            println("JcLog: I am going to get the global state before connecting the user")
+            println("JcLog: I obtained the global state -> ${ChatClient.instance().globalState}")
+        }
         ChatClient.instance().run {
             clientState.initializationState
                 .transformWhile {
Index: stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt	(revision bbeee84dd2a16f5fa8f22cdd6d2b3399fd6bbe3f)
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt	(date 1734007345405)
@@ -386,6 +386,7 @@
             }
         }
         while (initState == InitializationState.INITIALIZING && spendTime < timeoutMilliseconds) {
+            println("JcLog: Waiting for initialization to complete")
             java.lang.Thread.sleep(INITIALIZATION_DELAY)
             spendTime += INITIALIZATION_DELAY
         }
```

</details>

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZnp3aTczYXN1czFla3hpbHU3OXd2ZHhtZnJ3eG50bHJiaWgzNnMwOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/CopyusU3fUtljVwPWK/giphy-downsized.gif)