### PR TITLE
[AND-216] Fix error message text being overridden by moderation message.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fix error messages text being overridden by the default error message. [#5551](https://github.com/GetStream/stream-chat-android/pull/5551)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -284,7 +284,9 @@ internal fun DefaultMessageModeratedContent(moderatedMessageItemState: Moderated
         modifier = Modifier
             .fillMaxWidth()
             .padding(vertical = 12.dp, horizontal = 16.dp),
-        text = stringResource(id = R.string.stream_compose_message_moderated),
+        text = moderatedMessageItemState.message.text
+            .takeUnless { it.isBlank() }
+            ?: stringResource(id = R.string.stream_compose_message_moderated),
         color = ChatTheme.colors.textLowEmphasis,
         style = ChatTheme.typography.footnoteBold,
         textAlign = TextAlign.Center,


### PR DESCRIPTION
### 🎯 Goal
Fixes a problem in the Compose SDK where we override each error message text with the default "Moderation failed" text.

### 🛠 Implementation details
- Update the `DefaultMessageModeratedContent` (which is also used for showing Messages with `type = error`, not only moderated messages) so that it prioritises showing `text`, and falling back to `R.string.stream_compose_message_moderated` if `text` is blank.

_Note: It is now aligned with the XML implementation: `ErrorMessageViewHolder`_

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/b0bcf6b2-ea89-4de6-a427-1efecca50096" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/9d691b24-ecc4-4518-a822-625f4e49dc57" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Open compose sample app
2. Open any chat
3. Attempt to perform an undefined command, ex: `/test`
4. The displayed error message should be: `Sorry, command test doesn't exist...`, not `Message was blocked by moderation policies`