### PR TITLE
[AND-170] Intercept Members and add them to ChannelState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- The `ChannelState` is updated with new members after querying member with `ChatClient::queryMembers`. [#5517](https://github.com/GetStream/stream-chat-android/pull/5517)  
 
 ### ✅ Added
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.client.plugin.listeners.HideChannelListener
 import io.getstream.chat.android.client.plugin.listeners.MarkAllReadListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelsListener
+import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
 import io.getstream.chat.android.client.plugin.listeners.QueryThreadsListener
 import io.getstream.chat.android.client.plugin.listeners.SendAttachmentListener
 import io.getstream.chat.android.client.plugin.listeners.SendGiphyListener
@@ -53,6 +54,7 @@ import io.getstream.chat.android.state.plugin.listener.internal.HideChannelListe
 import io.getstream.chat.android.state.plugin.listener.internal.MarkAllReadListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryChannelListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryChannelsListenerState
+import io.getstream.chat.android.state.plugin.listener.internal.QueryMembersListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryThreadsListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.SendAttachmentListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.SendGiphyListenerState
@@ -96,6 +98,7 @@ public class StatePlugin internal constructor(
     private val queryingChannelsFree: MutableStateFlow<Boolean>,
     private val statePluginConfig: StatePluginConfig,
 ) : Plugin,
+    QueryMembersListener by QueryMembersListenerState(logic),
     QueryChannelsListener by QueryChannelsListenerState(logic, queryingChannelsFree),
     QueryChannelListener by QueryChannelListenerState(logic),
     ThreadQueryListener by ThreadQueryListenerState(logic, repositoryFacade),

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryMembersListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryMembersListenerState.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
+import io.getstream.chat.android.models.FilterObject
+import io.getstream.chat.android.models.Member
+import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
+import io.getstream.result.Result
+
+internal class QueryMembersListenerState(private val logic: LogicRegistry) : QueryMembersListener {
+    override suspend fun onQueryMembersResult(
+        result: Result<List<Member>>,
+        channelType: String,
+        channelId: String,
+        offset: Int,
+        limit: Int,
+        filter: FilterObject,
+        sort: QuerySorter<Member>,
+        members: List<Member>,
+    ) {
+        result.onSuccess { logic.channelState(channelType, channelId).upsertMembers(it) }
+    }
+}

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryMembersListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryMembersListenerStateTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.randomInt
+import io.getstream.chat.android.randomMembers
+import io.getstream.chat.android.randomString
+import io.getstream.chat.android.state.plugin.logic.channel.internal.ChannelStateLogic
+import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
+import io.getstream.result.Result
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+internal class QueryMembersListenerStateTest {
+    private val channelType = randomString()
+    private val channelId = randomString()
+    private val channelStateLogic: ChannelStateLogic = mock()
+    private val logicRegistry: LogicRegistry = mock {
+        on(
+            it.channelState(
+                channelType = eq(channelType),
+                channelId = eq(channelId),
+            ),
+        ) doReturn channelStateLogic
+    }
+    private val queryMembersListenerState = QueryMembersListenerState(logicRegistry)
+
+    @Test
+    fun `when querying members, should call channelStateLogic upsertMembers`() = runTest {
+        val members = randomMembers()
+
+        queryMembersListenerState.onQueryMembersResult(
+            result = Result.Success(members),
+            channelType = channelType,
+            channelId = channelId,
+            offset = randomInt(),
+            limit = randomInt(),
+            filter = mock(),
+            sort = mock(),
+            members = randomMembers(),
+        )
+
+        verify(channelStateLogic).upsertMembers(members)
+    }
+
+    @Test
+    fun `when querying members fails, should not call channelStateLogic upsertMembers`() = runTest {
+        queryMembersListenerState.onQueryMembersResult(
+            result = Result.Failure(mock()),
+            channelType = channelType,
+            channelId = channelId,
+            offset = randomInt(),
+            limit = randomInt(),
+            filter = mock(),
+            sort = mock(),
+            members = randomMembers(),
+        )
+
+        verify(channelStateLogic, never()).upsertMembers(any())
+    }
+}


### PR DESCRIPTION
### 🎯 Goal
Intercept members and add them to `ChannelState` whenever the LLC method `ChatClient.queryMembers()` is invoked.

### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExOHFjbzQzMjM2eWR2b3NncTNzbWFvZzhjbHEyc3ptYWsxenl0MnZ1dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/UQhE2VfDiHXOQDC3R6/giphy.gif)