### PR TITLE
[AND-188] Fix user blocking operations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fix `ChatClient::queryBlockedMembers` not working. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
+- Fix `ChatClient::blockUser` and `ChatClient::unblockUser` response parsing. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
 
 ### ⬆️ Improved
 
 ### ✅ Added
 
 ### ⚠️ Changed
+- 🚨 Breaking change: Change `ChatClient::unblockUser` return type from `Call<BlockUser>` to `Call<Unit>` as we no longer get information about the unblocked user. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
 
 ### ❌ Removed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2670,7 +2670,7 @@ internal constructor(
      * @param userId the user ID of the user that will be unblocked.
      */
     @CheckResult
-    public fun unblockUser(userId: String): Call<UserBlock> {
+    public fun unblockUser(userId: String): Call<Unit> {
         return api.unblockUser(userId)
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -223,7 +223,7 @@ internal interface ChatApi {
     fun blockUser(userId: String): Call<UserBlock>
 
     @CheckResult
-    fun unblockUser(userId: String): Call<UserBlock>
+    fun unblockUser(userId: String): Call<Unit>
 
     @CheckResult
     fun queryBlockedUsers(): Call<List<UserBlock>>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -881,7 +881,7 @@ constructor(
         return userApi.blockUser(
             body = BlockUserRequest(userId),
         ).map { response ->
-            response.block.toDomain()
+            response.toDomain()
         }
     }
 
@@ -891,12 +891,8 @@ constructor(
         }
     }
 
-    override fun unblockUser(userId: String): Call<UserBlock> {
-        return userApi.unblockUser(
-            body = UnblockUserRequest(userId),
-        ).map {
-            it.block.toDomain()
-        }
+    override fun unblockUser(userId: String): Call<Unit> {
+        return userApi.unblockUser(body = UnblockUserRequest(userId)).toUnitCall()
     }
 
     override fun partialUpdateUser(id: String, set: Map<String, Any>, unset: List<String>): Call<User> {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/endpoint/UserApi.kt
@@ -51,7 +51,7 @@ internal interface UserApi {
     @POST("/users/unblock")
     fun unblockUser(@Body body: UnblockUserRequest): RetrofitCall<UnblockUserResponse>
 
-    @GET
+    @GET("/users/block")
     fun queryBlockedUsers(): RetrofitCall<QueryBlockedUsersResponse>
 
     @PATCH("/users")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.api2.model.dto.DeviceDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserBlockDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserDto
 import io.getstream.chat.android.client.api2.model.dto.UpstreamUserDto
+import io.getstream.chat.android.client.api2.model.response.BlockUserResponse
 import io.getstream.chat.android.models.Device
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
@@ -65,9 +66,15 @@ internal fun DownstreamUserDto.toDomain(currentUserId: UserId?): User =
     )
 
 internal fun DownstreamUserBlockDto.toDomain(): UserBlock = UserBlock(
-    blockedBy = blocked_by_user_id,
+    blockedBy = user_id,
     userId = blocked_user_id,
     blockedAt = created_at,
 )
 
 internal fun List<DownstreamUserBlockDto>.toDomain(): List<UserBlock> = map { it.toDomain() }
+
+internal fun BlockUserResponse.toDomain(): UserBlock = UserBlock(
+    blockedBy = blocked_by_user_id,
+    userId = blocked_user_id,
+    blockedAt = created_at,
+)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -88,7 +88,7 @@ internal data class PartialUpdateUserDto(
 
 @JsonClass(generateAdapter = true)
 internal data class DownstreamUserBlockDto(
-    val blocked_by_user_id: String,
+    val user_id: String,
     val blocked_user_id: String,
     val created_at: Date,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BlockUserResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/BlockUserResponse.kt
@@ -17,9 +17,18 @@
 package io.getstream.chat.android.client.api2.model.response
 
 import com.squareup.moshi.JsonClass
-import io.getstream.chat.android.client.api2.model.dto.DownstreamUserBlockDto
+import java.util.Date
 
+/**
+ * Model representing the response from blocking a user.
+ *
+ * @param blocked_by_user_id The ID of the user who blocked the other user.
+ * @param blocked_user_id The ID of the user who was blocked.
+ * @param created_at The date when the block was created.
+ */
 @JsonClass(generateAdapter = true)
 internal data class BlockUserResponse(
-    val block: DownstreamUserBlockDto,
+    val blocked_by_user_id: String,
+    val blocked_user_id: String,
+    val created_at: Date,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/UnblockUserResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/UnblockUserResponse.kt
@@ -17,9 +17,8 @@
 package io.getstream.chat.android.client.api2.model.response
 
 import com.squareup.moshi.JsonClass
-import io.getstream.chat.android.client.api2.model.dto.DownstreamUserBlockDto
 
 @JsonClass(generateAdapter = true)
 internal data class UnblockUserResponse(
-    val block: DownstreamUserBlockDto,
+    val duration: String,
 )


### PR DESCRIPTION
### 🎯 Goal
Linear: https://linear.app/stream/issue/AND-188/user-blocking-feature-issue-with-android-sdk-version-680
The `queryBlockedUsers` operation had its API endpoint wrongly defined. This PR fixes that issue, and additionally ensures that the `blockUser` and `unblockUser` operation responses are correctly parsed.

- 🚨 Breaking change: The `ChatClient.unblockUser(userId: String)` operation returns `Call<Unit>` instead of `Call<UserBlock>`. this is changed because the API no longer gives us return information about the unblocked user as it can be deducted from the argument that was initially passed to the `unblockUser` method.

### 🛠 Implementation details
- Add the missing `GET` path to the `UserApi.queryBlockedUsers`
- Adjust the `BlockUserResponse` and `UnblockUserResponse` models to ensure they are properly parsed

### 🎨 UI Changes
_NA_

### 🧪 Testing
1. Apply the provided patch
2. Uncomment the relevant operation in the `ChannelsActivity`
3. Open the Compose Sample app
4. Check the `ChannelActivity` logs to ensure the `blockUser/unblockUser/queryBlockedUsers` operations are successful.

<details>

<summary>Patch</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(revision f23d2e75daea39b61fc7dab68331072906f1585e)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/ChannelsActivity.kt	(date 1734692303819)
@@ -19,6 +19,7 @@
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
 import androidx.compose.foundation.background
@@ -35,6 +36,7 @@
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -74,6 +76,7 @@
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.state.extensions.globalState
+import io.getstream.result.call.enqueue
 import kotlinx.coroutines.launch
 
 class ChannelsActivity : BaseConnectedActivity() {
@@ -151,6 +154,32 @@
                 listViewModel.refresh()
             },
         )
+        LaunchedEffect(Unit) {
+            // ChatClient.instance().unblockUser("dmitrii").enqueue(
+            //     onSuccess = { response ->
+            //         Log.d("ChannelsActivity", "Unblocked user: dmitrii")
+            //     },
+            //     onError = { error ->
+            //         Log.d("ChannelsActivity", "Error: $error")
+            //     },
+            // )
+            // ChatClient.instance().blockUser("dmitrii").enqueue(
+            //     onSuccess = { response ->
+            //         Log.d("ChannelsActivity", "Blocked user: $response")
+            //     },
+            //     onError = { error ->
+            //         Log.d("ChannelsActivity", "Error: $error")
+            //     },
+            // )
+            // ChatClient.instance().queryBlockedUsers().enqueue(
+            //     onSuccess = { blockedUsers ->
+            //         Log.d("ChannelsActivity", "Blocked users: $blockedUsers")
+            //     },
+            //     onError = { error ->
+            //         Log.d("ChannelsActivity", "Error: $error")
+            //     },
+            // )
+        }
 
 //                MyCustomUiSimplified()
 //                MyCustomUi()

```

</details>