### PR TITLE
[AND-296] Expose scrollToFirstUnreadMessage on MessageListViewModel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Fix `MessageListController#scrollToFirstUnreadMessage` not working when the first unread message was not loaded. [#5635](https://github.com/GetStream/stream-chat-android/pull/5635)
 
 ### ⬆️ Improved
 
@@ -60,6 +61,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessageListViewModel::scrollToFirstUnreadMessage` method. [#5635](https://github.com/GetStream/stream-chat-android/pull/5635)
 
 ### ⚠️ Changed
 
@@ -71,6 +73,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessageListViewModel::scrollToFirstUnreadMessage` method. [#5635](https://github.com/GetStream/stream-chat-android/pull/5635)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -3999,6 +3999,7 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 	public final fun removeVote (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Poll;Lio/getstream/chat/android/models/Vote;)V
 	public final fun scrollToBottom (ILkotlin/jvm/functions/Function0;)V
 	public static synthetic fun scrollToBottom$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel;ILkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun scrollToFirstUnreadMessage ()V
 	public final fun scrollToMessage (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun selectExtendedReactions (Lio/getstream/chat/android/models/Message;)V
 	public final fun selectMessage (Lio/getstream/chat/android/models/Message;)V

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -544,6 +544,17 @@ public class MessageListViewModel(
     }
 
     /**
+     * Scrolls to the first unread message in the list.
+     * If there are no unread messages, this method does nothing.
+     *
+     * Important: It is possible that the first unread message is not loaded in the list yet.
+     * In this case, the method will first try to load that message, and then scroll to it.
+     */
+    public fun scrollToFirstUnreadMessage() {
+        messageListController.scrollToFirstUnreadMessage()
+    }
+
+    /**
      * Sets a handler which determines the position of a message inside a group.
      *
      * @param messagePositionHandler The handler to use.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -599,10 +599,9 @@ public class MessageListController(
             val messages = messagesState.messageItems
                 .filterIsInstance<MessageItemState>()
                 .map { it.message }
-
             messages.firstOrNull { it.id == unreadLabel.lastReadMessageId }
                 ?.let { messages.focusUnreadMessage(it.id) }
-                ?: {
+                ?: run {
                     scope.launch {
                         chatClient.loadMessagesAroundId(cid, unreadLabel.lastReadMessageId)
                             .await()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4580,6 +4580,7 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public final fun onEvent (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event;)V
 	public final fun scrollToBottom (ILkotlin/jvm/functions/Function0;)V
 	public static synthetic fun scrollToBottom$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel;ILkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public final fun scrollToFirstUnreadMessage ()V
 	public final fun setAreSystemMessagesVisible (Z)V
 	public final fun setDateSeparatorHandler (Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;)V
 	public final fun setDeletedMessageVisibility (Lio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;)V

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -325,6 +325,17 @@ public class MessageListViewModel(
     }
 
     /**
+     * Scrolls to the first unread message in the list.
+     * If there are no unread messages, this method does nothing.
+     *
+     * Important: It is possible that the first unread message is not loaded in the list yet.
+     * In this case, the method will first try to load that message, and then scroll to it.
+     */
+    public fun scrollToFirstUnreadMessage() {
+        messageListController.scrollToFirstUnreadMessage()
+    }
+
+    /**
      * Sets the date separator handler which determines when to add date separators.
      * By default, a date separator will be added if the difference between two messages' dates is greater than 4h.
      *


### PR DESCRIPTION
### 🎯 Goal
Exposes the `scrollToFirstUnreadMessage` method from the `MessageListController` on the `MessageListViewModel`s.

Additionally, fixes a bug where the `chatClient.loadMessagesAroundId` wasn't called, when calling `scrollToFirstUnreadMessage` when the message wasn't already loaded.

### 🛠 Implementation details
- Expose `scrollToFirstUnreadMessage` on `MessageListViewModel`(compose)
- Expose `scrollToFirstUnreadMessage` on `MessageListViewModel`(xml)
- Fix `chatClient.loadMessagesAroundId` not called:
```kotlin
messages.firstOrNull { it.id == unreadLabel.lastReadMessageId }
                ?.let { messages.focusUnreadMessage(it.id) }
                ?: {  // <- This was never called as it is lambda that wasn't invoked
                    scope.launch {
                        chatClient.loadMessagesAroundId(cid, unreadLabel.lastReadMessageId)
                            .await()
                            .onSuccess { channel -> channel.messages.focusUnreadMessage(unreadLabel.lastReadMessageId) }
                    }
                }
```

### 🎨 UI Changes

Demo for bugfix:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/67820f7c-dc5a-4fa2-8f31-5cfcc4c2d3dd" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/c160c61f-f6b8-4591-8976-ecebada7a0cb" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### 🧪 Testing
1. Open XML sample app
2. Ensure there is a conversation with an unread message which is not yet loaded (older than the 30th message)
3. Tap on the "Unread messages" floating badge
4. You should now be scrolled to the first unread message (after a brief delay while the messages are loaded)
