### PR TITLE
[AND-325] Fix default camera photo/video picker

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerMediaCaptureTabFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerMediaCaptureTabFactory.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
@@ -100,8 +101,9 @@ public class AttachmentsPickerMediaCaptureTabFactory(private val pickerMediaMode
         val cameraPermissionState =
             if (requiresCameraPermission) rememberPermissionState(permission = Manifest.permission.CAMERA) else null
 
+        val contract = remember { CaptureMediaContract(pickerMediaMode.mode) }
         val mediaCaptureResultLauncher =
-            rememberLauncherForActivityResult(contract = CaptureMediaContract(pickerMediaMode.mode)) { file: File? ->
+            rememberLauncherForActivityResult(contract = contract) { file: File? ->
                 val attachments = if (file == null) {
                     emptyList()
                 } else {


### PR DESCRIPTION
### 🎯 Goal

Fix the default camera picker

### 🛠 Implementation details

Remember the `CaptureMediaContract` to avoid state loss.
That contract logic relies on two instance fields: `pictureFile` and `videoFile`
Every recomposition of `PickerTabContent` created a new `CaptureMediaContract` instance, hence losing those field references.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/5229a9ae-2946-40a3-8e4b-823a07df1fe0" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/8460b572-8ce6-4b9c-b3ca-bc08c3525575" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🎉 GIF

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExYnVmbW10bm82a2VnbWRhbmdod3EyMjdnenpkMjhteHEweXFwNmVoOSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/GN8vErNy5iHImrh45n/giphy.gif)
