### PR TITLE
[AND-394] Fix timestamp rendering in the message footer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fix wrong timestamp shown for updated GIPHY messages. [#5674](https://github.com/GetStream/stream-chat-android/pull/5674)
 
 ### ⬆️ Improved
 
@@ -79,6 +80,7 @@
 - Crash when recording audio on a message reply. [#5642](https://github.com/GetStream/stream-chat-android/pull/5642)
 - Fix fading issue in media attachment content items. [#5631](https://github.com/GetStream/stream-chat-android/pull/5631)
 - Fix additional padding applied to the `MessageComposer` on Android 15. [#5659](https://github.com/GetStream/stream-chat-android/pull/5659)
+- Fix wrong timestamp shown for updated messages. [#5674](https://github.com/GetStream/stream-chat-android/pull/5674)
 
 ### ⬆️ Improved
 - Autofocus the input fields in the poll creation screen. [#5629](https://github.com/GetStream/stream-chat-android/pull/5629)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.utils.message.belongsToThread
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.DateFormatType
@@ -102,16 +103,7 @@ public fun MessageFooter(
                     )
                 }
 
-                val updatedAt = message.updatedAt
-                val createdAt = message.createdAt ?: message.createdLocallyAt
-                val date = when {
-                    createdAt == null -> updatedAt
-                    updatedAt == null -> createdAt
-                    else -> when (updatedAt.after(createdAt)) {
-                        true -> updatedAt
-                        else -> createdAt
-                    }
-                }
+                val date = message.getCreatedAtOrNull()
                 if (date != null) {
                     Timestamp(date = date, formatType = DateFormatType.TIME)
                 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/internal/FootnoteDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/internal/FootnoteDecorator.kt
@@ -48,9 +48,7 @@ import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.imp
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.impl.PollViewHolder
 import io.getstream.chat.android.ui.font.setTextStyle
 import io.getstream.chat.android.ui.utils.extensions.getCreatedAtOrNull
-import io.getstream.chat.android.ui.utils.extensions.getUpdatedAtOrNull
 import io.getstream.chat.android.ui.utils.extensions.isBottomPosition
-import io.getstream.chat.android.ui.utils.extensions.isGiphyNotEphemeral
 import io.getstream.chat.android.ui.utils.extensions.isNotBottomPosition
 import io.getstream.chat.android.ui.utils.extensions.setStartDrawable
 import io.getstream.chat.android.ui.utils.extensions.updateConstraints
@@ -347,18 +345,10 @@ internal class FootnoteDecorator(
 
     private fun setupMessageFooterTime(footnoteView: FootnoteView, data: MessageListItem.MessageItem) {
         val createdAt = data.message.getCreatedAtOrNull()
-        val updatedAt = data.message.getUpdatedAtOrNull()
         val editedAt = data.message.messageTextUpdatedAt.truncateFuture()?.let(dateFormatter::formatRelativeTime)
 
         when {
             createdAt == null || !data.showMessageFooter -> footnoteView.hideTimeLabel()
-            data.message.isGiphyNotEphemeral() && updatedAt != null -> footnoteView.showTime(
-                dateFormatter.formatTime(
-                    updatedAt,
-                ),
-                null,
-                listViewStyle.itemStyle,
-            )
             else -> footnoteView.showTime(dateFormatter.formatTime(createdAt), editedAt, listViewStyle.itemStyle)
         }
     }


### PR DESCRIPTION
### 🎯 Goal
The message timestamp in the `MessageList` (Compose) was wrongly rendering the `updatedAt` date (if present), instead of the `createdAt` date. This means that any updates to the message such as reacting, pinning/unpinning or editing, resulted in updating the timestamp shown below the message. 
This is also different from the behaviour that we have in the XML SDK.

Additionally, in the XML SDK there was a specific case where the `updatedAt` was rendered instead of the `createdAt` - for non-ephemeral Giphy messages. This logic is now removed as well, because it had the same bug, but only present on Giphy messages. 

In this PR, the Compose and XML implementations are aligned.

### 🛠 Implementation details
- Compose: Always render the `createdAt` date as timestamp, and don't consider `updatedAt`
- XML: Remove the specific "giphy" message handling

### 🎨 UI Changes
<table>
<thead>
<tr>
<th>Use case</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
Compose
</td>
<td>
<video src="https://github.com/user-attachments/assets/d73ff0a5-f98f-4075-97a7-5fefc17692f0" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/d0024a51-3ba9-4022-83f5-55756fe98a94" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
Compose (Giphy)
</td>
<td>
<video src="https://github.com/user-attachments/assets/9f91fe87-bc57-47aa-8013-bc9d7eeb5db2" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/4854aa54-ea0b-411c-9b12-ef1995f56a55" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
XML (Giphy)
</td>
<td>
<video src="https://github.com/user-attachments/assets/35efea5b-5294-42df-bf9e-8746641a7bad" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/04c098cd-fd7e-4d5a-9415-1057a712ff05" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Open compose sample
2. Open a channel
3. Edit a message / react to a message / pin or unpin a message
4. The timestamp shown below the updated message should remain the original one (when the message was created)