### PR TITLE
[AND-203] Fix system messages not hidden if showSystemMessages=false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Fix `MessageListController` not respecting the `showSystemMessages` property when set to `false`. [#5546](https://github.com/GetStream/stream-chat-android/pull/5546)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -981,18 +981,22 @@ public class MessageListController(
     ): List<Message> {
         val currentUser = user.value
 
-        return messages.filter {
-            val shouldNotShowIfDeleted = when (deletedMessageVisibility) {
+        return messages.filter { message ->
+            val isDeleted = message.isDeleted()
+            val showIfDeleted = when (deletedMessageVisibility) {
                 DeletedMessageVisibility.ALWAYS_VISIBLE -> true
-                DeletedMessageVisibility.VISIBLE_FOR_CURRENT_USER -> {
-                    !(it.isDeleted() && it.user.id != currentUser?.id)
-                }
-
-                DeletedMessageVisibility.ALWAYS_HIDDEN -> !it.isDeleted()
+                DeletedMessageVisibility.VISIBLE_FOR_CURRENT_USER -> message.user.id == currentUser?.id
+                DeletedMessageVisibility.ALWAYS_HIDDEN -> false
             }
-            val isSystemMessage = it.isSystem() || it.isError()
+            val isSystemMessage = message.isSystem() || message.isError()
 
-            shouldNotShowIfDeleted || (isSystemMessage && showSystemMessages)
+            if (isDeleted) {
+                showIfDeleted
+            } else if (isSystemMessage) {
+                showSystemMessages
+            } else {
+                true
+            }
         }
     }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -982,20 +982,17 @@ public class MessageListController(
         val currentUser = user.value
 
         return messages.filter { message ->
-            val isDeleted = message.isDeleted()
-            val showIfDeleted = when (deletedMessageVisibility) {
-                DeletedMessageVisibility.ALWAYS_VISIBLE -> true
-                DeletedMessageVisibility.VISIBLE_FOR_CURRENT_USER -> message.user.id == currentUser?.id
-                DeletedMessageVisibility.ALWAYS_HIDDEN -> false
-            }
+            val isDeletedMessage = message.isDeleted()
             val isSystemMessage = message.isSystem() || message.isError()
 
-            if (isDeleted) {
-                showIfDeleted
-            } else if (isSystemMessage) {
-                showSystemMessages
-            } else {
-                true
+            when {
+                isDeletedMessage -> when (deletedMessageVisibility) {
+                    DeletedMessageVisibility.ALWAYS_VISIBLE -> true
+                    DeletedMessageVisibility.VISIBLE_FOR_CURRENT_USER -> message.user.id == currentUser?.id
+                    DeletedMessageVisibility.ALWAYS_HIDDEN -> false
+                }
+                isSystemMessage -> showSystemMessages
+                else -> true
             }
         }
     }


### PR DESCRIPTION
### 🎯 Goal
The `MessageListController` flag `showSystemMessages` was not respected, due to the `DeletedMessageVisibility` taking precedence. We now properly take this flag into consideration, if the message is not deleted.

### 🛠 Implementation details
Change the `MessageListController.filterMessagesToShow` logic to consider the `DeletedMessageVisibility` when the  message is deleted, and consider `showSystemMessages` if the message is a system one.

### 🎨 UI Changes
**Scenario where showSystemMessages = false**
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/a5ccc06a-bb88-49f9-902e-791fc92d2040" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/8ca1922a-5e27-4376-9ea4-0feabfce3622" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Apply the given patch
2. Run the compose sample app
3. Open a chat with a system message
4. The system message should NOT be visible

<details>

<summary>Patch</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 99dd6beefa5dd859fa7bafc0cac7d98c72105d18)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1736165306279)
@@ -113,6 +113,7 @@
             autoTranslationEnabled = ChatApp.autoTranslationEnabled,
             isComposerLinkPreviewEnabled = ChatApp.isComposerLinkPreviewEnabled,
             deletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
+            showSystemMessages = false,
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
         )

```

</details>
