### PR TITLE
[CI] Resolve some e2e tests issues

### DIFF
--- a/.github/workflows/e2e-test-cron.yml
+++ b/.github/workflows/e2e-test-cron.yml
@@ -37,7 +37,6 @@ jobs:
           - android_api_level: 33
           - android_api_level: 32
           - android_api_level: 31
-          - android_api_level: 29
           - android_api_level: 28
       fail-fast: false
     env:
@@ -68,6 +67,7 @@ jobs:
       - name: Allure TestOps Upload
         run: bundle exec fastlane allure_upload
         if: success() || failure()
+        timeout-minutes: 10
         env:
           ALLURE_TOKEN: ${{ secrets.ALLURE_TOKEN }}
           LAUNCH_ID: ${{ env.LAUNCH_ID }}
@@ -81,5 +81,5 @@ jobs:
         uses: actions/upload-artifact@v4.4.3
         if: failure()
         with:
-          name: test_report
+          name: logs_${{ env.android_api_level }}
           path: fastlane/stream-chat-test-mock-server/logs/*

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Upload test results
         uses: actions/upload-artifact@v4.4.3
         if: failure()
+        timeout-minutes: 10
         with:
-          name: test_report
+          name: logs_${{ env.ANDROID_API_LEVEL }}
           path: fastlane/stream-chat-test-mock-server/logs/*

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,11 +114,12 @@ lane :run_e2e_test do |options|
   UI.user_error!('Tests have failed!') if result.include?('Failures')
 end
 
+# This lane can be used for local linting
 lane :lint_e2e_test do |options|
   Dir.chdir('..') do
-    ['spotlessApply', 'apiDump', 'detekt'].each do |task|
+    ['spotlessApply', 'detekt'].each do |task|
       sh("./gradlew :stream-chat-android-e2e-test:#{task}")
-      sh("./gradlew :stream-chat-android-compose-sample:#{task}") unless task == 'apiDump'
+      sh("./gradlew :stream-chat-android-compose-sample:#{task}")
     end
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -114,6 +114,15 @@ lane :run_e2e_test do |options|
   UI.user_error!('Tests have failed!') if result.include?('Failures')
 end
 
+lane :lint_e2e_test do |options|
+  Dir.chdir('..') do
+    ['spotlessApply', 'apiDump', 'detekt'].each do |task|
+      sh("./gradlew :stream-chat-android-e2e-test:#{task}")
+      sh("./gradlew :stream-chat-android-compose-sample:#{task}") unless task == 'apiDump'
+    end
+  end
+end
+
 lane :upload_attachments do
   ['png', 'pdf'].each do |ext|
     [1, 2].each { |i| sh("adb push attachments/file.#{ext} /sdcard/Download/file_#{i}.#{ext}") }

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -117,9 +117,8 @@ end
 # This lane can be used for local linting
 lane :lint_e2e_test do |options|
   Dir.chdir('..') do
-    ['spotlessApply', 'detekt'].each do |task|
-      sh("./gradlew :stream-chat-android-e2e-test:#{task}")
-      sh("./gradlew :stream-chat-android-compose-sample:#{task}")
+    ['spotlessApply', 'detekt'].each do |target|
+      sh("./gradlew :#{target}:#{spotlessApply} :#{target}:#{detekt}")
     end
   end
 end

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -24,10 +24,12 @@ import io.getstream.chat.android.compose.pages.MessageListPage.Composer
 import io.getstream.chat.android.compose.pages.MessageListPage.MessageList.Message
 import io.getstream.chat.android.compose.pages.ThreadPage
 import io.getstream.chat.android.compose.uiautomator.appContext
+import io.getstream.chat.android.compose.uiautomator.device
 import io.getstream.chat.android.compose.uiautomator.findObject
 import io.getstream.chat.android.compose.uiautomator.findObjects
 import io.getstream.chat.android.compose.uiautomator.height
 import io.getstream.chat.android.compose.uiautomator.isDisplayed
+import io.getstream.chat.android.compose.uiautomator.retryOnStaleObjectException
 import io.getstream.chat.android.compose.uiautomator.wait
 import io.getstream.chat.android.compose.uiautomator.waitForCount
 import io.getstream.chat.android.compose.uiautomator.waitForText
@@ -372,7 +374,9 @@ fun UserRobot.assertThreadReplyLabelAvatars(count: Int): UserRobot {
 }
 
 fun UserRobot.assertMessages(text: String, count: Int): UserRobot {
-    val actualCount = Message.text.findObjects().count { it.text == text }
+    val actualCount = device.retryOnStaleObjectException {
+        Message.text.findObjects().count { it.text == text }
+    }
     assertEquals(count, actualCount)
     return this
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ChannelListTests.kt
@@ -24,6 +24,7 @@ import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.compose.uiautomator.device
 import io.getstream.chat.android.compose.uiautomator.disableInternetConnection
 import io.getstream.chat.android.compose.uiautomator.enableInternetConnection
+import io.getstream.chat.android.compose.uiautomator.seconds
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
@@ -84,14 +85,18 @@ class ChannelListTests : StreamTestCase() {
     @AllureId("6679")
     @Test
     fun test_channelPreviewUpdates_whenUserIsOfflineAndParticipantSendsMessage() {
+        val delay = 3
         step("GIVEN user opens a channel list") {
             userRobot.login().waitForChannelListToLoad()
         }
         step("AND user goes offline") {
+            participantRobot.sendMessage(sampleText, delay)
             device.disableInternetConnection()
+            userRobot.sleep((delay + 1).seconds)
         }
         step("WHEN participant sends a message") {
-            participantRobot.sendMessage(sampleText)
+            // this action has been completed above with given delay,
+            // because we can't send requests to the mock server being offline.
         }
         step("AND user goes back online") {
             device.enableInternetConnection()

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
@@ -208,7 +208,7 @@ class ReactionsTests : StreamTestCase() {
         }
     }
 
-    @AllureId("5714")
+    @AllureId("6713")
     @Ignore("https://linear.app/stream/issue/AND-247")
     @Test
     fun test_participantAddsReactionWhileUserIsOffline() {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.compose.sample.ui.InitTestActivity
 import io.getstream.chat.android.compose.uiautomator.device
 import io.getstream.chat.android.compose.uiautomator.disableInternetConnection
 import io.getstream.chat.android.compose.uiautomator.enableInternetConnection
+import io.getstream.chat.android.compose.uiautomator.seconds
 import io.getstream.chat.android.e2e.test.mockserver.ReactionType
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
@@ -210,7 +211,8 @@ class ReactionsTests : StreamTestCase() {
     @AllureId("5714")
     @Ignore("https://linear.app/stream/issue/AND-247")
     @Test
-    fun s() {
+    fun test_participantAddsReactionWhileUserIsOffline() {
+        val delay = 3
         step("GIVEN user opens the channel") {
             userRobot.login().openChannel()
         }
@@ -218,10 +220,13 @@ class ReactionsTests : StreamTestCase() {
             userRobot.sendMessage(sampleText)
         }
         step("AND user becomes offline") {
+            participantRobot.addReaction(type = ReactionType.LIKE, delay)
             device.disableInternetConnection()
+            userRobot.sleep((delay + 1).seconds)
         }
         step("WHEN participant adds a reaction") {
-            participantRobot.addReaction(type = ReactionType.LIKE)
+            // this action has been completed above with given delay,
+            // because we can't send requests to the mock server being offline.
         }
         step("AND user becomes online") {
             device.enableInternetConnection()

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/StreamTestCase.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/StreamTestCase.kt
@@ -79,13 +79,14 @@ abstract class StreamTestCase {
 
     @SuppressLint("InlinedApi")
     private fun grantAppPermissions() {
-        for (permission in arrayOf(
+        val permissions = arrayOf(
             POST_NOTIFICATIONS,
             READ_MEDIA_VIDEO,
             READ_MEDIA_IMAGES,
             READ_EXTERNAL_STORAGE,
-            WRITE_EXTERNAL_STORAGE)
-        ) {
+            WRITE_EXTERNAL_STORAGE,
+        )
+        for (permission in permissions) {
             device.grantPermission(permission)
         }
     }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/StreamTestCase.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/StreamTestCase.kt
@@ -17,8 +17,10 @@
 package io.getstream.chat.android.compose.tests
 
 import android.Manifest.permission.POST_NOTIFICATIONS
+import android.Manifest.permission.READ_EXTERNAL_STORAGE
 import android.Manifest.permission.READ_MEDIA_IMAGES
 import android.Manifest.permission.READ_MEDIA_VIDEO
+import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.annotation.SuppressLint
 import android.content.Intent
 import io.getstream.chat.android.compose.robots.UserRobot
@@ -77,7 +79,13 @@ abstract class StreamTestCase {
 
     @SuppressLint("InlinedApi")
     private fun grantAppPermissions() {
-        for (permission in arrayOf(POST_NOTIFICATIONS, READ_MEDIA_VIDEO, READ_MEDIA_IMAGES)) {
+        for (permission in arrayOf(
+            POST_NOTIFICATIONS,
+            READ_MEDIA_VIDEO,
+            READ_MEDIA_IMAGES,
+            READ_EXTERNAL_STORAGE,
+            WRITE_EXTERNAL_STORAGE)
+        ) {
             device.grantPermission(permission)
         }
     }

--- a/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
+++ b/stream-chat-android-e2e-test/api/stream-chat-android-e2e-test.api
@@ -6,6 +6,8 @@ public final class io/getstream/chat/android/compose/uiautomator/ActionsKt {
 	public static final fun goToForeground (Landroidx/test/uiautomator/UiDevice;)V
 	public static final fun longPress (Landroidx/test/uiautomator/UiObject2;I)V
 	public static synthetic fun longPress$default (Landroidx/test/uiautomator/UiObject2;IILjava/lang/Object;)V
+	public static final fun retryOnStaleObjectException (Landroidx/test/uiautomator/UiDevice;ILkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+	public static synthetic fun retryOnStaleObjectException$default (Landroidx/test/uiautomator/UiDevice;ILkotlin/jvm/functions/Function0;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun stopApp (Landroidx/test/uiautomator/UiDevice;)V
 	public static final fun swipeDown (Landroidx/test/uiautomator/UiDevice;II)V
 	public static synthetic fun swipeDown$default (Landroidx/test/uiautomator/UiDevice;IIILjava/lang/Object;)V
@@ -154,7 +156,8 @@ public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot {
 	public static final field Companion Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot$Companion;
 	public static final field name Ljava/lang/String;
 	public fun <init> (Lio/getstream/chat/android/e2e/test/mockserver/MockServer;)V
-	public final fun addReaction (Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public final fun addReaction (Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;I)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public static synthetic fun addReaction$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;IILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun deleteMessage (Z)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;ZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun deleteReaction (Lio/getstream/chat/android/e2e/test/mockserver/ReactionType;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
@@ -174,7 +177,8 @@ public final class io/getstream/chat/android/e2e/test/robots/ParticipantRobot {
 	public static synthetic fun quoteMessageWithGiphyInThread$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;ZZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun readMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun readMessage$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
-	public final fun sendMessage (Ljava/lang/String;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public final fun sendMessage (Ljava/lang/String;I)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
+	public static synthetic fun sendMessage$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Ljava/lang/String;IILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun sendMessageInThread (Ljava/lang/String;Z)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public static synthetic fun sendMessageInThread$default (Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;
 	public final fun sleep (J)Lio/getstream/chat/android/e2e/test/robots/ParticipantRobot;

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/robots/ParticipantRobot.kt
@@ -61,8 +61,12 @@ public class ParticipantRobot(
         return this
     }
 
-    public fun sendMessage(text: String): ParticipantRobot {
-        mockServer.postRequest("participant/message", text.toRequestBody("text".toMediaTypeOrNull()))
+    public fun sendMessage(text: String, delay: Int = 0): ParticipantRobot {
+        var endpoint = "participant/message"
+        if (delay > 0) {
+            endpoint += "?delay=$delay"
+        }
+        mockServer.postRequest(endpoint, text.toRequestBody("text".toMediaTypeOrNull()))
         return this
     }
 
@@ -180,8 +184,12 @@ public class ParticipantRobot(
         return this
     }
 
-    public fun addReaction(type: ReactionType): ParticipantRobot {
-        mockServer.postRequest("participant/reaction?type=${type.reaction}")
+    public fun addReaction(type: ReactionType, delay: Int = 0): ParticipantRobot {
+        var endpoint = "participant/reaction?type=${type.reaction}"
+        if (delay > 0) {
+            endpoint += "&delay=$delay"
+        }
+        mockServer.postRequest(endpoint)
         return this
     }
 

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
@@ -104,6 +104,7 @@ public fun <T> UiDevice.retryOnStaleObjectException(retries: Int = 3, action: ()
         try {
             return action()
         } catch (e: StaleObjectException) {
+            println(e)
             Thread.sleep(500)
         }
     }

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Actions.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.uiautomator
 
+import androidx.test.uiautomator.StaleObjectException
 import androidx.test.uiautomator.UiDevice
 import androidx.test.uiautomator.UiObject2
 import java.io.ByteArrayOutputStream
@@ -96,4 +97,15 @@ public fun UiDevice.dumpWindowHierarchy() {
     val outputStream = ByteArrayOutputStream()
     device.dumpWindowHierarchy(outputStream)
     println(outputStream.toString("UTF-8"))
+}
+
+public fun <T> UiDevice.retryOnStaleObjectException(retries: Int = 3, action: () -> T): T {
+    repeat(retries - 1) {
+        try {
+            return action()
+        } catch (e: StaleObjectException) {
+            Thread.sleep(500)
+        }
+    }
+    return action()
 }


### PR DESCRIPTION
### 🎯 Goal

- Make e2e tests more stable on PRs and Nightly

### 🛠 Implementation details

- Rename logs archives so they are no rewritten.
- Remove API 29 from nightly checks, it was not stable. Having 28 as a min tier should be fine.
- Add timeout to Allure upload (noticed it can get stuck)
- Grant read/write permissions for older APIs
- Implement a `retryOnStaleObjectException` workaround to wait until the message list is unstale after scrolling
- Implement an option to provide a `delay` to participants actions, so we can test offline mode properly
