### PR TITLE
(Part 1) `Stream-chat-android-client` unit tests - `api` package

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptor.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptor.kt
@@ -20,6 +20,12 @@ import io.getstream.chat.android.client.utils.HeadersUtil
 import okhttp3.Interceptor
 import okhttp3.Response
 
+/**
+ * Interceptor that adds the default headers to the request.
+ *
+ * @param isAnonymous a function that returns true if the logged in user is anonymous.
+ * @param headersUtil a utility class for building headers.
+ */
 internal class HeadersInterceptor(
     private val isAnonymous: () -> Boolean,
     private val headersUtil: HeadersUtil,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ErrorCallTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/ErrorCallTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api
+
+import io.getstream.chat.android.test.TestCoroutineRule
+import io.getstream.result.Error
+import io.getstream.result.Result
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.`should be instance of`
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Rule
+import org.junit.Test
+
+internal class ErrorCallTest {
+
+    @get:Rule
+    val coroutinesTestRule = TestCoroutineRule()
+
+    @Test
+    fun testErrorCallExecute() {
+        // given
+        val error = Error.GenericError("Generic error")
+        val errorCall = ErrorCall<Unit>(TestScope(), error)
+        // when
+        val result = errorCall.execute()
+        // then
+        result `should be instance of` Result.Failure::class
+        result as Result.Failure
+        result.value shouldBeEqualTo error
+    }
+
+    @Test
+    fun testErrorCallEnqueue() = runTest {
+        // given
+        val error = Error.GenericError("Generic error")
+        val errorCall = ErrorCall<Unit>(backgroundScope, error)
+        // when
+        errorCall.enqueue { result ->
+            // then
+            result `should be instance of` Result.Failure::class
+            result as Result.Failure
+            result.value shouldBeEqualTo error
+        }
+    }
+
+    @Test
+    fun testErrorCallAwait() = runTest {
+        // given
+        val error = Error.GenericError("Generic error")
+        val errorCall = ErrorCall<Unit>(TestScope(), error)
+        // when
+        val result = errorCall.await()
+        // then
+        result `should be instance of` Result.Failure::class
+        result as Result.Failure
+        result.value shouldBeEqualTo error
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/FakeChain.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/FakeChain.kt
@@ -24,7 +24,12 @@ import okhttp3.Request
 import okhttp3.Response
 import java.util.concurrent.TimeUnit
 
-internal class FakeChain(vararg val response: FakeResponse) : Interceptor.Chain {
+internal class FakeChain(
+    vararg val response: FakeResponse,
+    val request: Request = Request.Builder()
+        .url("https://hello.url")
+        .build(),
+) : Interceptor.Chain {
 
     var chainIndex = 0
 
@@ -61,9 +66,7 @@ internal class FakeChain(vararg val response: FakeResponse) : Interceptor.Chain 
     }
 
     override fun request(): Request {
-        return Request.Builder()
-            .url("https://hello.url")
-            .build()
+        return request
     }
 
     override fun withConnectTimeout(timeout: Int, unit: TimeUnit): Interceptor.Chain {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ApiKeyInterceptorTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ApiKeyInterceptorTest.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.interceptor
+
+import io.getstream.chat.android.client.api.FakeChain
+import io.getstream.chat.android.client.api.FakeResponse
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Test
+
+internal class ApiKeyInterceptorTest {
+
+    @Test
+    fun testApiKeyIsAddedAsHeader() {
+        // given
+        val apiKey = "apiKeyValue"
+        val interceptor = ApiKeyInterceptor(apiKey)
+        // when
+        val response = interceptor.intercept(FakeChain(FakeResponse(200)))
+        // then
+        val apiKeyQueryParam = response.request.url.queryParameter("api_key")
+        apiKeyQueryParam shouldBeEqualTo apiKey
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ApiRequestAnalyserInterceptorTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ApiRequestAnalyserInterceptorTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.interceptor
+
+import io.getstream.chat.android.client.api.FakeChain
+import io.getstream.chat.android.client.api.FakeResponse
+import io.getstream.chat.android.client.plugins.requests.ApiRequestsAnalyser
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doNothing
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class ApiRequestAnalyserInterceptorTest {
+
+    @Test
+    fun testApiRequestAnalyserInterceptorRegistersTheRequestInTheAnalyser() {
+        // given
+        val analyser = mock<ApiRequestsAnalyser>()
+        doNothing().whenever(analyser).registerRequest(any(), any())
+        val interceptor = ApiRequestAnalyserInterceptor(analyser)
+        // when
+        val chain = FakeChain(FakeResponse(200))
+        interceptor.intercept(chain)
+        // then
+        verify(analyser, times(1)).registerRequest(
+            requestName = chain.request().url.toString(),
+            data = mapOf("body" to "no_body"),
+        )
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptorTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptorTest.kt
@@ -1,0 +1,49 @@
+package io.getstream.chat.android.client.api.interceptor
+
+import io.getstream.chat.android.client.api.FakeChain
+import io.getstream.chat.android.client.api.FakeResponse
+import io.getstream.chat.android.client.utils.HeadersUtil
+import org.amshove.kluent.`should be equal to`
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class HeadersInterceptorTest {
+
+	@Test
+	fun testAnonymousUserHeaders() {
+		// given
+		val isAnonymous = { true }
+		val headersUtil = mock<HeadersUtil>()
+		whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
+		whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
+		val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
+		// when
+		val response = interceptor.intercept(FakeChain(FakeResponse(200)))
+		//then
+		response.request.header("User-Agent") `should be equal to` "userAgent"
+		response.request.header("Content-Type") `should be equal to` "application/json"
+		response.request.header("stream-auth-type") `should be equal to` "anonymous"
+		response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
+		response.request.header("Cache-Control") `should be equal to` "no-cache"
+	}
+
+	@Test
+	fun testAuthenticatedUserHeaders() {
+		// given
+		val isAnonymous = { false }
+		val headersUtil = mock<HeadersUtil>()
+		whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
+		whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
+		val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
+		// when
+		val response = interceptor.intercept(FakeChain(FakeResponse(200)))
+		//then
+		response.request.header("User-Agent") `should be equal to` "userAgent"
+		response.request.header("Content-Type") `should be equal to` "application/json"
+		response.request.header("stream-auth-type") `should be equal to` "jwt"
+		response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
+		response.request.header("Cache-Control") `should be equal to` "no-cache"
+	}
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptorTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/HeadersInterceptorTest.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.client.api.interceptor
 
 import io.getstream.chat.android.client.api.FakeChain
@@ -11,39 +27,39 @@ import org.mockito.kotlin.whenever
 
 internal class HeadersInterceptorTest {
 
-	@Test
-	fun testAnonymousUserHeaders() {
-		// given
-		val isAnonymous = { true }
-		val headersUtil = mock<HeadersUtil>()
-		whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
-		whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
-		val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
-		// when
-		val response = interceptor.intercept(FakeChain(FakeResponse(200)))
-		//then
-		response.request.header("User-Agent") `should be equal to` "userAgent"
-		response.request.header("Content-Type") `should be equal to` "application/json"
-		response.request.header("stream-auth-type") `should be equal to` "anonymous"
-		response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
-		response.request.header("Cache-Control") `should be equal to` "no-cache"
-	}
+    @Test
+    fun testAnonymousUserHeaders() {
+        // given
+        val isAnonymous = { true }
+        val headersUtil = mock<HeadersUtil>()
+        whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
+        whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
+        val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
+        // when
+        val response = interceptor.intercept(FakeChain(FakeResponse(200)))
+        // then
+        response.request.header("User-Agent") `should be equal to` "userAgent"
+        response.request.header("Content-Type") `should be equal to` "application/json"
+        response.request.header("stream-auth-type") `should be equal to` "anonymous"
+        response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
+        response.request.header("Cache-Control") `should be equal to` "no-cache"
+    }
 
-	@Test
-	fun testAuthenticatedUserHeaders() {
-		// given
-		val isAnonymous = { false }
-		val headersUtil = mock<HeadersUtil>()
-		whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
-		whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
-		val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
-		// when
-		val response = interceptor.intercept(FakeChain(FakeResponse(200)))
-		//then
-		response.request.header("User-Agent") `should be equal to` "userAgent"
-		response.request.header("Content-Type") `should be equal to` "application/json"
-		response.request.header("stream-auth-type") `should be equal to` "jwt"
-		response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
-		response.request.header("Cache-Control") `should be equal to` "no-cache"
-	}
+    @Test
+    fun testAuthenticatedUserHeaders() {
+        // given
+        val isAnonymous = { false }
+        val headersUtil = mock<HeadersUtil>()
+        whenever(headersUtil.buildSdkTrackingHeaders()).doReturn("sdkTrackingHeaders")
+        whenever(headersUtil.buildUserAgent()).doReturn("userAgent")
+        val interceptor = HeadersInterceptor(isAnonymous, headersUtil)
+        // when
+        val response = interceptor.intercept(FakeChain(FakeResponse(200)))
+        // then
+        response.request.header("User-Agent") `should be equal to` "userAgent"
+        response.request.header("Content-Type") `should be equal to` "application/json"
+        response.request.header("stream-auth-type") `should be equal to` "jwt"
+        response.request.header("X-Stream-Client") `should be equal to` "sdkTrackingHeaders"
+        response.request.header("Cache-Control") `should be equal to` "no-cache"
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ProgressInterceptorTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/interceptor/ProgressInterceptorTest.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.interceptor
+
+import io.getstream.chat.android.client.api.FakeChain
+import io.getstream.chat.android.client.api.FakeResponse
+import io.getstream.chat.android.client.api.models.ProgressRequestBody
+import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.result.Error
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import org.amshove.kluent.`should be instance of`
+import org.junit.Test
+
+internal class ProgressInterceptorTest {
+
+    @Test
+    fun testProgressInterceptor() {
+        // given
+        val interceptor = ProgressInterceptor()
+        val progressCallback = object : ProgressCallback {
+            override fun onSuccess(url: String?) { /* No-Op */ }
+            override fun onError(error: Error) { /* No-Op */ }
+            override fun onProgress(bytesUploaded: Long, totalBytes: Long) { /* No-Op */ }
+        }
+        val request = Request.Builder()
+            .url("https://hello.url")
+            .post("body".toRequestBody())
+            .tag(ProgressCallback::class.java, progressCallback)
+            .build()
+        val chain = FakeChain(FakeResponse(200), request = request)
+        // when
+        val response = interceptor.intercept(chain)
+        // then
+        response.request.body `should be instance of` ProgressRequestBody::class
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnablerTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiEnablerTest.kt
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.internal
+
+import android.annotation.SuppressLint
+import io.getstream.chat.android.client.api.ChatApi
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
+import io.getstream.chat.android.client.api.models.QueryChannelRequest
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.querysort.QuerySortByField
+import kotlinx.coroutines.test.TestScope
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+
+internal class DistinctChatApiEnablerTest {
+
+    @SuppressLint("CheckResult")
+    @Suppress("LongMethod")
+    @Test
+    fun testDistinctApiEnabled() {
+        // given
+        val api = mock<ChatApi>()
+        val distinctApi = spy(DistinctChatApi(TestScope(), api))
+        val enabler = DistinctChatApiEnabler(distinctApi) { true }
+        // when
+        enabler.getRepliesMore("messageId", "firstId", 10)
+        enabler.getReplies("messageId", 10)
+        enabler.getNewerReplies("parentId", 10, "lastId")
+        enabler.getReactions("messageId", 0, 10)
+        enabler.getMessage("messageId")
+        enabler.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "2",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        enabler.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        enabler.queryBannedUsers(
+            filter = Filters.ne("field", "value"),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        enabler.queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        enabler.queryChannel("channelType", "channelId", QueryChannelRequest())
+        // then
+        verify(distinctApi, times(1)).getRepliesMore("messageId", "firstId", 10)
+        verify(distinctApi, times(1)).getReplies("messageId", 10)
+        verify(distinctApi, times(1)).getNewerReplies("parentId", 10, "lastId")
+        verify(distinctApi, times(1)).getReactions("messageId", 0, 10)
+        verify(distinctApi, times(1)).getMessage("messageId")
+        verify(distinctApi, times(1)).getPinnedMessages(
+            channelType = "messaging",
+            channelId = "2",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        verify(distinctApi, times(1)).queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        verify(distinctApi, times(1)).queryBannedUsers(
+            filter = Filters.ne("field", "value"),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        verify(distinctApi, times(1)).queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        verify(distinctApi, times(1)).queryChannel("channelType", "channelId", QueryChannelRequest())
+        verifyNoInteractions(api)
+    }
+
+    @SuppressLint("CheckResult")
+    @Suppress("LongMethod")
+    @Test
+    fun testDistinctApiDisabled() {
+        // given
+        val api = mock<ChatApi>()
+        val distinctApi = spy(DistinctChatApi(TestScope(), api))
+        val enabler = DistinctChatApiEnabler(distinctApi) { false }
+        // when
+        enabler.getRepliesMore("messageId", "firstId", 10)
+        enabler.getReplies("messageId", 10)
+        enabler.getNewerReplies("parentId", 10, "lastId")
+        enabler.getReactions("messageId", 0, 10)
+        enabler.getMessage("messageId")
+        enabler.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "2",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        enabler.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        enabler.queryBannedUsers(
+            filter = Filters.ne("field", "value"),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        enabler.queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        enabler.queryChannel("channelType", "channelId", QueryChannelRequest())
+
+        // then
+        verify(api, times(1)).getRepliesMore("messageId", "firstId", 10)
+        verify(api, times(1)).getReplies("messageId", 10)
+        verify(api, times(1)).getNewerReplies("parentId", 10, "lastId")
+        verify(api, times(1)).getReactions("messageId", 0, 10)
+        verify(api, times(1)).getMessage("messageId")
+        verify(api, times(1)).getPinnedMessages(
+            channelType = "messaging",
+            channelId = "2",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        verify(api, times(1)).queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        verify(api, times(1)).queryBannedUsers(
+            filter = Filters.ne("field", "value"),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        verify(api, times(1)).queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        verify(api, times(1)).queryChannel("channelType", "channelId", QueryChannelRequest())
+        verify(distinctApi, times(0)).getRepliesMore(any(), any(), any())
+        verify(distinctApi, times(0)).getReplies(any(), any())
+        verify(distinctApi, times(0)).getNewerReplies(any(), any(), any())
+        verify(distinctApi, times(0)).getReactions(any(), any(), any())
+        verify(distinctApi, times(0)).getMessage(any())
+        verify(distinctApi, times(0)).getPinnedMessages(any(), any(), any(), any(), any())
+        verify(distinctApi, times(0)).queryChannels(any())
+        verify(distinctApi, times(0)).queryBannedUsers(any(), any(), any(), any(), any(), any(), any(), any())
+        verify(distinctApi, times(0)).queryMembers(any(), any(), any(), any(), any(), any(), any())
+        verify(distinctApi, times(0)).queryChannel(any(), any(), any())
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/internal/DistinctChatApiTest.kt
@@ -1,0 +1,585 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client.api.internal
+
+import io.getstream.chat.android.client.api.ChatApi
+import io.getstream.chat.android.client.api.models.PinnedMessagesPagination
+import io.getstream.chat.android.client.api.models.QueryChannelRequest
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
+import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.querysort.QuerySortByField
+import io.getstream.chat.android.test.TestCall
+import io.getstream.result.Result
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+internal class DistinctChatApiTest {
+
+    @Test
+    fun `When calling queryChannel with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryChannel("messaging", "1", QueryChannelRequest())
+        val call2 = distinctChatApi.queryChannel("messaging", "1", QueryChannelRequest())
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryChannel with same argument and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.queryChannel(any(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.queryChannel("messaging", "1", QueryChannelRequest())
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.queryChannel("messaging", "1", QueryChannelRequest())
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling queryChannel with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryChannel("messaging", "1", QueryChannelRequest())
+        val call2 = distinctChatApi.queryChannel("messaging", "2", QueryChannelRequest())
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getRepliesMore with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getRepliesMore("1", "2", 10)
+        val call2 = distinctChatApi.getRepliesMore("1", "2", 10)
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getRepliesMore with same argument and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getRepliesMore(any(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getRepliesMore("1", "2", 10)
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.getRepliesMore("1", "2", 10)
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getRepliesMore with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getRepliesMore("1", "2", 10)
+        val call2 = distinctChatApi.getRepliesMore("1", "3", 10)
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getReplies with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getReplies("1", 10)
+        val call2 = distinctChatApi.getReplies("1", 10)
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getReplies with same argument and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getReplies(any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getReplies("1", 10)
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.getReplies("1", 10)
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getReplies with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getReplies("1", 10)
+        val call2 = distinctChatApi.getReplies("2", 10)
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getNewerReplies with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getNewerReplies("1", 10, "2")
+        val call2 = distinctChatApi.getNewerReplies("1", 10, "2")
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getNewerReplies with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getNewerReplies(any(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getNewerReplies("1", 10, "2")
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.getNewerReplies("1", 10, "2")
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getNewerReplies with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getNewerReplies("1", 10, "2")
+        val call2 = distinctChatApi.getNewerReplies("2", 10, "2")
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getReactions with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getReactions("1", 0, 10)
+        val call2 = distinctChatApi.getReactions("1", 0, 10)
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getReactions with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getReactions(any(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getReactions("1", 0, 10)
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.getReactions("1", 0, 10)
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getReactions with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getReactions("1", 0, 10)
+        val call2 = distinctChatApi.getReactions("2", 0, 10)
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getMessage with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getMessage("1")
+        val call2 = distinctChatApi.getMessage("1")
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getMessage with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getMessage(any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getMessage("1")
+            // Complete first call
+            call1.await()
+            val call2 = distinctChatApi.getMessage("1")
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getMessage with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getMessage("1")
+        val call2 = distinctChatApi.getMessage("2")
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getPinnedMessages with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "1",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        val call2 = distinctChatApi.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "1",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling getPinnedMessages with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.getPinnedMessages(any(), any(), any(), any(), any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.getPinnedMessages(
+                channelType = "messaging",
+                channelId = "1",
+                limit = 10,
+                sort = QuerySortByField.ascByName("created_at"),
+                pagination = PinnedMessagesPagination.AroundMessage("1"),
+            )
+            call1.await()
+            val call2 = distinctChatApi.getPinnedMessages(
+                channelType = "messaging",
+                channelId = "1",
+                limit = 10,
+                sort = QuerySortByField.ascByName("created_at"),
+                pagination = PinnedMessagesPagination.AroundMessage("1"),
+            )
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling getPinnedMessages with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "1",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        val call2 = distinctChatApi.getPinnedMessages(
+            channelType = "messaging",
+            channelId = "2",
+            limit = 10,
+            sort = QuerySortByField.ascByName("created_at"),
+            pagination = PinnedMessagesPagination.AroundMessage("1"),
+        )
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryChannels with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        val call2 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryChannels with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val delegateApi = mock<ChatApi>()
+            whenever(delegateApi.queryChannels(any())).thenReturn(mock())
+            val distinctChatApi = DistinctChatApi(backgroundScope, delegateApi)
+            // when
+            val call1 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+            call1.await()
+            val call2 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling queryChannels with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.neutral(), limit = 10))
+        val call2 = distinctChatApi.queryChannels(QueryChannelsRequest(Filters.ne("name", "Test channel"), limit = 10))
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryBannedUsers with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryBannedUsers(
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        val call2 = distinctChatApi.queryBannedUsers(
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryBannedUsers with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val api = mock<ChatApi>()
+            whenever(
+                api.queryBannedUsers(any(), any(), any(), any(), anyOrNull(), anyOrNull(), anyOrNull(), anyOrNull()),
+            ).thenReturn(TestCall(Result.Success(emptyList())))
+            val distinctChatApi = DistinctChatApi(backgroundScope, api)
+            // when
+            val call1 = distinctChatApi.queryBannedUsers(
+                filter = Filters.neutral(),
+                sort = QuerySortByField.ascByName("created_at"),
+                offset = 0,
+                limit = 10,
+                createdAtAfter = null,
+                createdAtAfterOrEqual = null,
+                createdAtBefore = null,
+                createdAtBeforeOrEqual = null,
+            )
+            call1.await()
+            val call2 = distinctChatApi.queryBannedUsers(
+                filter = Filters.neutral(),
+                sort = QuerySortByField.ascByName("created_at"),
+                offset = 0,
+                limit = 10,
+                createdAtAfter = null,
+                createdAtAfterOrEqual = null,
+                createdAtBefore = null,
+                createdAtBeforeOrEqual = null,
+            )
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling queryBannedUsers with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryBannedUsers(
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        val call2 = distinctChatApi.queryBannedUsers(
+            filter = Filters.ne("field", "value"),
+            sort = QuerySortByField.ascByName("created_at"),
+            offset = 0,
+            limit = 10,
+            createdAtAfter = null,
+            createdAtAfterOrEqual = null,
+            createdAtBefore = null,
+            createdAtBeforeOrEqual = null,
+        )
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryMembers with same arguments, Then same instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        val call2 = distinctChatApi.queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        // then
+        // verify same instance of call is reused
+        Assert.assertTrue(call1 === call2)
+    }
+
+    @Test
+    fun `When calling queryMembers with same arguments and first call finishes, Then different instance of Call is returned`() =
+        runTest {
+            // given
+            val api = mock<ChatApi>()
+            whenever(
+                api.queryMembers(any(), any(), any(), any(), any(), any(), any()),
+            ).thenReturn(TestCall(Result.Success(emptyList())))
+            val distinctChatApi = DistinctChatApi(backgroundScope, api)
+            // when
+            val call1 = distinctChatApi.queryMembers(
+                channelType = "messaging",
+                channelId = "1",
+                offset = 0,
+                limit = 10,
+                filter = Filters.neutral(),
+                sort = QuerySortByField.ascByName("name"),
+                members = emptyList(),
+            )
+            call1.await()
+            val call2 = distinctChatApi.queryMembers(
+                channelType = "messaging",
+                channelId = "1",
+                offset = 0,
+                limit = 10,
+                filter = Filters.neutral(),
+                sort = QuerySortByField.ascByName("name"),
+                members = emptyList(),
+            )
+            // then
+            // verify different instance of call is returned
+            Assert.assertFalse(call1 === call2)
+        }
+
+    @Test
+    fun `When calling queryMembers with different arguments, Then different instance of Call is returned`() {
+        // given
+        val distinctChatApi = DistinctChatApi(TestScope(), mock())
+        // when
+        val call1 = distinctChatApi.queryMembers(
+            channelType = "messaging",
+            channelId = "1",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        val call2 = distinctChatApi.queryMembers(
+            channelType = "messaging",
+            channelId = "2",
+            offset = 0,
+            limit = 10,
+            filter = Filters.neutral(),
+            sort = QuerySortByField.ascByName("name"),
+            members = emptyList(),
+        )
+        // then
+        // verify different instance of call is returned
+        Assert.assertFalse(call1 === call2)
+    }
+}


### PR DESCRIPTION
### 🎯 Goal
Increase the unit test coverage of the project.
Cover the `api` package from the `stream-chat-android-client` package

### 🛠 Implementation details
Add tests (where applicable) for the `io.getstream.chat.android.client.api` package