### PR TITLE
Remove stream-chat-android-ui-uitests from Build and test pipeline

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v3.1.0
       - uses: ./.github/actions/setup-java
       - name: Build
-        run: ./gradlew assembleDebug :stream-chat-android-ui-uitests:assembleDebugAndroidTest
+        run: ./gradlew assembleDebug
 
   release_build:
     name: Release build


### PR DESCRIPTION
### 🎯 Goal

Remove `stream-chat-android-ui-uitests` from Build and test pipeline

### 🛠 Implementation details

Android tests from `stream-chat-android-ui-uitests` are not running at all, due to a bug with the screenshot library.
So, it would make sense to stop compiling it in our CI.
Besides, snapshot tests are faster with Paparazzi.

