### PR TITLE
[AND-381] Fix WS X-Stream-Client headers placement.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fix not being able to send `system` messages via the `ChatClient`. [#5657](https://github.com/GetStream/stream-chat-android/pull/5657)
+- Fix `X-Stream-Client` header placement in the WebSocket request URL. [#5668](https://github.com/GetStream/stream-chat-android/pull/5668)
 
 ### ⬆️ Improved
 - Add sending messages to only specific members. The `Message` entity contains a new property `restrictedVisibility` where a list of IDs for the desired members can be set.[#5644](https://github.com/GetStream/stream-chat-android/pull/5644)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -55,7 +55,12 @@ internal class SocketFactory(
         var json = buildUserDetailJson(connectionConf)
         return try {
             json = URLEncoder.encode(json, StandardCharsets.UTF_8.name())
-            val baseWsUrl = "${connectionConf.endpoint}connect?json=$json&api_key=${connectionConf.apiKey}"
+            val sdkTrackingHeaders =
+                URLEncoder.encode(headersUtil.buildSdkTrackingHeaders(), StandardCharsets.UTF_8.name())
+            val baseWsUrl = "${connectionConf.endpoint}connect?" +
+                "json=$json" +
+                "&api_key=${connectionConf.apiKey}" +
+                "&X-Stream-Client=$sdkTrackingHeaders"
             when (connectionConf) {
                 is ConnectionConf.AnonymousConnectionConf -> "$baseWsUrl&stream-auth-type=anonymous"
                 is ConnectionConf.UserConnectionConf -> {
@@ -75,7 +80,6 @@ internal class SocketFactory(
             "user_details" to connectionConf.reduceUserDetails(),
             "user_id" to connectionConf.id,
             "server_determines_connection_id" to true,
-            "X-Stream-Client" to headersUtil.buildSdkTrackingHeaders(),
         )
         return parser.toJson(data)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -47,6 +47,7 @@ internal class SocketFactory(
     private fun buildRequest(connectionConf: ConnectionConf): Request =
         Request.Builder()
             .url(buildUrl(connectionConf))
+            .addHeader(X_STREAM_CLIENT, headersUtil.buildSdkTrackingHeaders())
             .build()
 
     @Suppress("TooGenericExceptionCaught")
@@ -60,7 +61,7 @@ internal class SocketFactory(
             val baseWsUrl = "${connectionConf.endpoint}connect?" +
                 "json=$json" +
                 "&api_key=${connectionConf.apiKey}" +
-                "&X-Stream-Client=$sdkTrackingHeaders"
+                "&$X_STREAM_CLIENT=$sdkTrackingHeaders"
             when (connectionConf) {
                 is ConnectionConf.AnonymousConnectionConf -> "$baseWsUrl&stream-auth-type=anonymous"
                 is ConnectionConf.UserConnectionConf -> {
@@ -151,5 +152,9 @@ internal class SocketFactory(
                 is AnonymousConnectionConf -> user.id.replace("!", "")
                 is UserConnectionConf -> user.id
             }
+    }
+
+    companion object {
+        private const val X_STREAM_CLIENT = "X-Stream-Client"
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
@@ -82,25 +82,25 @@ internal class SocketFactoryTest {
             randomUser(image = randomString(), name = randomString(), language = randomString()).let {
                 Arguments.of(
                     SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it),
-                    "${endpoint}connect?json=${buildFullUserJson(it, it.id)}&api_key=$apiKey&authorization=$token&stream-auth-type=jwt",
+                    "${endpoint}connect?json=${buildFullUserJson(it, it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$token&stream-auth-type=jwt",
                 )
             },
             randomUser().let {
                 Arguments.of(
                     SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
-                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&authorization=$loadSyncToken&stream-auth-type=jwt",
+                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$loadSyncToken&stream-auth-type=jwt",
                 )
             },
             User("anon").let {
                 Arguments.of(
                     SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
-                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&stream-auth-type=anonymous",
+                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&stream-auth-type=anonymous",
                 )
             },
             User("!anon").let {
                 Arguments.of(
                     SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
-                    "${endpoint}connect?json=${buildMinimumUserJson("anon")}&api_key=$apiKey&stream-auth-type=anonymous",
+                    "${endpoint}connect?json=${buildMinimumUserJson("anon")}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&stream-auth-type=anonymous",
                 )
             },
         )
@@ -129,7 +129,6 @@ internal class SocketFactoryTest {
                 "user_details" to userDetails,
                 "user_id" to userId,
                 "server_determines_connection_id" to true,
-                "X-Stream-Client" to headersUtil.buildSdkTrackingHeaders(),
             )
 
         private fun encode(map: Map<String, Any>): String =


### PR DESCRIPTION
### 🎯 Goal
Fix the placement of the `X-Stream-Client` value in the WebSocket request URL

### 🛠 Implementation details
Move the `X-Stream-Client` value from the `json` query parameter, to a dedicated query parameter in the WebSocket request URL.