### PR TITLE
[AND-319] Improve poll creation process(compose).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,12 +71,14 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Autofocus the input fields in the poll creation screen. [#5629](https://github.com/GetStream/stream-chat-android/pull/5629)
 
 ### ✅ Added
 - Add `MessageListViewModel::scrollToFirstUnreadMessage` method. [#5635](https://github.com/GetStream/stream-chat-android/pull/5635)
 - Added Swipe To Reply feature to the Messages. [#5627](https://github.com/GetStream/stream-chat-android/pull/5627)
 
 ### ⚠️ Changed
+- 🚨Breaking change: Change the `AttachmentPickerPollCreation` event to hold a prepared `PollConfig` to simplify the poll creation handling. [#5634](https://github.com/GetStream/stream-chat-android/pull/5634)
 
 ### ❌ Removed
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -90,10 +90,8 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewM
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
 import io.getstream.chat.android.models.Channel
-import io.getstream.chat.android.models.PollConfig
 import io.getstream.chat.android.models.ReactionSortingByFirstReactionAt
 import io.getstream.chat.android.models.ReactionSortingByLastReactionAt
-import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.ui.common.state.messages.MessageMode
 import io.getstream.chat.android.ui.common.state.messages.Reply
 import io.getstream.chat.android.ui.common.state.messages.list.DeletedMessageVisibility
@@ -282,25 +280,7 @@ class MessagesActivity : BaseConnectedActivity() {
                     onTabClick = { _, tab -> isFullScreenContent = tab.isFullContent },
                     onAttachmentPickerAction = { action ->
                         if (action is AttachmentPickerPollCreation) {
-                            composerViewModel.createPoll(
-                                pollConfig = PollConfig(
-                                    name = action.question,
-                                    options = action.options.filter { it.title.isNotEmpty() }.map { it.title },
-                                    description = action.question,
-                                    allowUserSuggestedOptions = action.switches.any { it.key == "allowUserSuggestedOptions" && it.enabled },
-                                    votingVisibility = if (action.switches.any { it.key == "votingVisibility" && it.enabled }) {
-                                        VotingVisibility.ANONYMOUS
-                                    } else {
-                                        VotingVisibility.PUBLIC
-                                    },
-                                    maxVotesAllowed = if (action.switches.any { it.key == "maxVotesAllowed" && it.enabled }) {
-                                        action.switches.first { it.key == "maxVotesAllowed" }.pollSwitchInput?.value.toString()
-                                            .toInt()
-                                    } else {
-                                        1
-                                    },
-                                ),
-                            )
+                            composerViewModel.createPoll(action.pollConfig)
                         }
                     },
                     onDismiss = {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1556,16 +1556,12 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/fac
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation : io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerAction {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
-	public final fun component1 ()Ljava/lang/String;
-	public final fun component2 ()Ljava/util/List;
-	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;
+	public fun <init> (Lio/getstream/chat/android/models/PollConfig;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/PollConfig;
+	public final fun copy (Lio/getstream/chat/android/models/PollConfig;)Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;Lio/getstream/chat/android/models/PollConfig;ILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerPollCreation;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getOptions ()Ljava/util/List;
-	public final fun getQuestion ()Ljava/lang/String;
-	public final fun getSwitches ()Ljava/util/List;
+	public final fun getPollConfig ()Lio/getstream/chat/android/models/PollConfig;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -83,11 +83,9 @@ import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFac
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.LinkPreview
 import io.getstream.chat.android.models.Message
-import io.getstream.chat.android.models.PollConfig
 import io.getstream.chat.android.models.ReactionSorting
 import io.getstream.chat.android.models.ReactionSortingByFirstReactionAt
 import io.getstream.chat.android.models.User
-import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.ui.common.state.messages.Delete
 import io.getstream.chat.android.ui.common.state.messages.Edit
 import io.getstream.chat.android.ui.common.state.messages.Flag
@@ -703,26 +701,7 @@ public fun BoxScope.AttachmentsPickerMenu(
             },
             onAttachmentPickerAction = { action ->
                 if (action is AttachmentPickerPollCreation) {
-                    composerViewModel.createPoll(
-                        pollConfig = PollConfig(
-                            name = action.question,
-                            options = action.options.filter { it.title.isNotEmpty() }.map { it.title },
-                            allowUserSuggestedOptions = action.switches.any { it.key == "allowUserSuggestedOptions" && it.enabled },
-                            allowAnswers = action.switches.any { it.key == "allowAnswers" && it.enabled },
-                            votingVisibility = if (action.switches.any { it.key == "votingVisibility" && it.enabled }) {
-                                VotingVisibility.ANONYMOUS
-                            } else {
-                                VotingVisibility.PUBLIC
-                            },
-                            maxVotesAllowed = if (action.switches.any { it.key == "maxVotesAllowed" && it.enabled }) {
-                                action.switches.first { it.key == "maxVotesAllowed" }.pollSwitchInput?.value.toString()
-                                    .toInt()
-                            } else {
-                                1
-                            },
-                            enforceUniqueVote = action.switches.none { it.key == "maxVotesAllowed" && it.enabled },
-                        ),
-                    )
+                    composerViewModel.createPoll(action.pollConfig)
                 }
             },
             onTabClick = { _, tab -> isFullScreenContent = tab.isFullContent },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerAction.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerAction.kt
@@ -17,8 +17,7 @@
 package io.getstream.chat.android.compose.ui.messages.attachments.factory
 
 import androidx.compose.runtime.Stable
-import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollOptionItem
-import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItem
+import io.getstream.chat.android.models.PollConfig
 
 /**
  * An user action event that occurs inside the attachment picker screen.
@@ -34,10 +33,8 @@ public data object AttachmentPickerBack : AttachmentPickerAction
 
 /**
  * An user action that indicates a poll creation event.
+ *
+ * @param pollConfig The [PollConfig] object holding the data required to create the new poll.
  */
 @Stable
-public data class AttachmentPickerPollCreation(
-    public val question: String,
-    public val options: List<PollOptionItem>,
-    public val switches: List<PollSwitchItem>,
-) : AttachmentPickerAction
+public data class AttachmentPickerPollCreation(public val pollConfig: PollConfig) : AttachmentPickerAction

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerPollTabFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerPollTabFactory.kt
@@ -55,7 +55,9 @@ import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollOption
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollOptionList
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollQuestionInput
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItem
+import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItemKeys
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchList
+import io.getstream.chat.android.compose.ui.messages.attachments.poll.pollConfigFrom
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelCapabilities
@@ -149,9 +151,11 @@ public class AttachmentsPickerPollTabFactory : AttachmentsPickerTabFactory {
                 onPollCreateClicked = {
                     onAttachmentPickerAction.invoke(
                         AttachmentPickerPollCreation(
-                            question = question,
-                            options = optionItemList,
-                            switches = switchItemList,
+                            pollConfigFrom(
+                                pollQuestion = question,
+                                pollOptions = optionItemList,
+                                pollSwitches = switchItemList,
+                            ),
                         ),
                     )
                     onAttachmentPickerAction.invoke(AttachmentPickerBack)
@@ -236,7 +240,7 @@ private fun updateMaxVotesAllowedSwitch(
 ): List<PollSwitchItem> =
     switchItemList.map {
         when (it.key) {
-            "maxVotesAllowed" -> it.copy(
+            PollSwitchItemKeys.MAX_VOTES_ALLOWED -> it.copy(
                 pollSwitchInput = it.pollSwitchInput?.copy(
                     maxValue = optionItemList.count { item -> item.title.isNotBlank() },
                 ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/AttachmentsPickerPollUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/AttachmentsPickerPollUtils.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.messages.attachments.poll
+
+import io.getstream.chat.android.compose.ui.messages.attachments.factory.AttachmentPickerPollCreation
+import io.getstream.chat.android.models.PollConfig
+import io.getstream.chat.android.models.VotingVisibility
+
+/**
+ * Builds a [PollConfig] from the provided [AttachmentPickerPollCreation] data.
+ *
+ * @param pollQuestion The question of the poll.
+ * @param pollOptions The list of poll options.
+ * @param pollSwitches The list of poll switches.
+ */
+internal fun pollConfigFrom(
+    pollQuestion: String,
+    pollOptions: List<PollOptionItem>,
+    pollSwitches: List<PollSwitchItem>,
+): PollConfig {
+    val options = pollOptions
+        .filter { it.title.isNotEmpty() }
+        .map { it.title }
+    val allowUserSuggestedOptions = pollSwitches.any {
+        it.key == PollSwitchItemKeys.ALLOW_USER_SUGGESTED_OPTIONS && it.enabled
+    }
+    val allowAnswers = pollSwitches.any {
+        it.key == PollSwitchItemKeys.ALLOW_ANSWERS && it.enabled
+    }
+    val anonymousPoll = pollSwitches.any {
+        it.key == PollSwitchItemKeys.VOTING_VISIBILITY && it.enabled
+    }
+    val votingVisibility = if (anonymousPoll) {
+        VotingVisibility.ANONYMOUS
+    } else {
+        VotingVisibility.PUBLIC
+    }
+    val maxVotesEnabled = pollSwitches.any {
+        it.key == PollSwitchItemKeys.MAX_VOTES_ALLOWED && it.enabled
+    }
+    val maxVotesAllowed = if (maxVotesEnabled) {
+        pollSwitches.first { it.key == PollSwitchItemKeys.MAX_VOTES_ALLOWED }.pollSwitchInput?.value.toString().toInt()
+    } else {
+        1
+    }
+    val enforceUniqueVotes = pollSwitches.none {
+        it.key == PollSwitchItemKeys.MAX_VOTES_ALLOWED && it.enabled
+    }
+    return PollConfig(
+        name = pollQuestion,
+        options = options,
+        allowUserSuggestedOptions = allowUserSuggestedOptions,
+        allowAnswers = allowAnswers,
+        votingVisibility = votingVisibility,
+        maxVotesAllowed = maxVotesAllowed,
+        enforceUniqueVote = enforceUniqueVotes,
+    )
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchItem.kt
@@ -54,3 +54,29 @@ public data class PollSwitchInput(
     public val maxValue: Any? = null,
     public val keyboardType: KeyboardType = KeyboardType.Text,
 )
+
+/**
+ * Holds the internal keys identifying the different poll switch items.
+ */
+internal object PollSwitchItemKeys {
+
+    /**
+     * The key that identifies the maximum votes allowed switch.
+     */
+    internal const val MAX_VOTES_ALLOWED = "maxVotesAllowed"
+
+    /**
+     * The key that identifies the voting visibility switch.
+     */
+    internal const val VOTING_VISIBILITY = "votingVisibility"
+
+    /**
+     * The key that identifies the allow user suggested options switch.
+     */
+    internal const val ALLOW_USER_SUGGESTED_OPTIONS = "allowUserSuggestedOptions"
+
+    /**
+     * The key that identifies the allow answers switch.
+     */
+    internal const val ALLOW_ANSWERS = "allowAnswers"
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/PollSwitchItemFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/PollSwitchItemFactory.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchInput
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItem
+import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItemKeys
 
 /**
  * An interface that allows the creation of poll switch items for the creation screen.
@@ -67,22 +68,22 @@ public class DefaultPollSwitchItemFactory(
                     maxValue = 2,
                     keyboardType = KeyboardType.Decimal,
                 ),
-                key = "maxVotesAllowed",
+                key = PollSwitchItemKeys.MAX_VOTES_ALLOWED,
                 enabled = false,
             ),
             PollSwitchItem(
                 title = context.getString(R.string.stream_compose_poll_option_switch_anonymous_poll),
-                key = "votingVisibility",
+                key = PollSwitchItemKeys.VOTING_VISIBILITY,
                 enabled = false,
             ),
             PollSwitchItem(
                 title = context.getString(R.string.stream_compose_poll_option_switch_suggest_option),
-                key = "allowUserSuggestedOptions",
+                key = PollSwitchItemKeys.ALLOW_USER_SUGGESTED_OPTIONS,
                 enabled = false,
             ),
             PollSwitchItem(
                 title = context.getString(R.string.stream_compose_poll_option_switch_add_comment),
-                key = "allowAnswers",
+                key = PollSwitchItemKeys.ALLOW_ANSWERS,
                 enabled = false,
             ),
         )

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/attachments/poll/AttachmentsPickerPollUtilsTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/attachments/poll/AttachmentsPickerPollUtilsTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.messages.attachments.poll
+
+import android.content.Context
+import androidx.compose.ui.text.input.KeyboardType
+import io.getstream.chat.android.compose.ui.util.DefaultPollSwitchItemFactory
+import io.getstream.chat.android.models.PollConfig
+import io.getstream.chat.android.models.VotingVisibility
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class AttachmentsPickerPollUtilsTest {
+
+    @Test
+    fun testPollConfigWithoutSwitchOptions() {
+        // given
+        val pollQuestion = "Poll question"
+        val options = listOf(
+            PollOptionItem(title = "Answer 1"),
+            PollOptionItem(title = "Answer 2"),
+            PollOptionItem(title = ""),
+        )
+        val context = mock<Context>()
+        whenever(context.getString(any())).thenReturn("")
+        val switches = DefaultPollSwitchItemFactory(context).providePollSwitchItemList()
+        // when
+        val pollConfig = pollConfigFrom(pollQuestion, options, switches)
+        // then
+        val expected = PollConfig(
+            name = "Poll question",
+            options = listOf("Answer 1", "Answer 2"),
+            description = "",
+            votingVisibility = VotingVisibility.PUBLIC,
+            enforceUniqueVote = true,
+            maxVotesAllowed = 1,
+            allowUserSuggestedOptions = false,
+            allowAnswers = false,
+        )
+        pollConfig `should be equal to` expected
+    }
+
+    @Test
+    fun testPollConfigWithSwitchOptions() {
+        // given
+        val pollQuestion = "Poll question"
+        val options = listOf(
+            PollOptionItem(title = "Answer 1"),
+            PollOptionItem(title = "Answer 2"),
+            PollOptionItem(title = ""),
+        )
+        val context = mock<Context>()
+        whenever(context.getString(any())).thenReturn("")
+        val switches = listOf(
+            PollSwitchItem(
+                title = "Multiple answers",
+                pollSwitchInput = PollSwitchInput(
+                    value = "2",
+                    description = "Enter a number between 1 and 2",
+                    minValue = 1,
+                    maxValue = 2,
+                    keyboardType = KeyboardType.Decimal,
+                ),
+                key = PollSwitchItemKeys.MAX_VOTES_ALLOWED,
+                enabled = true,
+            ),
+            PollSwitchItem(
+                title = "Anonymous poll",
+                key = PollSwitchItemKeys.VOTING_VISIBILITY,
+                enabled = true,
+            ),
+            PollSwitchItem(
+                title = "Suggest an option",
+                key = PollSwitchItemKeys.ALLOW_USER_SUGGESTED_OPTIONS,
+                enabled = true,
+            ),
+            PollSwitchItem(
+                title = "Add a comment",
+                key = PollSwitchItemKeys.ALLOW_ANSWERS,
+                enabled = true,
+            ),
+        )
+
+        // when
+        val pollConfig = pollConfigFrom(pollQuestion, options, switches)
+        // then
+        val expected = PollConfig(
+            name = "Poll question",
+            options = listOf("Answer 1", "Answer 2"),
+            description = "",
+            votingVisibility = VotingVisibility.ANONYMOUS,
+            enforceUniqueVote = false,
+            maxVotesAllowed = 2,
+            allowUserSuggestedOptions = true,
+            allowAnswers = true,
+        )
+        pollConfig `should be equal to` expected
+    }
+}

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/DefaultPollSwitchItemFactoryTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/DefaultPollSwitchItemFactoryTest.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.compose.ui.util
 import android.content.Context
 import androidx.compose.ui.text.input.KeyboardType
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.messages.attachments.poll.PollSwitchItemKeys
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
@@ -49,7 +50,7 @@ internal class DefaultPollSwitchItemFactoryTest {
         Assertions.assertEquals(4, items.size)
         // Max votes item
         Assertions.assertEquals("Multiple answers", items[0].title)
-        Assertions.assertEquals("maxVotesAllowed", items[0].key)
+        Assertions.assertEquals(PollSwitchItemKeys.MAX_VOTES_ALLOWED, items[0].key)
         Assertions.assertFalse(items[0].enabled)
         Assertions.assertEquals("", items[0].pollSwitchInput?.value)
         Assertions.assertEquals(1, items[0].pollSwitchInput?.minValue)
@@ -59,19 +60,19 @@ internal class DefaultPollSwitchItemFactoryTest {
         Assertions.assertNull(items[0].pollOptionError)
         // Anonymous poll item
         Assertions.assertEquals("Anonymous poll", items[1].title)
-        Assertions.assertEquals("votingVisibility", items[1].key)
+        Assertions.assertEquals(PollSwitchItemKeys.VOTING_VISIBILITY, items[1].key)
         Assertions.assertFalse(items[1].enabled)
         Assertions.assertNull(items[1].pollSwitchInput)
         Assertions.assertNull(items[1].pollOptionError)
         // Hide results item
         Assertions.assertEquals("Suggest an option", items[2].title)
-        Assertions.assertEquals("allowUserSuggestedOptions", items[2].key)
+        Assertions.assertEquals(PollSwitchItemKeys.ALLOW_USER_SUGGESTED_OPTIONS, items[2].key)
         Assertions.assertFalse(items[2].enabled)
         Assertions.assertNull(items[2].pollSwitchInput)
         Assertions.assertNull(items[2].pollOptionError)
         // Close poll item
         Assertions.assertEquals("Add a comment", items[3].title)
-        Assertions.assertEquals("allowAnswers", items[3].key)
+        Assertions.assertEquals(PollSwitchItemKeys.ALLOW_ANSWERS, items[3].key)
         Assertions.assertFalse(items[3].enabled)
         Assertions.assertNull(items[3].pollSwitchInput)
         Assertions.assertNull(items[3].pollOptionError)


### PR DESCRIPTION
### 🎯 Goal
If a client is using the `AttachmentsPicker` component in their code, handling the creation of a poll is a bit difficult. They would need to copy-paste the whole logic for transforming the `AttachmentPickerPollCreation` into a `PollConfig`, which can be error prone, and is not something that they should know how it is done internally. They currently need to do the following:

```kotlin
AttachmentsPicker(
  onAttachmentPickerAction = { action ->
                        if (action is AttachmentPickerPollCreation) {
                            composerViewModel.createPoll(
                                pollConfig = PollConfig(
                                    name = action.question,
                                    options = action.options.filter { it.title.isNotEmpty() }.map { it.title },
                                    description = action.question,
                                    allowUserSuggestedOptions = action.switches.any { it.key == "allowUserSuggestedOptions" && it.enabled },
                                    votingVisibility = if (action.switches.any { it.key == "votingVisibility" && it.enabled }) {
                                        VotingVisibility.ANONYMOUS
                                    } else {
                                        VotingVisibility.PUBLIC
                                    },
                                    maxVotesAllowed = if (action.switches.any { it.key == "maxVotesAllowed" && it.enabled }) {
                                        action.switches.first { it.key == "maxVotesAllowed" }.pollSwitchInput?.value.toString()
                                            .toInt()
                                    } else {
                                        1
                                    },
                                ),
                            )
                        }
                    },
)
```

After the change, all they would need to do handle the poll creation properly is:

```kotlin
AttachmentsPicker(
  onAttachmentPickerAction = { action ->
    if (action is AttachmentPickerPollCreation) {
      composerViewModel.createPoll(action.toPollConfig())
    }
  }
)
```

🚨This is a breaking change. 🚨 However, I think that we must do this, as the code that integrators need to write to make this work currently is an internal logic, and it shouldn't be exposed like this. Additionally, a migration from this to the new API should be very straight forward.

### 🛠 Implementation details
- Change the `AttachmentPickerPollCreation` to hold a prepared `PollConfig`, instead of `question: String`, `options: List<PollOptionItem>` and `switches: List<PollSwitchItem>`.
- Make the `PollConfig` creation login internal in `AttachmentsPickerPollUtils`

### 🧪 Testing
1. Open compose app
2. Open channel
3. Open attachments picker and choose poll
4. The poll should be created successfully as before
