### PR TITLE
AND-217: Introduce ChatsScreen composable

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,6 +10,7 @@ androidxAppcompat = "1.7.0"
 androidxCompose = "1.7.5"
 androidxComposeConstraintLayout = "1.1.0"
 androidxComposeMaterial3 = "1.3.1"
+androidxComposeMaterial3Adaptive = "1.0.0"
 androidxCoreTest = "2.2.0"
 androidxFragment = "1.8.5"
 androidxKtx = "1.13.1"
@@ -100,6 +101,7 @@ androidx-benchmark-macro-junit4 = { module = "androidx.benchmark:benchmark-macro
 androidx-compose-constraintlayout-compose = { module = "androidx.constraintlayout:constraintlayout-compose", version.ref = "androidxComposeConstraintLayout"}
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose"}
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidxComposeMaterial3"}
+androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidxComposeMaterial3Adaptive"}
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "androidxCompose"}
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidxCompose"}
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxCompose"}

--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -55,6 +55,10 @@
             android:windowSoftInputMode="adjustResize"
             />
         <activity
+            android:name=".ui.chats.ChatsActivity"
+            android:exported="false"
+            />
+        <activity
             android:name=".feature.channel.list.ChannelsActivity"
             android:exported="false"
             />

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui.chats
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.lifecycleScope
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.compose.sample.ChatApp
+import io.getstream.chat.android.compose.sample.ChatHelper
+import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.feature.channel.ChannelConstants.CHANNEL_ARG_DRAFT
+import io.getstream.chat.android.compose.sample.feature.channel.add.AddChannelActivity
+import io.getstream.chat.android.compose.sample.feature.channel.list.CustomChatEventHandlerFactory
+import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
+import io.getstream.chat.android.compose.sample.ui.MessagesActivity
+import io.getstream.chat.android.compose.sample.ui.channel.ChannelInfoActivity
+import io.getstream.chat.android.compose.sample.ui.component.AppBottomBar
+import io.getstream.chat.android.compose.sample.ui.component.AppBottomBarOption
+import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
+import io.getstream.chat.android.compose.ui.channels.SearchMode
+import io.getstream.chat.android.compose.ui.chats.ChatsScreen
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.threads.ThreadList
+import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.threads.ThreadListViewModel
+import io.getstream.chat.android.compose.viewmodel.threads.ThreadsViewModelFactory
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.Thread
+import io.getstream.chat.android.models.querysort.QuerySortByField
+import io.getstream.chat.android.state.extensions.globalState
+import kotlinx.coroutines.launch
+
+class ChatsActivity : BaseConnectedActivity() {
+
+    private val channelViewModelFactory by lazy {
+        val chatClient = ChatClient.instance()
+        val currentUserId = chatClient.getCurrentUser()?.id ?: ""
+        ChannelViewModelFactory(
+            chatClient = chatClient,
+            querySort = QuerySortByField.descByName("last_updated"),
+            filters = Filters.and(
+                Filters.eq("type", "messaging"),
+                Filters.`in`("members", listOf(currentUserId)),
+                Filters.or(Filters.notExists(CHANNEL_ARG_DRAFT), Filters.eq(CHANNEL_ARG_DRAFT, false)),
+            ),
+            chatEventHandlerFactory = CustomChatEventHandlerFactory(),
+        )
+    }
+    private val threadsViewModelFactory by lazy { ThreadsViewModelFactory() }
+
+    private val threadsViewModel: ThreadListViewModel by viewModels { threadsViewModelFactory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            var selectedTab by rememberSaveable { mutableStateOf(AppBottomBarOption.CHATS) }
+            val globalState = ChatClient.instance().globalState
+            val unreadChannelsCount by globalState.channelUnreadCount.collectAsState()
+            val unreadThreadsCount by globalState.unreadThreadsCount.collectAsState()
+            var showBottomBar by remember { mutableStateOf(true) }
+
+            ChatTheme(
+                dateFormatter = ChatApp.dateFormatter,
+                autoTranslationEnabled = ChatApp.autoTranslationEnabled,
+                allowUIAutomationTest = true,
+            ) {
+                Scaffold(
+                    bottomBar = {
+                        if (showBottomBar) {
+                            AppBottomBar(
+                                unreadChannelsCount = unreadChannelsCount,
+                                unreadThreadsCount = unreadThreadsCount,
+                                selectedOption = selectedTab,
+                                onOptionSelected = { selectedTab = it },
+                            )
+                        }
+                    },
+                    content = { scaffoldPadding ->
+                        when (selectedTab) {
+                            AppBottomBarOption.CHATS -> ChannelsContent(
+                                modifier = Modifier.padding(scaffoldPadding),
+                                onNavigateToMessages = { channelId, singlePanel ->
+                                    showBottomBar = !singlePanel || channelId == null
+                                },
+                            )
+
+                            AppBottomBarOption.THREADS -> ThreadsContent(
+                                modifier = Modifier.padding(scaffoldPadding),
+                            )
+                        }
+                    },
+                )
+            }
+        }
+    }
+
+    @Composable
+    private fun ChannelsContent(
+        modifier: Modifier,
+        onNavigateToMessages: (channelId: String?, singlePanel: Boolean) -> Unit,
+    ) {
+        ChatsScreen(
+            modifier = modifier,
+            channelViewModelFactory = channelViewModelFactory,
+            title = stringResource(id = R.string.app_name),
+            isShowingHeader = true,
+            searchMode = SearchMode.Messages,
+            onNavigateToMessages = onNavigateToMessages,
+            onBackPressed = ::finish,
+            onChannelsHeaderAvatarClick = {
+                lifecycleScope.launch {
+                    ChatHelper.disconnectUser()
+                    openUserLogin()
+                }
+            },
+            onChannelsHeaderActionClick = ::openAddChannel,
+            onViewChannelInfoAction = ::openChannelInfo,
+            onMessagesHeaderTitleClick = ::openChannelInfo,
+        )
+    }
+
+    @Composable
+    private fun ThreadsContent(modifier: Modifier) {
+        ThreadList(
+            modifier = modifier,
+            viewModel = threadsViewModel,
+            onThreadClick = ::openThread,
+        )
+    }
+
+    private fun openThread(thread: Thread) {
+        startActivity(
+            MessagesActivity.createIntent(
+                context = applicationContext,
+                channelId = thread.parentMessage.cid,
+                parentMessageId = thread.parentMessageId,
+            ),
+        )
+    }
+
+    private fun openAddChannel() {
+        startActivity(Intent(applicationContext, AddChannelActivity::class.java))
+    }
+
+    private fun openUserLogin() {
+        startActivity(UserLoginActivity.createIntent(applicationContext))
+    }
+
+    private fun openChannelInfo(channel: Channel) {
+        startActivity(ChannelInfoActivity.createIntent(applicationContext, channel.cid))
+    }
+
+    companion object {
+        fun createIntent(context: Context): Intent =
+            Intent(context, ChatsActivity::class.java)
+                .setFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+    }
+}

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -755,6 +755,10 @@ public final class io/getstream/chat/android/compose/ui/channels/list/SearchResu
 	public static final fun SearchResultItem (Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;Lio/getstream/chat/android/models/User;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/chats/ChatsScreenKt {
+	public static final fun ChatsScreen (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/compose/ui/channels/SearchMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;III)V
+}
+
 public final class io/getstream/chat/android/compose/ui/components/BackButtonKt {
 	public static final fun BackButton (Landroidx/compose/ui/graphics/painter/Painter;Lkotlin/jvm/functions/Function0;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
 }

--- a/stream-chat-android-compose/build.gradle.kts
+++ b/stream-chat-android-compose/build.gradle.kts
@@ -85,6 +85,7 @@ dependencies {
     implementation(libs.androidx.compose.foundation)
     implementation(libs.androidx.compose.constraintlayout.compose)
     implementation(libs.androidx.compose.material3)
+    implementation(libs.androidx.compose.material3.adaptive)
 
     implementation(libs.androidx.activity.compose)
     implementation(libs.androidx.lifecycle.viewmodel.compose)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.chats
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.ContentTransform
+import androidx.compose.animation.Crossfade
+import androidx.compose.animation.SizeTransform
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.window.core.layout.WindowWidthSizeClass
+import io.getstream.chat.android.compose.ui.channels.ChannelsScreen
+import io.getstream.chat.android.compose.ui.channels.SearchMode
+import io.getstream.chat.android.compose.ui.messages.MessagesScreen
+import io.getstream.chat.android.compose.viewmodel.channels.ChannelListViewModel
+import io.getstream.chat.android.compose.viewmodel.channels.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.User
+
+/**
+ * Default Chat screen component, that provides adaptive layout based on the screen size.
+ *
+ * It can be used without most parameters for default behavior, that can be tweaked if necessary.
+ *
+ * @param modifier The modifier to be applied to the layout.
+ * @param channelViewModelFactory The factory used to build the [ChannelListViewModel] and power the behavior.
+ * You can use the default implementation by not passing in an instance yourself, or you
+ * can customize the behavior using its parameters.
+ * @param channelViewModelKey Key to differentiate between instances of [ChannelListViewModel].
+ * @param title The header title.
+ * @param isShowingHeader If a header should be shown.
+ * @param searchMode The search mode for the screen.
+ * @param onChannelsHeaderAvatarClick Called when the user clicks on the channels header avatar.
+ * @param onChannelsHeaderActionClick Called when the user clicks on the channels header action.
+ * @param onViewChannelInfoAction Called when the user clicks on the view channel info action.
+ * @param onMessagesHeaderTitleClick Called when the user clicks on the messages header title.
+ * @param onMessagesHeaderAvatarClick Called when the user clicks on the messages header avatar.
+ * @param onNavigateToMessages Called when the user navigates towards a channel or navigates back from a channel.
+ * The `channelId` is `null` when user navigates back from a channel.
+ * @param onBackPressed Handler for back press action.
+ */
+@ExperimentalStreamChatApi
+@Suppress("LongMethod")
+@Composable
+public fun ChatsScreen(
+    modifier: Modifier = Modifier,
+    channelViewModelFactory: ChannelViewModelFactory = ChannelViewModelFactory(),
+    channelViewModelKey: String? = null,
+    title: String = "Stream Chat",
+    isShowingHeader: Boolean = true,
+    searchMode: SearchMode = SearchMode.None,
+    onChannelsHeaderAvatarClick: () -> Unit = {},
+    onChannelsHeaderActionClick: () -> Unit = {},
+    onViewChannelInfoAction: (channel: Channel) -> Unit = {},
+    onMessagesHeaderTitleClick: (channel: Channel) -> Unit = {},
+    onMessagesHeaderAvatarClick: (user: User) -> Unit = {},
+    onNavigateToMessages: (channelId: String?, singlePanel: Boolean) -> Unit = { _, _ -> },
+    onBackPressed: () -> Unit = {},
+) {
+    val context = LocalContext.current
+    val singlePanel = singlePanel()
+    var clickedChannelId by rememberSaveable { mutableStateOf<String?>(null) }
+    val messagesViewModelFactory = remember(clickedChannelId) {
+        clickedChannelId?.let {
+            MessagesViewModelFactory(
+                context = context,
+                channelId = it,
+            )
+        }
+    }
+    val channelListViewModel =
+        viewModel(ChannelListViewModel::class.java, key = channelViewModelKey, factory = channelViewModelFactory)
+    val channelItems = channelListViewModel.channelsState.channelItems
+    val onSinglePanelBackPressed: () -> Unit = {
+        if (clickedChannelId != null) {
+            clickedChannelId = null
+        } else {
+            onBackPressed()
+        }
+    }
+
+    LaunchedEffect(channelItems) {
+        // Auto-select the first channel in the list when it loads on large screens
+        if (!singlePanel && channelItems.isNotEmpty() && clickedChannelId == null) {
+            clickedChannelId = channelItems.first().key
+        }
+    }
+    LaunchedEffect(clickedChannelId) {
+        onNavigateToMessages(clickedChannelId, singlePanel)
+    }
+
+    Scaffold(
+        modifier = modifier,
+    ) { scaffoldPadding ->
+        Box(
+            modifier = Modifier.padding(scaffoldPadding),
+        ) {
+            if (singlePanel) {
+                ChannelsScreen(
+                    title = title,
+                    viewModelFactory = channelViewModelFactory,
+                    viewModelKey = channelViewModelKey,
+                    isShowingHeader = isShowingHeader,
+                    searchMode = searchMode,
+                    onHeaderAvatarClick = onChannelsHeaderAvatarClick,
+                    onHeaderActionClick = onChannelsHeaderActionClick,
+                    onChannelClick = { channel ->
+                        clickedChannelId = channel.cid
+                    },
+                    onSearchMessageItemClick = { channel ->
+                        clickedChannelId = channel.cid
+                    },
+                    onViewChannelInfoAction = onViewChannelInfoAction,
+                    onBackPressed = onSinglePanelBackPressed,
+                )
+                AnimatedContent(
+                    targetState = messagesViewModelFactory,
+                    transitionSpec = slideTransitionSpec(),
+                ) { factory ->
+                    if (factory != null) {
+                        Messages(
+                            viewModelFactory = factory,
+                            onHeaderTitleClick = onMessagesHeaderTitleClick,
+                            onUserAvatarClick = onMessagesHeaderAvatarClick,
+                            onBackPressed = onSinglePanelBackPressed,
+                        )
+                    }
+                }
+            } else {
+                Row {
+                    Box(
+                        modifier = Modifier.weight(ListPanelWeight),
+                    ) {
+                        ChannelsScreen(
+                            viewModelFactory = channelViewModelFactory,
+                            viewModelKey = channelViewModelKey,
+                            title = title,
+                            isShowingHeader = isShowingHeader,
+                            searchMode = searchMode,
+                            onHeaderAvatarClick = onChannelsHeaderAvatarClick,
+                            onHeaderActionClick = onChannelsHeaderActionClick,
+                            onChannelClick = { channel ->
+                                clickedChannelId = channel.cid
+                            },
+                            onSearchMessageItemClick = { channel ->
+                                clickedChannelId = channel.cid
+                            },
+                            onViewChannelInfoAction = onViewChannelInfoAction,
+                            onBackPressed = onBackPressed,
+                        )
+                    }
+                    VerticalDivider()
+                    Box(
+                        modifier = Modifier.weight(DetailsPanelWeight),
+                    ) {
+                        Crossfade(targetState = messagesViewModelFactory) { factory ->
+                            if (factory != null) {
+                                Messages(
+                                    viewModelFactory = factory,
+                                    onHeaderTitleClick = onMessagesHeaderTitleClick,
+                                    onUserAvatarClick = onMessagesHeaderAvatarClick,
+                                    onBackPressed = onBackPressed,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private const val ListPanelWeight = 0.3f
+private const val DetailsPanelWeight = 0.7f
+
+/**
+ * @see <a href=https://developer.android.com/develop/ui/compose/layouts/adaptive/use-window-size-classes>
+ *     Use window size classes</a>
+ */
+@Composable
+private fun singlePanel(): Boolean {
+    val windowSizeClass = currentWindowAdaptiveInfo().windowSizeClass
+    return windowSizeClass.windowWidthSizeClass != WindowWidthSizeClass.EXPANDED
+}
+
+@Composable
+private fun Messages(
+    viewModelFactory: MessagesViewModelFactory,
+    onHeaderTitleClick: (channel: Channel) -> Unit,
+    onUserAvatarClick: (user: User) -> Unit,
+    onBackPressed: () -> Unit,
+) {
+    // Restart composition on every new instance of the factory
+    key(viewModelFactory) {
+        // Scope messages view models to a local store
+        // so that they are cleared when the user navigates between channels
+        val viewModelStore = remember { ViewModelStore() }
+        val viewModelStoreOwner = remember(viewModelStore) {
+            object : ViewModelStoreOwner {
+                override val viewModelStore: ViewModelStore get() = viewModelStore
+            }
+        }
+
+        // Ensure the store is cleared when the composable is disposed
+        DisposableEffect(Unit) {
+            onDispose {
+                viewModelStore.clear()
+            }
+        }
+
+        CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
+            MessagesScreen(
+                viewModelFactory = viewModelFactory,
+                onHeaderTitleClick = onHeaderTitleClick,
+                onUserAvatarClick = onUserAvatarClick,
+                onBackPressed = onBackPressed,
+            )
+        }
+    }
+}
+
+@Composable
+private fun <S> slideTransitionSpec(): AnimatedContentTransitionScope<S>.() -> ContentTransform = {
+    (
+        fadeIn() + slideInHorizontally(initialOffsetX = { fullWidth -> fullWidth }) togetherWith
+            slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut()
+        )
+        .using(
+            // Disable clipping to allow content to slide out fully
+            SizeTransform(clip = false),
+        )
+}


### PR DESCRIPTION
### 🎯 Goal

Make our chat screens compatible with large screens such as tablets.

### 🛠 Implementation details

A new `ChatsActivity` is introduced to the compose sample app to host the `ChatsScreen` and handle navigation between **Chats** and **Threads**

When the sample runs on a phone device, it should behave as is, rendering a single-pane screen.

When it runs on a larger device, e.g. a tablet, it should render two panels, one for channels and another one for messages of the selected channel.

⚠️ **There are a few flows that need to be revisited. For now, `ChatsScreen` is marked as experimental.**

### 🎨 UI Changes

### Tablet

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/b0c74c78-ed40-4888-9193-8c71a0a20a37" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/ed35b5df-24b6-45cf-82cd-fb4724faf53b" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Phone

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/db87885e-1b3d-480d-a8e7-82c43434687b" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/d8cf70ed-ea11-41b0-aa1c-8e4049f0b91d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

The sample is not yet ready to allow two configurations for channels/messages.
For now, you need to replace `ChannelsActivity` with `ChatsActivity` where you want to see the ChatsScreen in action.
For example:

`StartupActivity`

```kotlin
// Logged in, navigate to the channels screen
startActivity(ChatsActivity.createIntent(applicationContext))
```

`UserLoginActivity`

```kotlin
private fun openChannels() {
    startActivity(ChatsActivity.createIntent(applicationContext))
    finish()
}
```

### 🎉 GIF

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExZzRrcGQwNXBsOGM0YnRuN3drY2piazJiNmQzcWQ5enA1b2E1cGxuZyZlcD12MV9naWZzX3NlYXJjaCZjdD1n/l0JMrPWRQkTeg3jjO/giphy.gif)
