### PR TITLE
[AND-388] Render pinned messages in the info pane of ChatsScreen

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelInfoOptionItem.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelInfoOptionItem.kt
@@ -30,6 +30,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -71,7 +72,11 @@ fun ChannelInfoOptionItem(
         modifier = Modifier
             .fillMaxWidth()
             .background(ChatTheme.colors.appBackground)
-            .clickable { onClick() }
+            .clickable(
+                interactionSource = null,
+                indication = ripple(),
+                onClick = onClick,
+            )
             .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -55,9 +55,9 @@ import io.getstream.chat.android.compose.sample.ui.component.CustomChatComponent
 import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
 import io.getstream.chat.android.compose.sample.ui.pinned.PinnedMessagesScreen
 import io.getstream.chat.android.compose.ui.channels.SearchMode
+import io.getstream.chat.android.compose.ui.chats.ChatListContentMode
 import io.getstream.chat.android.compose.ui.chats.ChatMessageSelection
 import io.getstream.chat.android.compose.ui.chats.ChatsScreen
-import io.getstream.chat.android.compose.ui.chats.ListContentMode
 import io.getstream.chat.android.compose.ui.components.channels.ChannelOptionItemVisibility
 import io.getstream.chat.android.compose.ui.theme.ChannelOptionsTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -152,7 +152,7 @@ class ChatsActivity : BaseConnectedActivity() {
 
     @Composable
     private fun ScreenContent() {
-        var listContentMode by rememberSaveable { mutableStateOf(ListContentMode.Channels) }
+        var listContentMode by rememberSaveable { mutableStateOf(ChatListContentMode.Channels) }
         val navigator = rememberThreePaneNavigator()
         ChatsScreen(
             navigator = navigator,
@@ -186,8 +186,8 @@ class ChatsActivity : BaseConnectedActivity() {
                     listContentMode = listContentMode,
                     onOptionSelected = { option ->
                         listContentMode = when (option) {
-                            AppBottomBarOption.CHATS -> ListContentMode.Channels
-                            AppBottomBarOption.THREADS -> ListContentMode.Threads
+                            AppBottomBarOption.CHATS -> ChatListContentMode.Channels
+                            AppBottomBarOption.THREADS -> ChatListContentMode.Threads
                         }
                     },
                 )
@@ -203,15 +203,15 @@ class ChatsActivity : BaseConnectedActivity() {
 
     @Composable
     private fun ListFooterContent(
-        listContentMode: ListContentMode,
+        listContentMode: ChatListContentMode,
         onOptionSelected: (option: AppBottomBarOption) -> Unit,
     ) {
         val globalState = ChatClient.instance().globalState
         val unreadChannelsCount by globalState.channelUnreadCount.collectAsState()
         val unreadThreadsCount by globalState.unreadThreadsCount.collectAsState()
         val selectedOption = when (listContentMode) {
-            ListContentMode.Channels -> AppBottomBarOption.CHATS
-            ListContentMode.Threads -> AppBottomBarOption.THREADS
+            ChatListContentMode.Channels -> AppBottomBarOption.CHATS
+            ChatListContentMode.Threads -> AppBottomBarOption.THREADS
         }
         AppBottomBar(
             unreadChannelsCount = unreadChannelsCount,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -271,18 +271,20 @@ class ChatsActivity : BaseConnectedActivity() {
             factory = ChannelInfoViewModelFactory(channelId),
         )
         val state by viewModel.state.collectAsState()
-        ChannelInfoScreen(
-            state = state,
-            onPinnedMessagesClick = onPinnedMessagesClick,
-            onConfirmDelete = viewModel::onDeleteChannel,
-            navigationIcon = {
-                if (AdaptiveLayoutInfo.singlePaneWindow()) {
-                    DefaultChannelInfoNavigationIcon(onClick = onNavigationIconClick)
-                } else {
-                    CloseButton(onClick = onNavigationIconClick)
-                }
-            },
-        )
+        if (state.member != null) {
+            ChannelInfoScreen(
+                state = state,
+                onPinnedMessagesClick = onPinnedMessagesClick,
+                onConfirmDelete = viewModel::onDeleteChannel,
+                navigationIcon = {
+                    if (AdaptiveLayoutInfo.singlePaneWindow()) {
+                        DefaultChannelInfoNavigationIcon(onClick = onNavigationIconClick)
+                    } else {
+                        CloseButton(onClick = onNavigationIconClick)
+                    }
+                },
+            )
+        }
     }
 
     @Composable

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -195,7 +195,7 @@ class ChatsActivity : BaseConnectedActivity() {
             infoContent = { arguments ->
                 InfoContent(
                     navigator = navigator,
-                    mode = arguments as InfoContentMode
+                    mode = arguments as InfoContentMode,
                 )
             },
         )

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/InfoContentMode.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/InfoContentMode.kt
@@ -42,4 +42,9 @@ sealed class InfoContentMode(open val channelId: String) : Serializable {
      * Display the info for a group channel.
      */
     data class GroupChannelInfo(override val channelId: String) : InfoContentMode(channelId)
+
+    /**
+     * Display the pinned messages for a channel.
+     */
+    data class PinnedMessages(override val channelId: String) : InfoContentMode(channelId)
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/pinned/PinnedMessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/pinned/PinnedMessagesActivity.kt
@@ -21,21 +21,10 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
-import androidx.compose.material3.Scaffold
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.res.stringResource
-import io.getstream.chat.android.compose.sample.R
-import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
 import io.getstream.chat.android.compose.sample.ui.MessagesActivity
-import io.getstream.chat.android.compose.sample.ui.chats.ChatsActivity
-import io.getstream.chat.android.compose.sample.ui.component.AppToolbar
-import io.getstream.chat.android.compose.ui.pinned.PinnedMessageList
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.pinned.PinnedMessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.pinned.PinnedMessageListViewModelFactory
@@ -66,55 +55,28 @@ class PinnedMessagesActivity : BaseConnectedActivity() {
         )
     }
     private val viewModel by viewModels<PinnedMessageListViewModel> { viewModelFactory }
-    private val settings by lazy { customSettings() }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             ChatTheme {
-                Scaffold(
+                PinnedMessagesScreen(
                     modifier = Modifier.statusBarsPadding(),
-                    topBar = {
-                        AppToolbar(
-                            title = stringResource(id = R.string.channel_info_option_pinned_messages),
-                            onBack = ::finish,
-                        )
-                    },
-                    content = { padding ->
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(ChatTheme.colors.appBackground)
-                                .padding(padding),
-                        ) {
-                            PinnedMessageList(
-                                modifier = Modifier.fillMaxSize(),
-                                viewModel = viewModel,
-                                onPinnedMessageClick = ::openMessage,
-                            )
-                        }
-                    },
+                    viewModel = viewModel,
+                    onNavigationIconClick = ::finish,
+                    onMessageClick = ::openMessage,
                 )
             }
         }
     }
 
     private fun openMessage(message: Message) {
-        val intent = if (settings.isAdaptiveLayoutEnabled) {
-            ChatsActivity.createIntent(
-                context = applicationContext,
-                channelId = message.cid,
-                messageId = message.id,
-                parentMessageId = message.parentId,
-            )
-        } else {
-            MessagesActivity.createIntent(
-                context = applicationContext,
-                channelId = message.cid,
-                messageId = message.id,
-                parentMessageId = message.parentId,
-            )
-        }
+        val intent = MessagesActivity.createIntent(
+            context = applicationContext,
+            channelId = message.cid,
+            messageId = message.id,
+            parentMessageId = message.parentId,
+        )
         startActivity(intent)
     }
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/pinned/PinnedMessagesScreen.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/pinned/PinnedMessagesScreen.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui.pinned
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.ui.component.AppToolbar
+import io.getstream.chat.android.compose.ui.pinned.PinnedMessageList
+import io.getstream.chat.android.compose.viewmodel.pinned.PinnedMessageListViewModel
+import io.getstream.chat.android.models.Message
+
+@Composable
+fun PinnedMessagesScreen(
+    viewModel: PinnedMessageListViewModel,
+    onNavigationIconClick: () -> Unit,
+    onMessageClick: (message: Message) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        modifier = modifier,
+        topBar = {
+            AppToolbar(
+                title = stringResource(id = R.string.channel_info_option_pinned_messages),
+                onBack = onNavigationIconClick,
+            )
+        },
+        content = { padding ->
+            PinnedMessageList(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+                viewModel = viewModel,
+                onPinnedMessageClick = onMessageClick,
+            )
+        },
+    )
+}

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -751,6 +751,14 @@ public final class io/getstream/chat/android/compose/ui/channels/list/SearchResu
 	public static final fun SearchResultItem (Lio/getstream/chat/android/compose/state/channels/list/ItemState$SearchResultItemState;Lio/getstream/chat/android/models/User;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function4;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/chats/ChatListContentMode : java/lang/Enum {
+	public static final field Channels Lio/getstream/chat/android/compose/ui/chats/ChatListContentMode;
+	public static final field Threads Lio/getstream/chat/android/compose/ui/chats/ChatListContentMode;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/chats/ChatListContentMode;
+	public static fun values ()[Lio/getstream/chat/android/compose/ui/chats/ChatListContentMode;
+}
+
 public final class io/getstream/chat/android/compose/ui/chats/ChatMessageSelection : java/io/Serializable {
 	public static final field $stable I
 	public fun <init> ()V
@@ -770,7 +778,7 @@ public final class io/getstream/chat/android/compose/ui/chats/ChatMessageSelecti
 }
 
 public final class io/getstream/chat/android/compose/ui/chats/ChatsScreenKt {
-	public static final fun ChatsScreen (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator;Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Lio/getstream/chat/android/compose/viewmodel/threads/ThreadsViewModelFactory;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/channels/SearchMode;Lio/getstream/chat/android/compose/ui/chats/ListContentMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
+	public static final fun ChatsScreen (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator;Lio/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory;Lio/getstream/chat/android/compose/viewmodel/threads/ThreadsViewModelFactory;Lkotlin/jvm/functions/Function2;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/channels/SearchMode;Lio/getstream/chat/android/compose/ui/chats/ChatListContentMode;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function4;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class io/getstream/chat/android/compose/ui/chats/ComposableSingletons$ChatsScreenKt {
@@ -782,14 +790,6 @@ public final class io/getstream/chat/android/compose/ui/chats/ComposableSingleto
 	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda-2$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda-3$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-}
-
-public final class io/getstream/chat/android/compose/ui/chats/ListContentMode : java/lang/Enum {
-	public static final field Channels Lio/getstream/chat/android/compose/ui/chats/ListContentMode;
-	public static final field Threads Lio/getstream/chat/android/compose/ui/chats/ListContentMode;
-	public static fun getEntries ()Lkotlin/enums/EnumEntries;
-	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/chats/ListContentMode;
-	public static fun values ()[Lio/getstream/chat/android/compose/ui/chats/ListContentMode;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/BackButtonKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -3877,8 +3877,8 @@ public final class io/getstream/chat/android/compose/ui/util/adaptivelayout/Thre
 	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun canNavigateBack ()Z
 	public final fun navigateBack ()V
-	public final fun navigateTo (Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneDestination;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneRole;)V
-	public static synthetic fun navigateTo$default (Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneDestination;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneRole;ILjava/lang/Object;)V
+	public final fun navigateTo (Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneDestination;ZLio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneRole;)V
+	public static synthetic fun navigateTo$default (Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator;Lio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneDestination;ZLio/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneRole;ILjava/lang/Object;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigatorKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatListContentMode.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatListContentMode.kt
@@ -22,7 +22,7 @@ import io.getstream.chat.android.core.ExperimentalStreamChatApi
  * The mode for displaying the list content in the chat screen.
  */
 @ExperimentalStreamChatApi
-public enum class ListContentMode {
+public enum class ChatListContentMode {
     /**
      * Display the list of channels.
      */

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
@@ -95,7 +95,7 @@ import kotlin.math.abs
  * `channelId`, `messageId`, and `parentMessageId` are `null`.
  * @param title The title displayed in the list pane top bar. Default is `"Stream Chat"`.
  * @param searchMode The current search mode. Default is [SearchMode.None].
- * @param listContentMode The mode for displaying the list content. Default is [ListContentMode.Channels].
+ * @param listContentMode The mode for displaying the list content. Default is [ChatListContentMode.Channels].
  * @param onBackPress Callback invoked when the user presses the back button.
  * @param onListTopBarAvatarClick Callback invoked when the user clicks on the avatar in the list pane top bar.
  * @param onListTopBarActionClick Callback invoked when the user clicks on the action icon in the list pane top bar.
@@ -118,7 +118,7 @@ public fun ChatsScreen(
     messagesViewModelFactoryProvider: MessagesViewModelFactoryProvider = DefaultMessagesViewModelFactoryProvider(),
     title: String = "Stream Chat",
     searchMode: SearchMode = SearchMode.None,
-    listContentMode: ListContentMode = ListContentMode.Channels,
+    listContentMode: ChatListContentMode = ChatListContentMode.Channels,
     onBackPress: () -> Unit = {},
     onListTopBarAvatarClick: (User?) -> Unit = {},
     onListTopBarActionClick: () -> Unit = {},
@@ -175,7 +175,7 @@ public fun ChatsScreen(
                     targetState = listContentMode,
                 ) { mode ->
                     when (mode) {
-                        ListContentMode.Channels -> {
+                        ChatListContentMode.Channels -> {
                             ChannelsScreen(
                                 viewModelFactory = channelViewModelFactory,
                                 isShowingHeader = false,
@@ -206,7 +206,7 @@ public fun ChatsScreen(
                             )
                         }
 
-                        ListContentMode.Threads -> {
+                        ChatListContentMode.Threads -> {
                             val viewModel = viewModel(
                                 modelClass = ThreadListViewModel::class.java,
                                 factory = threadsViewModelFactory,
@@ -383,7 +383,7 @@ public fun ChatsScreen(
 
 @Composable
 private fun AutoSelectFirstItem(
-    listContentMode: ListContentMode,
+    listContentMode: ChatListContentMode,
     channelViewModelFactory: ChannelViewModelFactory,
     threadsViewModelFactory: ThreadsViewModelFactory,
     navigator: ThreePaneNavigator,
@@ -391,7 +391,7 @@ private fun AutoSelectFirstItem(
 ) {
     val context = LocalContext.current
     when (listContentMode) {
-        ListContentMode.Channels -> {
+        ChatListContentMode.Channels -> {
             FirstChannelLoadHandler(channelViewModelFactory) { selection ->
                 navigator.initialDetailNavigation(messagesViewModelFactoryProvider, context) ?: run {
                     navigator.navigateTo(ThreePaneDestination(ThreePaneRole.Detail, selection))
@@ -399,7 +399,7 @@ private fun AutoSelectFirstItem(
             }
         }
 
-        ListContentMode.Threads -> {
+        ChatListContentMode.Threads -> {
             FirstThreadLoadHandler(threadsViewModelFactory) { selection ->
                 navigator.initialDetailNavigation(messagesViewModelFactoryProvider, context) ?: run {
                     navigator.navigateTo(ThreePaneDestination(ThreePaneRole.Detail, selection))

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
@@ -76,6 +76,7 @@ import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.state.messages.MessageMode
+import kotlin.math.abs
 
 /**
  * Represents a complete screen for chat, including a list of channels, threads, and messages.
@@ -263,12 +264,18 @@ public fun ChatsScreen(
         }
 
         LaunchedEffect(navigator.destinations) {
-            if (navigator.destinations.size > pagerDestinations.size) {
+            val diff = navigator.destinations.size - pagerDestinations.size
+            if (diff > 0) {
                 // When navigating forward, postpone the scroll to the last page until the new page is ready.
                 pagerDestinations = navigator.destinations
-            } else if (navigator.destinations.size < pagerDestinations.size) {
-                // When navigating back, scroll to the previous page before removing the last page.
-                pagerState.animateScrollToPage(pagerState.currentPage - 1)
+            } else if (diff < 0) {
+                if (abs(diff) > 1) {
+                    // When navigating back multiple pages, scroll directly to the new page then update destinations.
+                    pagerState.scrollToPage(pagerState.currentPage - 1)
+                } else {
+                    // When navigating back to the previous page, scroll then update destinations.
+                    pagerState.animateScrollToPage(pagerState.currentPage - 1)
+                }
                 pagerDestinations = navigator.destinations
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigator.kt
@@ -36,17 +36,25 @@ public class ThreePaneNavigator(
     private val _destinations = mutableStateListOf(*destinations.toTypedArray())
     internal val destinations: List<ThreePaneDestination<*>> get() = _destinations.toList()
 
-    internal val current: ThreePaneDestination<*> get() = _destinations.last()
-
     /**
      * Navigates to the provided [destination].
      *
      * @param destination The destination to navigate to.
+     * @param replace Whether to replace an existing destination with a new one of the same pane *(if it exists)*,
+     * or add it to the stack.
      * @param popUpTo The role of the pane to pop up to before navigating to the destination.
      */
-    public fun navigateTo(destination: ThreePaneDestination<*>, popUpTo: ThreePaneRole? = null) {
+    public fun navigateTo(
+        destination: ThreePaneDestination<*>,
+        replace: Boolean = false,
+        popUpTo: ThreePaneRole? = null,
+    ) {
         popUpTo?.let(::popUpTo)
-        _destinations.add(destination)
+        if (replace) {
+            replace(destination)
+        } else {
+            _destinations.add(destination)
+        }
     }
 
     /**
@@ -64,6 +72,23 @@ public class ThreePaneNavigator(
     internal fun popUpTo(pane: ThreePaneRole) {
         while (canNavigateBack() && _destinations[_destinations.lastIndex].pane != pane) {
             _destinations.removeAt(_destinations.lastIndex)
+        }
+    }
+
+    /**
+     * Replace an existing destination with a new one of the same pane *(if it exists)*.
+     */
+    private fun replace(destination: ThreePaneDestination<*>) {
+        val operator = { existing: ThreePaneDestination<*> ->
+            if (existing.pane == destination.pane) {
+                destination
+            } else {
+                existing
+            }
+        }
+        val iterator = _destinations.listIterator()
+        while (iterator.hasNext()) {
+            iterator.set(operator(iterator.next()))
         }
     }
 

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigatorTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/adaptivelayout/ThreePaneNavigatorTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.util.adaptivelayout
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+internal class ThreePaneNavigatorTest {
+
+    @Test
+    fun `navigate to destination`() {
+        val navigator = ThreePaneNavigator()
+        val destination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+
+        navigator.navigateTo(destination)
+
+        assertEquals(2, navigator.destinations.size)
+        assertEquals(destination, navigator.destinations.last())
+    }
+
+    @Test
+    fun `navigate to destination with replace`() {
+        val navigator = ThreePaneNavigator()
+        val initialDestination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+        val newDestination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+
+        navigator.navigateTo(initialDestination)
+        navigator.navigateTo(newDestination, replace = true)
+
+        assertEquals(2, navigator.destinations.size)
+        assertEquals(newDestination, navigator.destinations.last())
+    }
+
+    @Test
+    fun `navigate to destination with pop up`() {
+        val navigator = ThreePaneNavigator()
+        val detailDestination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+        val infoDestination = ThreePaneDestination<Any>(ThreePaneRole.Info)
+
+        navigator.navigateTo(detailDestination)
+        navigator.navigateTo(infoDestination)
+        navigator.navigateTo(detailDestination, popUpTo = ThreePaneRole.List)
+
+        assertEquals(2, navigator.destinations.size)
+        assertEquals(detailDestination, navigator.destinations.last())
+    }
+
+    @Test
+    fun `can navigate back`() {
+        val navigator = ThreePaneNavigator()
+
+        assertFalse(navigator.canNavigateBack())
+
+        val destination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+        navigator.navigateTo(destination)
+
+        assertTrue(navigator.canNavigateBack())
+    }
+
+    @Test
+    fun `navigate back`() {
+        val navigator = ThreePaneNavigator()
+        val destination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+
+        navigator.navigateTo(destination)
+        navigator.navigateBack()
+
+        assertEquals(1, navigator.destinations.size)
+        assertEquals(ThreePaneRole.List, navigator.destinations.last().pane)
+    }
+
+    @Test
+    fun `pop up to`() {
+        val navigator = ThreePaneNavigator()
+        val detailDestination = ThreePaneDestination<Any>(ThreePaneRole.Detail)
+        val infoDestination = ThreePaneDestination<Any>(ThreePaneRole.Info)
+
+        navigator.navigateTo(detailDestination)
+        navigator.navigateTo(infoDestination)
+        navigator.popUpTo(ThreePaneRole.List)
+
+        assertEquals(1, navigator.destinations.size)
+        assertEquals(ThreePaneRole.List, navigator.destinations.last().pane)
+    }
+}


### PR DESCRIPTION
### 🎯 Goal

Render pinned messages in the info pane of `ChatsScreen`

### 🛠 Implementation details

- Navigate to `PinnedMessagesScreen`
- Reuse `PinnedMessagesScreen` in `PinnedMessagesActivity`
- Add ripple effect to the `ChannelInfoOptionItem`
- Rename `ListContentMode` to `ChatListContentMode`

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Phone</th>
<th>Tablet</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/a49a5e02-313f-4819-a479-286cf4c5c887" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/7df5937f-f295-41b9-b0f6-36b441e8447d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Enable Adaptive layout in the Advanced options
- Follow the video steps on tablet devices

### 🎉 GIF

![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExeHlkemxueWo3NDNmZWUwdWVqeDZ6azNrdWpnaDZqN2E2Z3c4YWxwZyZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/PhTy277HOzgpeCtdoi/giphy.gif)
