### PR TITLE
[AND-205] Improve network connectivity check in the NetworkStateProvider.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 - Fix `ChatClient::queryBlockedMembers` not working. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
 - Fix `ChatClient::blockUser` and `ChatClient::unblockUser` response parsing. [#5532](https://github.com/GetStream/stream-chat-android/pull/5532)
+- Fix rare bug where the `ConnectivityState` is not updated to `Offline` after disconnecting the device from network. [#5538](https://github.com/GetStream/stream-chat-android/pull/5538)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/network/NetworkStateProvider.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/network/NetworkStateProvider.kt
@@ -23,6 +23,9 @@ import android.net.NetworkRequest
 import android.os.Build
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -30,22 +33,29 @@ internal class NetworkStateProvider(
     private val scope: CoroutineScope,
     private val connectivityManager: ConnectivityManager,
 ) {
-
     private val logger by taggedLogger("Chat:NetworkStateProvider")
     private val lock: Any = Any()
     private val callback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
-            notifyListenersIfNetworkStateChanged()
+            // Note: It is not safe to call getNetworkCapabilities(Network) here, as the ConnectivityManager state might
+            // not be updated yet (see NetworkCallback#onAvailable(Network) documentation).
+            // Therefore, we introduce a delay before notifying listeners, to ensure the ConnectivityManager is updated.
+            notifyListenersIfNetworkStateChangedAsync()
         }
 
         override fun onCapabilitiesChanged(network: Network, networkCapabilities: NetworkCapabilities) {
-            notifyListenersIfNetworkStateChanged()
+            notifyListenersIfNetworkStateChangedAsync()
         }
 
         override fun onLost(network: Network) {
-            notifyListenersIfNetworkStateChanged()
+            // Note: It is not safe to call getNetworkCapabilities(Network) here, as the ConnectivityManager state might
+            // not be updated yet (see NetworkCallback#onLost(Network) documentation).
+            // Therefore, we introduce a delay before notifying listeners, to ensure the ConnectivityManager is updated.
+            notifyListenersIfNetworkStateChangedAsync()
         }
     }
+
+    private var notifyListenersJob: Job? = null
 
     @Volatile
     private var isConnected: Boolean = isConnected()
@@ -54,6 +64,16 @@ internal class NetworkStateProvider(
     private var listeners: Set<NetworkStateListener> = setOf()
 
     private val isRegistered: AtomicBoolean = AtomicBoolean(false)
+
+    private fun notifyListenersIfNetworkStateChangedAsync() {
+        notifyListenersJob?.cancel()
+        notifyListenersJob = scope.launch {
+            // Introduce delay before calling isConnected(), to ensure the ConnectivityManager state is updated.
+            delay(NOTIFY_LISTENERS_DELAY_MS)
+            if (!isActive) return@launch
+            notifyListenersIfNetworkStateChanged()
+        }
+    }
 
     private fun notifyListenersIfNetworkStateChanged() {
         val isNowConnected = isConnected()
@@ -109,6 +129,9 @@ internal class NetworkStateProvider(
             listeners = (listeners - listener).also {
                 if (it.isEmpty() && isRegistered.compareAndSet(true, false)) {
                     connectivityManager.unregisterNetworkCallback(callback)
+
+                    notifyListenersJob?.cancel()
+                    notifyListenersJob = null
                 }
             }
         }
@@ -118,5 +141,9 @@ internal class NetworkStateProvider(
         suspend fun onConnected()
 
         suspend fun onDisconnected()
+    }
+
+    private companion object {
+        private const val NOTIFY_LISTENERS_DELAY_MS = 100L
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Linear: https://linear.app/stream/issue/AND-205/race-condition-in-networkstateprovider-causes-the-connectionstate-to
Fixes a rare bug where turning off the network connectivity on the device doesn't update the `ConnectionState` to `Offline`.
The cause for this is that it is not safe to call `ConnectivityManager.getNetworkCapabilities(Network)` from the `ConnectivityManager.NetworkCallback.onLost` callback, as there is no guarantee that the `ConnectivityManager` state will be in the updated state from the callback. In some occasions, calling `NetworkStateProvider.isConnected()` from the `NetworkCallback.onLost` callback returns `true`, which is a false positive. See details: https://developer.android.com/reference/android/net/ConnectivityManager.NetworkCallback#onLost(android.net.Network)

### 🛠 Implementation details
- Keep track of available networks.
- If there are no available networks, notify the listeners that the network was disconnected

### 🎨 UI Changes
_NA_

### 🧪 Testing
This was difficult to reproduce with a real device, but it happened quite consistently on an Emulator. To easily reproduce the issue (and then test the fix), you can:
1. Create emulator (ex: Pixel 7, Android API 34)
2. Install the compose sample app
3. Apply the provided patch to easily log the changes in the `ConnectionState`
4. Turn all networks off (wifi and mobile)
5. In roughly 1 in 4 attempts, the `ConnectionState` will NOT change to `Offline` when turning off the connectivity, even though the device is not connected to the internet. If you are testing with the fixed version, this should no longer happen.

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(revision f9ca74e2c1b8086e4f02a639b63a8b5d89c9f3b1)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatHelper.kt	(date 1735569470902)
@@ -33,7 +33,11 @@
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 import io.getstream.result.Error
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.transformWhile
+import kotlinx.coroutines.launch
 
 /**
  * A helper class that is responsible for initializing the SDK and connecting/disconnecting
@@ -44,6 +48,8 @@
 
     private const val TAG = "ChatHelper"
 
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
     /**
      * Initializes the SDK with the given API key.
      */
@@ -90,6 +96,11 @@
                 }
             }
             .build()
+        scope.launch {
+            ChatClient.instance().clientState.connectionState.collect {
+                Log.d("ChatHelper", "Connection state: $it")
+            }
+        }
     }
 
     /**

```

</details>
