### PR TITLE
Fix broken link of Getting Started README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ The best place to start is the [Compose Chat Messaging Tutorial](https://getstre
 
 ## 🛠️ Installation and Getting Started 🚀
 
-See the [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/) and [Getting Started](https://getstream.io/chat/docs/sdk/android/basics/getting-started/) pages of the documentation.
+See the [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/) and [Getting Started](https://getstream.io/chat/docs/sdk/android/client/overview/) pages of the documentation.
 
 ## 🔮 Sample Apps
 

--- a/stream-chat-android-client/README.md
+++ b/stream-chat-android-client/README.md
@@ -6,4 +6,4 @@ The client library integrates directly with Stream Chat APIs and does not includ
 
 ## Setup
 
-To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/basics/getting-started/).
+To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/client/overview/).

--- a/stream-chat-android-compose/README.md
+++ b/stream-chat-android-compose/README.md
@@ -12,7 +12,7 @@ This module contains reusable UI components built in Jetpack Compose, which you 
 
 ## Setup
 
-To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/basics/getting-started/).
+To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/client/overview/).
 
 ## Sample app
 

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/docusaurus/GettingStarted.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/docusaurus/GettingStarted.java
@@ -14,7 +14,7 @@ import io.getstream.chat.android.state.plugin.config.StatePluginConfig;
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory;
 
 /**
- * @see <a href="https://getstream.io/chat/docs/sdk/android/basics/getting-started/#getting-started">Getting Started</a>
+ * @see <a href="https://getstream.io/chat/docs/sdk/android/client/overview/">Getting Started</a>
  */
 public class GettingStarted {
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/docusaurus/GettingStarted.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/client/docusaurus/GettingStarted.kt
@@ -12,7 +12,7 @@ import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 
 /**
- * @see <a href="https://getstream.io/chat/docs/sdk/android/basics/getting-started/#getting-started">Getting Started</a>
+ * @see <a href="https://getstream.io/chat/docs/sdk/android/client/overview/">Getting Started</a>
  */
 class GettingStarted {
 

--- a/stream-chat-android-offline/README.md
+++ b/stream-chat-android-offline/README.md
@@ -4,7 +4,7 @@ This module adds offline support and provides Flow APIs for Stream Chat. Check o
 
 ## Setup
 
-To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/basics/getting-started/).
+To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/client/overview/).
 
 ## Offline
 

--- a/stream-chat-android-ui-components/README.md
+++ b/stream-chat-android-ui-components/README.md
@@ -12,7 +12,7 @@ This module contains reusable UI components to use in combination with the [offl
 
 ## Setup
 
-To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/basics/getting-started/).
+To start using this library in your project, see [Dependencies](https://getstream.io/chat/docs/sdk/android/basics/dependencies/), and then [Getting Started](https://getstream.io/chat/docs/sdk/android/client/overview/).
 
 ## Sample app
 


### PR DESCRIPTION
![broken-link-ezgif com-webp-to-jpg-converter](https://github.com/user-attachments/assets/6024d279-dc2e-4083-87b1-e49c73f40f55)

### 🎯 Goal

Keep the documentation healthy

### 🛠 Implementation details

Fix broken links in the `Getting Started` section of the entire repo

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs


