### PR TITLE
[AND-250] Fix default poll input fields hints.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fix error messages text being overridden by the default error message. [#5551](https://github.com/GetStream/stream-chat-android/pull/5551)
+- Fix wrong hints in the poll creation dialog input fields. [#5561](https://github.com/GetStream/stream-chat-android/pull/5561)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1750,14 +1750,16 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/pol
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput {
 	public static final field $stable I
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Object;
-	public final fun component2 ()Ljava/lang/Object;
-	public final fun component3-PjHm6EE ()I
-	public final fun copy-GLO5gmY (Ljava/lang/Object;Ljava/lang/Object;I)Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;
-	public static synthetic fun copy-GLO5gmY$default (Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;Ljava/lang/Object;Ljava/lang/Object;IILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/Object;
+	public final fun component4-PjHm6EE ()I
+	public final fun copy-YyDlPXQ (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;I)Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;
+	public static synthetic fun copy-YyDlPXQ$default (Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/Object;IILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchInput;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDescription ()Ljava/lang/String;
 	public final fun getKeyboardType-PjHm6EE ()I
 	public final fun getMaxValue ()Ljava/lang/Object;
 	public final fun getValue ()Ljava/lang/Object;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
@@ -136,7 +136,7 @@ public fun PollOptionList(
                     PollOptionInput(
                         modifier = Modifier.weight(1f),
                         value = item.title,
-                        description = stringResource(id = R.string.stream_compose_poll_option_description),
+                        description = stringResource(id = R.string.stream_compose_poll_option_placeholder),
                         innerPadding = if (item.pollOptionError == null) {
                             PaddingValues(horizontal = 16.dp, vertical = 18.dp)
                         } else {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
@@ -136,6 +136,7 @@ public fun PollOptionList(
                     PollOptionInput(
                         modifier = Modifier.weight(1f),
                         value = item.title,
+                        description = stringResource(id = R.string.stream_compose_poll_option_description),
                         innerPadding = if (item.pollOptionError == null) {
                             PaddingValues(horizontal = 16.dp, vertical = 18.dp)
                         } else {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
@@ -136,7 +136,7 @@ public fun PollOptionList(
                     PollOptionInput(
                         modifier = Modifier.weight(1f),
                         value = item.title,
-                        description = stringResource(id = R.string.stream_compose_poll_option_placeholder),
+                        description = stringResource(id = R.string.stream_compose_poll_option_hint),
                         innerPadding = if (item.pollOptionError == null) {
                             PaddingValues(horizontal = 16.dp, vertical = 18.dp)
                         } else {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchItem.kt
@@ -41,11 +41,13 @@ public data class PollSwitchItem(
  * The input information that will be used to create a poll switch item.
  *
  * @property value The default value of the switch.
+ * @property description The description of the input in the switch (shown as hint/contentDescription).
  * @property maxValue The maximum vale of the switch. Normally, you can use the limit of the decimal format of the [value].
  * @property keyboardType The type of the input of the switch and decide the keyboard type of the input.
  */
 public data class PollSwitchInput(
     public var value: Any,
+    public val description: String = "",
     public val maxValue: Any? = null,
     public val keyboardType: KeyboardType = KeyboardType.Text,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
@@ -181,6 +181,7 @@ public fun PollSwitchList(
                                 .fillMaxWidth()
                                 .weight(1f),
                             value = switchInput.value.toString(),
+                            description = switchInput.description,
                             shape = RoundedCornerShape(0.dp),
                             keyboardOptions = KeyboardOptions(keyboardType = switchInput.keyboardType),
                             onValueChange = { newValue ->

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/PollSwitchItemFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/PollSwitchItemFactory.kt
@@ -60,7 +60,12 @@ public class DefaultPollSwitchItemFactory(
         listOf(
             PollSwitchItem(
                 title = context.getString(R.string.stream_compose_poll_option_switch_multiple_answers),
-                pollSwitchInput = PollSwitchInput(keyboardType = KeyboardType.Decimal, maxValue = 2, value = 0),
+                pollSwitchInput = PollSwitchInput(
+                    value = 0,
+                    description = context.getString(R.string.stream_compose_poll_option_max_number_of_answers_hint),
+                    maxValue = 2,
+                    keyboardType = KeyboardType.Decimal,
+                ),
                 key = "maxVotesAllowed",
                 enabled = false,
             ),

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -207,6 +207,7 @@
     <string name="stream_compose_poll_questions_description" translatable="false">Ask a question</string>
     <string name="stream_compose_poll_option_title" translatable="false">Options</string>
     <string name="stream_compose_poll_option_description" translatable="false">Add an option</string>
+    <string name="stream_compose_poll_option_placeholder" translatable="false">Add an option</string>
     <string name="stream_compose_poll_option_error_duplicated" translatable="false">This is already an option</string>
     <string name="stream_compose_poll_option_error_exceed" translatable="false">Type a number under %d</string>
     <string name="stream_compose_poll_option_discard_dialog_title" translatable="false">Discard poll</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -207,7 +207,7 @@
     <string name="stream_compose_poll_questions_description" translatable="false">Ask a question</string>
     <string name="stream_compose_poll_option_title" translatable="false">Options</string>
     <string name="stream_compose_poll_option_description" translatable="false">Add an option</string>
-    <string name="stream_compose_poll_option_placeholder" translatable="false">Add an option</string>
+    <string name="stream_compose_poll_option_hint" translatable="false">Add an option</string>
     <string name="stream_compose_poll_option_error_duplicated" translatable="false">This is already an option</string>
     <string name="stream_compose_poll_option_error_exceed" translatable="false">Type a number under %d</string>
     <string name="stream_compose_poll_option_discard_dialog_title" translatable="false">Discard poll</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -208,7 +208,7 @@
     <string name="stream_compose_poll_option_title" translatable="false">Options</string>
     <string name="stream_compose_poll_option_description" translatable="false">Add an option</string>
     <string name="stream_compose_poll_option_error_duplicated" translatable="false">This is already an option</string>
-    <string name="stream_compose_poll_option_error_exceed" translatable="false">Type a number under the %d</string>
+    <string name="stream_compose_poll_option_error_exceed" translatable="false">Type a number under %d</string>
     <string name="stream_compose_poll_option_discard_dialog_title" translatable="false">Discard poll</string>
     <string name="stream_compose_poll_option_discard_dialog_description" translatable="false">Are you sure want to discard your poll?</string>
     <string name="stream_compose_poll_option_discard_dialog_cancel" translatable="false">Keep Editing</string>
@@ -217,6 +217,7 @@
     <string name="stream_compose_poll_option_switch_anonymous_poll" translatable="false">Anonymous poll</string>
     <string name="stream_compose_poll_option_switch_suggest_option" translatable="false">Suggest an option</string>
     <string name="stream_compose_poll_option_switch_add_comment" translatable="false">Add a comment</string>
+    <string name="stream_compose_poll_option_max_number_of_answers_hint">Max number of answers</string>
     <string name="stream_compose_poll_view_result" translatable="false">View Results</string>
     <string name="stream_compose_poll_end_vote" translatable="false">End Vote</string>
     <string name="stream_compose_poll_suggest_option">Suggest Option</string>

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/poll/PollUITest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/poll/PollUITest.kt
@@ -96,6 +96,7 @@ internal class PollUITest : BaseComposeTest() {
                         title = stringResource(id = R.string.stream_compose_poll_option_switch_multiple_answers),
                         pollSwitchInput = PollSwitchInput(
                             keyboardType = KeyboardType.Decimal,
+                            description = stringResource(id = R.string.stream_compose_poll_option_max_number_of_answers_hint),
                             maxValue = 10,
                             value = 11,
                         ),

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/DefaultPollSwitchItemFactoryTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/DefaultPollSwitchItemFactoryTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.util
+
+import android.content.Context
+import androidx.compose.ui.text.input.KeyboardType
+import io.getstream.chat.android.compose.R
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class DefaultPollSwitchItemFactoryTest {
+
+    @Test
+    fun testDefaultPollSwitchItemFactory() {
+        // given
+        val context = mock<Context>()
+        whenever(context.getString(R.string.stream_compose_poll_option_switch_multiple_answers))
+            .thenReturn("Multiple answers")
+        whenever(context.getString(R.string.stream_compose_poll_option_max_number_of_answers_hint))
+            .thenReturn("Max number of answers")
+        whenever(context.getString(R.string.stream_compose_poll_option_switch_anonymous_poll))
+            .thenReturn("Anonymous poll")
+        whenever(context.getString(R.string.stream_compose_poll_option_switch_suggest_option))
+            .thenReturn("Suggest an option")
+        whenever(context.getString(R.string.stream_compose_poll_option_switch_add_comment))
+            .thenReturn("Add a comment")
+        // when
+        val items = PollSwitchItemFactory
+            .defaultFactory(context)
+            .providePollSwitchItemList()
+        // then
+        // Size
+        Assertions.assertEquals(4, items.size)
+        // Max votes item
+        Assertions.assertEquals("Multiple answers", items[0].title)
+        Assertions.assertEquals("maxVotesAllowed", items[0].key)
+        Assertions.assertFalse(items[0].enabled)
+        Assertions.assertEquals(0, items[0].pollSwitchInput?.value)
+        Assertions.assertEquals(2, items[0].pollSwitchInput?.maxValue)
+        Assertions.assertEquals("Max number of answers", items[0].pollSwitchInput?.description)
+        Assertions.assertEquals(KeyboardType.Decimal, items[0].pollSwitchInput?.keyboardType)
+        Assertions.assertNull(items[0].pollOptionError)
+        // Anonymous poll item
+        Assertions.assertEquals("Anonymous poll", items[1].title)
+        Assertions.assertEquals("votingVisibility", items[1].key)
+        Assertions.assertFalse(items[1].enabled)
+        Assertions.assertNull(items[1].pollSwitchInput)
+        Assertions.assertNull(items[1].pollOptionError)
+        // Hide results item
+        Assertions.assertEquals("Suggest an option", items[2].title)
+        Assertions.assertEquals("allowUserSuggestedOptions", items[2].key)
+        Assertions.assertFalse(items[2].enabled)
+        Assertions.assertNull(items[2].pollSwitchInput)
+        Assertions.assertNull(items[2].pollOptionError)
+        // Close poll item
+        Assertions.assertEquals("Add a comment", items[3].title)
+        Assertions.assertEquals("allowAnswers", items[3].key)
+        Assertions.assertFalse(items[3].enabled)
+        Assertions.assertNull(items[3].pollSwitchInput)
+        Assertions.assertNull(items[3].pollOptionError)
+    }
+}

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
@@ -23,7 +23,7 @@
         android:id="@+id/option"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:hint="@string/stream_ui_poll_add_an_option_placeholder"
+        android:hint="@string/stream_ui_poll_add_an_option_hint"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:padding="@dimen/stream_ui_spacing_small"
         android:gravity="center_vertical"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
@@ -23,7 +23,7 @@
         android:id="@+id/option"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:hint="@string/stream_ui_poll_add_an_option_label"
+        android:hint="@string/stream_ui_poll_add_an_option_placeholder"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:padding="@dimen/stream_ui_spacing_small"
         android:gravity="center_vertical"

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_poll_option.xml
@@ -23,7 +23,7 @@
         android:id="@+id/option"
         android:layout_width="match_parent"
         android:layout_height="56dp"
-        android:hint="Option"
+        android:hint="@string/stream_ui_poll_add_an_option_label"
         android:layout_marginTop="@dimen/stream_ui_spacing_small"
         android:padding="@dimen/stream_ui_spacing_small"
         android:gravity="center_vertical"

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -18,7 +18,8 @@
     <string name="stream_ui_poll_question_label">Question</string>
     <string name="stream_ui_poll_ask_a_question_hint">Ask a question</string>
     <string name="stream_ui_poll_options_label">Options</string>
-    <string name="stream_ui_poll_add_an_option_label">Add an Option</string>
+    <string name="stream_ui_poll_add_an_option_label">Add an option</string>
+    <string name="stream_ui_poll_add_an_option_placeholder">Add an option</string>
     <string name="stream_ui_poll_multiple_answers_label">Multiple answers</string>
     <string name="stream_ui_poll_max_number_of_answers_hint">Max number of answers</string>
     <string name="stream_ui_poll_anonymous_poll_label">Anonymous poll</string>

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="stream_ui_poll_ask_a_question_hint">Ask a question</string>
     <string name="stream_ui_poll_options_label">Options</string>
     <string name="stream_ui_poll_add_an_option_label">Add an option</string>
-    <string name="stream_ui_poll_add_an_option_placeholder">Add an option</string>
+    <string name="stream_ui_poll_add_an_option_hint">Add an option</string>
     <string name="stream_ui_poll_multiple_answers_label">Multiple answers</string>
     <string name="stream_ui_poll_max_number_of_answers_hint">Max number of answers</string>
     <string name="stream_ui_poll_anonymous_poll_label">Anonymous poll</string>


### PR DESCRIPTION
### 🎯 Goal
Resolves: https://linear.app/stream/issue/AND-250/incorrect-placeholder-in-text-fields-for-poll-options

The poll creation dialog had some wrong placeholders in the input fields:
- "Add an option" field -> "Ask a question" placeholder
- "Max number of answers" field -> "Ask a question" placeholder

This PR sets new, more appropriate placeholders to those fields 

### 🛠 Implementation details
- Add new `description` property `PollSwitchInput` to allow customisation of the description (placeholder) of the switch input fields
- Override the default `description` for the "Add option" field
- Replace hard-coded string "Option" with a localised resource in the XML SDK

**Note: For the "Add an option" placeholder, I re-used the same "Add an option" placeholder. If you think that this is not appropriate, we can update the text.**

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>SDK</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
XML
</td>
<td>
<video src="https://github.com/user-attachments/assets/c9cbe9b5-1a07-449c-a3e8-654a2ff9eeba" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/9aa1da44-7cf7-4b22-89c7-7592c8328f15" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
Compose
</td>
<td>
<video src="https://github.com/user-attachments/assets/fb7c81c3-52ce-473f-ae61-8eb5a772dc0a" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/1308baf0-fa89-433b-9bff-4557ae54722c" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing
1. Open Compose Sample App
2. Open a channel
3. Open attachment picker
4. Select poll
5. Add an option -> correct placeholder should be shown
6. Select "Multiple answers" -> correct placeholder should be shown
