### PR TITLE
Clear sizes so we can test changes push

### DIFF
--- a/metrics/size.json
+++ b/metrics/size.json
@@ -1,14 +1,14 @@
 {
   "debug": {
-    "stream-chat-android-client": 15036,
-    "stream-chat-android-offline": 15336,
-    "stream-chat-android-ui-components": 21028,
-    "stream-chat-android-compose": 22716
+    "stream-chat-android-client": 0,
+    "stream-chat-android-offline": 0,
+    "stream-chat-android-ui-components": 0,
+    "stream-chat-android-compose": 0
   },
   "release": {
-    "stream-chat-android-client": 3116,
-    "stream-chat-android-offline": 3324,
-    "stream-chat-android-ui-components": 8096,
-    "stream-chat-android-compose": 9256
+    "stream-chat-android-client": 0,
+    "stream-chat-android-offline": 0,
+    "stream-chat-android-ui-components": 0,
+    "stream-chat-android-compose": 0
   }
 }


### PR DESCRIPTION
### 🎯 Goal

Clear SDK sizes so we can test the changes being pushed from the workflow

