### PR TITLE
[AND-264] Avoid querying multiple times to WatchChannel if any property of the currentuser is updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Avoid multiple queries within on states when user's properties are updated. [#5572](https://github.com/GetStream/stream-chat-android/pull/5572)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -150,9 +150,10 @@ fun UserRobot.assertComposerSize(isChangeable: Boolean): UserRobot {
     val composer = Composer.inputField
     val initialComposerHeight: Int
     if (isChangeable) {
-        initialComposerHeight = composer.findObject().height
+        initialComposerHeight = composer.waitToAppear().height
         val text = "1\n2\n3"
         typeText(text)
+        sleep(500)
         assertTrue(initialComposerHeight != composer.findObject().height)
     } else {
         val text = "1\n2\n3\n4\n5\n6"


### PR DESCRIPTION
### 🎯 Goal
There were an issue on our `getStateOnNull()` method that propagated a new state on the case any of the properties of the current user was updated, even if the user was the same one. It would invoke multiple times the same queries for previous created states (Channels, All Active Channel and/or All Activy Threads).
In our sample apps it wasn't appreciated in a normal usage of the app because the current user wasn't update frequently, but it could be a big issue on a customer integration that by some reason the user's properties are updated more frequently.

### 🎉 GIF
![](https://media1.tenor.com/m/04xV1dROZ1IAAAAd/newfoundland-snow-storm.gif)
