### PR TITLE
[CI] Add Reaction E2E tests

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
@@ -94,7 +94,6 @@ open class MessageListPage {
                 val failedIcon = By.res("Stream_MessageFailedIcon")
                 val readCount = By.res("Stream_MessageReadCount")
                 val timestamp = By.res("Stream_Timestamp")
-                val reactions = By.res("Stream_MessageReaction")
                 val quotedMessage = By.res("Stream_QuotedMessage")
                 val quotedMessageAvatar = By.res("Stream_QuotedMessageAuthorAvatar")
                 val threadRepliesLabel = By.res("Stream_ThreadRepliesLabel")
@@ -117,11 +116,12 @@ open class MessageListPage {
             class Reactions {
 
                 companion object {
-                    private val like = By.res("Stream_Reaction_${ReactionType.LIKE.reaction}")
-                    private val love = By.res("Stream_Reaction_${ReactionType.LOVE.reaction}")
-                    private val lol = By.res("Stream_Reaction_${ReactionType.LOL.reaction}")
-                    private val wow = By.res("Stream_Reaction_${ReactionType.WOW.reaction}")
-                    private val sad = By.res("Stream_Reaction_${ReactionType.SAD.reaction}")
+                    val reactions = By.res("Stream_MessageReaction")
+                    private val like = By.res("Stream_MessageReaction_${ReactionType.LIKE.reaction}")
+                    private val love = By.res("Stream_MessageReaction_${ReactionType.LOVE.reaction}")
+                    private val lol = By.res("Stream_MessageReaction_${ReactionType.LOL.reaction}")
+                    private val wow = By.res("Stream_MessageReaction_${ReactionType.WOW.reaction}")
+                    private val sad = By.res("Stream_MessageReaction_${ReactionType.SAD.reaction}")
 
                     fun reaction(type: ReactionType): BySelector {
                         return when (type) {
@@ -159,6 +159,27 @@ open class MessageListPage {
                     val block = By.res("Stream_ContextMenu_Block user")
                     val delete = By.res("Stream_ContextMenu_Delete Message")
                     val ok = By.text("OK")
+                }
+
+                class ReactionsView {
+
+                    companion object {
+                        private val like = By.res("Stream_Reaction_${ReactionType.LIKE.reaction}")
+                        private val love = By.res("Stream_Reaction_${ReactionType.LOVE.reaction}")
+                        private val lol = By.res("Stream_Reaction_${ReactionType.LOL.reaction}")
+                        private val wow = By.res("Stream_Reaction_${ReactionType.WOW.reaction}")
+                        private val sad = By.res("Stream_Reaction_${ReactionType.SAD.reaction}")
+
+                        fun reaction(type: ReactionType): BySelector {
+                            return when (type) {
+                                ReactionType.LIKE -> like
+                                ReactionType.LOVE -> love
+                                ReactionType.LOL -> lol
+                                ReactionType.SAD -> sad
+                                ReactionType.WOW -> wow
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -116,7 +116,7 @@ class UserRobot {
 
     fun addReaction(type: ReactionType, messageCellIndex: Int = 0): UserRobot {
         openContextMenu(messageCellIndex)
-        Message.Reactions.reaction(type).waitToAppear().click()
+        ContextMenu.ReactionsView.reaction(type).waitToAppear().click()
         return this
     }
 
@@ -124,7 +124,7 @@ class UserRobot {
         if (usingContextMenu) {
             addReaction(type, messageCellIndex)
         } else {
-            Message.reactions.waitToAppear().click()
+            Message.Reactions.reactions.waitToAppear().click()
             Message.Reactions.reaction(type).waitToAppear().click()
         }
         return this

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.compose.uiautomator.waitForText
 import io.getstream.chat.android.compose.uiautomator.waitToAppear
 import io.getstream.chat.android.compose.uiautomator.waitToDisappear
 import io.getstream.chat.android.e2e.test.mockserver.MessageReadStatus
+import io.getstream.chat.android.e2e.test.mockserver.ReactionType
 import io.getstream.chat.android.e2e.test.robots.ParticipantRobot
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
@@ -248,5 +249,14 @@ fun UserRobot.assertAlsoInTheChannelLabelInThread(): UserRobot {
         Message.messageHeaderLabel.waitToAppear().text,
         appContext.getString(R.string.stream_compose_also_sent_to_channel),
     )
+    return this
+}
+
+fun UserRobot.assertReaction(type: ReactionType, isDisplayed: Boolean): UserRobot {
+    if (isDisplayed) {
+        assertTrue(Message.Reactions.reaction(type).waitToAppear().isDisplayed())
+    } else {
+        assertFalse(Message.Reactions.reaction(type).waitToDisappear().isDisplayed())
+    }
     return this
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
@@ -1,0 +1,231 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.tests
+
+import io.getstream.chat.android.compose.robots.assertReaction
+import io.getstream.chat.android.compose.uiautomator.device
+import io.getstream.chat.android.compose.uiautomator.disableInternetConnection
+import io.getstream.chat.android.compose.uiautomator.enableInternetConnection
+import io.getstream.chat.android.e2e.test.mockserver.ReactionType
+import io.qameta.allure.kotlin.Allure.step
+import io.qameta.allure.kotlin.AllureId
+import org.junit.Ignore
+import org.junit.Test
+
+class ReactionsTests : StreamTestCase() {
+
+    private val sampleText = "Test"
+
+    @AllureId("5675")
+    @Test
+    fun test_addsReaction() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends the message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND user adds the reaction") {
+            userRobot.addReaction(type = ReactionType.LIKE)
+        }
+        step("THEN the reaction is added") {
+            userRobot.assertReaction(type = ReactionType.LIKE, isDisplayed = true)
+        }
+    }
+
+    @AllureId("5679")
+    @Test
+    fun test_deletesReaction() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends the message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND user adds the reaction") {
+            userRobot.addReaction(type = ReactionType.WOW)
+        }
+        step("AND user removes the reaction") {
+            userRobot.deleteReaction(type = ReactionType.WOW)
+        }
+        step("THEN the reaction is removed") {
+            userRobot.assertReaction(type = ReactionType.WOW, isDisplayed = false)
+        }
+    }
+
+    @AllureId("5676")
+    @Test
+    fun test_reactionIsAdded_whenReactingToParticipantsMessage() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends the message") {
+            participantRobot.sendMessage(sampleText)
+        }
+        step("AND user adds the reaction") {
+            userRobot.addReaction(type = ReactionType.LOVE)
+        }
+        step("THEN the reaction is added") {
+            userRobot.assertReaction(type = ReactionType.LOVE, isDisplayed = true)
+        }
+    }
+
+    @AllureId("5680")
+    @Test
+    fun test_removesReaction_whenUnReactingToParticipantsMessage() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends the message") {
+            participantRobot.sendMessage(sampleText)
+        }
+        step("AND user adds the reaction") {
+            userRobot.addReaction(type = ReactionType.LOL)
+        }
+        step("AND user removes the reaction") {
+            userRobot.deleteReaction(type = ReactionType.LOL).sleep(5000)
+        }
+        step("THEN the reaction is removed") {
+            userRobot.assertReaction(type = ReactionType.LOL, isDisplayed = false)
+        }
+    }
+
+    @AllureId("5677")
+    @Test
+    fun test_reactionIsAddedByParticipant_whenReactingToUsersMessage() {
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("AND participant adds the reaction to user's message") {
+            participantRobot
+                .readMessage()
+                .addReaction(type = ReactionType.LIKE)
+        }
+        step("THEN the reaction is added") {
+            userRobot.assertReaction(type = ReactionType.LIKE, isDisplayed = true)
+        }
+    }
+
+    @AllureId("5681")
+    @Test
+    fun test_reactionIsRemovedByParticipant_whenUnReactingToUsersMessage() {
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("AND participant adds the reaction to user's message") {
+            participantRobot
+                .readMessage()
+                .addReaction(type = ReactionType.LOL)
+        }
+        step("AND participant removes the reaction") {
+            participantRobot.deleteReaction(type = ReactionType.LOL)
+        }
+        step("THEN the reaction is removed") {
+            userRobot.assertReaction(type = ReactionType.LOL, isDisplayed = false)
+        }
+    }
+
+    @AllureId("5678")
+    @Test
+    fun test_reactionIsAddedByParticipant_whenReactingToOwnMessage() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends the message") {
+            participantRobot.sendMessage(sampleText)
+        }
+        step("AND participant adds the reaction") {
+            participantRobot.addReaction(type = ReactionType.WOW)
+        }
+        step("THEN the reaction is added") {
+            userRobot.assertReaction(type = ReactionType.WOW, isDisplayed = true)
+        }
+    }
+
+    @AllureId("5682")
+    @Test
+    fun test_reactionIsRemovedByParticipant_whenUnReactingToOwnMessage() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends the message") {
+            participantRobot.sendMessage(sampleText)
+        }
+        step("AND participant adds the reaction") {
+            participantRobot.addReaction(type = ReactionType.SAD)
+        }
+        step("AND participant removes the reaction") {
+            participantRobot.deleteReaction(type = ReactionType.SAD)
+        }
+        step("THEN the reaction is removed") {
+            userRobot.assertReaction(type = ReactionType.SAD, isDisplayed = false)
+        }
+    }
+
+    @AllureId("5714")
+    @Ignore("https://linear.app/stream/issue/AND-247")
+    @Test
+    fun test_userAddsReactionWhileOffline() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND user becomes offline") {
+            device.disableInternetConnection()
+        }
+        step("WHEN user adds a reaction") {
+            userRobot.addReaction(type = ReactionType.LIKE)
+        }
+        step("THEN user observes a new reaction") {
+            userRobot.assertReaction(type = ReactionType.LIKE, isDisplayed = true)
+        }
+        step("WHEN user becomes online") {
+            device.enableInternetConnection()
+        }
+        step("THEN user still observes a new reaction") {
+            userRobot.assertReaction(type = ReactionType.LIKE, isDisplayed = true)
+        }
+    }
+
+    @AllureId("5714")
+    @Ignore("https://linear.app/stream/issue/AND-247")
+    @Test
+    fun s() {
+        step("GIVEN user opens the channel") {
+            userRobot.login().openChannel()
+        }
+        step("AND user sends a message") {
+            userRobot.sendMessage(sampleText)
+        }
+        step("AND user becomes offline") {
+            device.disableInternetConnection()
+        }
+        step("WHEN participant adds a reaction") {
+            participantRobot.addReaction(type = ReactionType.LIKE)
+        }
+        step("AND user becomes online") {
+            device.enableInternetConnection()
+        }
+        step("THEN user observes a new reaction") {
+            userRobot.assertReaction(type = ReactionType.LIKE, isDisplayed = true)
+        }
+    }
+}

--- a/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
+++ b/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
@@ -141,7 +141,7 @@ public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot {
 	public final fun addReaction (Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun deleteMessage (Z)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;ZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
-	public final fun deleteReaction (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public final fun deleteReaction (Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun editMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun pinMesage ()Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun quoteMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
@@ -165,8 +165,8 @@ public class ParticipantRobot {
         return this
     }
 
-    public fun deleteReaction(type: String): ParticipantRobot {
-        mockServer.postRequest("participant/reaction?type=$type&delete=true")
+    public fun deleteReaction(type: ReactionType): ParticipantRobot {
+        mockServer.postRequest("participant/reaction?type=${type.reaction}&delete=true")
         return this
     }
 }

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Element.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Element.kt
@@ -20,7 +20,7 @@ import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiObject2
 
 public fun UiObject2.isDisplayed(): Boolean {
-    return this.isFocusable
+    return this.visibleCenter.y > 0
 }
 
 public fun BySelector.isDisplayed(): Boolean {


### PR DESCRIPTION
Resolve https://linear.app/stream/issue/AND-185

### 🎯 Goal

Copy-paste all the `Reaction` E2E tests from iOS to Android

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2R3MGZsOWYwdXY4a3ZjcGdoZ2VraHhzc3Y0ZGdvdDBrNGswc2x0aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gw3IWyGkC0rsazTi/giphy.gif)
