### PR TITLE
[AND-176] Intercept Attachment Download Process within internal activities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fix keyboard not closing when opening the attachments picker from `MessagesScreen`. [#5506](https://github.com/GetStream/stream-chat-android/pull/5506)
+- The `ChatTheme.downloadAttachmentUriGenerator` and `ChatTheme.downloadRequestInterceptor` properties are forwarded within the `MediaGalleryPreviewActivity` to be used when downloading attachments. [#5522](https://github.com/GetStream/stream-chat-android/pull/5522)
 
 ### ⬆️ Improved
 - Add support for partial media access in `AttachmentsPickerImagesTabFactory` and `AttachmentsPickerFilesTabFactory` for Android 14+. [#5518](https://github.com/GetStream/stream-chat-android/pull/5518)

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -371,8 +371,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/AttachmentFa
 public final class io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories {
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;
-	public final fun defaultFactories (Lkotlin/jvm/functions/Function0;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Ljava/util/List;)Ljava/util/List;
-	public static synthetic fun defaultFactories$default (Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;Lkotlin/jvm/functions/Function0;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Ljava/util/List;ILjava/lang/Object;)Ljava/util/List;
+	public final fun defaultFactories (Lkotlin/jvm/functions/Function0;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Ljava/util/List;)Ljava/util/List;
+	public static synthetic fun defaultFactories$default (Lio/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories;Lkotlin/jvm/functions/Function0;ILio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;ZLkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Ljava/util/List;ILjava/lang/Object;)Ljava/util/List;
 	public final fun defaultQuotedFactories ()Ljava/util/List;
 }
 
@@ -463,7 +463,7 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Link
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContentKt {
-	public static final fun MediaAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MediaAttachmentContent (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Landroidx/compose/ui/Modifier;IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentPreviewContentKt {
@@ -544,8 +544,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Link
 public final class io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
-	public synthetic fun <init> (IZLkotlin/jvm/functions/Function6;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
+	public synthetic fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/QuotedAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
@@ -597,8 +597,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/preview/Medi
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity$Companion {
-	public final fun getIntent (Landroid/content/Context;Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;Z)Landroid/content/Intent;
-	public static synthetic fun getIntent$default (Lio/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity$Companion;Landroid/content/Context;Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZILjava/lang/Object;)Landroid/content/Intent;
+	public final fun getIntent (Landroid/content/Context;Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;Z)Landroid/content/Intent;
+	public static synthetic fun getIntent$default (Lio/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity$Companion;Landroid/content/Context;Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZILjava/lang/Object;)Landroid/content/Intent;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewContract : androidx/activity/result/contract/ActivityResultContract {
@@ -612,8 +612,10 @@ public final class io/getstream/chat/android/compose/ui/attachments/preview/Medi
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewContract$Input {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;Z)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;Z)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;IZLio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun getDownloadAttachmentUriGenerator ()Lio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;
+	public final fun getDownloadRequestInterceptor ()Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;
 	public final fun getInitialPosition ()I
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public final fun getSkipEnrichUrl ()Z

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/StreamAttachmentFactories.kt
@@ -42,6 +42,8 @@ import io.getstream.chat.android.compose.ui.theme.StreamDimens
 import io.getstream.chat.android.compose.viewmodel.messages.AudioPlayerViewModelFactory
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadRequestInterceptor
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
 import io.getstream.chat.android.ui.common.utils.GiphySizingMode
@@ -101,6 +103,8 @@ public object StreamAttachmentFactories {
             message: Message,
             attachmentPosition: Int,
             videoThumbnailsEnabled: Boolean,
+            downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+            downloadRequestInterceptor: DownloadRequestInterceptor,
             streamCdnImageResizing: StreamCdnImageResizing,
             skipEnrichUrl: Boolean,
         ) -> Unit = ::onMediaAttachmentContentItemClick,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -80,6 +80,8 @@ import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadRequestInterceptor
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
@@ -111,6 +113,8 @@ public fun MediaAttachmentContent(
         message: Message,
         attachmentPosition: Int,
         videoThumbnailsEnabled: Boolean,
+        downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        downloadRequestInterceptor: DownloadRequestInterceptor,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit = ::onMediaAttachmentContentItemClick,
@@ -182,6 +186,7 @@ public fun MediaAttachmentContent(
  * @param overlayContent Represents the content overlaid above attachment previews.
  * Usually used to display a play button over video previews.
  */
+@Suppress("LongParameterList")
 @Composable
 internal fun SingleMediaAttachment(
     attachment: Attachment,
@@ -194,6 +199,8 @@ internal fun SingleMediaAttachment(
         message: Message,
         attachmentPosition: Int,
         videoThumbnailsEnabled: Boolean,
+        downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        downloadRequestInterceptor: DownloadRequestInterceptor,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit,
@@ -276,6 +283,8 @@ internal fun RowScope.MultipleMediaAttachments(
         message: Message,
         attachmentPosition: Int,
         videoThumbnailsEnabled: Boolean,
+        downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        downloadRequestInterceptor: DownloadRequestInterceptor,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit,
@@ -392,6 +401,8 @@ internal fun MediaAttachmentContentItem(
         message: Message,
         attachmentPosition: Int,
         videoThumbnailsEnabled: Boolean,
+        downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        downloadRequestInterceptor: DownloadRequestInterceptor,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit,
@@ -445,6 +456,9 @@ internal fun MediaAttachmentContentItem(
     val areVideosEnabled = ChatTheme.videoThumbnailsEnabled
     val streamCdnImageResizing = ChatTheme.streamCdnImageResizing
 
+    val downloadAttachmentUriGenerator = ChatTheme.streamDownloadAttachmentUriGenerator
+    val downloadRequestInterceptor = ChatTheme.streamDownloadRequestInterceptor
+
     Box(
         modifier = modifier
             .background(Color.Black)
@@ -460,6 +474,8 @@ internal fun MediaAttachmentContentItem(
                             message,
                             attachmentPosition,
                             areVideosEnabled,
+                            downloadAttachmentUriGenerator,
+                            downloadRequestInterceptor,
                             streamCdnImageResizing,
                             skipEnrichUrl,
                         )
@@ -596,11 +612,14 @@ private const val EqualDimensionsRatio = 1f
  * a link attachment. Used when updating the message from the gallery by doing actions
  * such as deleting an attachment.
  */
+@Suppress("LongParameterList")
 internal fun onMediaAttachmentContentItemClick(
     mediaGalleryPreviewLauncher: ManagedActivityResultLauncher<MediaGalleryPreviewContract.Input, MediaGalleryPreviewResult?>,
     message: Message,
     attachmentPosition: Int,
     videoThumbnailsEnabled: Boolean,
+    downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+    downloadRequestInterceptor: DownloadRequestInterceptor,
     streamCdnImageResizing: StreamCdnImageResizing,
     skipEnrichUrl: Boolean,
 ) {
@@ -609,6 +628,8 @@ internal fun onMediaAttachmentContentItemClick(
             message = message,
             initialPosition = attachmentPosition,
             videoThumbnailsEnabled = videoThumbnailsEnabled,
+            downloadAttachmentUriGenerator = downloadAttachmentUriGenerator,
+            downloadRequestInterceptor = downloadRequestInterceptor,
             streamCdnImageResizing = streamCdnImageResizing,
             skipEnrichUrl = skipEnrichUrl,
         ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
@@ -41,6 +41,8 @@ import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmen
 import io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewContract.Input
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadRequestInterceptor
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 
 /**
@@ -64,6 +66,8 @@ public class MediaAttachmentFactory(
         message: Message,
         attachmentPosition: Int,
         videoThumbnailsEnabled: Boolean,
+        downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        downloadRequestInterceptor: DownloadRequestInterceptor,
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit = ::onMediaAttachmentContentItemClick,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
@@ -163,6 +163,9 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.streamcdn.image.StreamCdnCropImageMode
 import io.getstream.chat.android.models.streamcdn.image.StreamCdnResizeImageMode
+import io.getstream.chat.android.ui.common.helper.DefaultDownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadRequestInterceptor
 import io.getstream.chat.android.ui.common.images.internal.StreamImageLoader
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
@@ -260,6 +263,8 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
             ChatTheme(
                 videoThumbnailsEnabled = videoThumbnailsEnabled,
                 streamCdnImageResizing = streamCdnImageResizing,
+                downloadAttachmentUriGenerator = downloadAttachmentUriGenerator,
+                downloadRequestInterceptor = downloadRequestInterceptor,
             ) {
                 SetupEdgeToEdge()
 
@@ -1805,26 +1810,44 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
         private const val DefaultZoomScale: Float = 1f
 
         /**
+         * Used to generate download URIs for attachments.
+         */
+        private var downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator =
+            DefaultDownloadAttachmentUriGenerator
+
+        /**
+         * Used to intercept download requests.
+         */
+        private var downloadRequestInterceptor: DownloadRequestInterceptor = DownloadRequestInterceptor { }
+
+        /**
          * Used to build an [Intent] to start the [MediaGalleryPreviewActivity] with the required data.
          *
          * @param context The context to start the activity with.
          * @param message The [Message] containing the attachments.
          * @param attachmentPosition The initial position of the clicked media attachment.
          * @param videoThumbnailsEnabled Whether video thumbnails will be displayed in previews or not.
+         * @param downloadAttachmentUriGenerator Used to generate download URIs for attachments.
+         * @param downloadRequestInterceptor Used to intercept download requests.
          * @param streamCdnImageResizing Sets the Stream CDN hosted image resizing strategy. Turned off by default.
          * Please note that only Stream CDN hosted images containing original width (ow) and original height (oh)
          * parameters are able to be resized.
          * @param skipEnrichUrl If set to true will skip enriching URLs when you update the message
          * by deleting an attachment contained within it. Set to false by default.
          */
+        @Suppress("LongParameterList")
         public fun getIntent(
             context: Context,
             message: Message,
             attachmentPosition: Int,
             videoThumbnailsEnabled: Boolean,
+            downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+            downloadRequestInterceptor: DownloadRequestInterceptor,
             streamCdnImageResizing: StreamCdnImageResizing = StreamCdnImageResizing.defaultStreamCdnImageResizing(),
             skipEnrichUrl: Boolean = false,
         ): Intent {
+            this.downloadAttachmentUriGenerator = downloadAttachmentUriGenerator
+            this.downloadRequestInterceptor = downloadRequestInterceptor
             return Intent(context, MediaGalleryPreviewActivity::class.java).apply {
                 val mediaGalleryPreviewActivityState = message.toMediaGalleryPreviewActivityState()
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewContract.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewContract.kt
@@ -21,6 +21,8 @@ import android.content.Intent
 import androidx.activity.result.contract.ActivityResultContract
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResult
 import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
+import io.getstream.chat.android.ui.common.helper.DownloadRequestInterceptor
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 
 /**
@@ -41,6 +43,8 @@ public class MediaGalleryPreviewContract :
             context,
             message = input.message,
             attachmentPosition = input.initialPosition,
+            downloadAttachmentUriGenerator = input.downloadAttachmentUriGenerator,
+            downloadRequestInterceptor = input.downloadRequestInterceptor,
             videoThumbnailsEnabled = input.videoThumbnailsEnabled,
             streamCdnImageResizing = input.streamCdnImageResizing,
             skipEnrichUrl = input.skipEnrichUrl,
@@ -61,6 +65,8 @@ public class MediaGalleryPreviewContract :
      *
      * @param message The message containing the attachments.
      * @param initialPosition The initial position of the media gallery, based on the clicked item.
+     * @param downloadAttachmentUriGenerator The URI generator for downloading attachments.
+     * @param downloadRequestInterceptor The request interceptor for downloading attachments.
      * @param videoThumbnailsEnabled Whether video thumbnails will be displayed in previews or not.
      * @param skipEnrichUrl If set to true will skip enriching URLs when you update the message
      * by deleting an attachment contained within it. Set to false by default.
@@ -69,6 +75,8 @@ public class MediaGalleryPreviewContract :
         public val message: Message,
         public val initialPosition: Int = 0,
         public val videoThumbnailsEnabled: Boolean,
+        public val downloadAttachmentUriGenerator: DownloadAttachmentUriGenerator,
+        public val downloadRequestInterceptor: DownloadRequestInterceptor,
         public val streamCdnImageResizing: StreamCdnImageResizing,
         public val skipEnrichUrl: Boolean = false,
     )


### PR DESCRIPTION
### 🎯 Goal
Related PR: #5490

On implementing the previous PR, the use of `DownloadAttachmentUriGenerator` and `DownloadRequestInterceptor` was obtained from the ones configured within `ChatTheme` entity.
The problem is that our internal activities don't use the `ChatTheme` that our customers configure when they initialize the SDK. There aren't any static references to it, so the default implementation was used.

With this PR the customization used on `ChatTheme` is forwarded to our internal activities

### 🧪 Testing
To test it, you only need to add a custom implementation of those dependencies and check it is being used when downloading attachments.

| From Message List Attachment | From Media Gallery |
| --- | --- |
| ![Screenshot from 2024-12-16 09-42-23](https://github.com/user-attachments/assets/58dd12e5-260b-4b86-aa55-5dfd3b6938b1) | ![Screenshot from 2024-12-16 09-42-32](https://github.com/user-attachments/assets/5b071d10-517d-4e84-8831-c5a404fbc69c) |




<details>

<summary>Patch that prints some logs when the implementation is used</summary>

```
Subject: [PATCH] Print some logs
---
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 259e7dc09e4cec650d6d12b817adb44ce4270512)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1734352774963)
@@ -18,6 +18,7 @@
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.compose.setContent
@@ -92,11 +93,13 @@
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.PollConfig
 import io.getstream.chat.android.models.ReactionSortingByFirstReactionAt
 import io.getstream.chat.android.models.ReactionSortingByLastReactionAt
 import io.getstream.chat.android.models.VotingVisibility
+import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
 import io.getstream.chat.android.ui.common.state.messages.MessageMode
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.list.DeletedMessageVisibility
@@ -157,6 +160,14 @@
             isInDarkMode = isInDarkMode,
             colors = colors,
             shapes = shapes,
+            downloadAttachmentUriGenerator = { attachment ->
+                println("TestingLog: Generating Uri for attachment: $attachment")
+                Uri.parse(attachment.assetUrl ?: attachment.imageUrl)
+                                             },
+            downloadRequestInterceptor = { request ->
+                println("TestingLog: Intercepting request: $request")
+                request
+            },
             typography = typography,
             dateFormatter = ChatApp.dateFormatter,
             autoTranslationEnabled = ChatApp.autoTranslationEnabled,
```

</details>


### 🎉 GIF

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdjIzN3lnZnRraG9mc255MXNrazRidzF0NjY0dGhzajBzbHBoa2MzNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/oWjyixDbWuAk8/giphy.gif)
