### PR TITLE
[AND-275] Expose a new method to return a representation of relative date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added `DateFormatter::formatRelativeDate` method to format a relative date. [#5587](https://github.com/GetStream/stream-chat-android/pull/5587)
 
 ### ⚠️ Changed
 
@@ -63,6 +64,7 @@
 - Fix poll attachment picker not hidden if disabled in the dashboard. [#5562](https://github.com/GetStream/stream-chat-android/pull/5562)
 
 ### ⬆️ Improved
+- `DateDividerViewHolder` now uses `DateFormatter::formatRelativeDate` to format the date. [#5587](https://github.com/GetStream/stream-chat-android/pull/5587)
 
 ### ✅ Added
 
@@ -76,6 +78,7 @@
 
 ### ⬆️ Improved
 - Add a debounce to the queryChannels process to avoid multiple requests while typing for search channels. [#5615](https://github.com/GetStream/stream-chat-android/pull/5615)
+- `DefaultMessageDateSeparatorContent` now uses `DateFormatter::formatRelativeDate` to format the date. [#5587](https://github.com/GetStream/stream-chat-android/pull/5587)
 - Create snapshot tests for channels stateless components. [#5570](https://github.com/GetStream/stream-chat-android/pull/5570)
 - Introduce `ChatComponentFactory` for easier channel components customization. Initially supporting channel stateless components. [#5571](https://github.com/GetStream/stream-chat-android/pull/5571)
 - Deprecate `MessageContentFactory` in favor of `ChatComponentFactory`. [#5571](https://github.com/GetStream/stream-chat-android/pull/5571)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.compose.ui.messages.list
 
-import android.text.format.DateUtils
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -231,12 +230,7 @@ internal fun DefaultMessageDateSeparatorContent(dateSeparator: DateSeparatorItem
                 modifier = Modifier
                     .padding(vertical = 2.dp, horizontal = 16.dp)
                     .testTag("Stream_MessageDateSeparator"),
-                text = DateUtils.getRelativeTimeSpanString(
-                    dateSeparator.date.time,
-                    System.currentTimeMillis(),
-                    DateUtils.DAY_IN_MILLIS,
-                    DateUtils.FORMAT_ABBREV_RELATIVE,
-                ).toString(),
+                text = ChatTheme.dateFormatter.formatRelativeDate(dateSeparator.date),
                 style = ChatTheme.messageDateSeparatorTheme.textStyle,
             )
         }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/general/Configuration.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/general/Configuration.java
@@ -218,6 +218,19 @@ public class Configuration {
                                 0
                         ).toString();
                     }
+
+                    @NonNull
+                    @Override
+                    public String formatRelativeDate(@NonNull Date date) {
+                        // Provide a way to format relative date
+
+                        return DateUtils.getRelativeTimeSpanString(
+                                date.getTime(),
+                                System.currentTimeMillis(),
+                                DateUtils.DAY_IN_MILLIS,
+                                DateUtils.FORMAT_ABBREV_RELATIVE
+                        ).toString();
+                    }
                 }
         );
     }

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/messages/MessageList.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/ui/messages/MessageList.java
@@ -179,6 +179,19 @@ public class MessageList extends Fragment {
                                 0
                                 ).toString();
                     }
+
+                    @NonNull
+                    @Override
+                    public String formatRelativeDate(@NonNull Date date) {
+                        // Provide a way to format relative date
+
+                        return DateUtils.getRelativeTimeSpanString(
+                                date.getTime(),
+                                System.currentTimeMillis(),
+                                DateUtils.DAY_IN_MILLIS,
+                                DateUtils.FORMAT_ABBREV_RELATIVE
+                                ).toString();
+                    }
                 }
         );
     }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
@@ -147,6 +147,16 @@ private object ChatThemeDateFormatterSnippet : ChatThemeCustomization() {
                     0
                 ).toString()
             }
+
+            override fun formatRelativeDate(date: Date): String {
+                // Provide a way to format Relative Date
+                return DateUtils.getRelativeTimeSpanString(
+                    date.time,
+                    System.currentTimeMillis(),
+                    DateUtils.DAY_IN_MILLIS,
+                    DateUtils.FORMAT_ABBREV_RELATIVE,
+                ).toString()
+            }
         }
     }
 }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/Configuration.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/general/Configuration.kt
@@ -205,6 +205,15 @@ private class ChatUiSnippets {
                     0,
                 ).toString()
             }
+
+            override fun formatRelativeDate(date: Date): String {
+                return DateUtils.getRelativeTimeSpanString(
+                    date.time,
+                    System.currentTimeMillis(),
+                    DateUtils.DAY_IN_MILLIS,
+                    DateUtils.FORMAT_ABBREV_RELATIVE,
+                ).toString()
+            }
         }
     }
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/messages/MessageList.kt
@@ -205,6 +205,16 @@ class MessageListViewSnippets : Fragment() {
                         0,
                     ).toString()
                 }
+
+                override fun formatRelativeDate(date: Date): String {
+                    // Provide a way to format Relative Date
+                    return DateUtils.getRelativeTimeSpanString(
+                        date.time,
+                        System.currentTimeMillis(),
+                        DateUtils.DAY_IN_MILLIS,
+                        DateUtils.FORMAT_ABBREV_RELATIVE,
+                    ).toString()
+                }
             }
         )
     }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -444,6 +444,7 @@ public final class io/getstream/chat/android/ui/common/helper/ClipboardHandlerIm
 public abstract interface class io/getstream/chat/android/ui/common/helper/DateFormatter {
 	public static final field Companion Lio/getstream/chat/android/ui/common/helper/DateFormatter$Companion;
 	public abstract fun formatDate (Ljava/util/Date;)Ljava/lang/String;
+	public abstract fun formatRelativeDate (Ljava/util/Date;)Ljava/lang/String;
 	public abstract fun formatRelativeTime (Ljava/util/Date;)Ljava/lang/String;
 	public abstract fun formatTime (Ljava/util/Date;)Ljava/lang/String;
 	public static fun from (Landroid/content/Context;)Lio/getstream/chat/android/ui/common/helper/DateFormatter;

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/DateFormatter.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/DateFormatter.kt
@@ -39,6 +39,8 @@ public interface DateFormatter {
 
     /**
      * Formats the given date as a String.
+     * A normal implementation of this method would return a string like "Yesterday", "Saturday", "9:25 AM"/"9:25", ...
+     * It is used to format the date of the last message in the channel list and the when an user voted in a poll.
      *
      * @param date The [Date] to format as a String.
      * @return The formatted date-time string.
@@ -47,6 +49,8 @@ public interface DateFormatter {
 
     /**
      * Formats the given time as a String.
+     * A normal implementation of this method would return a string like "9:25 AM"/"9:25".
+     * It is used to format the time of the message in the message list.
      *
      * @param date The [Date] object to format as a String.
      * @return The formatted time string.
@@ -55,6 +59,8 @@ public interface DateFormatter {
 
     /**
      * Formats the given date as a relative time string.
+     * A normal implementation of this method would return a string like "Just now", "5 minutes ago", ...
+     * It is used to format the time when a message was edited in the message list.
      *
      * @param date The [Date] to format as a relative time string.
      * @return The formatted relative time string.
@@ -63,6 +69,8 @@ public interface DateFormatter {
 
     /**
      * Returns a relative date string for the given date.
+     * A normal implementation of this method would return a string like "Yesterday", "A day ago", ...
+     * It is used to format the date of the separator in the message list.
      *
      * @param date The [Date] to format as a relative date string.
      * @return The formatted relative date string.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/helper/DefaultDateFormatterTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/helper/DefaultDateFormatterTest.kt
@@ -16,11 +16,13 @@
 
 package io.getstream.chat.android.ui.common.helper
 
-import android.content.Context
 import com.google.testing.junit.testparameterinjector.TestParameter
 import com.google.testing.junit.testparameterinjector.TestParameterInjector
 import io.getstream.chat.android.core.utils.date.isWithinDurationFromNow
 import io.getstream.chat.android.models.TimeDuration
+import io.getstream.chat.android.randomDate
+import io.getstream.chat.android.randomString
+import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -37,9 +39,11 @@ import java.util.Locale
 internal class DefaultDateFormatterTest {
 
     class TestDateContext(
-        private val now: Date,
+        private val now: Date = LocalDate.of(2020, 12, 7).toDate(),
         private val is24Hour: Boolean = false,
         private val dateTimePattern: String = "yyyy-MM-dd",
+        private val relativeTime: String = RELATIVE_TIME_STRING,
+        private val relativeDate: String = RELATIVE_DATE_STRING,
     ) : DefaultDateFormatter.DateContext {
         private val oneMinuteDuration = TimeDuration.minutes(1)
 
@@ -51,11 +55,11 @@ internal class DefaultDateFormatterTest {
         }
 
         override fun yesterdayString() = YESTERDAY_STRING
+        override fun justNowString(): String = JUST_NOW_STRING
         override fun is24Hour(): Boolean = is24Hour
         override fun dateTimePattern(): String = dateTimePattern
-        override fun context(): Context {
-            TODO("Not yet implemented")
-        }
+        override fun relativeTime(date: Date): String = relativeTime
+        override fun relativeDate(date: Date): String = relativeDate
     }
 
     @Test
@@ -67,13 +71,49 @@ internal class DefaultDateFormatterTest {
 
         val formattedDate = formatter.formatDate(testCase.dateToFormat?.toDate())
 
-        formattedDate shouldBeEqualTo testCase.expectedResult
+        formattedDate shouldBeEqualTo testCase.expectedFormatDateResult
+    }
+
+    @Test
+    fun `Time formatting is correct`(@TestParameter testCase: TestCase) {
+        val formatter: DateFormatter = DefaultDateFormatter(
+            TestDateContext(testCase.now.toDate(), testCase.is24Hour, testCase.dateTimePattern),
+            Locale.US,
+        )
+
+        val formattedDate = formatter.formatTime(testCase.dateToFormat?.toDate())
+
+        formattedDate shouldBeEqualTo testCase.expectedFormatTimeResult
+    }
+
+    @Test
+    fun `Relative Time formatting is correct`(@TestParameter testCase: TestCase) {
+        val formatter: DateFormatter = DefaultDateFormatter(
+            TestDateContext(testCase.now.toDate(), testCase.is24Hour, testCase.dateTimePattern),
+            Locale.US,
+        )
+
+        val formattedDate = formatter.formatRelativeTime(testCase.dateToFormat?.toDate())
+
+        formattedDate shouldBeEqualTo testCase.expectedFormatRelativeTimeResult
+    }
+
+    @Test
+    fun `Relative date formatting is correct`() {
+        val formatter: DateFormatter = DefaultDateFormatter(
+            TestDateContext(),
+            Locale.US,
+        )
+
+        formatter.formatRelativeDate(randomDate()) `should be equal to` RELATIVE_DATE_STRING
     }
 
     @Suppress("unused")
     enum class TestCase(
         val dateToFormat: LocalDateTime?,
-        val expectedResult: String,
+        val expectedFormatDateResult: String,
+        val expectedFormatTimeResult: String,
+        val expectedFormatRelativeTimeResult: String,
         val now: LocalDate,
         val is24Hour: Boolean = true,
         val dateTimePattern: String = "",
@@ -81,45 +121,62 @@ internal class DefaultDateFormatterTest {
         NULL(
             dateToFormat = null,
             now = LocalDate.of(2020, 12, 7),
-            expectedResult = "",
+            expectedFormatDateResult = "",
+            expectedFormatTimeResult = "",
+            expectedFormatRelativeTimeResult = "",
         ),
         TODAY_12H(
             dateToFormat = LocalDateTime.of(2020, 12, 7, 9, 25),
             now = LocalDate.of(2020, 12, 7),
             is24Hour = false,
-            expectedResult = "9:25 AM",
+            expectedFormatDateResult = "9:25 AM",
+            expectedFormatTimeResult = "9:25 AM",
+            expectedFormatRelativeTimeResult = JUST_NOW_STRING,
         ),
         TODAY_24H(
             dateToFormat = LocalDateTime.of(2020, 12, 7, 9, 25),
             now = LocalDate.of(2020, 12, 7),
             is24Hour = true,
-            expectedResult = "09:25",
+            expectedFormatDateResult = "09:25",
+            expectedFormatTimeResult = "09:25",
+            expectedFormatRelativeTimeResult = JUST_NOW_STRING,
         ),
         YESTERDAY(
             dateToFormat = LocalDateTime.of(2020, 12, 6, 9, 25),
             now = LocalDate.of(2020, 12, 7),
-            expectedResult = YESTERDAY_STRING,
+            expectedFormatDateResult = YESTERDAY_STRING,
+            expectedFormatTimeResult = "09:25",
+            expectedFormatRelativeTimeResult = RELATIVE_TIME_STRING,
         ),
         DAY_BEFORE_YESTERDAY(
             dateToFormat = LocalDateTime.of(2020, 12, 5, 9, 25),
             now = LocalDate.of(2020, 12, 7),
-            expectedResult = "Saturday",
+            expectedFormatDateResult = "Saturday",
+            expectedFormatTimeResult = "09:25",
+            expectedFormatRelativeTimeResult = RELATIVE_TIME_STRING,
         ),
         SIX_DAYS_AGO(
             dateToFormat = LocalDateTime.of(2020, 12, 1, 9, 25),
             now = LocalDate.of(2020, 12, 7),
-            expectedResult = "Tuesday",
+            expectedFormatDateResult = "Tuesday",
+            expectedFormatTimeResult = "09:25",
+            expectedFormatRelativeTimeResult = RELATIVE_TIME_STRING,
         ),
         SEVEN_DAYS_AGO(
             dateToFormat = LocalDateTime.of(2020, 11, 30, 9, 25),
             now = LocalDate.of(2020, 12, 7),
             dateTimePattern = "dd/MM/yy",
-            expectedResult = "30/11/20",
+            expectedFormatDateResult = "30/11/20",
+            expectedFormatTimeResult = "09:25",
+            expectedFormatRelativeTimeResult = RELATIVE_TIME_STRING,
         ),
     }
 
     companion object {
         const val YESTERDAY_STRING = "YESTERDAY_STRING"
+        const val JUST_NOW_STRING = "JUST_NOW_STRING"
+        val RELATIVE_DATE_STRING: String = randomString()
+        val RELATIVE_TIME_STRING: String = randomString()
 
         private fun LocalDateTime.toDate(): Date {
             val instant = atZone(ZoneId.systemDefault())

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/DateDividerViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/DateDividerViewHolder.kt
@@ -16,10 +16,10 @@
 
 package io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.impl
 
-import android.text.format.DateUtils
 import android.view.ViewGroup
 import com.google.android.material.shape.MaterialShapeDrawable
 import com.google.android.material.shape.ShapeAppearanceModel
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.databinding.StreamUiItemDateDividerBinding
 import io.getstream.chat.android.ui.feature.messages.list.MessageListItemStyle
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem
@@ -47,14 +47,7 @@ public class DateDividerViewHolder internal constructor(
     override fun bindData(data: MessageListItem.DateSeparatorItem, diff: MessageListItemPayloadDiff) {
         super.bindData(data, diff)
 
-        binding.dateLabel.text =
-            DateUtils.getRelativeTimeSpanString(
-                data.date.time,
-                System.currentTimeMillis(),
-                DateUtils.DAY_IN_MILLIS,
-                DateUtils.FORMAT_ABBREV_RELATIVE,
-            )
-
+        binding.dateLabel.text = ChatUI.dateFormatter.formatRelativeDate(data.date)
         binding.dateLabel.setTextStyle(style.textStyleDateSeparator)
         binding.dateLabel.background = ShapeAppearanceModel.Builder().setAllCornerSizes(DEFAULT_CORNER_RADIUS).build()
             .let(::MaterialShapeDrawable).apply { setTint(style.dateSeparatorBackgroundColor) }


### PR DESCRIPTION
### 🎯 Goal
Expose a new method on `DateFormatter` to return a representation of relative data.
It is now used within our "Date Separator Views" on both SDKs, XML and Compose.
The default implementation continue using `DateUtils` from Android SDK, but it is customizable by our customers providing a custom implementation of `DateFormatter`

Fix: #5584

### 🎉 GIF
![](https://media4.giphy.com/media/v1.Y2lkPTc5MGI3NjExYmNkMjNwZW9yd2s5Y2s5M2NhMDc3Z2p2YTV3d2wybjFvbTUzdmw1dyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/l2QZVEsc0VGXA6VCU/giphy.gif)
