### PR TITLE
[AND-328] Fix crash when recording audio on message reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Crash when recording audio on a message reply. [#5642](https://github.com/GetStream/stream-chat-android/pull/5642)
 
 ### ⬆️ Improved
 - Autofocus the input fields in the poll creation screen. [#5629](https://github.com/GetStream/stream-chat-android/pull/5629)
@@ -102,6 +103,7 @@
 ### 🐞 Fixed
 - Fading issue with the `Avatar`. [#5625](https://github.com/GetStream/stream-chat-android/pull/5625)
 - Fix `InitialsAvatar` font size in Poll components. [#5625](https://github.com/GetStream/stream-chat-android/pull/5625)
+- Fix default camera photo/video picker. [#5637](https://github.com/GetStream/stream-chat-android/pull/5637)
 
 ### ⬆️ Improved
 - Autofocus the input fields in the poll creation screen. [#5629](https://github.com/GetStream/stream-chat-android/pull/5629)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ImageUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ImageUtils.kt
@@ -141,7 +141,11 @@ internal fun StreamAsyncImage(
 ) {
     var imageSize by remember { mutableStateOf(Size.ORIGINAL) }
     Box(
-        modifier = modifier.onSizeChanged { size -> imageSize = Size(size.width, size.height) },
+        modifier = modifier.onSizeChanged { size ->
+            if (size.width > 0 && size.height > 0) {
+                imageSize = Size(size.width, size.height)
+            }
+        },
     ) {
         if (imageSize == Size.ORIGINAL) {
             content(AsyncImagePainter.State.Empty)


### PR DESCRIPTION
### 🎯 Goal

Fix crash when recording audio on message reply

### 🛠 Implementation details

For some reason, when starting to record audio in a message reply, `onSizeChanged` of the user avatar calculates the size as `0x0`. That's not a valid size to load an image and Coil requires any dimension to be greater than zero.
We have to check for non-zero dimensions before using the `size`.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/5b22a44e-36b9-455a-8cba-b51c365129d9" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/b265cef8-7f0a-4e6a-8f83-e10b84da2a31" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Reply to a message and start recording audio.
