### PR TITLE
[AND-396] Unread label shouldn't be shown after an own message is sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@
 - Fix not being able to send `system` messages via the `ChatClient`. [#5657](https://github.com/GetStream/stream-chat-android/pull/5657)
 - Fix `ChatClient.deleteFile()` and `ChatClient.deleteImage()` not propagating errors. [#5666](https://github.com/GetStream/stream-chat-android/pull/5666)
 - Fix `X-Stream-Client` header placement in the WebSocket request URL. [#5668](https://github.com/GetStream/stream-chat-android/pull/5668)
-- Fix mark own message as unread. [#5677](https://github.com/GetStream/stream-chat-android/pull/5677)
 
 ### ⬆️ Improved
 - Add sending messages to only specific members. The `Message` entity contains a new property `restrictedVisibility` where a list of IDs for the desired members can be set.[#5644](https://github.com/GetStream/stream-chat-android/pull/5644)
@@ -55,6 +54,7 @@
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
 - Fix `MessageListController#scrollToFirstUnreadMessage` not working when the first unread message was not loaded. [#5635](https://github.com/GetStream/stream-chat-android/pull/5635)
+- Fix mark own message as unread. [#5677](https://github.com/GetStream/stream-chat-android/pull/5677) [#5680](https://github.com/GetStream/stream-chat-android/pull/5680)
 
 ### ⬆️ Improved
 - Use `partialUpdateMessage` when editing messages from the message composer. [#5669](https://github.com/GetStream/stream-chat-android/pull/5669)


### PR DESCRIPTION
### 🎯 Goal
PR #5677  introduced a side-effect that showed the unread label after a picture/video attachment was sent using a third-party activity.

On this PR we introduce an extra flag to check if the unreadLabel State should be updated or not.
Remember that this unreadLabel should only be updated when the conversation is opened and/or when the marAsUnread feature is used by the final user.


### 🎨 UI Changes

#### `compose`

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/c0b83ff3-3a35-49c2-9aa4-d99d1572fb0a" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/acffc044-343f-4017-a060-92eb2dcb9f48" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

#### `ui-components`

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/4cdcfa32-2a7b-4fa2-82f4-74853e9df6b4" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/9cdeaced-66e2-4cc5-87a0-0b1a890abcd6" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


