### PR TITLE
Fix channel list blinking UI when resuming from the recent apps.

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelList.kt
@@ -221,9 +221,18 @@ public fun ChannelList(
 ) {
     val (isLoading, _, _, channels, searchQuery) = channelsState
 
-    when {
-        isLoading -> loadingContent()
-        !isLoading && channels.isNotEmpty() -> Channels(
+    if (channels.isEmpty()) {
+        if (isLoading) {
+            loadingContent()
+        } else {
+            if (searchQuery.query.isBlank()) {
+                emptyContent()
+            } else {
+                emptySearchContent(searchQuery.query)
+            }
+        }
+    } else {
+        Channels(
             modifier = modifier,
             contentPadding = contentPadding,
             channelsState = channelsState,
@@ -240,8 +249,6 @@ public fun ChannelList(
             },
             divider = divider,
         )
-        searchQuery.query.isNotBlank() -> emptySearchContent(searchQuery.query)
-        else -> emptyContent()
     }
 }
 

--- a/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/compose/channels/ChannelListTest.kt
+++ b/stream-chat-android-ui-uitests/src/androidTest/java/io/getstream/chat/android/uitests/snapshot/compose/channels/ChannelListTest.kt
@@ -183,4 +183,70 @@ class ChannelListTest : ComposeScreenshotTest() {
             currentUser = TestData.user1(),
         )
     }
+
+    @Test
+    fun channelListWithContentAndLoadingState() = runScreenshotTest {
+        ChannelList(
+            modifier = Modifier.fillMaxSize(),
+            channelsState = ChannelsState(
+                isLoading = true,
+                isLoadingMore = false,
+                channelItems = listOf(
+                    ChannelItemState(
+                        channel = TestData.channel1().copy(
+                            members = listOf(
+                                TestData.member1(),
+                                TestData.member2(),
+                            ),
+                            messages = listOf(
+                                TestData.message1(),
+                            ),
+                            channelLastMessageAt = TestData.date1(),
+                        ),
+                        typingUsers = emptyList(),
+                    ),
+                    ChannelItemState(
+                        channel = TestData.channel2().copy(
+                            members = listOf(
+                                TestData.member1(),
+                                TestData.member3(),
+                            ),
+                            messages = listOf(
+                                TestData.message2(),
+                            ),
+                            channelLastMessageAt = TestData.date2(),
+                        ),
+                        typingUsers = emptyList(),
+                    ),
+                    ChannelItemState(
+                        channel = TestData.channel3().copy(
+                            members = listOf(
+                                TestData.member1(),
+                                TestData.member4(),
+                            ),
+                            messages = listOf(
+                                TestData.message3(),
+                            ),
+                            channelLastMessageAt = TestData.date3(),
+                        ),
+                        typingUsers = emptyList(),
+                    ),
+                    ChannelItemState(
+                        channel = TestData.channel4().copy(
+                            members = listOf(
+                                TestData.member1(),
+                                TestData.member5(),
+                            ),
+                            messages = listOf(
+                                TestData.message4(),
+                            ),
+                            channelLastMessageAt = TestData.date4(),
+                        ),
+                        typingUsers = emptyList(),
+                    ),
+                ),
+            ),
+            currentUser = TestData.user1(),
+        )
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

Fix the blinking UI when resuming from a paused state, for example, after switching back from the recent apps.

### 🛠 Implementation details

The previous implementation switched the channel list by the loading UI even when there were results in the list, causing the blink when the screen is resumed from a paused state.

The proposed implementation prevents that blinking by not rendering the loading UI if there is any result.

### 🎨 UI Changes

Before | After
-|-
![before-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/27b90c9a-9e9f-4eb4-8885-8df2f4620df5) | ![after-ezgif com-video-to-gif-converter](https://github.com/user-attachments/assets/6a4b08ec-f3ab-492a-b9cc-49531a95c66b)

### 🧪 Testing

It can be reproduced by switching apps from the recent apps.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![GIF](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExZG1meTczMXh3OGxjeDcydXEwaTI3eTUwZ2Y3eTd5eXV4cHpwaXhrOCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/XH9tzHRGQmLSFGP6E8/giphy.gif)
