### PR TITLE
Prevent multiple PR workflows running at the same time

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,7 +7,7 @@ on:
       - main
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -3,7 +3,7 @@ name: Check DB Entities
 on: [pull_request]
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -2,6 +2,10 @@ name: Check DB Entities
 
 on: [pull_request]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check-db-entities:
     name: Check DB Entities

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -3,6 +3,10 @@ name: SDK size checks
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   METRICS_PROJECT: "stream-chat-android-metrics"
   MODULES: "stream-chat-android-client stream-chat-android-offline stream-chat-android-ui-components stream-chat-android-compose"


### PR DESCRIPTION
### 🎯 Goal

By default, GitHub Actions permits multiple workflow runs to execute concurrently. As a result, if a second push is made to a PR branch before the CI workflow from the previous push completes, two workflow runs will execute in parallel. This is a waste of resources.

To address this, concurrency control is introduced by configuring a unique concurrency group. This ensures that only one workflow run per branch is active at a time, with any new runs automatically canceling previous ones in progress.
