### PR TITLE
[AND-262] Add unit tests and missing KDoc for stream-chat-android-core.

### DIFF
--- a/stream-chat-android-core/build.gradle.kts
+++ b/stream-chat-android-core/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     testImplementation(libs.junit.jupiter.api)
     testImplementation(libs.junit.jupiter.params)
     testImplementation(libs.kluent)
+    testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.mockito)
     testImplementation(libs.mockito.kotlin)
     testRuntimeOnly(libs.junit.jupiter.engine)

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/errors/NetworkError.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/client/errors/NetworkError.kt
@@ -21,11 +21,17 @@ import io.getstream.result.Error
 
 private const val HTTP_BAD_REQUEST = 400
 
+/**
+ * Checks if the [Error.NetworkError] was caused by a bad request (HTTP 400).
+ */
 @InternalStreamChatApi
 public fun Error.NetworkError.isStatusBadRequest(): Boolean {
     return statusCode == HTTP_BAD_REQUEST
 }
 
+/**
+ * Checks if the [Error.NetworkError] was caused by a server error code: [VALIDATION_ERROR_ERROR_CODE].
+ */
 @InternalStreamChatApi
 public fun Error.NetworkError.isValidationError(): Boolean {
     return serverErrorCode == ChatErrorCode.VALIDATION_ERROR.code

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/ExperimentalStreamChatApi.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/ExperimentalStreamChatApi.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.android.core
 
+/**
+ * Marks APIs that are experimental and might be changed or removed in the future.
+ */
 @RequiresOptIn(
     message = "These APIs are experimental. They might still contain bugs or be changed in the future.",
     level = RequiresOptIn.Level.WARNING,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/internal/lazy/ParameterizedLazy.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/internal/lazy/ParameterizedLazy.kt
@@ -20,6 +20,12 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
+/**
+ * A [lazy] delegate which takes a parameter and provides a value based on it.
+ * The value is calculated only once and stored in a map.
+ *
+ * @param initializer A function that creates a new value based on the parameter.
+ */
 @InternalStreamChatApi
 public class ParameterizedLazy<T, R>(
     private val initializer: suspend (T) -> R,
@@ -41,6 +47,9 @@ public class ParameterizedLazy<T, R>(
     }
 }
 
+/**
+ * Creates a [ParameterizedLazy] delegate from the provided [initializer] function.
+ */
 @InternalStreamChatApi
 public fun <T, R> parameterizedLazy(initializer: suspend (T) -> R): ParameterizedLazy<T, R> = ParameterizedLazy(
     initializer,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/utils/date/DateUtils.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/core/utils/date/DateUtils.kt
@@ -44,23 +44,26 @@ public fun max(dateA: Date?, dateB: Date?): Date? = when (dateA after dateB) {
     else -> dateB
 }
 
+/**
+ * Returns the minimum of two dates.
+ */
 @InternalStreamChatApi
 public fun min(dateA: Date?, dateB: Date?): Date? = when (dateA after dateB) {
     true -> dateB
     else -> dateA
 }
 
+/**
+ * Returns the maximum of the given dates.
+ */
 @InternalStreamChatApi
 public fun maxOf(vararg dates: Date?): Date? = dates.reduceOrNull { acc, date -> max(acc, date) }
 
-@InternalStreamChatApi
-public fun minOf(vararg dates: Date?): Date? = dates.reduceOrNull { acc, date -> min(acc, date) }
-
 /**
- * Check if current date has difference with [other] no more that [offset].
+ * Returns the minimum of the given dates.
  */
 @InternalStreamChatApi
-public fun Date.inOffsetWith(other: Date, offset: Long): Boolean = (time + offset) >= other.time
+public fun minOf(vararg dates: Date?): Date? = dates.reduceOrNull { acc, date -> min(acc, date) }
 
 /**
  * Returns difference between [this] date and the [otherTime] in [TimeDuration].

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/FloatExtensions.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/FloatExtensions.kt
@@ -18,6 +18,12 @@ package io.getstream.chat.android.extensions
 
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 
+/**
+ * Limits the float value to the given range.
+ *
+ * @param min The minimum value.
+ * @param max The maximum value.
+ */
 @InternalStreamChatApi
 public fun Float.limitTo(min: Float, max: Float): Float {
     return when {
@@ -27,6 +33,9 @@ public fun Float.limitTo(min: Float, max: Float): Float {
     }
 }
 
+/**
+ * Checks if the float value is an integer.
+ */
 @InternalStreamChatApi
 public fun Float.isInt(): Boolean {
     val diff = this - toInt()

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/IntExtensions.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/IntExtensions.kt
@@ -16,6 +16,12 @@
 
 package io.getstream.chat.android.extensions
 
+/**
+ * Limits the integer value to the given range.
+ *
+ * @param min The minimum value.
+ * @param max The maximum value.
+ */
 public fun Int.limitTo(min: Int, max: Int): Int {
     return when {
         this < min -> min

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/StringExtensions.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/extensions/StringExtensions.kt
@@ -29,6 +29,10 @@ internal fun String.snakeToLowerCamelCase(): String {
     }
 }
 
+/**
+ * Converts string written in lower camel case to a getter method name.
+ * For example string "createdAtSomeTime" is converted to "getCreatedAtSomeTime".
+ */
 internal fun String.lowerCamelCaseToGetter(): String = "get${this[0].uppercase()}${this.substring(1)}"
 
 /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/AppSettings.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/AppSettings.kt
@@ -28,6 +28,9 @@ public data class AppSettings(
     val app: App,
 ) {
     public companion object {
+        /**
+         * Default file size limit in bytes.
+         */
         public const val DEFAULT_SIZE_LIMIT_IN_BYTES: Long = 100 * 1024 * 1024
     }
 }
@@ -50,9 +53,10 @@ public data class App(
  * The configuration of file upload.
  *
  * @param allowedFileExtensions Allowed file extensions.
- * @param allowedFileExtensions Allowed mime types.
+ * @param allowedMimeTypes Allowed mime types.
  * @param blockedFileExtensions Blocked mime types.
  * @param blockedMimeTypes Blocked mime types.
+ * @param sizeLimitInBytes The size limit of the file in bytes.
  */
 @Immutable
 public data class FileUploadConfig(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Attachment.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Attachment.kt
@@ -44,6 +44,7 @@ import java.io.File
  * @param text The page description.
  * @param type The type of the attachment. e.g "file", "image, "audio".
  * @param image The image attachment.
+ * @param name The attachment name.
  * @param fallback Alternative description in the case of an image attachment
  * (img alt in HTML).
  * @param originalHeight The original height of the attachment.

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/BannedUser.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/BannedUser.kt
@@ -19,6 +19,17 @@ package io.getstream.chat.android.models
 import androidx.compose.runtime.Immutable
 import java.util.Date
 
+/**
+ * Model holding data related to a banned user.
+ *
+ * @param user The banned user.
+ * @param bannedBy The user who banned the user.
+ * @param channel The channel where the user was banned.
+ * @param createdAt The date when the user was banned.
+ * @param expires The date when the ban expires.
+ * @param shadow If the ban is shadow.
+ * @param reason The reason for the ban.
+ */
 @Immutable
 public data class BannedUser(
     val user: User,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/BannedUsersSort.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/BannedUsersSort.kt
@@ -20,6 +20,11 @@ import androidx.compose.runtime.Immutable
 import io.getstream.chat.android.models.querysort.ComparableFieldProvider
 import java.util.Date
 
+/**
+ * Sorter for banned users which takes into consideration the [Date] when the user was banned.
+ *
+ * @param createdAt The date when the user was banned.
+ */
 @Immutable
 public data class BannedUsersSort(val createdAt: Date) : ComparableFieldProvider {
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
@@ -301,6 +301,11 @@ public data class Channel(
     }
 }
 
+/**
+ * Updates the given [Channel] with data from another [Channel] object.
+ *
+ * @param that The [Channel] to take the new data from.
+ */
 @InternalStreamChatApi
 public fun Channel.mergeChannelFromEvent(that: Channel): Channel {
     return copy(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
@@ -161,6 +161,11 @@ public data class ChannelData(
     }
 }
 
+/**
+ * Updates the given [ChannelData] with data from another [ChannelData] object.
+ *
+ * @param that The [ChannelData] to take the new data from.
+ */
 @InternalStreamChatApi
 public fun ChannelData.mergeFromEvent(that: ChannelData): ChannelData {
     return copy(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelUserRead.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelUserRead.kt
@@ -26,6 +26,7 @@ import java.util.Date
  * @property lastReceivedEventDate The time of the event that updated this [ChannelUserRead] object.
  * @property lastRead The time of the last read message.
  * @property unreadMessages How many messages are unread.
+ * @property lastReadMessageId The ID of the last read message.
  */
 @Immutable
 public data class ChannelUserRead(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Config.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Config.kt
@@ -19,6 +19,9 @@ package io.getstream.chat.android.models
 import androidx.compose.runtime.Immutable
 import java.util.Date
 
+/**
+ * Model representing the configuration of a channel.
+ */
 @Immutable
 public data class Config(
 
@@ -82,8 +85,14 @@ public data class Config(
      */
     val urlEnrichmentEnabled: Boolean = true,
 
+    /**
+     * Determines if custom events are enabled. Disabled by default.
+     */
     val customEventsEnabled: Boolean = false,
 
+    /**
+     * Determines if push notifications are enabled. Enabled by default.
+     */
     val pushNotificationsEnabled: Boolean = true,
 
     /**
@@ -111,8 +120,14 @@ public data class Config(
      */
     val automod: String = "disabled",
 
+    /**
+     * Represents the automod behaviour.
+     */
     val automodBehavior: String = "",
 
+    /**
+     * Represents the blocklist behaviour.
+     */
     val blocklistBehavior: String = "",
 
     /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ConnectionData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ConnectionData.kt
@@ -18,5 +18,11 @@ package io.getstream.chat.android.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Model holding data about the SDK connection.
+ *
+ * @param user The connected [User].
+ * @param connectionId The ID of the connection.
+ */
 @Immutable
 public data class ConnectionData(val user: User, val connectionId: String)

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/CustomObject.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/CustomObject.kt
@@ -16,9 +16,19 @@
 
 package io.getstream.chat.android.models
 
+/**
+ * Marks a given object as an object which contains custom data (extraData).
+ */
 public sealed interface CustomObject {
+
+    /**
+     * The custom key-value data associated with this object.
+     */
     public val extraData: Map<String, Any>
 
+    /**
+     * Returns the value associated with the given [key], or [default] if the key is not present in the [extraData].
+     */
     @Suppress("UNCHECKED_CAST")
     public fun <T> getExtraValue(key: String, default: T): T {
         return if (extraData.containsKey(key)) {

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Device.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Device.kt
@@ -51,7 +51,16 @@ public enum class PushProvider(public val key: String) {
     ;
 
     public companion object {
+
+        /**
+         * Creates [PushProvider] instance from the provided [key].
+         * Supported keys:
+         * - "firebase" for [FIREBASE]
+         * - "huawei" for [HUAWEI]
+         * - "xiaomi" for [XIAOMI]
+         * - any other key for [UNKNOWN]
+         */
         public fun fromKey(key: String): PushProvider =
-            values().firstOrNull { it.key == key } ?: UNKNOWN
+            entries.firstOrNull { it.key == key } ?: UNKNOWN
     }
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Flag.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Flag.kt
@@ -19,6 +19,20 @@ package io.getstream.chat.android.models
 import androidx.compose.runtime.Immutable
 import java.util.Date
 
+/**
+ * Model holding data about a user flag.
+ *
+ * @param user The user who created the flag.
+ * @param targetUser The user who was flagged.
+ * @param targetMessageId The ID of the message that was flagged.
+ * @param reviewedBy The user who reviewed the flag.
+ * @param createdByAutomod True if the flag was created by the automod.
+ * @param createdAt The date when the flag was created.
+ * @param updatedAt The date when the flag was last updated.
+ * @param reviewedAt The date when the flag was reviewed.
+ * @param approvedAt The date when the flag was approved.
+ * @param rejectedAt The date when the flag was rejected.
+ */
 @Immutable
 public data class Flag(
     val user: User,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/GuestUser.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/GuestUser.kt
@@ -18,5 +18,11 @@ package io.getstream.chat.android.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Model holding data about a guest user.
+ *
+ * @param user The guest [User].
+ * @param token The token of the guest user.
+ */
 @Immutable
 public data class GuestUser(val user: User, val token: String)

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/HMSRoom.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/HMSRoom.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.Immutable
  * Represents HMS room information that contains available room in a chat channel.
  *
  * @property roomId A new room id.
- * @property roomId A new room name.
+ * @property roomName A new room name.
  */
 @Immutable
 public data class HMSRoom(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Message.kt
@@ -20,6 +20,9 @@ import androidx.compose.runtime.Immutable
 import io.getstream.chat.android.models.querysort.ComparableFieldProvider
 import java.util.Date
 
+/**
+ * Model holding data about a message.
+ */
 @Immutable
 public data class Message(
     /**
@@ -170,6 +173,9 @@ public data class Message(
      */
     val showInChannel: Boolean = false,
 
+    /**
+     * Contains information about the channel where the message was sent.
+     */
     val channelInfo: ChannelInfo? = null,
 
     /**
@@ -244,8 +250,19 @@ public data class Message(
     val poll: Poll? = null,
 ) : CustomObject, ComparableFieldProvider {
     public companion object {
+        /**
+         * Represents a 'regular' message.
+         */
         public const val TYPE_REGULAR: String = "regular"
+
+        /**
+         * Represents an 'ephemeral' message.
+         */
         public const val TYPE_EPHEMERAL: String = "ephemeral"
+
+        /**
+         * Represents an 'error' message.
+         */
         public const val TYPE_ERROR: String = "error"
     }
 
@@ -274,8 +291,17 @@ public data class Message(
             else -> extraData[fieldName] as? Comparable<*>
         }
 
+    /**
+     * Retrieves the translated text message for the given []language].
+     *
+     * @param language The language code for the translation.
+     * @return The translated text message, or empty if the translation is not available.
+     */
     public fun getTranslation(language: String): String = i18n.get("${language}_text", "")
 
+    /**
+     * Retrieves the original language of the message.
+     */
     public val originalLanguage: String
         get() = i18n.get("language", "")
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MessageModerationDetails.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/MessageModerationDetails.kt
@@ -20,6 +20,10 @@ import androidx.compose.runtime.Immutable
 
 /**
  * Describes the details of a message which was moderated.
+ *
+ * @param originalText The original text of the moderated message.
+ * @param action The moderation action that was performed on the message.
+ * @param errorMsg The error message that was returned by the moderation service.
  */
 @Immutable
 public data class MessageModerationDetails(
@@ -30,6 +34,8 @@ public data class MessageModerationDetails(
 
 /**
  * The type of moderation performed to a message.
+ *
+ * @property rawValue The raw value of the moderation action.
  */
 @Immutable
 public data class MessageModerationAction(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Mute.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Mute.kt
@@ -19,6 +19,15 @@ package io.getstream.chat.android.models
 import androidx.compose.runtime.Immutable
 import java.util.Date
 
+/**
+ * Model holding data about a user mute.
+ *
+ * @param user The user who muted the target user.
+ * @param target The muted user.
+ * @param createdAt The date when the mute was created.
+ * @param updatedAt The date when the mute was last updated.
+ * @param expires The date when the mute expires.
+ */
 @Immutable
 public data class Mute(
     val user: User?,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Poll.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Poll.kt
@@ -38,6 +38,7 @@ import java.util.Date
  * @property createdAt The creation date of the poll.
  * @property updatedAt The last update date of the poll.
  * @property closed If set to true, the poll is closed and no more votes can be cast.
+ * @property answers The list of poll answers.
  */
 @Immutable
 public data class Poll(
@@ -68,6 +69,16 @@ public data class Poll(
     public fun getVotes(option: Option): List<Vote> = votes.filter { it.optionId == option.id }
 }
 
+/**
+ * The Answer object represents an answer in a poll.
+ *
+ * @property id The unique identifier of the answer.
+ * @property pollId The unique identifier of the poll.
+ * @property text The text of the answer.
+ * @property createdAt The creation date of the answer.
+ * @property updatedAt The last update date of the answer.
+ * @property user The user who sent the answer.
+ */
 @Immutable
 public data class Answer(
     val id: String,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/PushMessage.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/PushMessage.kt
@@ -18,6 +18,16 @@ package io.getstream.chat.android.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Model holding data for a push message.
+ *
+ * @param messageId The id of the message.
+ * @param channelId The id of the channel.
+ * @param channelType The type of the channel.
+ * @param getstream Custom 'Stream' data.
+ * @param extraData Custom extra (not pre-reserved) data.
+ * @param metadata Notification metadata.
+ */
 @Immutable
 public data class PushMessage(
     val messageId: String,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Reaction.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Reaction.kt
@@ -19,6 +19,21 @@ package io.getstream.chat.android.models
 import androidx.compose.runtime.Immutable
 import java.util.Date
 
+/**
+ * Model representing a message reaction.
+ *
+ * @param messageId The id of the message.
+ * @param type The type of the reaction.
+ * @param score The score(count) of the reaction, used if you want to allow users to clap/like etc multiple times.
+ * @param user The user who sent the reaction.
+ * @param userId The id of the user who sent the reaction.
+ * @param createdAt The date when the reaction was created.
+ * @param createdLocallyAt The date when the reaction was created locally.
+ * @param updatedAt The date when the reaction was updated.
+ * @param deletedAt The date when the reaction was deleted.
+ * @param syncStatus The synchronization status of the reaction.
+ * @param enforceUnique If true, only one reaction of this type is allowed per user.
+ */
 @Immutable
 public data class Reaction(
     val messageId: String = "",
@@ -35,6 +50,9 @@ public data class Reaction(
     val enforceUnique: Boolean = false,
 ) : CustomObject {
 
+    /**
+     * The unique identifier of the reaction.
+     */
     val id: String
         get() = messageId + type + score + fetchUserId()
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/SearchMessagesResult.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/SearchMessagesResult.kt
@@ -18,6 +18,9 @@ package io.getstream.chat.android.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Model representing a result of messages search operation.
+ */
 @Immutable
 public data class SearchMessagesResult(
     /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/SyncStatus.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/SyncStatus.kt
@@ -24,6 +24,8 @@ private const val AWAITING_ATTACHMENTS_STATUS_CODE = 4
 
 /**
  * If the message has been sent to the servers.
+ *
+ * @param status The numeric identifier of the status.
  */
 public enum class SyncStatus(public val status: Int) {
     /**
@@ -53,7 +55,11 @@ public enum class SyncStatus(public val status: Int) {
     ;
 
     public companion object {
-        private val map = values().associateBy(SyncStatus::status)
+        private val map = entries.associateBy(SyncStatus::status)
+
+        /**
+         * Get the [SyncStatus] from the given [type].
+         */
         public fun fromInt(type: Int): SyncStatus? = map[type]
     }
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/TypingEvent.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/TypingEvent.kt
@@ -18,5 +18,11 @@ package io.getstream.chat.android.models
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Model representing a typing event.
+ *
+ * @param channelId The ID of the channel where the typing event occurred.
+ * @param users The users who are currently typing in the channel.
+ */
 @Immutable
 public data class TypingEvent(val channelId: String, val users: List<User>)

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/UserEntity.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/UserEntity.kt
@@ -16,10 +16,19 @@
 
 package io.getstream.chat.android.models
 
+/**
+ * Marks a class as a user entity.
+ */
 public sealed interface UserEntity {
 
+    /**
+     * The user entity.
+     */
     public val user: User
 
+    /**
+     * Returns the user ID.
+     */
     public fun getUserId(): String {
         return user.id
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/VideoCallInfo.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/VideoCallInfo.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.Immutable
  * @property type The call type.
  * @property agoraChannel The available channel info of Agora.
  * @property hmsRoom The available room info of HMS.
+ * @property videoCallToken The token info of the video call.
  */
 @Immutable
 public data class VideoCallInfo(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySortByField.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySortByField.kt
@@ -59,10 +59,20 @@ public class QuerySortByField<T : ComparableFieldProvider> : BaseQuerySort<T>() 
         return this
     }
 
+    /**
+     * Adds a field to [QuerySortByField] using the name of field in the direction ASC.
+     *
+     * @param fieldName The name of the field.
+     */
     public fun asc(fieldName: String): QuerySortByField<T> {
         return add(SortSpecification(SortAttribute.FieldNameSortAttribute(fieldName), SortDirection.ASC))
     }
 
+    /**
+     * Adds a field to [QuerySortByField] using the name of field in the direction DESC.
+     *
+     * @param fieldName The name of the field.
+     */
     public fun desc(fieldName: String): QuerySortByField<T> {
         return add(SortSpecification(SortAttribute.FieldNameSortAttribute(fieldName), SortDirection.DESC))
     }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySortByReflection.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySortByReflection.kt
@@ -67,7 +67,6 @@ public open class QuerySortByReflection<T : Any> : BaseQuerySort<T>() {
             }
         }
 
-    @Suppress("UNCHECKED_CAST")
     private fun String.comparator(sortDirection: SortDirection): Comparator<T> =
         Comparator { o1, o2 ->
             compare(

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySorter.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/QuerySorter.kt
@@ -34,6 +34,9 @@ public interface QuerySorter<T : Any> {
      */
     public val comparator: Comparator<in T>
 
+    /**
+     * Converts the sorter to a DTO.
+     */
     public fun toDto(): List<Map<String, Any>>
 
     public companion object {

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/Comparations.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/Comparations.kt
@@ -21,6 +21,13 @@ import io.getstream.chat.android.models.querysort.QuerySorter.Companion.LESS_ON_
 import io.getstream.chat.android.models.querysort.QuerySorter.Companion.MORE_ON_COMPARISON
 import io.getstream.chat.android.models.querysort.SortDirection
 
+/**
+ * Compares two [Comparable] values based on the given [SortDirection].
+ *
+ * @param first The first value to compare.
+ * @param second The second value to compare.
+ * @param sortDirection The direction of sorting.
+ */
 internal fun compare(
     first: Comparable<Any>?,
     second: Comparable<Any>?,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/CompositeComparator.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/CompositeComparator.kt
@@ -18,6 +18,12 @@ package io.getstream.chat.android.models.querysort.internal
 
 import io.getstream.chat.android.models.querysort.QuerySorter
 
+/**
+ * Composite comparator that combines multiple comparators into one.
+ *
+ * @param T The type of elements to be compared.
+ * @param comparators The list of comparators to be combined.
+ */
 internal class CompositeComparator<T>(private val comparators: List<Comparator<T>>) : Comparator<T> {
     override fun compare(o1: T, o2: T): Int =
         comparators.fold(QuerySorter.EQUAL_ON_COMPARISON) { currentComparisonValue, comparator ->

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/SortSpecification.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/querysort/internal/SortSpecification.kt
@@ -18,6 +18,13 @@ package io.getstream.chat.android.models.querysort.internal
 
 import io.getstream.chat.android.models.querysort.SortDirection
 
+/**
+ * Defines a sorting specification for collections of elements of type [T].
+ *
+ * @param T The type of elements to be sorted.
+ * @param sortAttribute The attribute to be used for sorting.
+ * @param sortDirection The direction of sorting.
+ */
 public data class SortSpecification<T>(
     val sortAttribute: SortAttribute<T>,
     val sortDirection: SortDirection,

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/PayloadValidatorTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/PayloadValidatorTest.kt
@@ -152,15 +152,6 @@ internal class PayloadValidatorTest {
             Arguments.of(
                 mapOf(
                     "version" to "v1",
-                    "channel_id" to randomString(),
-                    "message_id" to randomString(),
-                    "channel_type" to randomString(),
-                ),
-                true,
-            ),
-            Arguments.of(
-                mapOf(
-                    "version" to "v1",
                     "channel_id" to null,
                     "message_id" to randomString(),
                     "channel_type" to randomString(),
@@ -184,6 +175,42 @@ internal class PayloadValidatorTest {
                     "channel_type" to null,
                 ),
                 false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v1",
+                    "channel_id" to "",
+                    "message_id" to randomString(),
+                    "channel_type" to randomString(),
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v1",
+                    "channel_id" to randomString(),
+                    "message_id" to "",
+                    "channel_type" to randomString(),
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v1",
+                    "channel_id" to randomString(),
+                    "message_id" to randomString(),
+                    "channel_type" to "",
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v1",
+                    "channel_id" to randomString(),
+                    "message_id" to randomString(),
+                    "channel_type" to randomString(),
+                ),
+                true,
             ),
         )
 
@@ -240,16 +267,6 @@ internal class PayloadValidatorTest {
                 mapOf(
                     "version" to "v2",
                     "type" to "message.new",
-                    "channel_id" to randomString(),
-                    "message_id" to randomString(),
-                    "channel_type" to randomString(),
-                ),
-                true,
-            ),
-            Arguments.of(
-                mapOf(
-                    "version" to "v2",
-                    "type" to "message.new",
                     "channel_id" to null,
                     "message_id" to randomString(),
                     "channel_type" to randomString(),
@@ -275,6 +292,46 @@ internal class PayloadValidatorTest {
                     "channel_type" to null,
                 ),
                 false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v2",
+                    "type" to "message.new",
+                    "channel_id" to "",
+                    "message_id" to randomString(),
+                    "channel_type" to randomString(),
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v2",
+                    "type" to "message.new",
+                    "channel_id" to randomString(),
+                    "message_id" to "",
+                    "channel_type" to randomString(),
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v2",
+                    "type" to "message.new",
+                    "channel_id" to randomString(),
+                    "message_id" to randomString(),
+                    "channel_type" to "",
+                ),
+                false,
+            ),
+            Arguments.of(
+                mapOf(
+                    "version" to "v2",
+                    "type" to "message.new",
+                    "channel_id" to randomString(),
+                    "message_id" to randomString(),
+                    "channel_type" to randomString(),
+                ),
+                true,
             ),
         )
     }

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/ChatErrorCodeTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/ChatErrorCodeTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.errors
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ChatErrorCodeTest {
+
+    @ParameterizedTest
+    @MethodSource("isAuthenticationErrorArguments")
+    fun testIsAuthenticationError(
+        code: Int,
+        isAuthenticationError: Boolean,
+    ) {
+        ChatErrorCode.isAuthenticationError(code) `should be equal to` isAuthenticationError
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun isAuthenticationErrorArguments() = listOf(
+            arrayOf(ChatErrorCode.NETWORK_FAILED.code, false),
+            arrayOf(ChatErrorCode.PARSER_ERROR.code, false),
+            arrayOf(ChatErrorCode.SOCKET_CLOSED.code, false),
+            arrayOf(ChatErrorCode.SOCKET_FAILURE.code, false),
+            arrayOf(ChatErrorCode.CANT_PARSE_CONNECTION_EVENT.code, false),
+            arrayOf(ChatErrorCode.CANT_PARSE_EVENT.code, false),
+            arrayOf(ChatErrorCode.INVALID_TOKEN.code, false),
+            arrayOf(ChatErrorCode.UNDEFINED_TOKEN.code, false),
+            arrayOf(ChatErrorCode.UNABLE_TO_PARSE_SOCKET_EVENT.code, false),
+            arrayOf(ChatErrorCode.NO_ERROR_BODY.code, false),
+            arrayOf(ChatErrorCode.VALIDATION_ERROR.code, false),
+            arrayOf(ChatErrorCode.AUTHENTICATION_ERROR.code, true),
+            arrayOf(ChatErrorCode.TOKEN_EXPIRED.code, true),
+            arrayOf(ChatErrorCode.TOKEN_NOT_VALID.code, true),
+            arrayOf(ChatErrorCode.TOKEN_DATE_INCORRECT.code, true),
+            arrayOf(ChatErrorCode.TOKEN_SIGNATURE_INCORRECT.code, true),
+            arrayOf(ChatErrorCode.API_KEY_NOT_FOUND.code, false),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/ChatErrorTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/ChatErrorTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.errors
+
+import io.getstream.result.Error
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.net.UnknownHostException
+
+internal class ChatErrorTest {
+
+    @Test
+    fun testCreateErrorFromChatErrorCode() {
+        // Given
+        val chatErrorCode = ChatErrorCode.NETWORK_FAILED
+        val statusCode = 404
+        val cause = Throwable("Bad request")
+        // When
+        val error = Error.NetworkError.fromChatErrorCode(chatErrorCode, statusCode, cause)
+        // Then
+        error.message `should be equal to` chatErrorCode.description
+        error.serverErrorCode `should be equal to` chatErrorCode.code
+        error.statusCode `should be equal to` statusCode
+        error.cause `should be equal to` cause
+    }
+
+    @Test
+    fun testCreateErrorFromChatErrorCodeWithUnknownCause() {
+        // Given
+        val chatErrorCode = ChatErrorCode.NETWORK_FAILED
+        // When
+        val error = Error.NetworkError.fromChatErrorCode(chatErrorCode)
+        // Then
+        error.message `should be equal to` chatErrorCode.description
+        error.serverErrorCode `should be equal to` chatErrorCode.code
+        error.statusCode `should be equal to` Error.NetworkError.UNKNOWN_STATUS_CODE
+        error.cause `should be equal to` null
+    }
+
+    @ParameterizedTest
+    @MethodSource("isPermanentErrorArguments")
+    fun testIsPermanentError(
+        error: Error,
+        isPermanent: Boolean,
+    ) {
+        error.isPermanent() `should be equal to` isPermanent
+    }
+
+    @ParameterizedTest
+    @MethodSource("copyWithMessageArguments")
+    fun testCopyWithMessage(
+        error: Error,
+        message: String,
+        expected: Error,
+    ) {
+        error.copyWithMessage(message) `should be equal to` expected
+    }
+
+    @ParameterizedTest
+    @MethodSource("extractCauseArguments")
+    fun testExtractCause(
+        error: Error,
+        expected: Throwable?,
+    ) {
+        error.extractCause() `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun isPermanentErrorArguments() = listOf(
+            Arguments.of(Error.GenericError("Error"), false),
+            Arguments.of(Error.ThrowableError("Error", Throwable()), false),
+            Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, statusCode = 408), false),
+            Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, statusCode = 429), false),
+            Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, 500), false),
+            Arguments.of(
+                networkError(ChatErrorCode.NETWORK_FAILED, statusCode = 400, cause = UnknownHostException()),
+                false,
+            ),
+            Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, 400), true),
+            Arguments.of(networkError(ChatErrorCode.PARSER_ERROR, 400), true),
+            Arguments.of(networkError(ChatErrorCode.SOCKET_CLOSED, 400), true),
+            Arguments.of(networkError(ChatErrorCode.SOCKET_FAILURE, 400), true),
+            Arguments.of(networkError(ChatErrorCode.CANT_PARSE_CONNECTION_EVENT, 400), true),
+            Arguments.of(networkError(ChatErrorCode.CANT_PARSE_EVENT, 400), true),
+            Arguments.of(networkError(ChatErrorCode.INVALID_TOKEN, 400), true),
+            Arguments.of(networkError(ChatErrorCode.UNDEFINED_TOKEN, 400), true),
+            Arguments.of(networkError(ChatErrorCode.UNABLE_TO_PARSE_SOCKET_EVENT, 400), true),
+            Arguments.of(networkError(ChatErrorCode.NO_ERROR_BODY, 400), true),
+            Arguments.of(networkError(ChatErrorCode.VALIDATION_ERROR, 400), true),
+            Arguments.of(networkError(ChatErrorCode.AUTHENTICATION_ERROR, 400), true),
+            Arguments.of(networkError(ChatErrorCode.TOKEN_EXPIRED, 400), true),
+            Arguments.of(networkError(ChatErrorCode.TOKEN_NOT_VALID, 400), true),
+            Arguments.of(networkError(ChatErrorCode.TOKEN_DATE_INCORRECT, 400), true),
+            Arguments.of(networkError(ChatErrorCode.TOKEN_SIGNATURE_INCORRECT, 400), true),
+            Arguments.of(networkError(ChatErrorCode.API_KEY_NOT_FOUND, 400), true),
+        )
+
+        @JvmStatic
+        fun copyWithMessageArguments() = listOf(
+            Arguments.of(
+                Error.GenericError("Error"),
+                "New error",
+                Error.GenericError("New error"),
+            ),
+            Arguments.of(
+                Error.ThrowableError("Error", Throwable()),
+                "New error",
+                Error.ThrowableError("New error", Throwable()),
+            ),
+            Arguments.of(
+                Error.NetworkError("Error", ChatErrorCode.NETWORK_FAILED.code, 400),
+                "New error",
+                Error.NetworkError("New error", ChatErrorCode.NETWORK_FAILED.code, 400),
+            ),
+        )
+
+        @JvmStatic
+        fun extractCauseArguments(): List<Arguments> {
+            val cause = Throwable("Error")
+            return listOf(
+                Arguments.of(Error.GenericError("Error"), null),
+                Arguments.of(Error.ThrowableError("Error", cause), cause),
+                Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, statusCode = 400), null),
+                Arguments.of(networkError(ChatErrorCode.NETWORK_FAILED, statusCode = 400, cause = cause), cause),
+            )
+        }
+
+        private fun networkError(
+            code: ChatErrorCode,
+            statusCode: Int = 400,
+            cause: Throwable? = null,
+        ): Error.NetworkError {
+            return Error.NetworkError("Error", code.code, statusCode, cause)
+        }
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/NetworkErrorTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/client/errors/NetworkErrorTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.errors
+
+import io.getstream.result.Error
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class NetworkErrorTest {
+
+    @Test
+    fun testIsStatusBadRequest() {
+        val error = Error.NetworkError("Error", ChatErrorCode.NETWORK_FAILED.code, 400)
+        Assertions.assertTrue(error.isStatusBadRequest())
+    }
+
+    @Test
+    fun testIsValidationError() {
+        val error = Error.NetworkError("Error", ChatErrorCode.VALIDATION_ERROR.code, 400)
+        Assertions.assertTrue(error.isValidationError())
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/concurrency/SynchronizedReferenceTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/concurrency/SynchronizedReferenceTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.core.internal.concurrency
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class SynchronizedReferenceTest {
+
+    @Test
+    fun testGet() {
+        val ref = SynchronizedReference(value = "sync")
+        ref.get() `should be equal to` "sync"
+    }
+
+    @Test
+    fun testGetOrCreateWhenInitialized() {
+        val ref = SynchronizedReference(value = "sync")
+        val value = ref.getOrCreate { "new" }
+        value `should be equal to` "sync"
+    }
+
+    @Test
+    fun testGetOrCreateWhenNotInitialized() {
+        val ref = SynchronizedReference<String>()
+        val value = ref.getOrCreate { "new" }
+        value `should be equal to` "new"
+    }
+
+    @Test
+    fun testReset() {
+        val ref = SynchronizedReference(value = "sync")
+        ref.reset() `should be equal to` true
+    }
+
+    @Test
+    fun testSet() {
+        val ref = SynchronizedReference<String>()
+        ref.set("sync") `should be equal to` null
+        ref.get() `should be equal to` "sync"
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/coroutines/TubeTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/coroutines/TubeTest.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.core.internal.coroutines
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class TubeTest {
+
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+    private val scope = TestScope(testDispatcher)
+
+    @Test
+    fun testTubeCollectionAndEmission() = runTest {
+        // given
+        var collected1 = false
+        var collected2 = false
+
+        val tube = Tube<Unit>()
+        scope.launch {
+            tube.collect {
+                collected1 = true
+            }
+        }
+        scope.launch {
+            tube.collect {
+                collected2 = true
+            }
+        }
+        // when
+        tube.emit(Unit)
+        // then
+        collected1 `should be equal to` true
+        collected2 `should be equal to` true
+        // cleanup
+        scope.cancel()
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/fsm/FiniteStateMachineTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/fsm/FiniteStateMachineTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.core.internal.fsm
+
+import kotlinx.coroutines.runBlocking
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class FiniteStateMachineTest {
+
+    @Test
+    fun testInitialState() {
+        val subject = createFsm()
+        subject.state `should be equal to` State.NotInitialized
+    }
+
+    @Test
+    fun testUnsupportedEvent() {
+        val subject = createFsm()
+        runBlocking {
+            subject.sendEvent(Event.Update(1))
+        }
+        subject.state `should be equal to` State.NotInitialized
+    }
+
+    @Test
+    fun testSupportedEvents() {
+        val subject = createFsm()
+        runBlocking {
+            subject.sendEvent(Event.Initialize(1))
+        }
+        subject.state `should be equal to` State.Initialized(1)
+        runBlocking {
+            subject.sendEvent(Event.Update(2))
+        }
+        subject.state `should be equal to` State.Initialized(2)
+        runBlocking {
+            subject.sendEvent(Event.Reset)
+        }
+        subject.state `should be equal to` State.NotInitialized
+    }
+
+    @Test
+    fun testStay() {
+        val subject = createFsm()
+        runBlocking {
+            subject.sendEvent(Event.Initialize(1))
+        }
+        subject.state `should be equal to` State.Initialized(1)
+        subject.stay()
+        subject.state `should be equal to` State.Initialized(1)
+    }
+
+    private fun createFsm() = FiniteStateMachine<State, Event> {
+        defaultHandler { state, _ -> state }
+        initialState(State.NotInitialized)
+        state<State.NotInitialized> {
+            onEvent<Event.Initialize> { event -> State.Initialized(event.value) }
+        }
+        state<State.Initialized> {
+            onEvent<Event.Update> { event -> State.Initialized(event.value) }
+            onEvent<Event.Reset> { State.NotInitialized }
+        }
+    }
+
+    sealed interface State {
+        data object NotInitialized : State
+        data class Initialized(val value: Int) : State
+    }
+
+    sealed interface Event {
+        data class Initialize(val value: Int) : Event
+        data class Update(val value: Int) : Event
+        data object Reset : Event
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/lazy/ParameterizedLazyTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/internal/lazy/ParameterizedLazyTest.kt
@@ -31,7 +31,7 @@ internal class ParameterizedLazyTest {
             counter.incrementAndGet()
             "test$it"
         }
-        val loadStringForNumber = ParameterizedLazy(initializer)
+        val loadStringForNumber = parameterizedLazy(initializer)
         val string1a = loadStringForNumber(1)
         val string1b = loadStringForNumber(1)
         val string2a = loadStringForNumber(2)

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/utils/DebouncerTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/utils/DebouncerTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.core.utils
+
+import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class DebouncerTest {
+
+    private val testDispatcher: TestDispatcher = UnconfinedTestDispatcher(TestCoroutineScheduler())
+
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        DispatcherProvider.set(
+            mainDispatcher = testDispatcher,
+            ioDispatcher = testDispatcher,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        DispatcherProvider.reset()
+    }
+
+    @Test
+    fun testWorkInDebounceInterval() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submit {
+            acc += 1
+        }
+        delay(100)
+        debouncer.submit {
+            acc += 1
+        }
+        delay(300)
+        // then
+        acc `should be equal to` 1
+    }
+
+    @Test
+    fun testWorkOutsideDebounceInterval() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submit {
+            acc += 1
+        }
+        delay(300)
+        debouncer.submit {
+            acc += 1
+        }
+        delay(300)
+        // then
+        acc `should be equal to` 2
+    }
+
+    @Test
+    fun testSuspendableWorkInDebounceInterval() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submitSuspendable {
+            acc += 1
+        }
+        delay(100)
+        debouncer.submitSuspendable {
+            acc += 1
+        }
+        delay(300)
+        // then
+        acc `should be equal to` 1
+    }
+
+    @Test
+    fun testSuspendableWorkOutsideDebounceInterval() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submitSuspendable {
+            acc += 1
+        }
+        delay(300)
+        debouncer.submitSuspendable {
+            acc += 1
+        }
+        delay(300)
+        // then
+        acc `should be equal to` 2
+    }
+
+    @Test
+    fun testCancelLastDebounce() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submit {
+            acc += 1
+        }
+        delay(100)
+        debouncer.cancelLastDebounce()
+        delay(300)
+        // then
+        acc `should be equal to` 0
+    }
+
+    @Test
+    fun testShutdown() = runTest {
+        // given
+        val debouncer = Debouncer(200)
+        var acc = 0
+        // when
+        debouncer.submit {
+            acc += 1
+        }
+        debouncer.shutdown()
+        delay(300)
+        // then
+        acc `should be equal to` 0
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/utils/date/DateUtilsTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/core/utils/date/DateUtilsTest.kt
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.core.utils.date
+
+import io.getstream.chat.android.models.TimeDuration
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Instant
+import java.util.Date
+
+internal class DateUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsAfterArguments")
+    fun testDateUtilsAfter(
+        date1: Date?,
+        date2: Date?,
+        isAfter: Boolean,
+    ) {
+        date1 after date2 `should be equal to` isAfter
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsMaxArguments")
+    fun testDateUtilsMax(
+        date1: Date?,
+        date2: Date?,
+        max: Date?,
+    ) {
+        max(date1, date2) `should be equal to` max
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsMinArguments")
+    fun testDateUtilsMin(
+        date1: Date?,
+        date2: Date?,
+        min: Date?,
+    ) {
+        min(date1, date2) `should be equal to` min
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsMaxOfArguments")
+    fun testDateUtilsMaxOf(
+        dates: Array<Date?>,
+        max: Date?,
+    ) {
+        maxOf(*dates) `should be equal to` max
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsMinOfArguments")
+    fun testDateUtilsMinOf(
+        dates: Array<Date?>,
+        min: Date?,
+    ) {
+        minOf(*dates) `should be equal to` min
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsDiffWithOtherTimeArguments")
+    fun testDateUtilsDiffWithOtherTime(
+        date: Date,
+        time: Long,
+        diff: TimeDuration,
+    ) {
+        date.diff(time) `should be equal to` diff
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsDiffWithOtherDateArguments")
+    fun testDateUtilsDiffWithOtherDate(
+        date1: Date,
+        date2: Date,
+        diff: TimeDuration,
+    ) {
+        date1.diff(date2) `should be equal to` diff
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsIsWithinDurationFromNowArguments")
+    fun testDateUtilsIsWithinDurationFromNow(
+        date: Date?,
+        duration: TimeDuration,
+        now: Long,
+        isWithinDuration: Boolean,
+    ) {
+        date.isWithinDurationFromNow(duration) { now } `should be equal to` isWithinDuration
+    }
+
+    @ParameterizedTest
+    @MethodSource("dateUtilsTruncateFutureArguments")
+    fun testDateUtilsTruncateFuture(
+        date: Date,
+        now: Long,
+        truncatedDate: Date,
+    ) {
+        date.truncateFuture { now } `should be equal to` truncatedDate
+    }
+
+    companion object {
+
+        private val dateBefore = Date.from(Instant.ofEpochMilli(1737389237))
+        private val date = Date.from(Instant.ofEpochMilli(1737389238))
+        private val dateAfter = Date.from(Instant.ofEpochMilli(1737389239))
+
+        @JvmStatic
+        fun dateUtilsAfterArguments(): List<Arguments> {
+            return listOf(
+                Arguments.of(null, null, false),
+                Arguments.of(null, dateBefore, false),
+                Arguments.of(dateBefore, null, true),
+                Arguments.of(dateBefore, dateBefore, false),
+                Arguments.of(dateBefore, dateAfter, false),
+                Arguments.of(dateAfter, dateBefore, true),
+            )
+        }
+
+        @JvmStatic
+        fun dateUtilsMaxArguments() = listOf(
+            Arguments.of(dateBefore, dateBefore, dateBefore),
+            Arguments.of(dateBefore, dateAfter, dateAfter),
+            Arguments.of(dateAfter, dateBefore, dateAfter),
+        )
+
+        @JvmStatic
+        fun dateUtilsMinArguments() = listOf(
+            Arguments.of(dateBefore, dateBefore, dateBefore),
+            Arguments.of(dateBefore, dateAfter, dateBefore),
+            Arguments.of(dateAfter, dateBefore, dateBefore),
+        )
+
+        @JvmStatic
+        fun dateUtilsMaxOfArguments() = listOf(
+            Arguments.of(arrayOf(dateAfter, dateAfter), dateAfter),
+            Arguments.of(arrayOf(dateBefore, date, dateAfter), dateAfter),
+            Arguments.of(arrayOf(dateAfter, date, dateBefore), dateAfter),
+            Arguments.of(arrayOf<Date?>(null), null),
+        )
+
+        @JvmStatic
+        fun dateUtilsMinOfArguments() = listOf(
+            Arguments.of(arrayOf(dateBefore, dateBefore), dateBefore),
+            Arguments.of(arrayOf(dateBefore, date, dateAfter), dateBefore),
+            Arguments.of(arrayOf(dateAfter, date, dateBefore), dateBefore),
+            Arguments.of(arrayOf<Date?>(null), null),
+        )
+
+        @JvmStatic
+        fun dateUtilsDiffWithOtherTimeArguments() = listOf(
+            Arguments.of(dateBefore, dateAfter.time, TimeDuration.millis(2)),
+            Arguments.of(dateAfter, dateBefore.time, TimeDuration.millis(2)),
+        )
+
+        @JvmStatic
+        fun dateUtilsDiffWithOtherDateArguments() = listOf(
+            Arguments.of(dateBefore, dateAfter, TimeDuration.millis(2)),
+            Arguments.of(dateAfter, dateBefore, TimeDuration.millis(2)),
+        )
+
+        @JvmStatic
+        fun dateUtilsIsWithinDurationFromNowArguments() = listOf(
+            Arguments.of(null, TimeDuration.millis(1), date.time, false),
+            Arguments.of(dateBefore, TimeDuration.millis(1), date.time, false),
+            Arguments.of(dateBefore, TimeDuration.millis(2), date.time, true),
+        )
+
+        @JvmStatic
+        fun dateUtilsTruncateFutureArguments() = listOf(
+            // Note: clone the 'this' date, because it is
+            // mutated internally in the `truncateFuture` method
+            Arguments.of(dateBefore.clone(), date.time, dateBefore),
+            Arguments.of(date.clone(), date.time, date),
+            Arguments.of(dateAfter.clone(), date.time, date),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/FloatExtensionsTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/FloatExtensionsTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.extensions
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class FloatExtensionsTest {
+
+    @ParameterizedTest
+    @MethodSource("floatExtensionsLimitToArguments")
+    fun testFloatExtensionsLimitTo(
+        value: Float,
+        min: Float,
+        max: Float,
+        expected: Float,
+    ) {
+        value.limitTo(min, max) `should be equal to` expected
+    }
+
+    @ParameterizedTest
+    @MethodSource("floatExtensionsIsIntArguments")
+    fun testFloatExtensionsIsInt(
+        value: Float,
+        expected: Boolean,
+    ) {
+        value.isInt() `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun floatExtensionsLimitToArguments() = listOf(
+            Arguments.of(1f, 0f, 2f, 1f),
+            Arguments.of(1f, 2f, 3f, 2f),
+            Arguments.of(3f, 1f, 2f, 2f),
+        )
+
+        @JvmStatic
+        fun floatExtensionsIsIntArguments() = listOf(
+            Arguments.of(1.0f, true),
+            Arguments.of(1.1f, false),
+            Arguments.of(1.9f, false),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/IntExtensionsTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/IntExtensionsTest.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.extensions
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class IntExtensionsTest {
+
+    @ParameterizedTest
+    @MethodSource("intExtensionsLimitToArguments")
+    fun testIntExtensionsLimitTo(
+        value: Int,
+        min: Int,
+        max: Int,
+        expected: Int,
+    ) {
+        value.limitTo(min, max) `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun intExtensionsLimitToArguments() = listOf(
+            Arguments.of(1, 0, 2, 1),
+            Arguments.of(1, 2, 3, 2),
+            Arguments.of(3, 1, 2, 2),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/StringExtensionsTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/extensions/StringExtensionsTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.extensions
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class StringExtensionsTest {
+
+    @Test
+    fun testStringExtensionsSnakeToLowerCamelCase() {
+        val text = "created_at_some_time"
+        val expected = "createdAtSomeTime"
+        text.snakeToLowerCamelCase() `should be equal to` expected
+    }
+
+    @Test
+    fun testStringExtensionsLowerCamelCaseToGetter() {
+        val text = "cammelCase"
+        val expected = "getCammelCase"
+        text.lowerCamelCaseToGetter() `should be equal to` expected
+    }
+
+    @Test
+    fun testStringExtensionsCamelCaseToSnakeCase() {
+        val text = "createdAtSomeTime"
+        val expected = "created_at_some_time"
+        text.camelCaseToSnakeCase() `should be equal to` expected
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/FiltersTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/FiltersTest.kt
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class FiltersTest {
+
+    @Test
+    fun testFiltersNeutral() {
+        val filter = Filters.neutral()
+        filter `should be equal to` NeutralFilterObject
+    }
+
+    @Test
+    fun testFiltersExists() {
+        val filter = Filters.exists("fieldName")
+        filter `should be equal to` ExistsFilterObject("fieldName")
+    }
+
+    @Test
+    fun testFiltersNotExists() {
+        val filter = Filters.notExists("fieldName")
+        filter `should be equal to` NotExistsFilterObject("fieldName")
+    }
+
+    @Test
+    fun testFiltersContains() {
+        val filter = Filters.contains("fieldName", "value")
+        filter `should be equal to` ContainsFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersAnd() {
+        val filter1 = Filters.eq("fieldName1", "value1")
+        val filter2 = Filters.eq("fieldName2", "value2")
+        val andFilter = Filters.and(filter1, filter2)
+        andFilter `should be equal to` AndFilterObject(setOf(filter1, filter2))
+    }
+
+    @Test
+    fun testFiltersOr() {
+        val filter1 = Filters.eq("fieldName1", "value1")
+        val filter2 = Filters.eq("fieldName2", "value2")
+        val orFilter = Filters.or(filter1, filter2)
+        orFilter `should be equal to` OrFilterObject(setOf(filter1, filter2))
+    }
+
+    @Test
+    fun testFiltersNor() {
+        val filter1 = Filters.eq("fieldName1", "value1")
+        val filter2 = Filters.eq("fieldName2", "value2")
+        val norFilter = Filters.nor(filter1, filter2)
+        norFilter `should be equal to` NorFilterObject(setOf(filter1, filter2))
+    }
+
+    @Test
+    fun testFiltersEq() {
+        val filter = Filters.eq("fieldName", "value")
+        filter `should be equal to` EqualsFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersNe() {
+        val filter = Filters.ne("fieldName", "value")
+        filter `should be equal to` NotEqualsFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersGreaterThan() {
+        val filter = Filters.greaterThan("fieldName", "value")
+        filter `should be equal to` GreaterThanFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersGreaterThanOrEquals() {
+        val filter = Filters.greaterThanEquals("fieldName", "value")
+        filter `should be equal to` GreaterThanOrEqualsFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersLessThan() {
+        val filter = Filters.lessThan("fieldName", "value")
+        filter `should be equal to` LessThanFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersLessThanOrEquals() {
+        val filter = Filters.lessThanEquals("fieldName", "value")
+        filter `should be equal to` LessThanOrEqualsFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersInStringArray() {
+        val filter = Filters.`in`("fieldName", "value1", "value2")
+        filter `should be equal to` InFilterObject("fieldName", setOf("value1", "value2"))
+    }
+
+    @Test
+    fun testFiltersInList() {
+        val filter = Filters.`in`("fieldName", listOf("value1", "value2"))
+        filter `should be equal to` InFilterObject("fieldName", setOf("value1", "value2"))
+    }
+
+    @Test
+    fun testFiltersInNumberArray() {
+        val filter = Filters.`in`("fieldName", 1, 2)
+        filter `should be equal to` InFilterObject("fieldName", setOf(1, 2))
+    }
+
+    @Test
+    fun testFiltersAutocomplete() {
+        val filter = Filters.autocomplete("fieldName", "value")
+        filter `should be equal to` AutocompleteFilterObject("fieldName", "value")
+    }
+
+    @Test
+    fun testFiltersDistinct() {
+        val filter = Filters.distinct(listOf("memberId1", "memberId2"))
+        filter `should be equal to` DistinctFilterObject(setOf("memberId1", "memberId2"))
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageModerationActionTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageModerationActionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class MessageModerationActionTest {
+
+    @ParameterizedTest
+    @MethodSource("messageModerationActionFromRawValueArguments")
+    fun testMessageModerationActionFromRawValue(rawValue: String, expected: MessageModerationAction) {
+        MessageModerationAction.fromRawValue(rawValue) `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun messageModerationActionFromRawValueArguments() = listOf(
+            Arguments.of("MESSAGE_RESPONSE_ACTION_BOUNCE", MessageModerationAction.bounce),
+            Arguments.of("MESSAGE_RESPONSE_ACTION_FLAG", MessageModerationAction.flag),
+            Arguments.of("MESSAGE_RESPONSE_ACTION_BLOCK", MessageModerationAction.block),
+            Arguments.of("other", MessageModerationAction("other")),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTransformerTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/MessageTransformerTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class MessageTransformerTest {
+
+    @Test
+    fun testNoOpMessageTransformer() {
+        // given
+        val message = Message(id = "mid1", text = "message")
+        // when
+        val transformed = NoOpMessageTransformer.transform(message)
+        // then
+        transformed `should be equal to` message
+    }
+
+    @Test
+    fun testCustomMessageTransformed() {
+        // given
+        val message = Message(id = "mid1", text = "message")
+        val customTransformer = MessageTransformer { it.copy(text = "transformed") }
+        // when
+        val transformed = customTransformer.transform(message)
+        // then
+        val expected = Message(id = "mid1", text = "transformed")
+        transformed `should be equal to` expected
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/ModerationActionTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/ModerationActionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class ModerationActionTest {
+
+    @ParameterizedTest
+    @MethodSource("moderationActionFromValueArguments")
+    fun testModerationActionFromValue(value: String, expected: ModerationAction) {
+        ModerationAction.fromValue(value) `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun moderationActionFromValueArguments() = listOf(
+            Arguments.of("bounce", ModerationAction.bounce),
+            Arguments.of("remove", ModerationAction.remove),
+            Arguments.of("flag", ModerationAction.flag),
+            Arguments.of("other", ModerationAction("other")),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/NoOpChannelTransformerTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/NoOpChannelTransformerTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class NoOpChannelTransformerTest {
+
+    @Test
+    fun testNoOpChannelTransformer() {
+        // given
+        val channel = Channel(id = "cid1", type = "messaging")
+        // when
+        val transformed = NoOpChannelTransformer.transform(channel)
+        // then
+        transformed `should be equal to` channel
+    }
+
+    @Test
+    fun testCustomChannelTransformed() {
+        // given
+        val channel = Channel(id = "cid1", type = "messaging", name = "channel")
+        val customTransformer = ChannelTransformer { it.copy(name = "transformed") }
+        // when
+        val transformed = customTransformer.transform(channel)
+        // then
+        val expected = Channel(id = "cid1", type = "messaging", name = "transformed")
+        transformed `should be equal to` expected
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/PushProviderTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/PushProviderTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class PushProviderTest {
+
+    @ParameterizedTest
+    @MethodSource("pushProviderFromKeyArguments")
+    fun testPushProviderFromKey(key: String, expected: PushProvider) {
+        PushProvider.fromKey(key) `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun pushProviderFromKeyArguments() = listOf(
+            Arguments.of("firebase", PushProvider.FIREBASE),
+            Arguments.of("huawei", PushProvider.HUAWEI),
+            Arguments.of("xiaomi", PushProvider.XIAOMI),
+            Arguments.of("unknown", PushProvider.UNKNOWN),
+            Arguments.of("invalid", PushProvider.UNKNOWN),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/SyncStatusTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/SyncStatusTest.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class SyncStatusTest {
+
+    @ParameterizedTest
+    @MethodSource("syncStatusFromIntArguments")
+    fun testSyncStatusFromInt(value: Int, expected: SyncStatus) {
+        SyncStatus.fromInt(value) `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun syncStatusFromIntArguments() = listOf(
+            Arguments.of(-1, SyncStatus.SYNC_NEEDED),
+            Arguments.of(1, SyncStatus.COMPLETED),
+            Arguments.of(2, SyncStatus.FAILED_PERMANENTLY),
+            Arguments.of(3, SyncStatus.IN_PROGRESS),
+            Arguments.of(4, SyncStatus.AWAITING_ATTACHMENTS),
+        )
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/UserTransformerTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/UserTransformerTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.api.Test
+
+internal class UserTransformerTest {
+
+    @Test
+    fun testNoOpUserTransformer() {
+        // given
+        val user = User(id = "uid1", name = "username")
+        // when
+        val transformed = NoOpUserTransformer.transform(user)
+        // then
+        transformed `should be equal to` user
+    }
+
+    @Test
+    fun testCustomUserTransformed() {
+        // given
+        val user = User(id = "uid1", name = "username")
+        val customTransformer = UserTransformer { it.copy(name = "transformed") }
+        // when
+        val transformed = customTransformer.transform(user)
+        // then
+        val expected = User(id = "uid1", name = "transformed")
+        transformed `should be equal to` expected
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/FieldSearcherTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/FieldSearcherTest.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models.querysort
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class FieldSearcherTest {
+
+    /**
+     * Test subject class.
+     *
+     * @property comparableField a comparable field.
+     */
+    data class TestSubject(val comparableField: String)
+
+    @Test
+    fun `Should find comparable camel case member property`() {
+        // Given
+        val fieldName = "comparableField"
+        val kClass = TestSubject::class
+
+        // When
+        val result = FieldSearcher().findComparableMemberProperty(fieldName, kClass)
+
+        // Then
+        Assertions.assertNotNull(result)
+    }
+
+    @Test
+    fun `Should find comparable snake case member property`() {
+        // Given
+        val fieldName = "comparable_field"
+        val kClass = TestSubject::class
+
+        // When
+        val result = FieldSearcher().findComparableMemberProperty(fieldName, kClass)
+
+        // Then
+        Assertions.assertNotNull(result)
+    }
+
+    @Test
+    fun `Should not find comparable camel case member property`() {
+        // Given
+        val fieldName = "unknownField"
+        val kClass = TestSubject::class
+
+        // When
+        val result = FieldSearcher().findComparableMemberProperty(fieldName, kClass)
+
+        // Then
+        Assertions.assertNull(result)
+    }
+
+    @Test
+    fun `Should not find comparable snake case member property`() {
+        // Given
+        val fieldName = "unknown_field"
+        val kClass = TestSubject::class
+
+        // When
+        val result = FieldSearcher().findComparableMemberProperty(fieldName, kClass)
+
+        // Then
+        Assertions.assertNull(result)
+    }
+
+    @Test
+    fun `Should find comparable camel case`() {
+        // Given
+        val any = TestSubject("test")
+        val fieldName = "comparableField"
+
+        // When
+        val result = FieldSearcher().findComparable(any, fieldName)
+
+        // Then
+        Assertions.assertNotNull(result)
+    }
+
+    @Test
+    fun `Should find comparable snake case`() {
+        // Given
+        val any = TestSubject("test")
+        val fieldName = "comparable_field"
+
+        // When
+        val result = FieldSearcher().findComparable(any, fieldName)
+
+        // Then
+        Assertions.assertNotNull(result)
+    }
+
+    @Test
+    fun `Should not find comparable camel case`() {
+        // Given
+        val any = TestSubject("test")
+        val fieldName = "unknownField"
+
+        // When
+        val result = FieldSearcher().findComparable(any, fieldName)
+
+        // Then
+        Assertions.assertNull(result)
+    }
+
+    @Test
+    fun `Should not find comparable snake case`() {
+        // Given
+        val any = TestSubject("test")
+        val fieldName = "unknown_field"
+
+        // When
+        val result = FieldSearcher().findComparable(any, fieldName)
+
+        // Then
+        Assertions.assertNull(result)
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/QuerySortByFieldTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/QuerySortByFieldTest.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models.querysort
+
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.ascByName
+import io.getstream.chat.android.models.querysort.QuerySortByField.Companion.descByName
+import io.getstream.chat.android.models.querysort.internal.SortAttribute
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+internal class QuerySortByFieldTest {
+
+    @Test
+    fun `When using QuerySortByField, when calling comparatorFromFieldSort, should throw exception`() {
+        // given
+        val querySortByField = QuerySortByField<Channel>()
+        // when / then
+        Assertions.assertThrows(IllegalArgumentException::class.java) {
+            querySortByField.comparatorFromFieldSort(
+                firstSort = SortAttribute.FieldSortAttribute(
+                    field = Channel::memberCount,
+                    name = Channel::memberCount.name,
+                ),
+                sortDirection = SortDirection.ASC,
+            )
+        }
+    }
+
+    @Test
+    fun `When using QuerySortByField, when calling comparatorFromNameAttribute, should return comparator`() {
+        // given
+        val querySortByField = QuerySortByField<Channel>()
+        // when
+        val comparator = querySortByField.comparatorFromNameAttribute(
+            name = SortAttribute.FieldNameSortAttribute(Channel::memberCount.name),
+            sortDirection = SortDirection.ASC,
+        )
+        // then
+        comparator `should be instance of` Comparator::class
+    }
+
+    @Test
+    fun `When creating QuerySortByField via ascByName, Then correct object is created`() {
+        // given
+        val querySort = QuerySortByField.ascByName<Channel>("created_at")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        specifications[0].sortDirection `should be equal to` SortDirection.ASC
+    }
+
+    @Test
+    fun `When creating QuerySortByField via descByName, Then correct object is created`() {
+        // given
+        val querySort = QuerySortByField.descByName<Channel>("created_at")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        specifications[0].sortDirection `should be equal to` SortDirection.DESC
+    }
+
+    @Test
+    fun `When creating QuerySortByField via ascByName extension, Then correct object is created`() {
+        // given
+        val querySort = QuerySortByField<Channel>().ascByName("created_at")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        specifications[0].sortDirection `should be equal to` SortDirection.ASC
+    }
+
+    @Test
+    fun `When creating QuerySortByField via descByName extension, Then correct object is created`() {
+        // given
+        val querySort = QuerySortByField<Channel>().descByName("created_at")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        specifications[0].sortDirection `should be equal to` SortDirection.DESC
+    }
+
+    @Test
+    fun `When using QuerySortByField asc, Then objects are sorted in ascending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel2, channel1)
+        val querySort = QuerySortByField<Channel>().asc("name")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel1, channel2)
+    }
+
+    @Test
+    fun `When using QuerySortByField desc, Then objects are sorted in descending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel1, channel2)
+        val querySort = QuerySortByField<Channel>().desc("name")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel1)
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/QuerySortByReflectionTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/QuerySortByReflectionTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models.querysort
+
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.querysort.QuerySortByReflection.Companion.asc
+import io.getstream.chat.android.models.querysort.QuerySortByReflection.Companion.desc
+import io.getstream.chat.android.models.querysort.internal.SortAttribute
+import org.amshove.kluent.`should be equal to`
+import org.amshove.kluent.`should be instance of`
+import org.junit.jupiter.api.Test
+
+internal class QuerySortByReflectionTest {
+
+    @Test
+    fun `When creating QuerySortByReflection via asc(fieldName), Then correct object is created`() {
+        // given
+        val querySort = asc<Channel>("name")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldSortAttribute::class
+        val fieldSortAttribute = specifications[0].sortAttribute as SortAttribute.FieldSortAttribute
+        fieldSortAttribute.field.name `should be equal to` "name"
+        specifications[0].sortDirection `should be equal to` SortDirection.ASC
+    }
+
+    @Test
+    fun `When creating QuerySortByReflection via desc(fieldName), Then correct object is created`() {
+        // given
+        val querySort = desc<Channel>("name")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldSortAttribute::class
+        val fieldSortAttribute = specifications[0].sortAttribute as SortAttribute.FieldSortAttribute
+        fieldSortAttribute.field.name `should be equal to` "name"
+        specifications[0].sortDirection `should be equal to` SortDirection.DESC
+    }
+
+    @Test
+    fun `When creating QuerySortByReflection via asc(field), Then correct object is created`() {
+        // given
+        val querySort = asc(Channel::name)
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldSortAttribute::class
+        val fieldSortAttribute = specifications[0].sortAttribute as SortAttribute.FieldSortAttribute
+        fieldSortAttribute.field.name `should be equal to` "name"
+        specifications[0].sortDirection `should be equal to` SortDirection.ASC
+    }
+
+    @Test
+    fun `When creating QuerySortByReflection via desc(field), Then correct object is created`() {
+        // given
+        val querySort = desc(Channel::name)
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldSortAttribute::class
+        val fieldSortAttribute = specifications[0].sortAttribute as SortAttribute.FieldSortAttribute
+        fieldSortAttribute.field.name `should be equal to` "name"
+        specifications[0].sortDirection `should be equal to` SortDirection.DESC
+    }
+
+    @Test
+    fun `When creating QuerySortByReflection by custom field asc, Then the sortSpecifications are updated`() {
+        // given
+        val querySort = QuerySortByReflection<Channel>()
+        // when
+        querySort.asc("some_custom_field")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        val sortAttribute = specifications[0].sortAttribute as SortAttribute.FieldNameSortAttribute
+        sortAttribute.name `should be equal to` "some_custom_field"
+        specifications[0].sortDirection `should be equal to` SortDirection.ASC
+    }
+
+    @Test
+    fun `When creating QuerySortByReflection by custom field desc, Then the sortSpecifications are updated`() {
+        // given
+        val querySort = QuerySortByReflection<Channel>()
+        // when
+        querySort.desc("some_custom_field")
+        // then
+        val specifications = querySort.sortSpecifications
+        specifications.size `should be equal to` 1
+        specifications[0].sortAttribute `should be instance of` SortAttribute.FieldNameSortAttribute::class
+        val sortAttribute = specifications[0].sortAttribute as SortAttribute.FieldNameSortAttribute
+        sortAttribute.name `should be equal to` "some_custom_field"
+        specifications[0].sortDirection `should be equal to` SortDirection.DESC
+    }
+
+    @Test
+    fun `When using QuerySortByReflection asc(fieldName), Then objects are sorted in ascending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel2, channel1)
+        val querySort = asc<Channel>("name")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel1, channel2)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection desc(fieldName), Then objects are sorted in descending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel1, channel2)
+        val querySort = desc<Channel>("name")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel1)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection asc(field), Then objects are sorted in ascending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel2, channel1)
+        val querySort = asc(Channel::name)
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel1, channel2)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection desc(field), Then objects are sorted in descending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1")
+        val channel2 = Channel(id = "cid2", name = "Channel 2")
+        val channelsToSort = listOf(channel1, channel2)
+        val querySort = desc(Channel::name)
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel1)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection asc by custom field, Then objects are sorted in ascending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1", extraData = mutableMapOf("sort_order" to 2))
+        val channel2 = Channel(id = "cid2", name = "Channel 2", extraData = mutableMapOf("sort_order" to 1))
+        val channelsToSort = listOf(channel1, channel2)
+        val querySort = QuerySortByReflection<Channel>().asc("sort_order")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel1)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection desc by custom field, Then objects are sorted in descending order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1", extraData = mutableMapOf("sort_order" to 1))
+        val channel2 = Channel(id = "cid2", name = "Channel 2", extraData = mutableMapOf("sort_order" to 2))
+        val channelsToSort = listOf(channel1, channel2)
+        val querySort = QuerySortByReflection<Channel>().desc("sort_order")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel1)
+    }
+
+    @Test
+    fun `When using QuerySortByReflection by multiple field, Then object are sorted in correct order`() {
+        // given
+        val channel1 = Channel(id = "cid1", name = "Channel 1", extraData = mutableMapOf("importance" to 1))
+        val channel2 = Channel(id = "cid2", name = "Channel 2", extraData = mutableMapOf("importance" to 1))
+        val channel3 = Channel(id = "cid3", name = "Channel 2", extraData = mutableMapOf("importance" to 2))
+        val channelsToSort = listOf(channel1, channel2, channel3)
+        val querySort = QuerySortByReflection<Channel>()
+            .desc("name")
+            .asc("importance")
+        // when
+        val sortedChannels = channelsToSort.sortedWith(querySort.comparator)
+        // then
+        sortedChannels `should be equal to` listOf(channel2, channel3, channel1)
+    }
+}

--- a/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/SortDirectionTest.kt
+++ b/stream-chat-android-core/src/test/java/io/getstream/chat/android/models/querysort/SortDirectionTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.models.querysort
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class SortDirectionTest {
+
+    @Test
+    fun testSortDirectionFromNumberAsc() {
+        val sortDirection = SortDirection.fromNumber(1)
+        assert(sortDirection == SortDirection.ASC)
+    }
+
+    @Test
+    fun testSortDirectionFromNumberDesc() {
+        val sortDirection = SortDirection.fromNumber(-1)
+        assert(sortDirection == SortDirection.DESC)
+    }
+
+    @Test
+    fun testSortDirectionFromNumberUnsupported() {
+        assertThrows<IllegalArgumentException> {
+            SortDirection.fromNumber(0)
+        }
+    }
+}


### PR DESCRIPTION
### 🎯 Goal
- Increase the test coverage of the Chat SDK
- Cover the `stream-chat-android-core` module
- Additionally, add some missing KDocs and remove some warnings

### 🛠 Implementation details
- Add tests for non-model classes
- Add missing KDocs
- Remove redundant warning suppressions
- Replace `enum.values` with `enum.entries`

### 🧪 Testing
Run unit tests in `stream-chat-android-core`.
