### PR TITLE
AND-116: SDK size analysis

### DIFF
--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -1,0 +1,117 @@
+name: SDK size checks
+
+on:
+  pull_request:
+
+env:
+  MODULES: "stream-chat-android-client stream-chat-android-offline stream-chat-android-ui-components stream-chat-android-compose"
+  METRICS_FILE: "metrics/size.json"
+  MAX_TOLERANCE: 500
+  FINE_TOLERANCE: 250
+
+jobs:
+  compare-sdk-sizes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/gradle-cache
+        with:
+          key-prefix: gradle-build
+
+      - name: Assemble SDKs
+        run: |
+          for module in $MODULES; do
+            modules+=" :$module:assembleDebug"
+          done
+          ./gradlew $modules
+
+      - name: Get current SDK sizes
+        run: |
+          # Reads current SDK sizes from the metrics file
+          # and define to a variable using a compact JSON format
+          # so it can be exported for the next job step
+          CURRENT_SDK_SIZES=$(jq -c .debug $METRICS_FILE)
+          echo "CURRENT_SDK_SIZES=$CURRENT_SDK_SIZES" >> $GITHUB_ENV
+
+      - name: Calculate PR branch SDK sizes
+        run: |
+          echo '{}' > pr_sdk_sizes.json
+
+          # Calculate sizes from the .aar files and save them into a temporary JSON file
+          # so it can be exported for the next job step
+          for module in $MODULES; do
+            size=$(du -k $module/build/outputs/aar/*debug.aar | awk '{print $1}')
+            jq -c --arg sdk "$module" --arg size "$size" '. + {($sdk): ($size | tonumber)}' pr_sdk_sizes.json > temp.json && mv temp.json pr_sdk_sizes.json
+          done
+
+          echo "PR_SDK_SIZES=$(cat pr_sdk_sizes.json)" >> $GITHUB_ENV
+
+      - name: Post comment on PR
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const maxTolerance = process.env.MAX_TOLERANCE
+            const fineTolerance = process.env.FINE_TOLERANCE
+            const currentSdkSizes = process.env.CURRENT_SDK_SIZES ? JSON.parse(process.env.CURRENT_SDK_SIZES) : {};
+            const prSdkSizes = JSON.parse(process.env.PR_SDK_SIZES);
+            const commentHeader = '## SDK Size Comparison';
+
+            // Prepare the comparison table
+
+            let commentBody = `
+            ${commentHeader}
+
+            | SDK | Before | After | Difference | Status |
+            |-|-|-|-|-|
+            `;
+            
+            Object.keys(prSdkSizes).forEach(sdk => {
+              const currentSize = currentSdkSizes[sdk] || 0;
+              const prSize = prSdkSizes[sdk];
+              const diff = prSize - currentSize;
+
+              let status;
+              if (diff < 0) {
+                status = "🚀";
+              } else if (diff >= maxTolerance) {
+                status = "🔴";
+              } else if (diff >= fineTolerance) {
+                status = "🟡";
+              } else {
+                status = "🟢";
+              }
+
+              commentBody += `| ${sdk} | ${currentSize} KB | ${prSize} KB | ${diff} KB | ${status} |\n`;
+            });            
+
+            // Post or update the PR comment
+
+            // Find existing comment
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+
+            const comment = comments.find(c => c.body.includes(commentHeader));
+
+            if (comment) {
+              // Update the existing comment
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: comment.id,
+                body: commentBody,
+              });
+            } else {
+              // Create a new comment
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                body: commentBody,
+              });
+            }

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -72,19 +72,20 @@ jobs:
               const currentSize = currentSdkSizes[sdk] || 0;
               const prSize = prSdkSizes[sdk];
               const diff = prSize - currentSize;
+              const currentSizeInMb = (currentSize / 1024).toFixed(2)
+              const prSizeInMb = (prSize / 1024).toFixed(2)
+              const diffInMb = (diff / 1024).toFixed(2)
 
-              let status;
+              let status = "🟢";
               if (diff < 0) {
                 status = "🚀";
               } else if (diff >= maxTolerance) {
                 status = "🔴";
               } else if (diff >= fineTolerance) {
                 status = "🟡";
-              } else {
-                status = "🟢";
               }
 
-              commentBody += `| ${sdk} | ${currentSize} KB | ${prSize} KB | ${diff} KB | ${status} |\n`;
+              commentBody += `| ${sdk} | ${currentSizeInMb} MB | ${prSizeInMb} MB | ${diffInMb} MB | ${status} |\n`;
             });            
 
             // Post or update the PR comment

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -70,7 +70,8 @@ jobs:
         run: |
           for module in $MODULES; do
             size=$(jq --arg module "$module" ".release.\"$module\"" $METRICS_FILE)
-            badgeUrl="https://img.shields.io/badge/${module//-/--}-$size%20KB-lightgreen"
+            sizeInMb=$(echo "scale=2; $size / 1024" | bc)
+            badgeUrl="https://img.shields.io/badge/${module//-/--}-$sizeInMb%20MB-lightgreen"
             sed -i "s|!\[$module\](.*)|![$module](${badgeUrl})|" README.md
           done
 

--- a/.github/workflows/sdk-size-updates.yml
+++ b/.github/workflows/sdk-size-updates.yml
@@ -1,0 +1,93 @@
+name: SDK size updates
+
+on:
+  push:
+    branches:
+      - develop
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MODULES: "stream-chat-android-client stream-chat-android-offline stream-chat-android-ui-components stream-chat-android-compose"
+  VARIANTS: "debug release"
+  METRICS_FILE: "metrics/size.json"
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  update-sdk-sizes:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - uses: ./.github/actions/setup-java
+      - uses: ./.github/actions/gradle-cache
+        with:
+          key-prefix: gradle-build
+
+      - name: Assemble SDKs
+        run: |
+          for module in $MODULES; do
+            modules+=" :$module:assemble"
+          done
+          ./gradlew $modules
+
+      - name: Update size metrics
+        run: |
+          # Create temporary JSON file
+          echo '{}' > metrics.json
+
+          # Calculate sizes
+          for module in $MODULES; do
+            for variant in $VARIANTS; do
+              file="$module/build/outputs/aar/$module-$variant.aar"
+          
+              # Ensure file exists
+              if [ -f "$file" ]; then
+                size=$(du -k "$file" | awk '{print $1}')
+              else
+                echo "Warning: $file not found. Setting size to 0."
+                size=0
+              fi
+          
+              # Update JSON
+              jq --arg module "$module" --arg variant "$variant" --argjson size "$size" \
+                ".\"$variant\".\"$module\" = $size" metrics.json > temp.json && mv temp.json metrics.json
+            done
+          done
+
+          # Validate Generated JSON
+          jq . metrics.json
+          
+          # Move temporary JSON file to the final file
+          mv metrics.json $METRICS_FILE
+
+      - name: Update size badges
+        run: |
+          for module in $MODULES; do
+            size=$(jq --arg module "$module" ".release.\"$module\"" $METRICS_FILE)
+            badgeUrl="https://img.shields.io/badge/${module//-/--}-$size%20KB-lightgreen"
+            sed -i "s|!\[$module\](.*)|![$module](${badgeUrl})|" README.md
+          done
+
+      - name: Commit and Push JSON
+        run: |
+          git fetch origin $BRANCH_NAME
+          git checkout $BRANCH_NAME
+          
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"         
+
+          # Add and commit updated metrics file
+          git add $METRICS_FILE
+          git commit -m "Update SDK size metrics" || echo "No metrics changes to commit"
+          
+          # Add and commit updated README file
+          git add README.md
+          git commit -m "Update SDK size badges" || echo "No README changes to commit"
+
+          git push origin HEAD:$BRANCH_NAME

--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@
   <a href="https://github.com/GetStream/stream-chat-android/releases"><img src="https://img.shields.io/github/v/release/GetStream/stream-chat-android" /></a>
 </p>
 
+<div align="center">
+
+![stream-chat-android-client](https://img.shields.io/badge/stream--chat--android--client-2584%20KB-lightgreen)
+![stream-chat-android-offline](https://img.shields.io/badge/stream--chat--android--offline-796%20KB-lightgreen)
+![stream-chat-android-ui-components](https://img.shields.io/badge/stream--chat--android--ui--components-2700%20KB-lightgreen)
+![stream-chat-android-compose](https://img.shields.io/badge/stream--chat--android--compose-3684%20KB-lightgreen)
+
+</div>
+
 This is the official Android SDK for [Stream Chat](https://getstream.io/chat/sdk/android/), a service for building chat and messaging applications. This library includes both a low-level chat SDK and a set of reusable UI components. Most users start with the UI components, and fall back to the lower level API when they want to customize things.
 
 We're proud to say that we're the first Android Chat SDK that supports Jetpack Compose! We [released](https://github.com/GetStream/stream-chat-android/releases/tag/4.15.0) our Compose UI Components one day after the official Jetpack Compose 1.0 release and our team members have been working hard on it since then.

--- a/metrics/size.json
+++ b/metrics/size.json
@@ -1,0 +1,14 @@
+{
+  "debug": {
+    "stream-chat-android-client": 2744,
+    "stream-chat-android-offline": 840,
+    "stream-chat-android-ui-components": 2840,
+    "stream-chat-android-compose": 4012
+  },
+  "release": {
+    "stream-chat-android-client": 2584,
+    "stream-chat-android-offline": 796,
+    "stream-chat-android-ui-components": 2700,
+    "stream-chat-android-compose": 3684
+  }
+}


### PR DESCRIPTION
### 🎯 Goal

#### Show SDK size badges in the README file, e.g.:

![stream-chat-android-client](https://img.shields.io/badge/stream--chat--android--client-2.68%20MB-lightgreen)

#### Compare sizes before and after a PR and show them in a comparison table as a PR comment, e.g.:

| SDK | Before | After | Difference | Status |
|-|-|-|-|-|
| stream-chat-android-client | 2.68 MB | 2.68 MB | 0.00 MB | 🟢 |

Max tolerance is `500 KB`
Fine tolerance is `250 KB`

if the difference is less than zero, then the status is 🚀
if the difference is greater or equal to the max tolerance, then the status is 🔴
if the difference is greater or equal to the fine tolerance, then the status is 🟡
otherwise, the status is 🟢

#### Sizes are calculated for the following SDKs:

- stream-chat-android-client
- stream-chat-android-offline
- stream-chat-android-ui-components
- stream-chat-android-compose

### 🛠 Implementation details

- Due to the many factors that can influence the impact of an SDK dependency's size on installed apps (Proguard, device properties, Play store optimizations), the calculation we make here is by measuring the size of the aar file.

- The comparison task is triggered on every push request

- The metrics update is triggered on every merge to develop

### ℹ️ Further information

Once this PR gets merged and tested on the develop workflow, other PRs can be created to share these workflows in a shared repo so they can be reused in the video repo.

### 🎉 GIF

![Size matters](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExcTdwZ3AyMGxkMHkydDBobDhobjMyMnJxZzB4bWFqeGZ4bjY3MDg4YyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/xT1XGD02MRIfS829qw/giphy.gif)
