### PR TITLE
[AND-307] Expose `UserId` alias to avoid InternalStreamChatApi issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 
 ### ❌ Removed
 
+## stream-chat-android-core
+### ✅ Added
+- Expose `UserId` alias that Represents a user id. [#5616](https://github.com/GetStream/stream-chat-android/pull/5616)
+
 ## stream-chat-android-offline
 ### 🐞 Fixed
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/UserId.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/UserId.kt
@@ -16,10 +16,7 @@
 
 package io.getstream.chat.android.models
 
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
-
 /**
  * Represents [User.id] String.
  */
-@InternalStreamChatApi
 public typealias UserId = String


### PR DESCRIPTION
### 🎯 Goal
The public `Channel.currentUserUnreadCount()` extension function is using `UserId` alias as argument, what make this function unavailable to anyone that is not opt-in for `@InternalStreamChatApi`.
Exposing `UserId` alias avoid @InternalStreamChatApi issues


### 🎉 GIF
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExN2x5YzRhbzIwbWEwNGd2djVhZnMyM3hxbXpuMzdmcnplemlmMXc4biZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/W0VNVSm24um4yLUYfY/giphy.gif)
