### PR TITLE
[CI] Add Giphy E2E tests

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/pages/MessageListPage.kt
@@ -79,6 +79,7 @@ open class MessageListPage {
             val unreadMessagesBadge = By.res("Stream_UnreadMessagesBadge")
             val typingIndicator = By.res("Stream_MessageListTypingIndicator")
             val scrollToBottomButton = By.res("Stream_ScrollToBottomButton")
+            val systemMessage = By.res("Stream_SystemMessage")
         }
 
         class Message {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -238,7 +238,9 @@ class UserRobot {
         if (useComposerCommand) {
             openComposerCommands()
             Composer.giphyButton.waitToAppear().click()
-            sendMessage(giphyMessageText)
+            Composer.inputField.findObject().click()
+            device.typeText(giphyMessageText)
+            Composer.sendButton.findObject().click()
         } else {
             sendMessage("/giphy $giphyMessageText")
         }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.robots
 
+import androidx.test.uiautomator.By
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.pages.MessageListPage
 import io.getstream.chat.android.compose.pages.MessageListPage.Composer
@@ -248,5 +249,41 @@ fun UserRobot.assertAlsoInTheChannelLabelInThread(): UserRobot {
         Message.messageHeaderLabel.waitToAppear().text,
         appContext.getString(R.string.stream_compose_also_sent_to_channel),
     )
+    return this
+}
+
+fun UserRobot.assertGiphyImage(isDisplayed: Boolean = true): UserRobot {
+    if (isDisplayed) {
+        assertTrue(Message.giphy.waitToAppear().isDisplayed())
+    } else {
+        assertFalse(Message.giphy.waitToDisappear().isDisplayed())
+    }
+    return this
+}
+
+fun UserRobot.assertGiphyButtons(areDisplayed: Boolean = true): UserRobot {
+    if (areDisplayed) {
+        assertTrue(Message.GiphyButtons.send.waitToAppear().isDisplayed())
+        assertTrue(Message.GiphyButtons.cancel.findObject().isDisplayed())
+        assertTrue(Message.GiphyButtons.shuffle.findObject().isDisplayed())
+    } else {
+        assertFalse(Message.GiphyButtons.send.waitToDisappear().isDisplayed())
+        assertTrue(Message.GiphyButtons.cancel.findObjects().isEmpty())
+        assertTrue(Message.GiphyButtons.shuffle.findObjects().isEmpty())
+    }
+    return this
+}
+
+fun UserRobot.assertSystemMessage(text: String, isDisplayed: Boolean = true): UserRobot {
+    if (isDisplayed) {
+        By.text(text).waitToAppear().isDisplayed()
+    } else {
+        By.text(text).waitToDisappear().isDisplayed()
+    }
+    return this
+}
+
+fun UserRobot.assertInvalidCommandMessage(text: String, isDisplayed: Boolean = true): UserRobot {
+    assertSystemMessage("Sorry, command $text doesn't exist. Try posting your message without the starting /")
     return this
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/GiphyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/GiphyTests.kt
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2014-2024 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.tests
+
+import io.getstream.chat.android.compose.robots.assertGiphyButtons
+import io.getstream.chat.android.compose.robots.assertGiphyImage
+import io.getstream.chat.android.compose.robots.assertInvalidCommandMessage
+import io.getstream.chat.android.compose.robots.assertMessageDeliveryStatus
+import io.getstream.chat.android.compose.robots.assertMessageInChannelPreview
+import io.getstream.chat.android.compose.robots.assertMessageTimestamps
+import io.getstream.chat.android.compose.robots.assertSystemMessage
+import io.qameta.allure.kotlin.Allure.step
+import io.qameta.allure.kotlin.AllureId
+import org.junit.Ignore
+import org.junit.Test
+
+class GiphyTests : StreamTestCase() {
+
+    @AllureId("5698")
+    @Test
+    fun test_userObservesAnimatedGiphy_whenUserAddsGiphyMessage() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a giphy using giphy command") {
+            userRobot.uploadGiphy()
+        }
+        step("THEN user observes the animated gif") {
+            userRobot.assertGiphyImage()
+        }
+    }
+
+    @AllureId("5699")
+    @Test
+    fun test_userObservesAnimatedGiphy_whenParticipantAddsGiphyMessage() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends a giphy") {
+            participantRobot.uploadGiphy()
+        }
+        step("THEN user observes the animated gif") {
+            userRobot.assertGiphyImage()
+        }
+    }
+
+    @AllureId("5783")
+    @Test
+    fun test_userObservesAnimatedGiphy_whenUserAddsGiphyMessageInThread() {
+        step("GIVEN user opens a channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("WHEN user runs a giphy command in thread") {
+            userRobot
+                .openThread()
+                .uploadGiphy()
+        }
+        step("THEN user observes the animated gif in thread") {
+            userRobot.assertGiphyImage()
+        }
+    }
+
+    @AllureId("6714")
+    @Test
+    fun test_userObservesAnimatedGiphy_whenParticipantAddsGiphyMessageInThread() {
+        step("GIVEN user opens a channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("WHEN participant sends a giphy") {
+            participantRobot.uploadGiphyInThread()
+        }
+        step("THEN user observes the animated gif in thread") {
+            userRobot
+                .openThread()
+                .assertGiphyImage()
+        }
+    }
+
+    @AllureId("5707")
+    @Test
+    fun test_messageIsNotSent_whenUserSendsInvalidCommand() {
+        val invalidCommand = "invalid command"
+
+        step("GIVEN user opens the channel") {
+            backendRobot.generateChannels(channelsCount = 1, messagesCount = 1)
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a message with invalid command") {
+            userRobot.sendMessage("/$invalidCommand")
+        }
+        step("THEN user observes error message") {
+            userRobot.assertInvalidCommandMessage(invalidCommand)
+        }
+        step("AND the previous message has timestamp and delivery status shown") {
+            userRobot
+                .assertMessageDeliveryStatus(shouldBeVisible = true)
+                .assertMessageTimestamps(count = 1)
+        }
+    }
+
+    @AllureId("5787")
+    @Ignore("https://linear.app/stream/issue/AND-218")
+    @Test
+    fun test_channelListNotModified_whenEphemeralMessageShown() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user runs a giphy command") {
+            userRobot.uploadGiphy(send = false)
+        }
+        step("WHEN user goes back to channel list") {
+            userRobot.tapOnBackButton()
+        }
+        step("THEN message is not added to the channel list") {
+            userRobot.assertMessageInChannelPreview("No messages", fromCurrentUser = false)
+        }
+    }
+
+    @AllureId("5782")
+    @Ignore("https://linear.app/stream/issue/AND-245")
+    @Test
+    fun test_deliveryStatusHidden_whenEphemeralMessageShown() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user runs a giphy command") {
+            userRobot.uploadGiphy(send = false)
+        }
+        step("THEN delivery status is hidden for ephemeral messages") {
+            userRobot
+                .assertMessageDeliveryStatus(false)
+                .assertSystemMessage("Only visible to you")
+        }
+    }
+
+    @AllureId("5823")
+    @Test
+    fun test_userObservesAnimatedGiphy_afterAddingGiphyThroughComposerMenu() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user sends a giphy using giphy command") {
+            userRobot.uploadGiphy(useComposerCommand = true)
+        }
+        step("THEN user observes the animated gif") {
+            userRobot.assertGiphyImage()
+        }
+    }
+
+    @AllureId("5824")
+    @Test
+    fun test_messageIsNotSent_whenUserCancelsEphemeralMessage() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user cancels a giphy") {
+            userRobot
+                .uploadGiphy(send = false)
+                .sleep(1000)
+                .tapOnCancelGiphyButton()
+        }
+        step("THEN user does not observe the animated gif") {
+            userRobot
+                .assertGiphyImage(isDisplayed = false)
+                .assertGiphyButtons(areDisplayed = false)
+        }
+    }
+
+    @AllureId("5815")
+    @Test
+    fun test_userObservesAnimatedGiphy_whenUserAddsGiphyMessage_AfterShuffling() {
+        step("GIVEN user opens a channel") {
+            userRobot.login().openChannel()
+        }
+        step("WHEN user shuffles a giphy") {
+            userRobot
+                .uploadGiphy(send = false)
+                .tapOnShuffleGiphyButton()
+        }
+        step("THEN the giphy is shuffled but not sent") {
+            userRobot
+                .assertGiphyImage(isDisplayed = true)
+                .assertGiphyButtons(areDisplayed = true)
+        }
+        step("WHEN user sends a giphy") {
+            userRobot.tapOnSendGiphyButton()
+        }
+        step("THEN user observes the animated gif") {
+            userRobot
+                .assertGiphyImage(isDisplayed = true)
+                .assertGiphyButtons(areDisplayed = false)
+        }
+    }
+}

--- a/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
+++ b/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
@@ -12,6 +12,7 @@ public final class io/getstream/chat/android/compose/uiautomator/ActionsKt {
 	public static final fun swipeUp (Landroidx/test/uiautomator/UiDevice;II)V
 	public static synthetic fun swipeUp$default (Landroidx/test/uiautomator/UiDevice;IIILjava/lang/Object;)V
 	public static final fun tapOnScreenCenter (Landroidx/test/uiautomator/UiDevice;)V
+	public static final fun typeText (Landroidx/test/uiautomator/UiDevice;Ljava/lang/String;)V
 	public static final fun typeText (Landroidx/test/uiautomator/UiObject2;Ljava/lang/String;)Landroidx/test/uiautomator/UiObject2;
 }
 
@@ -156,8 +157,6 @@ public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot {
 	public static synthetic fun quoteMessageWithGiphyInThread$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;ZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun readMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun readMessage$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
-	public final fun sendGiphy ()Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
-	public final fun sendGiphyInThread ()Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun sendMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun sendMessageInThread (Ljava/lang/String;Z)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun sendMessageInThread$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
@@ -172,6 +171,8 @@ public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot {
 	public static synthetic fun uploadAttachment$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Lio/getstream/chat/android/e2e/test/mockserver/AttachmentType;IILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun uploadAttachmentInThread (Lio/getstream/chat/android/e2e/test/mockserver/AttachmentType;IZ)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun uploadAttachmentInThread$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Lio/getstream/chat/android/e2e/test/mockserver/AttachmentType;IZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public final fun uploadGiphy ()Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public final fun uploadGiphyInThread ()Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 }
 
 public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot$Companion {

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
@@ -99,12 +99,12 @@ public class ParticipantRobot {
         return this
     }
 
-    public fun sendGiphy(): ParticipantRobot {
+    public fun uploadGiphy(): ParticipantRobot {
         mockServer.postRequest("participant/message?giphy=true")
         return this
     }
 
-    public fun sendGiphyInThread(): ParticipantRobot {
+    public fun uploadGiphyInThread(): ParticipantRobot {
         mockServer.postRequest("participant/message?giphy=true&thread=true")
         return this
     }

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
@@ -32,6 +32,10 @@ public fun UiDevice.stopApp() {
     executeShellCommand("pm clear $packageName")
 }
 
+public fun UiDevice.typeText(text: String) {
+    executeShellCommand("input text '$text'")
+}
+
 public fun UiObject2.typeText(text: String): UiObject2 {
     this.text = text
     return this

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Element.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Element.kt
@@ -20,7 +20,7 @@ import androidx.test.uiautomator.BySelector
 import androidx.test.uiautomator.UiObject2
 
 public fun UiObject2.isDisplayed(): Boolean {
-    return this.isFocusable
+    return this.visibleCenter.y > 0
 }
 
 public fun BySelector.isDisplayed(): Boolean {


### PR DESCRIPTION
Resolve https://linear.app/stream/issue/AND-226

### 🎯 Goal

Copy-paste all the `Giphy` E2E tests from iOS to Android

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![gif](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExa2R3MGZsOWYwdXY4a3ZjcGdoZ2VraHhzc3Y0ZGdvdDBrNGswc2x0aiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/gw3IWyGkC0rsazTi/giphy.gif)
