### PR TITLE
[AND-190] Add "Unblock user" as message option in the UI SDKs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `ClientState::user::blockedUserIds` exposing the list of the current user's blocked users. [#5533](https://github.com/GetStream/stream-chat-android/pull/5533)
 
 ### ⚠️ Changed
 - 🚨 Breaking change: Change `ChatClient::unblockUser` return type from `Call<BlockUser>` to `Call<Unit>` as we no longer get information about the unblocked user. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
@@ -41,6 +42,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `GlobalState::blockedUserIds` exposing the list of the current user's blocked users. [#5533](https://github.com/GetStream/stream-chat-android/pull/5533)
 
 ### ⚠️ Changed
 
@@ -63,6 +65,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add "Unblock user" message menu option shown for messages from blocked users. [#5533](https://github.com/GetStream/stream-chat-android/pull/5533)
 
 ### ⚠️ Changed
 
@@ -74,6 +77,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add "Unblock user" message menu option shown for messages from blocked users. [#5533](https://github.com/GetStream/stream-chat-android/pull/5533)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2766,9 +2766,10 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun createRepositoryFactory (Lio/getstream/chat/android/models/User;)Lio/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory;
 }
 
-public abstract interface class io/getstream/chat/android/client/plugin/Plugin : io/getstream/chat/android/client/plugin/DependencyResolver, io/getstream/chat/android/client/plugin/listeners/ChannelMarkReadListener, io/getstream/chat/android/client/plugin/listeners/CreateChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteMessageListener, io/getstream/chat/android/client/plugin/listeners/DeleteReactionListener, io/getstream/chat/android/client/plugin/listeners/EditMessageListener, io/getstream/chat/android/client/plugin/listeners/FetchCurrentUserListener, io/getstream/chat/android/client/plugin/listeners/GetMessageListener, io/getstream/chat/android/client/plugin/listeners/HideChannelListener, io/getstream/chat/android/client/plugin/listeners/MarkAllReadListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelsListener, io/getstream/chat/android/client/plugin/listeners/QueryMembersListener, io/getstream/chat/android/client/plugin/listeners/QueryThreadsListener, io/getstream/chat/android/client/plugin/listeners/SendAttachmentListener, io/getstream/chat/android/client/plugin/listeners/SendGiphyListener, io/getstream/chat/android/client/plugin/listeners/SendMessageListener, io/getstream/chat/android/client/plugin/listeners/SendReactionListener, io/getstream/chat/android/client/plugin/listeners/ShuffleGiphyListener, io/getstream/chat/android/client/plugin/listeners/ThreadQueryListener, io/getstream/chat/android/client/plugin/listeners/TypingEventListener {
+public abstract interface class io/getstream/chat/android/client/plugin/Plugin : io/getstream/chat/android/client/plugin/DependencyResolver, io/getstream/chat/android/client/plugin/listeners/BlockUserListener, io/getstream/chat/android/client/plugin/listeners/ChannelMarkReadListener, io/getstream/chat/android/client/plugin/listeners/CreateChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteMessageListener, io/getstream/chat/android/client/plugin/listeners/DeleteReactionListener, io/getstream/chat/android/client/plugin/listeners/EditMessageListener, io/getstream/chat/android/client/plugin/listeners/FetchCurrentUserListener, io/getstream/chat/android/client/plugin/listeners/GetMessageListener, io/getstream/chat/android/client/plugin/listeners/HideChannelListener, io/getstream/chat/android/client/plugin/listeners/MarkAllReadListener, io/getstream/chat/android/client/plugin/listeners/QueryBlockedUsersListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelsListener, io/getstream/chat/android/client/plugin/listeners/QueryMembersListener, io/getstream/chat/android/client/plugin/listeners/QueryThreadsListener, io/getstream/chat/android/client/plugin/listeners/SendAttachmentListener, io/getstream/chat/android/client/plugin/listeners/SendGiphyListener, io/getstream/chat/android/client/plugin/listeners/SendMessageListener, io/getstream/chat/android/client/plugin/listeners/SendReactionListener, io/getstream/chat/android/client/plugin/listeners/ShuffleGiphyListener, io/getstream/chat/android/client/plugin/listeners/ThreadQueryListener, io/getstream/chat/android/client/plugin/listeners/TypingEventListener, io/getstream/chat/android/client/plugin/listeners/UnblockUserListener {
 	public abstract fun getErrorHandler ()Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
 	public abstract fun onAttachmentSendRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onBlockUserResult (Lio/getstream/result/Result;)V
 	public abstract fun onChannelMarkReadPrecondition (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onCreateChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/util/List;)Lio/getstream/result/Result;
 	public abstract fun onCreateChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2799,6 +2800,7 @@ public abstract interface class io/getstream/chat/android/client/plugin/Plugin :
 	public abstract fun onMessageEditRequest (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onMessageEditResult (Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onMessageSendResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun onQueryBlockedUsersResult (Lio/getstream/result/Result;)V
 	public abstract fun onQueryChannelPrecondition (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onQueryChannelResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2816,6 +2818,7 @@ public abstract interface class io/getstream/chat/android/client/plugin/Plugin :
 	public abstract fun onTypingEventPrecondition (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
 	public abstract fun onTypingEventRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
 	public abstract fun onTypingEventResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
+	public abstract fun onUnblockUserResult (Ljava/lang/String;Lio/getstream/result/Result;)V
 	public abstract fun onUserDisconnected ()V
 	public abstract fun onUserSet (Lio/getstream/chat/android/models/User;)V
 }
@@ -2823,6 +2826,7 @@ public abstract interface class io/getstream/chat/android/client/plugin/Plugin :
 public final class io/getstream/chat/android/client/plugin/Plugin$DefaultImpls {
 	public static fun getErrorHandler (Lio/getstream/chat/android/client/plugin/Plugin;)Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
 	public static fun onAttachmentSendRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onBlockUserResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;)V
 	public static fun onChannelMarkReadPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun onCreateChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/util/List;)Lio/getstream/result/Result;
 	public static fun onCreateChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2854,6 +2858,7 @@ public final class io/getstream/chat/android/client/plugin/Plugin$DefaultImpls {
 	public static fun onMessageEditRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun onMessageEditResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun onMessageSendResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun onQueryBlockedUsersResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;)V
 	public static fun onQueryChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun onQueryChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun onQueryChannelResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2871,10 +2876,15 @@ public final class io/getstream/chat/android/client/plugin/Plugin$DefaultImpls {
 	public static fun onTypingEventPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
 	public static fun onTypingEventRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
 	public static fun onTypingEventResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
+	public static fun onUnblockUserResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/factory/PluginFactory : io/getstream/chat/android/client/plugin/DependencyResolver {
 	public abstract fun get (Lio/getstream/chat/android/models/User;)Lio/getstream/chat/android/client/plugin/Plugin;
+}
+
+public abstract interface class io/getstream/chat/android/client/plugin/listeners/BlockUserListener {
+	public abstract fun onBlockUserResult (Lio/getstream/result/Result;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/ChannelMarkReadListener {
@@ -2927,6 +2937,10 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/MarkAllReadListener {
 	public abstract fun onMarkAllReadRequest (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class io/getstream/chat/android/client/plugin/listeners/QueryBlockedUsersListener {
+	public abstract fun onQueryBlockedUsersResult (Lio/getstream/result/Result;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/QueryChannelListener {
@@ -2991,6 +3005,10 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 	public abstract fun onTypingEventPrecondition (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
 	public abstract fun onTypingEventRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
 	public abstract fun onTypingEventResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
+}
+
+public abstract interface class io/getstream/chat/android/client/plugin/listeners/UnblockUserListener {
+	public abstract fun onUnblockUserResult (Ljava/lang/String;Lio/getstream/result/Result;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/plugins/requests/ApiRequestsAnalyser {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2661,7 +2661,18 @@ internal constructor(
      */
     @CheckResult
     public fun blockUser(userId: String): Call<UserBlock> {
-        return api.blockUser(userId)
+        return api.blockUser(userId).doOnResult(userScope) { result ->
+            plugins.forEach { it.onBlockUserResult(result) }
+            if (result is Result.Success) {
+                // Note: Update local user state manually as we don't get WS events for blocked users updates
+                val currentUser = mutableClientState.user.value ?: return@doOnResult
+                if (!currentUser.blockedUserIds.contains(userId)) {
+                    val updatedCurrentUser = currentUser.copy(blockedUserIds = currentUser.blockedUserIds + userId)
+                    userStateService.onUserUpdated(updatedCurrentUser)
+                    mutableClientState.setUser(updatedCurrentUser)
+                }
+            }
+        }
     }
 
     /**
@@ -2671,7 +2682,18 @@ internal constructor(
      */
     @CheckResult
     public fun unblockUser(userId: String): Call<Unit> {
-        return api.unblockUser(userId)
+        return api.unblockUser(userId).doOnResult(userScope) { result ->
+            plugins.forEach { it.onUnblockUserResult(userId, result) }
+            if (result is Result.Success) {
+                // Note: Update local user state manually as we don't get WS events for blocked users updates
+                val currentUser = mutableClientState.user.value ?: return@doOnResult
+                if (currentUser.blockedUserIds.contains(userId)) {
+                    val updatedCurrentUser = currentUser.copy(blockedUserIds = currentUser.blockedUserIds - userId)
+                    userStateService.onUserUpdated(updatedCurrentUser)
+                    mutableClientState.setUser(updatedCurrentUser)
+                }
+            }
+        }
     }
 
     /**
@@ -2679,7 +2701,9 @@ internal constructor(
      */
     @CheckResult
     public fun queryBlockedUsers(): Call<List<UserBlock>> {
-        return api.queryBlockedUsers()
+        return api.queryBlockedUsers().doOnResult(userScope) { result ->
+            plugins.forEach { it.onQueryBlockedUsersResult(result) }
+        }
     }
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/UserMapping.kt
@@ -62,6 +62,7 @@ internal fun DownstreamUserDto.toDomain(currentUserId: UserId?): User =
         mutes = mutes.orEmpty().map { it.toDomain(currentUserId) },
         teams = teams,
         channelMutes = channel_mutes.orEmpty().map { it.toDomain(currentUserId) },
+        blockedUserIds = blocked_user_ids.orEmpty(),
         extraData = extraData.toMutableMap(),
     )
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -75,6 +75,7 @@ internal data class DownstreamUserDto(
     val mutes: List<DownstreamMuteDto>?,
     val teams: List<String> = emptyList(),
     val channel_mutes: List<DownstreamChannelMuteDto>?,
+    val blocked_user_ids: List<String>?,
 
     val extraData: Map<String, Any>,
 ) : ExtraDataDto

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/Plugin.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/Plugin.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.api.models.QueryThreadsRequest
 import io.getstream.chat.android.client.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.events.ChatEvent
+import io.getstream.chat.android.client.plugin.listeners.BlockUserListener
 import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
 import io.getstream.chat.android.client.plugin.listeners.CreateChannelListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteChannelListener
@@ -32,6 +33,7 @@ import io.getstream.chat.android.client.plugin.listeners.FetchCurrentUserListene
 import io.getstream.chat.android.client.plugin.listeners.GetMessageListener
 import io.getstream.chat.android.client.plugin.listeners.HideChannelListener
 import io.getstream.chat.android.client.plugin.listeners.MarkAllReadListener
+import io.getstream.chat.android.client.plugin.listeners.QueryBlockedUsersListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelsListener
 import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
@@ -43,6 +45,7 @@ import io.getstream.chat.android.client.plugin.listeners.SendReactionListener
 import io.getstream.chat.android.client.plugin.listeners.ShuffleGiphyListener
 import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.plugin.listeners.TypingEventListener
+import io.getstream.chat.android.client.plugin.listeners.UnblockUserListener
 import io.getstream.chat.android.client.query.CreateChannelParams
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.FilterObject
@@ -51,6 +54,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.QueryThreadsResult
 import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.models.UserBlock
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.result.Result
 import java.util.Date
@@ -81,7 +85,10 @@ public interface Plugin :
     DeleteChannelListener,
     GetMessageListener,
     FetchCurrentUserListener,
-    QueryThreadsListener {
+    QueryThreadsListener,
+    BlockUserListener,
+    UnblockUserListener,
+    QueryBlockedUsersListener {
 
     public fun getErrorHandler(): ErrorHandler? = null
 
@@ -420,6 +427,18 @@ public interface Plugin :
     }
 
     override suspend fun onQueryThreadsResult(result: Result<QueryThreadsResult>, request: QueryThreadsRequest) {
+        /* No-Op */
+    }
+
+    override fun onBlockUserResult(result: Result<UserBlock>) {
+        /* No-Op */
+    }
+
+    override fun onUnblockUserResult(userId: String, result: Result<Unit>) {
+        /* No-Op */
+    }
+
+    override fun onQueryBlockedUsersResult(result: Result<List<UserBlock>>) {
         /* No-Op */
     }
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/BlockUserListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/BlockUserListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.listeners
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.result.Result
+
+/**
+ * Listener for [ChatClient.blockUser] requests.
+ */
+public interface BlockUserListener {
+
+    /**
+     * Runs side effect after the request was completed.
+     *
+     * @param result The [Result] containing the successfully retrieved [UserBlock] or the error.
+     */
+    public fun onBlockUserResult(result: Result<UserBlock>)
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/QueryBlockedUsersListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/QueryBlockedUsersListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.listeners
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.result.Result
+
+/**
+ * Listener for [ChatClient.queryBlockedUsers] requests.
+ */
+public interface QueryBlockedUsersListener {
+
+    /**
+     * Runs side effect after the request was completed.
+     *
+     * @param result The [Result] containing the successfully retrieved list of blocked users or the error.
+     */
+    public fun onQueryBlockedUsersResult(result: Result<List<UserBlock>>)
+}

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/UnblockUserListener.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/plugin/listeners/UnblockUserListener.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.plugin.listeners
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.result.Result
+
+/**
+ * Listener for [ChatClient.unblockUser] requests.
+ */
+public interface UnblockUserListener {
+
+    /**
+     * Runs side effect after the request was completed.
+     *
+     * @param userId The id of the user that was unblocked.
+     * @param result The [Result] of the unblock operation.
+     */
+    public fun onUnblockUserResult(userId: String, result: Result<Unit>)
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenBlockUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenBlockUser.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.chatclient
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.clientstate.UserState
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.test.TestCall
+import io.getstream.chat.android.test.callFrom
+import io.getstream.result.Error
+import io.getstream.result.Result
+import io.getstream.result.call.Call
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+internal class WhenBlockUser : BaseChatClientTest() {
+
+    @Test
+    fun `Given blockUser api call successful ChatClient should return success result adn update local data`() = runTest {
+        val apiResult = callFrom { UserBlock("user1", "user2", Date()) }
+        val user = randomUser(id = "user1")
+        val plugin = mock<Plugin>().apply {
+            doNothing().whenever(this).onBlockUserResult(any())
+        }
+        val sut = Fixture()
+            .givenPlugin(plugin)
+            .givenUserState(user)
+            .givenClientState(user)
+            .givenBlockUserApiResult(apiResult)
+            .get()
+
+        val result = sut.blockUser("user2").await()
+
+        result shouldBeInstanceOf Result.Success::class
+        verify(plugin).onBlockUserResult(result)
+        val expectedUser = user.copy(blockedUserIds = listOf("user2"))
+        verify(userStateService).onUserUpdated(expectedUser)
+        verify(mutableClientState).setUser(expectedUser)
+    }
+
+    @Test
+    fun `Given blockUser api call fails ChatClient should return error result`() = runTest {
+        val apiResult = TestCall<UserBlock>(Result.Failure(Error.GenericError("Error")))
+        val user = randomUser(id = "user1")
+        val plugin = mock<Plugin>().apply {
+            doNothing().whenever(this).onBlockUserResult(any())
+        }
+        val sut = Fixture()
+            .givenPlugin(plugin)
+            .givenUserState(user)
+            .givenClientState(user)
+            .givenBlockUserApiResult(apiResult)
+            .get()
+
+        val result = sut.blockUser("user2").await()
+        verify(plugin).onBlockUserResult(result)
+        result shouldBeInstanceOf Result.Failure::class
+        verify(userStateService, never()).onUserUpdated(any())
+        verify(mutableClientState, never()).setUser(any())
+    }
+
+    private inner class Fixture {
+
+        fun givenPlugin(plugin: Plugin) = apply {
+            plugins.add(plugin)
+        }
+
+        fun givenBlockUserApiResult(result: Call<UserBlock>) = apply {
+            whenever(api.blockUser(any())) doReturn result
+        }
+
+        fun givenUserState(user: User) = apply {
+            // userStateService = mock()
+            whenever(userStateService.state) doReturn UserState.UserSet(user)
+        }
+
+        fun givenClientState(user: User) = apply {
+            whenever(mutableClientState.user) doReturn MutableStateFlow(user)
+        }
+
+        fun get(): ChatClient = chatClient.apply { plugins = this@WhenBlockUser.plugins }
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryBlockedUsers.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenQueryBlockedUsers.kt
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.chatclient
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.test.TestCall
+import io.getstream.chat.android.test.callFrom
+import io.getstream.result.Error
+import io.getstream.result.Result
+import io.getstream.result.call.Call
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class WhenQueryBlockedUsers : BaseChatClientTest() {
+
+    @Test
+    fun `Given queryBlockedUsers api call successful ChatClient should return success result`() {
+        val apiResult = callFrom { emptyList<UserBlock>() }
+        val plugin = mock<Plugin>().apply {
+            doNothing().whenever(this).onQueryBlockedUsersResult(any())
+        }
+        val sut = Fixture()
+            .givenPlugin(plugin)
+            .givenQueryBlockedUsersUserApiResult(apiResult)
+            .get()
+
+        val result = sut.queryBlockedUsers().execute()
+
+        result shouldBeInstanceOf Result.Success::class
+        verify(plugin).onQueryBlockedUsersResult(result)
+    }
+
+    @Test
+    fun `Given queryBlockedUsers api call fails ChatClient should return error result`() {
+        val apiResult = TestCall<List<UserBlock>>(Result.Failure(Error.GenericError("error")))
+        val plugin = mock<Plugin>().apply {
+            doNothing().whenever(this).onQueryBlockedUsersResult(any())
+        }
+        val sut = Fixture()
+            .givenPlugin(plugin)
+            .givenQueryBlockedUsersUserApiResult(apiResult)
+            .get()
+
+        val result = sut.queryBlockedUsers().execute()
+
+        result shouldBeInstanceOf Result.Failure::class
+        verify(plugin).onQueryBlockedUsersResult(result)
+    }
+
+    private inner class Fixture {
+
+        fun givenPlugin(plugin: Plugin) = apply {
+            plugins.add(plugin)
+        }
+
+        fun givenQueryBlockedUsersUserApiResult(result: Call<List<UserBlock>>) = apply {
+            whenever(api.queryBlockedUsers()) doReturn result
+        }
+
+        fun get(): ChatClient = chatClient.apply { plugins = this@WhenQueryBlockedUsers.plugins }
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenUnblockUser.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/chatclient/WhenUnblockUser.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.chatclient
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.clientstate.UserState
+import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.test.TestCall
+import io.getstream.chat.android.test.callFrom
+import io.getstream.result.Error
+import io.getstream.result.Result
+import io.getstream.result.call.Call
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class WhenUnblockUser : BaseChatClientTest() {
+
+    @Test
+    fun `Given unblockUser api call successful ChatClient should return success result and update local data`() =
+        runTest {
+            val apiResult = callFrom { }
+            val user = randomUser(id = "user1", blockedUserIds = listOf("user2"))
+            val plugin = mock<Plugin>().apply {
+                doNothing().whenever(this).onUnblockUserResult(any(), any())
+            }
+            val sut = Fixture()
+                .givenPlugin(plugin)
+                .givenUserState(user)
+                .givenClientState(user)
+                .givenUnblockUserApiResult(apiResult)
+                .get()
+
+            val result = sut.unblockUser("user2").await()
+
+            result shouldBeInstanceOf Result.Success::class
+            verify(plugin).onUnblockUserResult("user2", result)
+            val expectedUser = user.copy(blockedUserIds = emptyList())
+            verify(userStateService).onUserUpdated(expectedUser)
+            verify(mutableClientState).setUser(expectedUser)
+        }
+
+    @Test
+    fun `Given unblockUser api call fails ChatClient should return error result`() = runTest {
+        val apiResult = TestCall<Unit>(Result.Failure(Error.GenericError("Error")))
+        val user = randomUser(id = "user1", blockedUserIds = listOf("user2"))
+        val plugin = mock<Plugin>().apply {
+            doNothing().whenever(this).onUnblockUserResult(any(), any())
+        }
+        val sut = Fixture()
+            .givenPlugin(plugin)
+            .givenUserState(user)
+            .givenClientState(user)
+            .givenUnblockUserApiResult(apiResult)
+            .get()
+
+        val result = sut.unblockUser("user2").await()
+
+        result shouldBeInstanceOf Result.Failure::class
+        verify(plugin).onUnblockUserResult("user2", result)
+        verify(userStateService, never()).onUserUpdated(any())
+        verify(mutableClientState, never()).setUser(any())
+    }
+
+    private inner class Fixture {
+
+        fun givenPlugin(plugin: Plugin) = apply {
+            plugins.add(plugin)
+        }
+
+        fun givenUnblockUserApiResult(result: Call<Unit>) = apply {
+            whenever(api.unblockUser(any())) doReturn result
+        }
+
+        fun givenUserState(user: User) = apply {
+            // userStateService = mock()
+            whenever(userStateService.state) doReturn UserState.UserSet(user)
+        }
+
+        fun givenClientState(user: User) = apply {
+            whenever(mutableClientState.user) doReturn MutableStateFlow(user)
+        }
+
+        fun get(): ChatClient = chatClient.apply { plugins = this@WhenUnblockUser.plugins }
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
@@ -74,6 +74,7 @@ internal object UserDtoTestData {
             mutes = emptyList(),
             teams = emptyList(),
             channel_mutes = emptyList(),
+            blocked_user_ids = null,
             extraData = emptyMap(),
         )
 
@@ -122,6 +123,7 @@ internal object UserDtoTestData {
             mutes = emptyList(),
             teams = emptyList(),
             channel_mutes = emptyList(),
+            blocked_user_ids = null,
             extraData = emptyMap(),
         )
 
@@ -206,6 +208,7 @@ internal object UserDtoTestData {
             ),
             teams = listOf("team1", "team2"),
             channel_mutes = emptyList(),
+            blocked_user_ids = null,
             extraData = emptyMap(),
         )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -51,6 +51,7 @@ import io.getstream.chat.android.ui.common.state.messages.Pin
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.Resend
 import io.getstream.chat.android.ui.common.state.messages.ThreadReply
+import io.getstream.chat.android.ui.common.state.messages.UnblockUser
 import io.getstream.chat.android.uiutils.extension.hasLink
 
 /**
@@ -250,10 +251,21 @@ public fun defaultMessageOptionsState(
             null
         },
         if (visibility.isBlockUserVisible && !isOwnMessage) {
+            val isSenderBlocked = currentUser?.blockedUserIds?.contains(selectedMessageUserId) == true
+            val title = if (isSenderBlocked) {
+                R.string.stream_compose_unblock_user
+            } else {
+                R.string.stream_compose_block_user
+            }
+            val action = if (isSenderBlocked) {
+                UnblockUser(selectedMessage)
+            } else {
+                BlockUser(selectedMessage)
+            }
             MessageOptionItemState(
-                title = R.string.stream_compose_block_user,
+                title = title,
                 iconPainter = painterResource(R.drawable.stream_compose_ic_clear),
-                action = BlockUser(selectedMessage),
+                action = action,
                 iconColor = ChatTheme.colors.textLowEmphasis,
                 titleColor = ChatTheme.colors.textHighEmphasis,
             )

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -92,6 +92,7 @@
 
     <!-- Selected Message Menu -->
     <string name="stream_compose_block_user">Block user</string>
+    <string name="stream_compose_unblock_user">Unblock user</string>
     <string name="stream_compose_resend_message">Resend</string>
     <string name="stream_compose_reply">Reply</string>
     <string name="stream_compose_thread_reply">Thread reply</string>

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -1914,8 +1914,8 @@ public final class io/getstream/chat/android/models/UploadedFile {
 
 public final class io/getstream/chat/android/models/User : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Ljava/util/Date;
@@ -1928,8 +1928,9 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component18 ()Ljava/util/List;
 	public final fun component19 ()Ljava/util/List;
 	public final fun component2 ()Ljava/lang/String;
-	public final fun component20 ()Ljava/util/Map;
-	public final fun component21 ()Ljava/util/Date;
+	public final fun component20 ()Ljava/util/List;
+	public final fun component21 ()Ljava/util/Map;
+	public final fun component22 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Boolean;
@@ -1937,10 +1938,11 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBanned ()Ljava/lang/Boolean;
+	public final fun getBlockedUserIds ()Ljava/util/List;
 	public final fun getChannelMutes ()Ljava/util/List;
 	public fun getComparableField (Ljava/lang/String;)Ljava/lang/Comparable;
 	public final fun getCreatedAt ()Ljava/util/Date;
@@ -1977,6 +1979,7 @@ public final class io/getstream/chat/android/models/User$Builder {
 	public fun <init> (Lio/getstream/chat/android/models/User;)V
 	public final fun build ()Lio/getstream/chat/android/models/User;
 	public final fun withBanned (Ljava/lang/Boolean;)Lio/getstream/chat/android/models/User$Builder;
+	public final fun withBlockedUserIds (Ljava/util/List;)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withChannelMutes (Ljava/util/List;)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withCreatedAt (Ljava/util/Date;)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withDeactivatedAt (Ljava/util/Date;)Lio/getstream/chat/android/models/User$Builder;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
@@ -43,6 +43,7 @@ import java.util.Date
  * @param mutes A list of users muted by the current user.
  * @param teams List of teams user is a part of.
  * @param channelMutes A list of channels muted by the current user.
+ * @param blockedUserIds A list of user ids blocked by the current user.
  * @param extraData A map of custom fields for the user.
  * @param deactivatedAt Date/time of deactivation.
  */
@@ -67,6 +68,7 @@ public data class User(
     val mutes: List<Mute> = listOf(),
     val teams: List<String> = listOf(),
     val channelMutes: List<ChannelMute> = emptyList(),
+    val blockedUserIds: List<String> = emptyList(),
     override val extraData: Map<String, Any> = mapOf(),
     val deactivatedAt: Date? = null,
 ) : CustomObject, ComparableFieldProvider {
@@ -136,6 +138,7 @@ public data class User(
         private var mutes: List<Mute> = listOf()
         private var teams: List<String> = listOf()
         private var channelMutes: List<ChannelMute> = emptyList()
+        private var blockedUserIds: List<String> = emptyList()
         private var extraData: Map<String, Any> = mutableMapOf()
         private var deactivatedAt: Date? = null
 
@@ -159,6 +162,7 @@ public data class User(
             mutes = user.mutes
             teams = user.teams
             channelMutes = user.channelMutes
+            blockedUserIds = user.blockedUserIds
             extraData = user.extraData
             deactivatedAt = user.deactivatedAt
         }
@@ -186,6 +190,9 @@ public data class User(
         public fun withChannelMutes(channelMutes: List<ChannelMute>): Builder = apply {
             this.channelMutes = channelMutes
         }
+        public fun withBlockedUserIds(blockedUserIds: List<String>): Builder = apply {
+            this.blockedUserIds = blockedUserIds
+        }
         public fun withExtraData(extraData: Map<String, Any>): Builder = apply { this.extraData = extraData }
         public fun withDeactivatedAt(deactivatedAt: Date?): Builder = apply { this.deactivatedAt = deactivatedAt }
 
@@ -210,6 +217,7 @@ public data class User(
                 mutes = mutes,
                 teams = teams,
                 channelMutes = channelMutes,
+                blockedUserIds = blockedUserIds,
                 extraData = extraData.toMutableMap(),
                 deactivatedAt = deactivatedAt,
             )

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -84,6 +84,7 @@ public fun randomUser(
     mutes: List<Mute> = mutableListOf(),
     teams: List<String> = listOf(),
     channelMutes: List<ChannelMute> = emptyList(),
+    blockedUserIds: List<String> = emptyList(),
     extraData: MutableMap<String, Any> = mutableMapOf(),
 ): User = User(
     id = id,
@@ -104,6 +105,7 @@ public fun randomUser(
     mutes = mutes,
     teams = teams,
     channelMutes = channelMutes,
+    blockedUserIds = blockedUserIds,
     extraData = extraData,
 )
 

--- a/stream-chat-android-state/api/stream-chat-android-state.api
+++ b/stream-chat-android-state/api/stream-chat-android-state.api
@@ -143,6 +143,7 @@ public abstract interface class io/getstream/chat/android/state/plugin/state/cha
 
 public abstract interface class io/getstream/chat/android/state/plugin/state/global/GlobalState {
 	public abstract fun getBanned ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getBlockedUserIds ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getChannelMutes ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getChannelUnreadCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMuted ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -288,6 +288,7 @@ internal class EventHandlerSequential(
         var totalUnreadCount = mutableGlobalState.totalUnreadCount.value
         var channelUnreadCount = mutableGlobalState.channelUnreadCount.value
         var unreadThreadsCount = mutableGlobalState.unreadThreadsCount.value
+        var blockedUserIds = mutableGlobalState.blockedUserIds.value
 
         val modifyValuesFromEvent = { event: HasUnreadCounts ->
             totalUnreadCount = event.totalUnreadCount
@@ -299,6 +300,7 @@ internal class EventHandlerSequential(
             totalUnreadCount = user.totalUnreadCount
             channelUnreadCount = user.unreadChannels
             unreadThreadsCount = user.unreadThreads
+            blockedUserIds = user.blockedUserIds
         }
 
         val modifyUnreadThreadsCount = { newValue: Int? ->
@@ -367,6 +369,7 @@ internal class EventHandlerSequential(
         mutableGlobalState.setTotalUnreadCount(totalUnreadCount)
         mutableGlobalState.setChannelUnreadCount(channelUnreadCount)
         mutableGlobalState.setUnreadThreadsCount(unreadThreadsCount)
+        mutableGlobalState.setBlockedUserIds(blockedUserIds)
         logger.v { "[updateGlobalState] completed batchId: ${batchEvent.id}" }
     }
 

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/utils/SelfUserUtils.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/utils/SelfUserUtils.kt
@@ -38,4 +38,5 @@ internal fun MutableGlobalState.updateCurrentUser(currentUser: User?, receivedUs
     setTotalUnreadCount(me.totalUnreadCount)
     setChannelUnreadCount(me.unreadChannels)
     setUnreadThreadsCount(me.unreadThreads)
+    setBlockedUserIds(me.blockedUserIds)
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/internal/StatePlugin.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.errorhandler.ErrorHandler
 import io.getstream.chat.android.client.errorhandler.factory.ErrorHandlerFactory
 import io.getstream.chat.android.client.persistance.repository.RepositoryFacade
 import io.getstream.chat.android.client.plugin.Plugin
+import io.getstream.chat.android.client.plugin.listeners.BlockUserListener
 import io.getstream.chat.android.client.plugin.listeners.ChannelMarkReadListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteChannelListener
 import io.getstream.chat.android.client.plugin.listeners.DeleteMessageListener
@@ -28,6 +29,7 @@ import io.getstream.chat.android.client.plugin.listeners.EditMessageListener
 import io.getstream.chat.android.client.plugin.listeners.FetchCurrentUserListener
 import io.getstream.chat.android.client.plugin.listeners.HideChannelListener
 import io.getstream.chat.android.client.plugin.listeners.MarkAllReadListener
+import io.getstream.chat.android.client.plugin.listeners.QueryBlockedUsersListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelListener
 import io.getstream.chat.android.client.plugin.listeners.QueryChannelsListener
 import io.getstream.chat.android.client.plugin.listeners.QueryMembersListener
@@ -39,11 +41,13 @@ import io.getstream.chat.android.client.plugin.listeners.SendReactionListener
 import io.getstream.chat.android.client.plugin.listeners.ShuffleGiphyListener
 import io.getstream.chat.android.client.plugin.listeners.ThreadQueryListener
 import io.getstream.chat.android.client.plugin.listeners.TypingEventListener
+import io.getstream.chat.android.client.plugin.listeners.UnblockUserListener
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.event.handler.internal.EventHandler
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
+import io.getstream.chat.android.state.plugin.listener.internal.BlockUserListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.ChannelMarkReadListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.DeleteChannelListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.DeleteMessageListenerState
@@ -52,6 +56,7 @@ import io.getstream.chat.android.state.plugin.listener.internal.EditMessageListe
 import io.getstream.chat.android.state.plugin.listener.internal.FetchCurrentUserListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.HideChannelListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.MarkAllReadListenerState
+import io.getstream.chat.android.state.plugin.listener.internal.QueryBlockedUsersListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryChannelListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryChannelsListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.QueryMembersListenerState
@@ -63,6 +68,7 @@ import io.getstream.chat.android.state.plugin.listener.internal.SendReactionList
 import io.getstream.chat.android.state.plugin.listener.internal.ShuffleGiphyListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.ThreadQueryListenerState
 import io.getstream.chat.android.state.plugin.listener.internal.TypingEventListenerState
+import io.getstream.chat.android.state.plugin.listener.internal.UnblockUserListenerState
 import io.getstream.chat.android.state.plugin.logic.internal.LogicRegistry
 import io.getstream.chat.android.state.plugin.state.StateRegistry
 import io.getstream.chat.android.state.plugin.state.global.GlobalState
@@ -116,7 +122,10 @@ public class StatePlugin internal constructor(
     TypingEventListener by TypingEventListenerState(stateRegistry),
     SendAttachmentListener by SendAttachmentListenerState(logic),
     FetchCurrentUserListener by FetchCurrentUserListenerState(clientState, globalState),
-    QueryThreadsListener by QueryThreadsListenerState(logic) {
+    QueryThreadsListener by QueryThreadsListenerState(logic),
+    BlockUserListener by BlockUserListenerState(globalState),
+    UnblockUserListener by UnblockUserListenerState(globalState),
+    QueryBlockedUsersListener by QueryBlockedUsersListenerState(globalState) {
 
     private val lazyErrorHandler: ErrorHandler by lazy { errorHandlerFactory.create() }
     override fun getErrorHandler(): ErrorHandler = lazyErrorHandler

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/BlockUserListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/BlockUserListenerState.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.client.plugin.listeners.BlockUserListener
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Result
+
+/**
+ * [BlockUserListener] implementation for the [StatePlugin].
+ * Updates the global state with the result of the "Block User" operation.
+ *
+ * @param globalState The global state of the plugin.
+ */
+internal class BlockUserListenerState(private val globalState: MutableGlobalState) : BlockUserListener {
+
+    override fun onBlockUserResult(result: Result<UserBlock>) {
+        if (result is Result.Success) {
+            val userId = result.value.userId
+            val blockedUserIds = globalState.blockedUserIds.value
+            if (!blockedUserIds.contains(userId)) {
+                globalState.setBlockedUserIds(blockedUserIds + userId)
+            }
+        }
+    }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryBlockedUsersListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/QueryBlockedUsersListenerState.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.client.plugin.listeners.QueryBlockedUsersListener
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Result
+
+/**
+ * [QueryBlockedUsersListener] implementation for the [StatePlugin].
+ * Updates the global state with the result of the "Query blocked users" operation.
+ *
+ * @param globalState The global state of the plugin.
+ */
+internal class QueryBlockedUsersListenerState(private val globalState: MutableGlobalState) : QueryBlockedUsersListener {
+
+    override fun onQueryBlockedUsersResult(result: Result<List<UserBlock>>) {
+        if (result is Result.Success) {
+            val blockedUserIds = result.value.map { it.userId }
+            globalState.setBlockedUserIds(blockedUserIds)
+        }
+    }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/UnblockUserListenerState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/listener/internal/UnblockUserListenerState.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.client.plugin.listeners.UnblockUserListener
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Result
+
+/**
+ * [UnblockUserListener] implementation for the [StatePlugin].
+ * Updates the global state with the result of the "Unblock User" operation.
+ *
+ * @param globalState The global state of the plugin.
+ */
+internal class UnblockUserListenerState(private val globalState: MutableGlobalState) : UnblockUserListener {
+
+    override fun onUnblockUserResult(userId: String, result: Result<Unit>) {
+        if (result is Result.Success) {
+            val blockedUserIds = globalState.blockedUserIds.value
+            if (blockedUserIds.contains(userId)) {
+                globalState.setBlockedUserIds(blockedUserIds - userId)
+            }
+        }
+    }
+}

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/GlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/GlobalState.kt
@@ -55,6 +55,11 @@ public interface GlobalState {
     public val channelMutes: StateFlow<List<ChannelMute>>
 
     /**
+     * List of users that you've blocked.
+     */
+    public val blockedUserIds: StateFlow<List<String>>
+
+    /**
      * if the current user is banned or not.
      */
     public val banned: StateFlow<Boolean>

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
@@ -35,6 +35,7 @@ internal class MutableGlobalState : GlobalState {
     private var _banned: MutableStateFlow<Boolean>? = MutableStateFlow(false)
     private var _mutedUsers: MutableStateFlow<List<Mute>>? = MutableStateFlow(emptyList())
     private var _channelMutes: MutableStateFlow<List<ChannelMute>>? = MutableStateFlow(emptyList())
+    private var _blockedUsersIds: MutableStateFlow<List<String>>? = MutableStateFlow(emptyList())
     private var _typingChannels: MutableStateFlow<Map<String, TypingEvent>>? = MutableStateFlow(emptyMap())
 
     override val totalUnreadCount: StateFlow<Int> = _totalUnreadCount!!
@@ -42,6 +43,7 @@ internal class MutableGlobalState : GlobalState {
     override val unreadThreadsCount: StateFlow<Int> = _unreadThreadsCount!!
     override val muted: StateFlow<List<Mute>> = _mutedUsers!!
     override val channelMutes: StateFlow<List<ChannelMute>> = _channelMutes!!
+    override val blockedUserIds: StateFlow<List<String>> = _blockedUsersIds!!
     override val banned: StateFlow<Boolean> = _banned!!
     override val typingChannels: StateFlow<Map<String, TypingEvent>> = _typingChannels!!
 
@@ -54,6 +56,7 @@ internal class MutableGlobalState : GlobalState {
         _unreadThreadsCount = null
         _mutedUsers = null
         _channelMutes = null
+        _blockedUsersIds = null
         _banned = null
         _typingChannels = null
     }
@@ -76,6 +79,15 @@ internal class MutableGlobalState : GlobalState {
 
     fun setChannelMutes(channelMutes: List<ChannelMute>) {
         _channelMutes?.value = channelMutes
+    }
+
+    /**
+     * Updates the current list of blocked users.
+     *
+     * @param blockedUserIds The new list of block user ids.
+     */
+    fun setBlockedUserIds(blockedUserIds: List<String>) {
+        _blockedUsersIds?.value = blockedUserIds
     }
 
     fun setMutedUsers(mutedUsers: List<Mute>) {

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/BlockUserListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/BlockUserListenerStateTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Error
+import io.getstream.result.Result
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+internal class BlockUserListenerStateTest {
+
+    private val globalState: MutableGlobalState = mock()
+    private val listener = BlockUserListenerState(globalState)
+
+    @Test
+    fun `when blockUser is successful and user is not already blocked, the blocked user should be added to the global state`() {
+        // given
+        val blockedUsers = listOf("user1")
+        whenever(globalState.blockedUserIds) doReturn MutableStateFlow(blockedUsers)
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val result = Result.Success(
+            value = UserBlock(
+                userId = "user2",
+                blockedBy = "blockedBy",
+                blockedAt = Date(),
+            ),
+        )
+        // when
+        listener.onBlockUserResult(result)
+        // then
+        verify(globalState, times(1)).setBlockedUserIds(listOf("user1", "user2"))
+    }
+
+    @Test
+    fun `when blockUser is successful and user already blocked, the blocked user should not be added to the global state`() {
+        // given
+        val blockedUsers = listOf("user1")
+        whenever(globalState.blockedUserIds) doReturn MutableStateFlow(blockedUsers)
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val result = Result.Success(
+            value = UserBlock(
+                userId = "user1",
+                blockedBy = "blockedBy",
+                blockedAt = Date(),
+            ),
+        )
+        // when
+        listener.onBlockUserResult(result)
+        // then
+        verify(globalState, never()).setBlockedUserIds(any())
+    }
+
+    @Test
+    fun `when blockUser fails, the blocked user should not be added to the global state`() {
+        // given
+        val result = Result.Failure(Error.GenericError("Generic error"))
+        // when
+        listener.onBlockUserResult(result)
+        // then
+        verify(globalState, never()).setBlockedUserIds(any())
+    }
+}

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryBlockedUsersListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/QueryBlockedUsersListenerStateTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Error
+import io.getstream.result.Result
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+internal class QueryBlockedUsersListenerStateTest {
+
+    private val globalState: MutableGlobalState = mock()
+    private val listener = QueryBlockedUsersListenerState(globalState)
+
+    @Test
+    fun `when queryBlockedUsers is successful, the blocked user ids should be set in the global state`() {
+        // given
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val blockedUsers = listOf(
+            UserBlock("user1", "user2", Date()),
+        )
+        val result = Result.Success(blockedUsers)
+        // when
+        listener.onQueryBlockedUsersResult(result)
+        // then
+        verify(globalState, times(1)).setBlockedUserIds(listOf("user2"))
+    }
+
+    @Test
+    fun `when queryBlockedUsers is unsuccessful, the blocked user ids should not be set in the global state`() {
+        // given
+        val result = Result.Failure(Error.GenericError("Generic error"))
+        // when
+        listener.onQueryBlockedUsersResult(result)
+        // then
+        verify(globalState, times(0)).setBlockedUserIds(any())
+    }
+}

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/UnblockUserListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/UnblockUserListenerStateTest.kt
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.state.plugin.listener.internal
+
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
+import io.getstream.result.Error
+import io.getstream.result.Result
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.whenever
+
+internal class UnblockUserListenerStateTest {
+
+    private val globalState: MutableGlobalState = mock()
+    private val listener = UnblockUserListenerState(globalState)
+
+    @Test
+    fun `when unblockUser is successful and user is blocked, the blocked user should be removed from the global state`() {
+        // given
+        val blockedUsers = listOf("user1", "user2")
+        whenever(globalState.blockedUserIds) doReturn MutableStateFlow(blockedUsers)
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val result = Result.Success(value = Unit)
+        // when
+        listener.onUnblockUserResult("user2", result)
+        // then
+        verify(globalState, times(1)).setBlockedUserIds(listOf("user1"))
+    }
+
+    @Test
+    fun `when unblockUser is successful and user is not blocked, the blocked user should not be removed from the global state`() {
+        // given
+        val blockedUsers = listOf("user1")
+        whenever(globalState.blockedUserIds) doReturn MutableStateFlow(blockedUsers)
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val result = Result.Success(Unit)
+        // when
+        listener.onUnblockUserResult("user2", result)
+        // then
+        verify(globalState, never()).setBlockedUserIds(any())
+    }
+
+    @Test
+    fun `when unblockUser fails, the blocked user should not be removed from the global state`() {
+        // given
+        val blockedUsers = listOf("user1", "user2")
+        whenever(globalState.blockedUserIds) doReturn MutableStateFlow(blockedUsers)
+        doNothing().whenever(globalState).setBlockedUserIds(any())
+        val result = Result.Failure(Error.GenericError("Generic error"))
+        // when
+        listener.onUnblockUserResult("user2", result)
+        // then
+        verify(globalState, never()).setBlockedUserIds(any())
+    }
+}

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -355,6 +355,18 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnblockUserError : io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/result/Error;)V
+	public final fun component1 ()Lio/getstream/result/Error;
+	public final fun copy (Lio/getstream/result/Error;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnblockUserError;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnblockUserError;Lio/getstream/result/Error;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnblockUserError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getStreamError ()Lio/getstream/result/Error;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent$UnflagUserError : io/getstream/chat/android/ui/common/feature/messages/list/MessageListController$ErrorEvent {
 	public static final field $stable I
 	public fun <init> (Lio/getstream/result/Error;)V
@@ -943,6 +955,18 @@ public final class io/getstream/chat/android/ui/common/state/messages/ThreadRepl
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
 	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/common/state/messages/ThreadReply;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/ThreadReply;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/ThreadReply;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/state/messages/UnblockUser : io/getstream/chat/android/ui/common/state/messages/MessageAction {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/models/Message;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Message;
+	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/common/state/messages/UnblockUser;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/UnblockUser;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/UnblockUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public fun hashCode ()I

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -74,6 +74,7 @@ import io.getstream.chat.android.ui.common.state.messages.React
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.Resend
 import io.getstream.chat.android.ui.common.state.messages.ThreadReply
+import io.getstream.chat.android.ui.common.state.messages.UnblockUser
 import io.getstream.chat.android.ui.common.state.messages.list.CancelGiphy
 import io.getstream.chat.android.ui.common.state.messages.list.DateSeparatorItemState
 import io.getstream.chat.android.ui.common.state.messages.list.DeletedMessageVisibility
@@ -1522,6 +1523,7 @@ public class MessageListController(
             }
 
             is BlockUser -> blockUser(messageAction.message.user.id)
+            is UnblockUser -> unblockUser(messageAction.message.user.id)
             is Copy -> copyMessage(messageAction.message)
             is React -> reactToMessage(messageAction.reaction, messageAction.message)
             is Pin -> updateMessagePin(messageAction.message)
@@ -2390,6 +2392,13 @@ public class MessageListController(
          * @param streamError Contains the original [Throwable] along with a message.
          */
         public data class BlockUserError(override val streamError: Error) : ErrorEvent(streamError)
+
+        /**
+         * When an error occurs while unblocking a user.
+         *
+         * @param streamError Contains the original [Throwable] along with a message.
+         */
+        public data class UnblockUserError(override val streamError: Error) : ErrorEvent(streamError)
 
         /**
          * Error occurring during the operation of flagging a user.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageAction.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageAction.kt
@@ -104,6 +104,11 @@ public data class Flag(
 public data class BlockUser(override val message: Message) : MessageAction()
 
 /**
+ * Unblock the sender of the message.
+ */
+public data class UnblockUser(override val message: Message) : MessageAction()
+
+/**
  * User-customizable action, with any number of extra properties.
  *
  * @param extraProperties Map of key-value pairs that let you store extra data for this action.
@@ -127,5 +132,6 @@ public fun MessageAction.updateMessage(message: Message): MessageAction {
         is Flag -> copy(message = message)
         is CustomAction -> copy(message = message)
         is BlockUser -> copy(message = message)
+        is UnblockUser -> copy(message = message)
     }
 }

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2220,6 +2220,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun setMessageRetryListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageRetryListener;)V
 	public final fun setMessageUnpinHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageUnpinHandler;)V
 	public final fun setMessageUserBlockHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageUserBlockHandler;)V
+	public final fun setMessageUserUnblockHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageUserUnblockHandler;)V
 	public final fun setMessageViewHolderFactory (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemViewHolderFactory;)V
 	public final fun setModeratedMessageHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ModeratedMessageOptionHandler;)V
 	public final fun setModeratedMessageLongClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ModeratedMessageLongClickListener;)V
@@ -2388,6 +2389,10 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 	public abstract fun onUserBlocked (Lio/getstream/chat/android/models/Message;)V
 }
 
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$MessageUserUnblockHandler {
+	public abstract fun onUserUnblocked (Lio/getstream/chat/android/models/Message;)V
+}
+
 public final class io/getstream/chat/android/ui/feature/messages/list/MessageListView$MessagesStart : java/lang/Enum {
 	public static final field BOTTOM Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessagesStart;
 	public static final field TOP Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$MessagesStart;
@@ -2534,7 +2539,7 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 
 public final class io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
 	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle$Companion;
-	public fun <init> (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)V
+	public fun <init> (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;
 	public final fun component10 ()I
 	public final fun component11 ()Z
@@ -2554,29 +2559,29 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun component24 ()I
 	public final fun component25 ()Z
 	public final fun component26 ()I
-	public final fun component27 ()Z
+	public final fun component27 ()I
 	public final fun component28 ()Z
 	public final fun component29 ()Z
 	public final fun component3 ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;
 	public final fun component30 ()Z
 	public final fun component31 ()Z
 	public final fun component32 ()Z
-	public final fun component33 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component33 ()Z
 	public final fun component34 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component35 ()I
+	public final fun component35 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component36 ()I
-	public final fun component37 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component38 ()I
-	public final fun component39 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component37 ()I
+	public final fun component38 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component39 ()I
 	public final fun component4 ()Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;
-	public final fun component40 ()I
+	public final fun component40 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component41 ()I
 	public final fun component42 ()I
 	public final fun component43 ()I
 	public final fun component44 ()I
 	public final fun component45 ()I
-	public final fun component46 ()Z
-	public final fun component47 ()I
+	public final fun component46 ()I
+	public final fun component47 ()Z
 	public final fun component48 ()I
 	public final fun component49 ()I
 	public final fun component5 ()Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;
@@ -2589,14 +2594,15 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun component56 ()I
 	public final fun component57 ()I
 	public final fun component58 ()I
-	public final fun component59 ()Z
+	public final fun component59 ()I
 	public final fun component6 ()Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;
 	public final fun component60 ()Z
+	public final fun component61 ()Z
 	public final fun component7 ()Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;
 	public final fun component8 ()Z
 	public final fun component9 ()I
-	public final fun copy (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZ)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/ScrollButtonViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;Lio/getstream/chat/android/ui/feature/messages/list/MessageListItemStyle;Lio/getstream/chat/android/ui/feature/messages/list/GiphyViewHolderStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;Lio/getstream/chat/android/ui/feature/messages/list/MessageReplyStyle;Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;ZIIZIZIIIZIIZIIZIZIIZZZZZZLio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;IILio/getstream/chat/android/ui/font/TextStyle;ILio/getstream/chat/android/ui/font/TextStyle;IIIIIIZIIIIIIIIIIIIZZIILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAudioRecordPlayerViewStyle ()Lio/getstream/chat/android/ui/feature/messages/list/MessageViewStyle;
 	public final fun getBackgroundColor ()I
@@ -2653,6 +2659,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun getThreadMessagesStart ()I
 	public final fun getThreadReplyIcon ()I
 	public final fun getThreadsEnabled ()Z
+	public final fun getUnblockUserIcon ()I
 	public final fun getUnpinIcon ()I
 	public final fun getUnreadLabelButtonStyle ()Lio/getstream/chat/android/ui/feature/messages/list/UnreadLabelButtonStyle;
 	public final fun getUserReactionsBackgroundColor ()I
@@ -4908,6 +4915,17 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnbanUser;Lio/getstream/chat/android/models/User;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnbanUser;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getUser ()Lio/getstream/chat/android/models/User;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnblockUser : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnblockUser;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnblockUser;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$UnblockUser;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getUserId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -67,6 +67,7 @@ import io.getstream.chat.android.ui.common.state.messages.React
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.Resend
 import io.getstream.chat.android.ui.common.state.messages.ThreadReply
+import io.getstream.chat.android.ui.common.state.messages.UnblockUser
 import io.getstream.chat.android.ui.common.state.messages.list.DeletedMessageVisibility
 import io.getstream.chat.android.ui.common.state.messages.list.GiphyAction
 import io.getstream.chat.android.ui.common.state.messages.list.ModeratedMessageOption
@@ -211,6 +212,9 @@ public class MessageListView : ConstraintLayout {
     private var messageUserBlockHandler = MessageUserBlockHandler {
         throw IllegalStateException("onMessageFlagHandler must be set.")
     }
+    private var messageUserUnblockHandler = MessageUserUnblockHandler {
+        throw IllegalStateException("onMessageFlagHandler must be set.")
+    }
     private var flagMessageResultHandler = FlagMessageResultHandler {
         // no-op
     }
@@ -309,6 +313,7 @@ public class MessageListView : ConstraintLayout {
             is MessageListController.ErrorEvent.MuteUserError -> R.string.stream_ui_message_list_error_mute_user
             is MessageListController.ErrorEvent.UnmuteUserError -> R.string.stream_ui_message_list_error_unmute_user
             is MessageListController.ErrorEvent.BlockUserError -> R.string.stream_ui_message_list_error_block_user
+            is MessageListController.ErrorEvent.UnblockUserError -> R.string.stream_ui_message_list_error_unblock_user
             is MessageListController.ErrorEvent.FlagUserError -> R.string.stream_ui_message_list_error_flag_user
             is MessageListController.ErrorEvent.UnflagUserError -> R.string.stream_ui_message_list_error_unflag_user
             is MessageListController.ErrorEvent.FlagMessageError -> R.string.stream_ui_message_list_error_flag_message
@@ -1935,6 +1940,15 @@ public class MessageListView : ConstraintLayout {
     }
 
     /**
+     * Set a handler for the user unblock action.
+     *
+     * @param messageUserUnblockHandler the handler
+     */
+    public fun setMessageUserUnblockHandler(messageUserUnblockHandler: MessageUserUnblockHandler) {
+        this.messageUserUnblockHandler = messageUserUnblockHandler
+    }
+
+    /**
      * Sets the handler used to handle when the message is going to be unpinned.
      *
      * @param messageUnpinHandler The handler to use.
@@ -2190,6 +2204,9 @@ public class MessageListView : ConstraintLayout {
 
             is BlockUser -> {
                 messageUserBlockHandler.onUserBlocked(message)
+            }
+            is UnblockUser -> {
+                messageUserUnblockHandler.onUserUnblocked(message)
             }
         }
     }
@@ -2461,6 +2478,10 @@ public class MessageListView : ConstraintLayout {
 
     public fun interface MessageUserBlockHandler {
         public fun onUserBlocked(message: Message)
+    }
+
+    public fun interface MessageUserUnblockHandler {
+        public fun onUserUnblocked(message: Message)
     }
 
     public fun interface MessagePinHandler {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListViewStyle.kt
@@ -65,6 +65,9 @@ import io.getstream.chat.android.ui.utils.extensions.use
  * @property pinMessageEnabled Enables/disables pin message feature. Disabled by default.
  * @property deleteIcon Icon for delete message option. Default value is [R.drawable.stream_ui_ic_delete].
  * @property deleteMessageEnabled Enables/disables delete message feature. Enabled by default.
+ * @property blockUserIcon Icon for block user option. Default value is [R.drawable.stream_ui_ic_clear].
+ * @property unblockUserIcon Icon for unblock user option. Default value is [R.drawable.stream_ui_ic_clear].
+ * @property blockUserEnabled Enables/disables block user feature. Enabled by default.
  * @property copyTextEnabled Enables/disables copy text feature. Enabled by default.
  * @property retryMessageEnabled Enables/disables retry failed message feature. Enabled by default.
  * @property deleteConfirmationEnabled Enables/disables showing confirmation dialog before deleting message. Enabled by default.
@@ -125,6 +128,7 @@ public data class MessageListViewStyle(
     val deleteIcon: Int,
     val deleteMessageEnabled: Boolean,
     val blockUserIcon: Int,
+    val unblockUserIcon: Int,
     val blockUserEnabled: Boolean,
     val copyTextEnabled: Boolean,
     val markAsUnreadEnabled: Boolean,
@@ -599,10 +603,15 @@ public data class MessageListViewStyle(
                     R.styleable.MessageListView_streamUiBlockUserOptionIcon,
                     R.drawable.stream_ui_ic_clear,
                 )
+                val userUnblockIcon = attributes.getResourceId(
+                    R.styleable.MessageListView_streamUiUnblockUserOptionIcon,
+                    R.drawable.stream_ui_ic_clear,
+                )
 
                 return MessageListViewStyle(
                     blockUserEnabled = userBlockEnabled,
                     blockUserIcon = userBlockIcon,
+                    unblockUserIcon = userUnblockIcon,
                     scrollButtonViewStyle = scrollButtonViewStyle,
                     scrollButtonBehaviour = scrollButtonBehaviour,
                     scrollButtonBottomMargin = scrollButtonMarginBottom,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/options/message/MessageOptionItemsFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/options/message/MessageOptionItemsFactory.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.ui.common.state.messages.Pin
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.Resend
 import io.getstream.chat.android.ui.common.state.messages.ThreadReply
+import io.getstream.chat.android.ui.common.state.messages.UnblockUser
 import io.getstream.chat.android.ui.feature.messages.list.MessageListViewStyle
 import io.getstream.chat.android.ui.utils.extensions.getDrawableCompat
 import io.getstream.chat.android.uiutils.extension.hasLink
@@ -204,10 +205,26 @@ public open class DefaultMessageOptionItemsFactory(
                 null
             },
             if (style.blockUserEnabled && !isOwnMessage) {
+                val isSenderBlocked = currentUser?.blockedUserIds?.contains(selectedMessageUserId) == true
+                val text = if (isSenderBlocked) {
+                    R.string.stream_ui_message_list_unblock_user
+                } else {
+                    R.string.stream_ui_message_list_block_user
+                }
+                val icon = if (isSenderBlocked) {
+                    style.unblockUserIcon
+                } else {
+                    style.blockUserIcon
+                }
+                val action = if (isSenderBlocked) {
+                    UnblockUser(selectedMessage)
+                } else {
+                    BlockUser(selectedMessage)
+                }
                 MessageOptionItem(
-                    optionText = context.getString(R.string.stream_ui_message_list_block_user),
-                    optionIcon = context.getDrawableCompat(style.blockUserIcon)!!,
-                    messageAction = BlockUser(selectedMessage),
+                    optionText = context.getString(text),
+                    optionIcon = context.getDrawableCompat(icon)!!,
+                    messageAction = action,
                 )
             } else {
                 null

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -293,6 +293,7 @@ public class MessageListViewModel(
                 false -> messageListController.disableUnreadLabelButton()
             }
             is Event.BlockUser -> messageListController.blockUser(event.userId)
+            is Event.UnblockUser -> messageListController.unblockUser(event.userId)
             is Event.PollOptionUpdated -> messageListController.updatePollOption(
                 message = event.message,
                 poll = event.poll,
@@ -755,6 +756,13 @@ public class MessageListViewModel(
          * @param userId the id of the user that is blocked.
          */
         public data class BlockUser(val userId: String) : Event()
+
+        /**
+         * Unblock a user.
+         *
+         * @param userId the id of the user that is unblocked.
+         */
+        public data class UnblockUser(val userId: String) : Event()
 
         /**
          * When the user updates a poll option.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
@@ -109,6 +109,9 @@ public fun MessageListViewModel.bindView(
             ),
         )
     }
+    view.setMessageUserUnblockHandler {
+        onEvent(MessageListViewModel.Event.UnblockUser(it.user.id))
+    }
 
     ownCapabilities.observe(lifecycleOwner) {
         view.setOwnCapabilities(it)

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_message_list_view.xml
@@ -427,7 +427,8 @@
         <attr name="streamUiThreadReplyOptionIcon" format="reference" />
         <attr name="streamUiMessageOptionBackgroundColor" format="color" />
         <attr name="streamUiBlockUserOptionEnabled" format="boolean" />
-        <attr name="streamUiBlockUserOptionIcon" format="boolean" />
+        <attr name="streamUiBlockUserOptionIcon" format="reference" />
+        <attr name="streamUiUnblockUserOptionIcon" format="reference" />
 
         <attr name="streamUiMessageOptionsTextSize" format="dimension|reference" />
         <attr name="streamUiMessageOptionsTextColor" format="color|reference" />

--- a/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings_message_list.xml
@@ -58,6 +58,7 @@
     <string name="stream_ui_message_list_mute_user">Mute User</string>
     <string name="stream_ui_message_list_unmute_user">Unmute User</string>
     <string name="stream_ui_message_list_block_user">Block user</string>
+    <string name="stream_ui_message_list_unblock_user">Unblock user</string>
     <string name="stream_ui_message_list_delete_message">Delete Message</string>
     <plurals name="stream_ui_message_list_message_reactions">
         <item quantity="one">%d Message Reaction</item>
@@ -88,6 +89,7 @@
     <string name="stream_ui_message_list_error_mute_user">Failed to mute user</string>
     <string name="stream_ui_message_list_error_unmute_user">Failed to unmute user</string>
     <string name="stream_ui_message_list_error_block_user">Failed to block user</string>
+    <string name="stream_ui_message_list_error_unblock_user">Failed to unblock user</string>
     <string name="stream_ui_message_list_error_flag_user">Failed to flag user</string>
     <string name="stream_ui_message_list_error_unflag_user">Failed to un-flag user</string>
     <string name="stream_ui_message_list_error_flag_message">Failed to flag message</string>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -500,6 +500,9 @@
         <item name="streamUiPinOptionIcon">@drawable/stream_ui_ic_pin</item>
         <item name="streamUiUnpinOptionIcon">@drawable/stream_ui_ic_unpin</item>
         <item name="streamUiPinMessageEnabled">false</item>
+        <item name="streamUiBlockUserOptionEnabled">true</item>
+        <item name="streamUiBlockUserOptionIcon">@drawable/stream_ui_ic_clear</item>
+        <item name="streamUiUnblockUserOptionIcon">@drawable/stream_ui_ic_clear</item>
         <item name="streamUiDeleteOptionIcon">@drawable/stream_ui_ic_delete</item>
         <item name="streamUiDeleteConfirmationEnabled">true</item>
         <item name="streamUiDeleteMessageEnabled">true</item>


### PR DESCRIPTION
### 🎯 Goal
Linear: https://linear.app/stream/issue/AND-190/implement-unblock-user-message-menu-option
Implements the "Unblock user" message option, which would be shown in the default message menu instead of the "Block user" option if the user is already blocked.
Additionally we expose two ways of fetching/observing the current user's blocked users:
- Via the `GlobalState` (in the `StatePlugin`)
- Via `ClientState.user` (in case the `StatePlugin` is not applied)

### 🛠 Implementation details
#### Client / State
- Add `blockedUserIds` field in the `User` model. Can be read for the currently logged in user.
- Add `blockedUserIds` field in the `GlobalState`. Can be observed from `ChatClient.globalState` from the `StatePlugin`.
- The `blockedUserIds` field is delivered via `HasOwnUser` WS events. 
- Add handling for `HasOwnUser` events in `EventHandlerSequential` to ensure the data is up-to-date.
- Add `BlockUserListener`/`UnblockUserListener`/`QueryBlockedUsersListener` as part of the `Plugin`.
- Implement `BlockUserListenerState`/`UnblockUserListenerState`/`QueryBlockedUsersListenerState` to ensure the `GlobalState.blockedUserIds` is up-to-date.
- Extend the `ChatClient` `blockUser`/`unblockUser` with logic updating the `mutableClientState` and `userStateService`. This makes sure that the `blockedUserIds` data stored in the `ChatClient current user` is up-to-date. (relevant for customers not using the state plugin)

#### UI
- Extend the logic for showing the "Block user" message menu item: It will now toggle between "Block user" and "Unblock user" based on the block status of the sender message.
- The visibility option for the "Unblock user" is handled together with the "Block user" option.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Compose Demo</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/f120b11b-a6b9-41c3-9d27-f1000bf04c27" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Open any of the sample apps (compose/xml)
2. Open a channel 
3. Long press on a message (not your)
4. Tap on "Block user" / "Unblock user"
5. (The user should be blocked/unblocked in the background)
6. Long press on a message from the same user
7. The option should now have to changed to the opposite option (unblock/block)
