### PR TITLE
[AND-390] Revert "[PBE-5891] Remove `NotInFilterObject` (#5394)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 
 ### ✅ Added
 - Add a way to inject a TokenProvider from PN on the case an expired token needs to be refreshed. [#5655](https://github.com/GetStream/stream-chat-android/pull/5655)
+- Recover deprecated `NotInFilterObject` to avoid breaking changes. [#5672](https://github.com/GetStream/stream-chat-android/pull/5672)
 
 ### ⚠️ Changed
 

--- a/DEPRECATIONS.md
+++ b/DEPRECATIONS.md
@@ -4,7 +4,7 @@ This document lists deprecated constructs in the SDK, with their expected time �
 
 | API / Feature | Deprecated (warning) | Deprecated (error) | Removed | Notes |
 | --- | --- | --- | --- | --- |
-| `NotInFilterObject` | 2024.09.03 <br/>6.5.1 | 2024.10.17 ⌛| 2024.10.03 ⌛| This filter is not supported backend-side anymore, if you are using it and need help with your integration, contact us and we will provide you an alternative. |
+| `NotInFilterObject` | 2024.09.03 <br/>6.5.1 | ⌛ | ⌛ | This filter is not supported backend-side anymore, if you are using it and need help with your integration, contact us and we will provide you an alternative. |
 | `AttachmentSelectionListener` | 2024.02.21 <br/>6.0.15 | 2024.03.21 ⌛ | 2024.04.21 ⌛ | Use `AttachmentsPickerDialogFragment.AttachmentsSelectionListener` instead. |
 | `ImageAttachmentQuotedContent` | 2022.09.13 <br/>5.9.1 | 2022.09.27<br/>5.9.1 | 2023.08.29<br/>6.0.0 | Deprecated in favor of `MediaAttachmentQuotedContent`. The new function has the ability to preview videos as well as images. |
 | `StreamDimens` constructor containing parameter `attachmentsContentImageGridSpacing`  | 2022.09.13 <br/>5.9.1 | 2022.09.27<br/>5.9.1 | 2023.08.29<br/>6.0.0 | This constructor has been deprecated. Use the constructor that does not contain the parameter `attachmentsContentImageGridSpacing`. |

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/FilterObjectToMap.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser/FilterObjectToMap.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.models.NeutralFilterObject
 import io.getstream.chat.android.models.NorFilterObject
 import io.getstream.chat.android.models.NotEqualsFilterObject
 import io.getstream.chat.android.models.NotExistsFilterObject
+import io.getstream.chat.android.models.NotInFilterObject
 import io.getstream.chat.android.models.OrFilterObject
 
 @Suppress("ComplexMethod")
@@ -49,6 +50,7 @@ internal fun FilterObject.toMap(): Map<String, Any> = when (this) {
     is LessThanFilterObject -> mapOf(this.fieldName to mapOf(KEY_LESS_THAN to this.value))
     is LessThanOrEqualsFilterObject -> mapOf(this.fieldName to mapOf(KEY_LESS_THAN_OR_EQUALS to this.value))
     is InFilterObject -> mapOf(this.fieldName to mapOf(KEY_IN to this.values))
+    is NotInFilterObject -> mapOf(this.fieldName to mapOf(KEY_NOT_IN to this.values))
     is AutocompleteFilterObject -> mapOf(this.fieldName to mapOf(KEY_AUTOCOMPLETE to this.value))
     is DistinctFilterObject -> mapOf(KEY_DISTINCT to true, KEY_MEMBERS to this.memberIds)
     is NeutralFilterObject -> emptyMap<String, String>()
@@ -65,6 +67,7 @@ private const val KEY_GREATER_THAN_OR_EQUALS: String = "\$gte"
 private const val KEY_LESS_THAN: String = "\$lt"
 private const val KEY_LESS_THAN_OR_EQUALS: String = "\$lte"
 private const val KEY_IN: String = "\$in"
+private const val KEY_NOT_IN: String = "\$nin"
 private const val KEY_AUTOCOMPLETE: String = "\$autocomplete"
 private const val KEY_DISTINCT: String = "distinct"
 private const val KEY_MEMBERS: String = "members"

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/FilterObjectTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api/models/FilterObjectTests.kt
@@ -34,7 +34,7 @@ internal class FilterObjectTests {
     @Test
     fun `Two filters with different types Should not be equal`() {
         val filterObject1 = Filters.`in`("members", listOf("userId1"))
-        val filterObject2 = Filters.ne("members", listOf("userId1"))
+        val filterObject2 = Filters.nin("members", listOf("userId1"))
 
         filterObject1 `should not be equal to` filterObject2
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/FilterObjectTypeAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/FilterObjectTypeAdapterTest.kt
@@ -199,6 +199,30 @@ internal class FilterObjectTypeAdapterTest {
                 }
             },
             randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomString() }.let { values ->
+                    Arguments.of(
+                        Filters.nin(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[\"${values.toSet().joinToString(separator = "\",\"")}\"]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomInt() }.let { values ->
+                    Arguments.of(
+                        Filters.nin(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[${values.toSet().joinToString(separator = ",")}]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomBoolean() }.let { values ->
+                    Arguments.of(
+                        Filters.nin(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[${values.toSet().joinToString(separator = ",")}]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
                 List(positiveRandomInt(20)) { randomInt() }.let { values ->
                     Arguments.of(
                         Filters.and(

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -884,6 +884,9 @@ public final class io/getstream/chat/android/models/Filters {
 	public static final fun lessThanEquals (Ljava/lang/String;Ljava/lang/Object;)Lio/getstream/chat/android/models/FilterObject;
 	public static final fun ne (Ljava/lang/String;Ljava/lang/Object;)Lio/getstream/chat/android/models/FilterObject;
 	public static final fun neutral ()Lio/getstream/chat/android/models/FilterObject;
+	public static final fun nin (Ljava/lang/String;Ljava/util/List;)Lio/getstream/chat/android/models/FilterObject;
+	public static final fun nin (Ljava/lang/String;[Ljava/lang/Number;)Lio/getstream/chat/android/models/FilterObject;
+	public static final fun nin (Ljava/lang/String;[Ljava/lang/String;)Lio/getstream/chat/android/models/FilterObject;
 	public static final fun nor ([Lio/getstream/chat/android/models/FilterObject;)Lio/getstream/chat/android/models/FilterObject;
 	public static final fun notExists (Ljava/lang/String;)Lio/getstream/chat/android/models/FilterObject;
 	public static final fun or ([Lio/getstream/chat/android/models/FilterObject;)Lio/getstream/chat/android/models/FilterObject;
@@ -1428,6 +1431,18 @@ public final class io/getstream/chat/android/models/NotExistsFilterObject : io/g
 	public final fun component1 ()Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFieldName ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/models/NotInFilterObject : io/getstream/chat/android/models/FilterObject {
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/util/Set;
+	public final fun copy (Ljava/lang/String;Ljava/util/Set;)Lio/getstream/chat/android/models/NotInFilterObject;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/NotInFilterObject;Ljava/lang/String;Ljava/util/Set;ILjava/lang/Object;)Lio/getstream/chat/android/models/NotInFilterObject;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFieldName ()Ljava/lang/String;
+	public final fun getValues ()Ljava/util/Set;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -1438,8 +1438,6 @@ public final class io/getstream/chat/android/models/NotExistsFilterObject : io/g
 public final class io/getstream/chat/android/models/NotInFilterObject : io/getstream/chat/android/models/FilterObject {
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Set;
-	public final fun copy (Ljava/lang/String;Ljava/util/Set;)Lio/getstream/chat/android/models/NotInFilterObject;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/NotInFilterObject;Ljava/lang/String;Ljava/util/Set;ILjava/lang/Object;)Lio/getstream/chat/android/models/NotInFilterObject;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getFieldName ()Ljava/lang/String;
 	public final fun getValues ()Ljava/util/Set;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/FilterObject.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/FilterObject.kt
@@ -20,6 +20,12 @@ package io.getstream.chat.android.models
  * Filter object that specifies requests for backend queries.
  */
 public sealed class FilterObject
+
+@Deprecated(
+    message = "This filter will stop to be supported in the future.",
+    level = DeprecationLevel.WARNING,
+)
+public data class NotInFilterObject internal constructor(val fieldName: String, val values: Set<Any>) : FilterObject()
 public data class AndFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()
 public data class OrFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()
 public data class NorFilterObject internal constructor(val filterObjects: Set<FilterObject>) : FilterObject()

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Filters.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Filters.kt
@@ -84,6 +84,29 @@ public object Filters {
     public fun `in`(fieldName: String, vararg values: Number): FilterObject = InFilterObject(fieldName, values.toSet())
 
     @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
+    public fun nin(fieldName: String, vararg values: String): FilterObject =
+        NotInFilterObject(fieldName, values.toSet())
+
+    @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
+    public fun nin(fieldName: String, values: List<Any>): FilterObject = NotInFilterObject(fieldName, values.toSet())
+
+    @JvmStatic
+    @Deprecated(
+        message = "This filter will stop to be supported in the future.",
+        level = DeprecationLevel.WARNING,
+    )
+    public fun nin(fieldName: String, vararg values: Number): FilterObject =
+        NotInFilterObject(fieldName, values.toSet())
+
+    @JvmStatic
     public fun autocomplete(fieldName: String, value: String): FilterObject = AutocompleteFilterObject(fieldName, value)
 
     @JvmStatic

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/converter/internal/FilterObjectConverter.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/converter/internal/FilterObjectConverter.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.models.NeutralFilterObject
 import io.getstream.chat.android.models.NorFilterObject
 import io.getstream.chat.android.models.NotEqualsFilterObject
 import io.getstream.chat.android.models.NotExistsFilterObject
+import io.getstream.chat.android.models.NotInFilterObject
 import io.getstream.chat.android.models.OrFilterObject
 import java.lang.IllegalArgumentException
 
@@ -83,6 +84,7 @@ private fun Map.Entry<String, Any>.toFilterObject(): FilterObject = when (this.k
             KEY_LESS_THAN -> Filters.lessThan(this.key, it.value)
             KEY_LESS_THAN_OR_EQUALS -> Filters.lessThanEquals(this.key, it.value)
             KEY_IN -> Filters.`in`(this.key, (it.value as List<Any>))
+            KEY_NOT_IN -> Filters.nin(this.key, (it.value as List<Any>))
             KEY_AUTOCOMPLETE -> Filters.autocomplete(this.key, it.value as String)
             else -> throw IllegalArgumentException("FilterObject can be create with this map `$this`")
         }
@@ -103,6 +105,7 @@ private fun FilterObject.toMap(): Map<String, Any> = when (this) {
     is LessThanFilterObject -> mapOf(this.fieldName to mapOf(KEY_LESS_THAN to this.value))
     is LessThanOrEqualsFilterObject -> mapOf(this.fieldName to mapOf(KEY_LESS_THAN_OR_EQUALS to this.value))
     is InFilterObject -> mapOf(this.fieldName to mapOf(KEY_IN to this.values))
+    is NotInFilterObject -> mapOf(this.fieldName to mapOf(KEY_NOT_IN to this.values))
     is AutocompleteFilterObject -> mapOf(this.fieldName to mapOf(KEY_AUTOCOMPLETE to this.value))
     is DistinctFilterObject -> mapOf(KEY_DISTINCT to true, KEY_MEMBERS to this.memberIds)
     is NeutralFilterObject -> emptyMap<String, String>()
@@ -120,6 +123,7 @@ private const val KEY_GREATER_THAN_OR_EQUALS: String = "\$gte"
 private const val KEY_LESS_THAN: String = "\$lt"
 private const val KEY_LESS_THAN_OR_EQUALS: String = "\$lte"
 private const val KEY_IN: String = "\$in"
+private const val KEY_NOT_IN: String = "\$nin"
 private const val KEY_AUTOCOMPLETE: String = "\$autocomplete"
 private const val KEY_DISTINCT: String = "distinct"
 private const val KEY_MEMBERS: String = "members"

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/database/converter/FilterObjectConverterTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/database/converter/FilterObjectConverterTest.kt
@@ -207,6 +207,30 @@ internal class FilterObjectConverterTest {
                 }
             },
             randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomString() }.distinct().let { values ->
+                    Arguments.of(
+                        Filters.`nin`(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[\"${values.joinToString(separator = "\",\"")}\"]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomInt() }.distinct().let { values ->
+                    Arguments.of(
+                        Filters.`nin`(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[${values.joinToString(separator = ",")}]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomBoolean() }.distinct().let { values ->
+                    Arguments.of(
+                        Filters.`nin`(fieldName, values),
+                        "{\"$fieldName\":{\"\$nin\":[${values.joinToString(separator = ",")}]}}",
+                    )
+                }
+            },
+            randomString().let { fieldName ->
                 List(positiveRandomInt(20)) { randomInt() }.distinct().let { values ->
                     Arguments.of(
                         Filters.and(
@@ -398,6 +422,30 @@ internal class FilterObjectConverterTest {
                     Arguments.of(
                         "{\"$fieldName\":{\"\$in\":[${values.joinToString(separator = ",")}]}}",
                         Filters.`in`(fieldName, values),
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomString() }.distinct().let { values ->
+                    Arguments.of(
+                        "{\"$fieldName\":{\"\$nin\":[\"${values.joinToString(separator = "\",\"")}\"]}}",
+                        Filters.`nin`(fieldName, values),
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomInt().toDouble() }.distinct().let { values ->
+                    Arguments.of(
+                        "{\"$fieldName\":{\"\$nin\":[${values.joinToString(separator = ",")}]}}",
+                        Filters.`nin`(fieldName, values),
+                    )
+                }
+            },
+            randomString().let { fieldName ->
+                List(positiveRandomInt(20)) { randomBoolean() }.distinct().let { values ->
+                    Arguments.of(
+                        "{\"$fieldName\":{\"\$nin\":[${values.joinToString(separator = ",")}]}}",
+                        Filters.`nin`(fieldName, values),
                     )
                 }
             },

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/utils/internal/CustomObjectFiltering.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/utils/internal/CustomObjectFiltering.kt
@@ -36,6 +36,7 @@ import io.getstream.chat.android.models.NeutralFilterObject
 import io.getstream.chat.android.models.NorFilterObject
 import io.getstream.chat.android.models.NotEqualsFilterObject
 import io.getstream.chat.android.models.NotExistsFilterObject
+import io.getstream.chat.android.models.NotInFilterObject
 import io.getstream.chat.android.models.OrFilterObject
 import java.lang.ClassCastException
 import kotlin.reflect.KClass
@@ -77,6 +78,17 @@ internal fun <T : CustomObject> FilterObject.filter(t: T): Boolean = try {
                     values.any(fieldValue::contains)
                 } else {
                     values.contains(fieldValue)
+                }
+            }
+        }
+        is NotInFilterObject -> when (fieldName) {
+            MEMBERS_FIELD_NAME -> values.none(t.getMembersId()::contains)
+            else -> {
+                val fieldValue = t.getMemberPropertyOrExtra(fieldName, Any::class)
+                if (fieldValue is List<*>) {
+                    values.none(fieldValue::contains)
+                } else {
+                    !values.contains(fieldValue)
                 }
             }
         }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/utils/CustomObjectFilteringTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/utils/CustomObjectFilteringTest.kt
@@ -74,6 +74,7 @@ internal class CustomObjectFilteringTest {
             lessThanFilterArguments() +
             lessThanOrEqualsFilterArguments() +
             inFilterArguments() +
+            notInFilterArguments() +
             andFilterArguments() +
             norFilterArguments() +
             orFilterArguments()
@@ -1356,6 +1357,165 @@ internal class CustomObjectFilteringTest {
                         Arguments.of(
                             (expectedList + List(positiveRandomInt(10)) { randomChannel() }).shuffled(),
                             Filters.`in`("someField", stringList),
+                            expectedList,
+                        )
+                    },
+                )
+            }
+
+        @JvmStatic
+        fun notInFilterArguments() = List(positiveRandomInt(10)) { randomInt() }.let { intList ->
+            val notIntList = List(positiveRandomInt(10)) { randomInt() } - intList
+            listOf(
+                List(positiveRandomInt(10)) {
+                    randomChannel(
+                        extraData = mapOf("someField" to notIntList.random()),
+                    )
+                }.let { expectedList ->
+                    Arguments.of(
+                        (
+                            expectedList + List(positiveRandomInt(10)) {
+                                randomChannel(
+                                    extraData = mapOf("someField" to intList.random()),
+                                )
+                            }
+                            ).shuffled(),
+                        Filters.nin("someField", intList),
+                        expectedList,
+                    )
+                },
+                List(positiveRandomInt(10)) { randomChannel() }.let { expectedList ->
+                    Arguments.of(
+                        (
+                            expectedList + List(positiveRandomInt(10)) {
+                                randomChannel(
+                                    extraData = mapOf("someField" to intList.random()),
+                                )
+                            }
+                            ).shuffled(),
+                        Filters.nin("someField", intList),
+                        expectedList,
+                    )
+                },
+            )
+        } +
+            List(positiveRandomInt(10)) { randomLong() }.let { longList ->
+                val notLongList = List(positiveRandomInt(10)) { randomLong() } - longList
+                listOf(
+                    List(positiveRandomInt(10)) {
+                        randomChannel(
+                            extraData = mapOf("someField" to notLongList.random()),
+                        )
+                    }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to longList.random()),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", longList),
+                            expectedList,
+                        )
+                    },
+                    List(positiveRandomInt(10)) { randomChannel() }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to longList.random()),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", longList),
+                            expectedList,
+                        )
+                    },
+                )
+            } +
+            List(positiveRandomInt(10)) { randomString() }.let { stringList ->
+                val notStringList = List(positiveRandomInt(10)) { randomString() } - stringList
+                listOf(
+                    List(positiveRandomInt(10)) {
+                        randomChannel(
+                            extraData = mapOf("someField" to notStringList.random()),
+                        )
+                    }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to stringList.random()),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", stringList),
+                            expectedList,
+                        )
+                    },
+                    List(positiveRandomInt(10)) { randomChannel() }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to stringList.random()),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", stringList),
+                            expectedList,
+                        )
+                    },
+                )
+            } +
+            List(positiveRandomInt(10)) { randomChannel() }.let { expectedList ->
+                Arguments.of(
+                    (
+                        expectedList +
+                            memberIds.take(positiveRandomInt(memberIds.size))
+                                .map { randomMember(user = randomUser(id = it)) }.let { members ->
+                                    List(positiveRandomInt(10)) {
+                                        randomChannel(
+                                            members = (List(positiveRandomInt(10)) { randomMember() } + members).shuffled(),
+                                        )
+                                    }
+                                }
+                        ).shuffled(),
+                    Filters.nin("members", memberIds),
+                    expectedList,
+                )
+            } +
+            List(positiveRandomInt(10)) { randomString() }.let { stringList ->
+                val notStringList = List(positiveRandomInt(10)) { randomString() } - stringList
+                listOf(
+                    List(positiveRandomInt(10)) {
+                        randomChannel(
+                            extraData = mapOf("someField" to listOf(notStringList.random())),
+                        )
+                    }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to listOf(stringList.random())),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", stringList),
+                            expectedList,
+                        )
+                    },
+                    List(positiveRandomInt(10)) { randomChannel() }.let { expectedList ->
+                        Arguments.of(
+                            (
+                                expectedList + List(positiveRandomInt(10)) {
+                                    randomChannel(
+                                        extraData = mapOf("someField" to listOf(stringList.random())),
+                                    )
+                                }
+                                ).shuffled(),
+                            Filters.nin("someField", stringList),
                             expectedList,
                         )
                     },

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/utils/CustomObjectFilteringTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/utils/CustomObjectFilteringTest.kt
@@ -1363,6 +1363,7 @@ internal class CustomObjectFilteringTest {
                 )
             }
 
+        @Suppress("LongMethod")
         @JvmStatic
         fun notInFilterArguments() = List(positiveRandomInt(10)) { randomInt() }.let { intList ->
             val notIntList = List(positiveRandomInt(10)) { randomInt() } - intList
@@ -1477,7 +1478,9 @@ internal class CustomObjectFilteringTest {
                                 .map { randomMember(user = randomUser(id = it)) }.let { members ->
                                     List(positiveRandomInt(10)) {
                                         randomChannel(
-                                            members = (List(positiveRandomInt(10)) { randomMember() } + members).shuffled(),
+                                            members = (
+                                                List(positiveRandomInt(10)) { randomMember() } + members
+                                                ).shuffled(),
                                         )
                                     }
                                 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/group/users/GroupChatInfoAddUsersViewModel.kt
@@ -127,11 +127,15 @@ class GroupChatInfoAddUsersViewModel(
         if (members.isEmpty()) {
             return
         }
+        val currentMembers = members
         val currentState = _state.value!!
         val filter = if (currentState.query.isEmpty()) {
-            Filters.neutral()
+            Filters.nin("id", currentMembers.map { it.getUserId() })
         } else {
-            Filters.autocomplete("name", currentState.query)
+            Filters.and(
+                Filters.autocomplete("name", currentState.query),
+                Filters.nin("id", currentMembers.map { it.getUserId() }),
+            )
         }
 
         val result = ChatClient.instance().queryUsers(


### PR DESCRIPTION
### 🎯 Goal
Revert changes where `NotInFilterObject` was removed.
We keep it as deprecated and will be removed on a future version.

This reverts commit 7bfe302fc1c1d273df263b3ca53efc7db8501b4c.
