### PR TITLE
[AND-378] Fix deleteFile/deleteImage not propagating errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fix not being able to send `system` messages via the `ChatClient`. [#5657](https://github.com/GetStream/stream-chat-android/pull/5657)
+- Fix `ChatClient.deleteFile()` and `ChatClient.deleteImage()` not propagating errors. [#5666](https://github.com/GetStream/stream-chat-android/pull/5666)
 
 ### ⬆️ Improved
 - Add sending messages to only specific members. The `Message` entity contains a new property `restrictedVisibility` where a list of IDs for the desired members can be set.[#5644](https://github.com/GetStream/stream-chat-android/pull/5644)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -128,7 +128,6 @@ import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.models.VotingVisibility
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.log.taggedLogger
-import io.getstream.result.Result
 import io.getstream.result.call.Call
 import io.getstream.result.call.CoroutineCall
 import io.getstream.result.call.map
@@ -458,7 +457,6 @@ constructor(
                 userId = userId,
                 url = url,
             )
-            Result.Success(Unit)
         }
     }
 
@@ -470,7 +468,6 @@ constructor(
                 userId = userId,
                 url = url,
             )
-            Result.Success(Unit)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal
The `ChatClient#deleteFile` and the `ChatClient#deleteImage` will always return `Result.Success`, even if the operation fails. The underlying problem is in the `MoshiChatApi` implementation, where in the `deleteFile` and `deleteImage` methods ignore the `FileUploader.deleteImage/File` result, and return a hard-coded `Result.Success(Unit)`.

### 🛠 Implementation details
Remove the hard-coded `Result.Success(Unit)` return, and propagate the original result of the `FileUploader.deleteImage/File` operation.