### PR TITLE
[AND-406] Draft Messages on UI Components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - Enable pagination in `MentionListView`. [#5692](https://github.com/GetStream/stream-chat-android/pull/5692)
 
 ### ✅ Added
+- Add `ChatUI.draftMessagesEnabled` property to enable/disable Draft Messages. [#5687](https://github.com/GetStream/stream-chat-android/pull/5687)
 
 ### ⚠️ Changed
 - 🚨Breaking change: Move `MentionListViewModel` logic and its state to a shared component so they can be reused in Compose. [#5692](https://github.com/GetStream/stream-chat-android/pull/5692)
@@ -82,6 +83,8 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `MessagesViewModelFactory.isComposerDraftMessageEnabled` property to enable/disable Draft Messages within `MessageComposer`. [#5687](https://github.com/GetStream/stream-chat-android/pull/5687)
+- Add `ChannelViewModelFactory.isDraftMessageEnabled` property to enable/disable Draft Messages within `ChannelList`. [#5687](https://github.com/GetStream/stream-chat-android/pull/5687)
 
 ### ⚠️ Changed
 - `defaultMessageOptionsState()` now accepts an `isInThread` flag to show/hide the "Thread reply" option. [#5683](https://github.com/GetStream/stream-chat-android/pull/5683)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -1916,6 +1916,16 @@ internal constructor(
             }
     }
 
+    /**
+     * Create a new draft message.
+     * The call will be retried accordingly to [retryPolicy].
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param message The draft message to create.
+     *
+     * @return Executable async [Call] responsible for creating a draft message.
+     */
     @CheckResult
     public fun createDraftMessage(
         channelType: String,
@@ -1935,6 +1945,16 @@ internal constructor(
         }
     }
 
+    /**
+     * Delete a draft message.
+     * The call will be retried accordingly to [retryPolicy].
+     *
+     * @param channelType The channel type. ie messaging.
+     * @param channelId The channel id. ie 123.
+     * @param message The draft message to delete.
+     *
+     * @return Executable async [Call] responsible for deleting a draft message.
+     */
     @CheckResult
     public fun deleteDraftMessages(
         channelType: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -214,7 +214,7 @@ internal class DomainMapping(
             attachments = message.attachments?.map { it.toDomain() } ?: emptyList(),
             cid = channel_cid,
             id = message.id,
-            parentId = parent_message?.id,
+            parentId = parent_message?.id ?: parent_id,
             replyMessage = quoted_message?.toDomain(),
             showInChannel = message.show_in_channel,
             mentionedUsersIds = message.mentioned_users?.map { it.id } ?: emptyList(),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
@@ -107,6 +107,7 @@ internal data class DownstreamDraftDto(
     val message: DownstreamDraftMessageDto,
     val channel_cid: String,
     val quoted_message: DownstreamMessageDto? = null,
+    val parent_id: String? = null,
     val parent_message: DownstreamMessageDto? = null,
 )
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
@@ -101,6 +101,7 @@ class ChannelsActivity : BaseConnectedActivity() {
                 Filters.or(Filters.notExists(CHANNEL_ARG_DRAFT), Filters.eq(CHANNEL_ARG_DRAFT, false)),
             ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),
+            isDraftMessageEnabled = true,
         )
     }
     private val threadsViewModelFactory by lazy { ThreadsViewModelFactory() }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -110,6 +110,7 @@ class MessagesActivity : BaseConnectedActivity() {
             deletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
+            isComposerDraftMessageEnabled = true,
         )
     }
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -86,15 +86,17 @@ public abstract class io/getstream/chat/android/compose/state/channels/list/Item
 
 public final class io/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState : io/getstream/chat/android/compose/state/channels/list/ItemState {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;Lio/getstream/chat/android/models/DraftMessage;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;Lio/getstream/chat/android/models/DraftMessage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Channel;
 	public final fun component2 ()Z
 	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;Lio/getstream/chat/android/models/Channel;ZLjava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;
+	public final fun component4 ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun copy (Lio/getstream/chat/android/models/Channel;ZLjava/util/List;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;Lio/getstream/chat/android/models/Channel;ZLjava/util/List;Lio/getstream/chat/android/models/DraftMessage;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/channels/list/ItemState$ChannelItemState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
+	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
 	public fun getKey ()Ljava/lang/String;
 	public final fun getTypingUsers ()Ljava/util/List;
 	public fun hashCode ()I
@@ -3715,12 +3717,13 @@ public final class io/getstream/chat/android/compose/ui/util/MessageListUtilsKt 
 
 public abstract interface class io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter {
 	public static final field Companion Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter$Companion;
+	public abstract fun formatDraftMessagePreview (Lio/getstream/chat/android/models/DraftMessage;)Landroidx/compose/ui/text/AnnotatedString;
 	public abstract fun formatMessagePreview (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;)Landroidx/compose/ui/text/AnnotatedString;
 	public abstract fun formatMessageTitle (Lio/getstream/chat/android/models/Message;)Landroidx/compose/ui/text/AnnotatedString;
 }
 
 public final class io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter$Companion {
-	public final fun defaultFormatter (Landroid/content/Context;ZLio/getstream/chat/android/compose/ui/theme/StreamTypography;Ljava/util/List;)Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;
+	public final fun defaultFormatter (Landroid/content/Context;ZLio/getstream/chat/android/compose/ui/theme/StreamTypography;Ljava/util/List;Lio/getstream/chat/android/compose/ui/theme/StreamColors;)Lio/getstream/chat/android/compose/ui/util/MessagePreviewFormatter;
 }
 
 public abstract interface class io/getstream/chat/android/compose/ui/util/MessagePreviewIconFactory {
@@ -3911,8 +3914,8 @@ public final class io/getstream/chat/android/compose/util/KeyValuePair {
 
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;J)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;JILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;JZ)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;JZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun archiveChannel (Lio/getstream/chat/android/models/Channel;)V
 	public final fun deleteConversation (Lio/getstream/chat/android/models/Channel;)V
 	public final fun dismissChannelAction ()V
@@ -3944,8 +3947,8 @@ public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelL
 public final class io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Z)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/models/querysort/QuerySorter;Lio/getstream/chat/android/models/FilterObject;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 
@@ -4134,8 +4137,8 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageL
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZ)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZZ)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.compose.state.channels.list
 
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 
@@ -32,11 +33,13 @@ public sealed class ItemState {
      * @param channel The channel to show.
      * @param isMuted If the channel is muted for the current user.
      * @param typingUsers The list of users currently typing in the channel.
+     * @param draftMessage The draft message for the current user in the channel.
      */
     public data class ChannelItemState(
         val channel: Channel,
         val isMuted: Boolean = false,
         val typingUsers: List<User> = emptyList(),
+        val draftMessage: DraftMessage?,
     ) : ItemState() {
         override val key: String = channel.cid
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/channels/list/ItemState.kt
@@ -39,7 +39,7 @@ public sealed class ItemState {
         val channel: Channel,
         val isMuted: Boolean = false,
         val typingUsers: List<User> = emptyList(),
-        val draftMessage: DraftMessage?,
+        val draftMessage: DraftMessage? = null,
     ) : ItemState() {
         override val key: String = channel.cid
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -42,11 +42,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -42,7 +42,11 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -57,6 +61,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.getLastMessage
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.previewdata.PreviewChannelData
 import io.getstream.chat.android.previewdata.PreviewUserData
@@ -216,9 +221,13 @@ internal fun RowScope.DefaultChannelItemCenterContent(
         if (channelItemState.typingUsers.isNotEmpty()) {
             UserTypingIndicator(channelItemState.typingUsers)
         } else {
-            val lastMessageText = channelItemState.channel.getLastMessage(currentUser)?.let { lastMessage ->
-                ChatTheme.messagePreviewFormatter.formatMessagePreview(lastMessage, currentUser)
-            } ?: AnnotatedString("")
+            val lastMessageText =
+                channelItemState.draftMessage
+                    ?.let { ChatTheme.messagePreviewFormatter.formatDraftMessagePreview(it) }
+                    ?: channelItemState.channel.getLastMessage(currentUser)?.let { lastMessage ->
+                        ChatTheme.messagePreviewFormatter.formatMessagePreview(lastMessage, currentUser)
+                    }
+                    ?: AnnotatedString("")
 
             if (lastMessageText.isNotEmpty()) {
                 Text(
@@ -377,6 +386,7 @@ private fun ChannelItemPreview(
     channel: Channel,
     isMuted: Boolean = false,
     currentUser: User? = null,
+    draftMessage: DraftMessage? = null,
 ) {
     ChatPreviewTheme {
         ChannelItem(
@@ -384,6 +394,7 @@ private fun ChannelItemPreview(
                 channel = channel,
                 isMuted = isMuted,
                 typingUsers = emptyList(),
+                draftMessage = draftMessage,
             ),
             currentUser = currentUser,
             onChannelClick = {},

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelList.kt
@@ -51,6 +51,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.previewdata.PreviewChannelData
+import io.getstream.chat.android.previewdata.PreviewMessageData
 import io.getstream.chat.android.previewdata.PreviewUserData
 
 /**
@@ -379,22 +380,32 @@ private fun ChannelListForContentStatePreview() {
                 ItemState.ChannelItemState(
                     channel = PreviewChannelData.channelWithImage,
                     typingUsers = emptyList(),
+                    draftMessage = null,
                 ),
                 ItemState.ChannelItemState(
                     channel = PreviewChannelData.channelWithMessages,
                     typingUsers = emptyList(),
+                    draftMessage = null,
                 ),
                 ItemState.ChannelItemState(
                     channel = PreviewChannelData.channelWithFewMembers,
                     typingUsers = emptyList(),
+                    draftMessage = null,
                 ),
                 ItemState.ChannelItemState(
                     channel = PreviewChannelData.channelWithManyMembers,
                     typingUsers = emptyList(),
+                    draftMessage = null,
                 ),
                 ItemState.ChannelItemState(
                     channel = PreviewChannelData.channelWithOnlineUser,
                     typingUsers = emptyList(),
+                    draftMessage = null,
+                ),
+                ItemState.ChannelItemState(
+                    channel = PreviewChannelData.channelWithOnlineUser,
+                    typingUsers = emptyList(),
+                    draftMessage = PreviewMessageData.draftMessage,
                 ),
             ),
         ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatTheme.kt
@@ -331,6 +331,7 @@ public fun ChatTheme(
         typography = typography,
         attachmentFactories = attachmentFactories,
         autoTranslationEnabled = autoTranslationEnabled,
+        colors = colors,
     ),
     searchResultNameFormatter: SearchResultNameFormatter = SearchResultNameFormatter.defaultFormatter(),
     imageLoaderFactory: StreamCoilImageLoaderFactory = StreamCoilImageLoaderFactory.defaultFactory(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
@@ -30,8 +30,10 @@ import io.getstream.chat.android.client.utils.message.isPollClosed
 import io.getstream.chat.android.client.utils.message.isSystem
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
+import io.getstream.chat.android.compose.ui.theme.StreamColors
 import io.getstream.chat.android.compose.ui.theme.StreamTypography
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 
@@ -57,6 +59,15 @@ public interface MessagePreviewFormatter {
      */
     public fun formatMessagePreview(message: Message, currentUser: User?): AnnotatedString
 
+    /**
+     * Generates a preview text for the given draft message.
+     * This is used to show a preview of the draft message in the the channel list.
+     *
+     * @param draftMessage The draft message whose data is used to generate the preview text.
+     * @return The formatted text representation for the given draft message.
+     */
+    public fun formatDraftMessagePreview(draftMessage: DraftMessage): AnnotatedString
+
     public companion object {
         /**
          * Builds the default message preview text formatter.
@@ -74,10 +85,12 @@ public interface MessagePreviewFormatter {
             autoTranslationEnabled: Boolean,
             typography: StreamTypography,
             attachmentFactories: List<AttachmentFactory>,
+            colors: StreamColors,
         ): MessagePreviewFormatter {
             return DefaultMessagePreviewFormatter(
                 context = context,
                 autoTranslationEnabled = autoTranslationEnabled,
+                draftMessageLabelTextStyle = typography.footnoteBold.copy(color = colors.primaryAccent),
                 messageTextStyle = typography.bodyBold,
                 senderNameTextStyle = typography.bodyBold,
                 attachmentTextFontStyle = typography.bodyItalic,
@@ -96,6 +109,7 @@ public interface MessagePreviewFormatter {
 private class DefaultMessagePreviewFormatter(
     private val context: Context,
     private val autoTranslationEnabled: Boolean,
+    private val draftMessageLabelTextStyle: TextStyle,
     private val messageTextStyle: TextStyle,
     private val senderNameTextStyle: TextStyle,
     private val attachmentTextFontStyle: TextStyle,
@@ -187,6 +201,37 @@ private class DefaultMessagePreviewFormatter(
                         attachmentTextStyle = attachmentTextFontStyle,
                     )
                 }
+            }
+        }
+    }
+
+    /**
+     * Generates a preview text for the given draft message.
+     * This is used to show a preview of the draft message in the the channel list.
+     *
+     * @param draftMessage The draft message whose data is used to generate the preview text.
+     * @return The formatted text representation for the given draft message.
+     */
+    override fun formatDraftMessagePreview(draftMessage: DraftMessage): AnnotatedString {
+        return buildAnnotatedString {
+            withStyle(
+                    style = SpanStyle(
+                        fontStyle = draftMessageLabelTextStyle.fontStyle,
+                        fontFamily = draftMessageLabelTextStyle.fontFamily,
+                        color = draftMessageLabelTextStyle.color,
+                )
+            ) {
+                append(context.getString(R.string.stream_compose_channel_list_draft))
+            }
+            append(SPACE)
+            withStyle(
+                style = SpanStyle(
+                    fontStyle = messageTextStyle.fontStyle,
+                    fontFamily = messageTextStyle.fontFamily,
+                    color = messageTextStyle.color,
+                )
+            ) {
+                append(draftMessage.text)
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewFormatter.kt
@@ -106,6 +106,7 @@ public interface MessagePreviewFormatter {
  *
  * @param context The context to load string resources.
  */
+@Suppress("LongParameterList")
 private class DefaultMessagePreviewFormatter(
     private val context: Context,
     private val autoTranslationEnabled: Boolean,
@@ -212,27 +213,25 @@ private class DefaultMessagePreviewFormatter(
      * @param draftMessage The draft message whose data is used to generate the preview text.
      * @return The formatted text representation for the given draft message.
      */
-    override fun formatDraftMessagePreview(draftMessage: DraftMessage): AnnotatedString {
-        return buildAnnotatedString {
-            withStyle(
-                    style = SpanStyle(
-                        fontStyle = draftMessageLabelTextStyle.fontStyle,
-                        fontFamily = draftMessageLabelTextStyle.fontFamily,
-                        color = draftMessageLabelTextStyle.color,
-                )
-            ) {
-                append(context.getString(R.string.stream_compose_channel_list_draft))
-            }
-            append(SPACE)
-            withStyle(
-                style = SpanStyle(
-                    fontStyle = messageTextStyle.fontStyle,
-                    fontFamily = messageTextStyle.fontFamily,
-                    color = messageTextStyle.color,
-                )
-            ) {
-                append(draftMessage.text)
-            }
+    override fun formatDraftMessagePreview(draftMessage: DraftMessage): AnnotatedString = buildAnnotatedString {
+        withStyle(
+            style = SpanStyle(
+                fontStyle = draftMessageLabelTextStyle.fontStyle,
+                fontFamily = draftMessageLabelTextStyle.fontFamily,
+                color = draftMessageLabelTextStyle.color,
+            ),
+        ) {
+            append(context.getString(R.string.stream_compose_channel_list_draft))
+        }
+        append(SPACE)
+        withStyle(
+            style = SpanStyle(
+                fontStyle = messageTextStyle.fontStyle,
+                fontFamily = messageTextStyle.fontFamily,
+                color = messageTextStyle.color,
+            ),
+        ) {
+            append(draftMessage.text)
         }
     }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -46,6 +46,7 @@ public class ChannelViewModelFactory(
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
+    private val isDraftMessageEnabled: Boolean = true,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(
@@ -58,6 +59,7 @@ public class ChannelViewModelFactory(
                 messageLimit = messageLimit,
                 memberLimit = memberLimit,
                 chatEventHandlerFactory = chatEventHandlerFactory,
+                isDraftMessageEnabled = isDraftMessageEnabled,
             )
         },
     )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelViewModelFactory.kt
@@ -46,7 +46,7 @@ public class ChannelViewModelFactory(
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
-    private val isDraftMessageEnabled: Boolean = true,
+    private val isDraftMessageEnabled: Boolean = false,
 ) : ViewModelProvider.Factory {
 
     private val factories: Map<Class<*>, () -> ViewModel> = mapOf(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -106,7 +106,7 @@ public class MessagesViewModelFactory(
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
     private val isComposerLinkPreviewEnabled: Boolean = false,
-    private val isComposerDraftMessageEnabled: Boolean = true,
+    private val isComposerDraftMessageEnabled: Boolean = false,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -133,7 +133,7 @@ public class MessagesViewModelFactory(
                     config = MessageComposerController.Config(
                         maxAttachmentCount = maxAttachmentCount,
                         isLinkPreviewEnabled = isComposerLinkPreviewEnabled,
-                        isDraftMessageEnabled = isComposerDraftMessageEnabled
+                        isDraftMessageEnabled = isComposerDraftMessageEnabled,
                     ),
                 ),
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -106,7 +106,7 @@ public class MessagesViewModelFactory(
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
     private val isComposerLinkPreviewEnabled: Boolean = false,
-    private val isComposerDraftMessageEnabled: Boolean = false,
+    private val isComposerDraftMessageEnabled: Boolean = true,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessagesViewModelFactory.kt
@@ -73,6 +73,8 @@ import java.io.File
  * @param showThreadSeparatorInEmptyThread Configures if we show a thread separator when threads are empty.
  * Adds the separator item when the value is `true`.
  * @param threadLoadOlderToNewer Configures if the thread should load older messages to newer messages.
+ * @param isComposerLinkPreviewEnabled If the link preview is enabled in the composer.
+ * @param isComposerDraftMessageEnabled If the draft message is enabled in the composer.
  */
 public class MessagesViewModelFactory(
     private val context: Context,
@@ -104,6 +106,7 @@ public class MessagesViewModelFactory(
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
     private val isComposerLinkPreviewEnabled: Boolean = false,
+    private val isComposerDraftMessageEnabled: Boolean = false,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {
@@ -127,8 +130,11 @@ public class MessagesViewModelFactory(
                     userLookupHandler = userLookupHandler,
                     fileToUri = fileToUriConverter,
                     channelCid = channelId,
-                    maxAttachmentCount = maxAttachmentCount,
-                    isLinkPreviewEnabled = isComposerLinkPreviewEnabled,
+                    config = MessageComposerController.Config(
+                        maxAttachmentCount = maxAttachmentCount,
+                        isLinkPreviewEnabled = isComposerLinkPreviewEnabled,
+                        isDraftMessageEnabled = isComposerDraftMessageEnabled
+                    ),
                 ),
             )
         },

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="stream_compose_search_input_hint">Search channels by name</string>
 
     <!-- Channel List -->
+    <string name="stream_compose_channel_list_draft">Draft: </string>
     <string name="stream_compose_channel_list_you">You</string>
     <string name="stream_compose_channel_list_empty_channels">No channels available</string>
     <string name="stream_compose_channel_list_empty_search_results">No results for \"%1$s\"</string>

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -357,6 +357,7 @@ internal class ChannelListViewModelTest {
             whenever(chatClient.channel(any())) doReturn channelClient
             whenever(chatClient.channel(any(), any())) doReturn channelClient
             whenever(chatClient.clientState) doReturn clientState
+            whenever(globalState.channelDraftMessages) doReturn MutableStateFlow(emptyMap())
         }
 
         fun givenCurrentUser(currentUser: User = User(id = "Jc")) = apply {
@@ -417,6 +418,7 @@ internal class ChannelListViewModelTest {
                 chatClient = chatClient,
                 initialSort = initialSort,
                 initialFilters = initialFilters,
+                isDraftMessageEnabled = false,
                 chatEventHandlerFactory = ChatEventHandlerFactory(clientState),
             )
             testScope.advanceUntilIdle()

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -439,7 +439,10 @@ internal class MessageComposerViewModelTest {
                     mediaRecorder = mock(),
                     userLookupHandler = DefaultUserLookupHandler(chatClient, channelId),
                     fileToUri = { it.path },
-                    maxAttachmentCount = maxAttachmentCount,
+                    globalState = globalState,
+                    config = MessageComposerController.Config(
+                        maxAttachmentCount = maxAttachmentCount,
+                    ),
                     channelState = MutableStateFlow(channelState),
                 ),
             )

--- a/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/docusaurus/ChannelListUpdates.java
+++ b/stream-chat-android-docs/src/main/java/io/getstream/chat/docs/java/client/docusaurus/ChannelListUpdates.java
@@ -109,12 +109,14 @@ public class ChannelListUpdates {
         int limit = 30;
         int messageLimit = 1;
         int memberLimit = 30;
+        boolean isDraftMessagesEnabled = false;
         ChannelListViewModelFactory factory = new ChannelListViewModelFactory(
                 filter,
                 sort,
                 limit,
                 messageLimit,
                 memberLimit,
+                isDraftMessagesEnabled,
                 chatEventHandlerFactory
         );
     }

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.compose.ui.util.MessagePreviewFormatter
 import io.getstream.chat.android.compose.ui.util.MessageTextFormatter
 import io.getstream.chat.android.compose.ui.util.QuotedMessageTextFormatter
 import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.helper.DateFormatter
@@ -216,6 +217,13 @@ private object ChatThemeMessageTextFormatterDefaultSnippet : ChatThemeCustomizat
             override fun formatMessagePreview(message: Message, currentUser: User?): AnnotatedString {
                 return buildAnnotatedString {
                     append(message.text)
+                    // add your custom styling here
+                }
+            }
+
+            override fun formatDraftMessagePreview(draftMessage: DraftMessage): AnnotatedString {
+                return buildAnnotatedString {
+                    append(draftMessage.text)
                     // add your custom styling here
                 }
             }

--- a/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewMessageData.kt
+++ b/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewMessageData.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.previewdata
 
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageType
 import io.getstream.chat.android.models.Reaction
@@ -105,5 +106,11 @@ public object PreviewMessageData {
         createdAt = Date(),
         type = MessageType.REGULAR,
         mentionedUsers = listOf(PreviewUserData.user7),
+    )
+
+    public val draftMessage: DraftMessage = DraftMessage(
+        id = "draft-message",
+        cid = "channel-id",
+        text = "Some text for the draft message",
     )
 }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -951,6 +951,14 @@ public final class io/getstream/chat/android/ui/common/state/messages/MessageInp
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class io/getstream/chat/android/ui/common/state/messages/MessageInput$Source$DraftMessage : io/getstream/chat/android/ui/common/state/messages/MessageInput$Source$Internal {
+	public static final field $stable I
+	public static final field INSTANCE Lio/getstream/chat/android/ui/common/state/messages/MessageInput$Source$DraftMessage;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/common/state/messages/MessageInput$Source$Edit : io/getstream/chat/android/ui/common/state/messages/MessageInput$Source$Internal {
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/ui/common/state/messages/MessageInput$Source$Edit;

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -488,7 +488,7 @@ public class MessageComposerController(
     private suspend fun saveDraftMessage(messageMode: MessageMode) {
         if (!config.isDraftMessageEnabled) return
         when (val messageText = messageInput.value.text) {
-            "" -> clearDraftMessage()
+            "" -> clearDraftMessage(messageMode)
             else -> {
                 globalState.getDraftMessageOrEmpty(messageMode).let {
                     chatClient.createDraftMessage(
@@ -633,16 +633,16 @@ public class MessageComposerController(
      */
     public fun clearData() {
         logger.i { "[clearData]" }
-        scope.launch { clearDraftMessage() }
+        scope.launch { clearDraftMessage(messageMode.value) }
         messageInput.value = MessageInput()
         selectedAttachments.value = emptyList()
         validationErrors.value = emptyList()
         alsoSendToChannel.value = false
     }
 
-    private suspend fun clearDraftMessage() {
+    private suspend fun clearDraftMessage(messageMode: MessageMode) {
         if (!config.isDraftMessageEnabled) return
-        globalState.getDraftMessage(messageMode.value)?.let { draftMessage ->
+        globalState.getDraftMessage(messageMode)?.let { draftMessage ->
             chatClient.deleteDraftMessages(
                 channelType = channelType,
                 channelId = channelId,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -391,6 +391,7 @@ public class MessageComposerController(
      * Sets up the observing operations for various composer states.
      */
     @OptIn(FlowPreview::class)
+    @Suppress("LongMethod")
     private fun setupComposerState() {
         fetchDraftMessage(messageMode.value)
         messageInput.onEach { value ->

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -531,13 +531,6 @@ public class MessageComposerController(
 
     private fun fetchDraftMessage(messageMode: MessageMode) {
         if (!config.isDraftMessageEnabled) return
-        (messageMode as? MessageMode.MessageThread)?.let {
-            println("JcLog: parentId: ${it.parentMessage.id}")
-            globalState.threadDraftMessages.value.values.forEachIndexed { index, draftMessage ->
-                println("JcLog: #$index ${draftMessage.id} -> ${draftMessage.parentId}")
-            }
-            println("JcLog: draftMessage: ${globalState.threadDraftMessages.value[it.parentMessage.id]}")
-        }
         globalState.getDraftMessageOrEmpty(messageMode).let { draftMessage ->
             currentDraftId = draftMessage.id
             setMessageInputInternal(draftMessage.text, MessageInput.Source.DraftMessage)

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -507,6 +507,13 @@ public class MessageComposerController(
 
     private fun fetchDraftMessage(messageMode: MessageMode) {
         if (!config.isDraftMessageEnabled) return
+        (messageMode as? MessageMode.MessageThread)?.let {
+            println("JcLog: parentId: ${it.parentMessage.id}")
+            globalState.threadDraftMessages.value.values.forEachIndexed { index, draftMessage ->
+                println("JcLog: #$index ${draftMessage.id} -> ${draftMessage.parentId}")
+            }
+            println("JcLog: draftMessage: ${globalState.threadDraftMessages.value[it.parentMessage.id]}")
+        }
         globalState.getDraftMessageOrEmpty(messageMode).let { draftMessage ->
             setMessageInputInternal(draftMessage.text, MessageInput.Source.DraftMessage)
             setAlsoSendToChannel(draftMessage.showInChannel)

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -444,7 +444,7 @@ public class MessageComposerController(
 
         alsoSendToChannel.onEach { alsoSendToChannel ->
             state.value = state.value.copy(alsoSendToChannel = alsoSendToChannel)
-            currentDraftMessage.copy(showInChannel = alsoSendToChannel)
+            currentDraftMessage = currentDraftMessage.copy(showInChannel = alsoSendToChannel)
         }.launchIn(scope)
 
         ownCapabilities.onEach { ownCapabilities ->
@@ -484,6 +484,7 @@ public class MessageComposerController(
         currentDraftMessage = globalState.getDraftMessage(messageMode)
         setMessageInputInternal(currentDraftMessage.text, MessageInput.Source.DraftMessage)
         setAlsoSendToChannel(currentDraftMessage.showInChannel)
+        currentDraftMessage.replyMessage?.let { performMessageAction(Reply(it)) }
     }
 
     /**
@@ -522,6 +523,7 @@ public class MessageComposerController(
             }
             is Reply -> {
                 messageActions.value = (messageActions.value.filterNot { it is Reply } + messageAction).toSet()
+                currentDraftMessage = currentDraftMessage.copy(replyMessage = messageAction.message)
             }
             is Edit -> {
                 setMessageInputInternal(messageAction.message.text, MessageInput.Source.Edit)

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageInput.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/MessageInput.kt
@@ -51,5 +51,7 @@ public data class MessageInput(
          * The message was created internally by the SDK
          */
         public data object MentionSelected : Internal()
+
+        public data object DraftMessage : Internal()
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/MessageComposerState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/MessageComposerState.kt
@@ -19,7 +19,6 @@ package io.getstream.chat.android.ui.common.state.messages.composer
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.ChannelCapabilities
 import io.getstream.chat.android.models.Command
-import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.LinkPreview
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.state.messages.MessageAction

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/MessageComposerState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/MessageComposerState.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.ui.common.state.messages.composer
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.ChannelCapabilities
 import io.getstream.chat.android.models.Command
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.LinkPreview
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.state.messages.MessageAction

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTests.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.models.Command
 import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.state.global.GlobalState
 import io.getstream.chat.android.test.TestCoroutineExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -117,6 +118,7 @@ internal class MessageComposerControllerTests {
 
         private val clientState: ClientState = mock()
         private val channelState: ChannelState = mock()
+        private val globalState: GlobalState = mock()
 
         fun givenAppSettings(appSettings: AppSettings) = apply {
             whenever(chatClient.getAppSettings()) doReturn appSettings
@@ -154,6 +156,7 @@ internal class MessageComposerControllerTests {
                 mediaRecorder = mock(),
                 userLookupHandler = mock(),
                 fileToUri = mock(),
+                globalState = globalState,
             )
         }
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -113,7 +113,7 @@ class ChatInitializer(
         val messageTranslator = MessageTranslator(client::getCurrentUser, autoTranslationEnabled)
         ChatUI.autoTranslationEnabled = autoTranslationEnabled
         ChatUI.messageTextTransformer = MarkdownTextTransformer(context, messageTranslator)
-        ChatUI.draftMessageEnabled = true
+        ChatUI.draftMessagesEnabled = true
 
         TransformStyle.viewReactionsStyleTransformer = StyleTransformer { defaultStyle ->
             defaultStyle.copy(

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
@@ -113,6 +113,7 @@ class ChatInitializer(
         val messageTranslator = MessageTranslator(client::getCurrentUser, autoTranslationEnabled)
         ChatUI.autoTranslationEnabled = autoTranslationEnabled
         ChatUI.messageTextTransformer = MarkdownTextTransformer(context, messageTranslator)
+        ChatUI.draftMessageEnabled = true
 
         TransformStyle.viewReactionsStyleTransformer = StyleTransformer { defaultStyle ->
             defaultStyle.copy(

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -10,7 +10,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun getDecoratorProviderFactory ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/DecoratorProviderFactory;
 	public static final fun getDownloadAttachmentUriGenerator ()Lio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;
 	public static final fun getDownloadRequestInterceptor ()Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;
-	public static final fun getDraftMessageEnabled ()Z
+	public static final fun getDraftMessagesEnabled ()Z
 	public static final fun getFonts ()Lio/getstream/chat/android/ui/font/ChatFonts;
 	public static final fun getImageAssetTransformer ()Lio/getstream/chat/android/ui/common/helper/ImageAssetTransformer;
 	public static final fun getImageHeadersProvider ()Lio/getstream/chat/android/ui/common/helper/ImageHeadersProvider;
@@ -35,7 +35,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun setDecoratorProviderFactory (Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/DecoratorProviderFactory;)V
 	public static final fun setDownloadAttachmentUriGenerator (Lio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;)V
 	public static final fun setDownloadRequestInterceptor (Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;)V
-	public static final fun setDraftMessageEnabled (Z)V
+	public static final fun setDraftMessagesEnabled (Z)V
 	public static final fun setFonts (Lio/getstream/chat/android/ui/font/ChatFonts;)V
 	public static final fun setImageAssetTransformer (Lio/getstream/chat/android/ui/common/helper/ImageAssetTransformer;)V
 	public static final fun setImageHeadersProvider (Lio/getstream/chat/android/ui/common/helper/ImageHeadersProvider;)V
@@ -4397,7 +4397,7 @@ public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListVi
 	public final fun build ()Landroidx/lifecycle/ViewModelProvider$Factory;
 	public final fun chatEventHandlerFactory (Lio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun filter (Lio/getstream/chat/android/models/FilterObject;)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
-	public final fun isDraftMessageEnabled (Z)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
+	public final fun isDraftMessagesEnabled (Z)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun limit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun memberLimit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun messageLimit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -10,6 +10,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun getDecoratorProviderFactory ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/DecoratorProviderFactory;
 	public static final fun getDownloadAttachmentUriGenerator ()Lio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;
 	public static final fun getDownloadRequestInterceptor ()Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;
+	public static final fun getDraftMessageEnabled ()Z
 	public static final fun getFonts ()Lio/getstream/chat/android/ui/font/ChatFonts;
 	public static final fun getImageAssetTransformer ()Lio/getstream/chat/android/ui/common/helper/ImageAssetTransformer;
 	public static final fun getImageHeadersProvider ()Lio/getstream/chat/android/ui/common/helper/ImageHeadersProvider;
@@ -34,6 +35,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun setDecoratorProviderFactory (Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/DecoratorProviderFactory;)V
 	public static final fun setDownloadAttachmentUriGenerator (Lio/getstream/chat/android/ui/common/helper/DownloadAttachmentUriGenerator;)V
 	public static final fun setDownloadRequestInterceptor (Lio/getstream/chat/android/ui/common/helper/DownloadRequestInterceptor;)V
+	public static final fun setDraftMessageEnabled (Z)V
 	public static final fun setFonts (Lio/getstream/chat/android/ui/font/ChatFonts;)V
 	public static final fun setImageAssetTransformer (Lio/getstream/chat/android/ui/common/helper/ImageAssetTransformer;)V
 	public static final fun setImageHeadersProvider (Lio/getstream/chat/android/ui/common/helper/ImageHeadersProvider;)V
@@ -335,45 +337,47 @@ public final class io/getstream/chat/android/ui/feature/channels/list/ChannelLis
 }
 
 public final class io/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
-	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIF)V
+	public fun <init> (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIF)V
 	public final fun component1 ()Landroid/graphics/drawable/Drawable;
 	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component11 ()Landroid/graphics/drawable/Drawable;
+	public final fun component11 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component12 ()Landroid/graphics/drawable/Drawable;
 	public final fun component13 ()Landroid/graphics/drawable/Drawable;
-	public final fun component14 ()I
-	public final fun component15 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun component16 ()I
-	public final fun component17 ()Landroid/graphics/drawable/Drawable;
+	public final fun component14 ()Landroid/graphics/drawable/Drawable;
+	public final fun component15 ()I
+	public final fun component16 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component17 ()I
 	public final fun component18 ()Landroid/graphics/drawable/Drawable;
-	public final fun component19 ()I
+	public final fun component19 ()Landroid/graphics/drawable/Drawable;
 	public final fun component2 ()Landroid/graphics/drawable/Drawable;
 	public final fun component20 ()I
 	public final fun component21 ()I
-	public final fun component22 ()Ljava/lang/Integer;
-	public final fun component23 ()Z
+	public final fun component22 ()I
+	public final fun component23 ()Ljava/lang/Integer;
 	public final fun component24 ()Z
-	public final fun component25 ()I
+	public final fun component25 ()Z
 	public final fun component26 ()I
 	public final fun component27 ()I
 	public final fun component28 ()I
 	public final fun component29 ()I
 	public final fun component3 ()Z
-	public final fun component30 ()F
+	public final fun component30 ()I
+	public final fun component31 ()F
 	public final fun component4 ()Z
 	public final fun component5 ()Z
 	public final fun component6 ()I
 	public final fun component7 ()I
 	public final fun component8 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component9 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIF)Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIFILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;
+	public final fun copy (Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIF)Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ZZZIILio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;ILio/getstream/chat/android/ui/font/TextStyle;ILandroid/graphics/drawable/Drawable;Landroid/graphics/drawable/Drawable;IIILjava/lang/Integer;ZZIIIIIFILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundColor ()I
 	public final fun getBackgroundLayoutColor ()I
 	public final fun getChannelTitleText ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getDeleteEnabled ()Z
 	public final fun getDeleteIcon ()Landroid/graphics/drawable/Drawable;
+	public final fun getDraftMessageLabel ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getEdgeEffectColor ()Ljava/lang/Integer;
 	public final fun getEmptyStateView ()I
 	public final fun getForegroundLayoutColor ()I
@@ -407,13 +411,15 @@ public abstract class io/getstream/chat/android/ui/feature/channels/list/adapter
 }
 
 public final class io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem : io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem {
-	public fun <init> (Lio/getstream/chat/android/models/Channel;Ljava/util/List;)V
+	public fun <init> (Lio/getstream/chat/android/models/Channel;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Channel;
 	public final fun component2 ()Ljava/util/List;
-	public final fun copy (Lio/getstream/chat/android/models/Channel;Ljava/util/List;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/models/Channel;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
+	public final fun component3 ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun copy (Lio/getstream/chat/android/models/Channel;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;Lio/getstream/chat/android/models/Channel;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem$ChannelItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
+	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun getTypingUsers ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -431,7 +437,7 @@ public final class io/getstream/chat/android/ui/feature/channels/list/adapter/Ch
 }
 
 public final class io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff {
-	public fun <init> (ZZZZZZZZ)V
+	public fun <init> (ZZZZZZZZZ)V
 	public final fun component1 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
@@ -440,10 +446,12 @@ public final class io/getstream/chat/android/ui/feature/channels/list/adapter/Ch
 	public final fun component6 ()Z
 	public final fun component7 ()Z
 	public final fun component8 ()Z
-	public final fun copy (ZZZZZZZZ)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;ZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
+	public final fun component9 ()Z
+	public final fun copy (ZZZZZZZZZ)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;ZZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAvatarViewChanged ()Z
+	public final fun getDraftMessageChanged ()Z
 	public final fun getExtraDataChanged ()Z
 	public final fun getLastMessageChanged ()Z
 	public final fun getNameChanged ()Z
@@ -4275,10 +4283,10 @@ public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListHe
 public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel : androidx/lifecycle/ViewModel {
 	public static final field Companion Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel$Companion;
 	public static final field DEFAULT_SORT Lio/getstream/chat/android/models/querysort/QuerySorter;
-	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/state/plugin/state/global/GlobalState;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/state/plugin/state/global/GlobalState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIIZLio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/state/plugin/state/global/GlobalState;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIIZLio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/state/plugin/state/global/GlobalState;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun deleteChannel (Lio/getstream/chat/android/models/Channel;)V
+	public final fun getDraftMessages ()Landroidx/lifecycle/LiveData;
 	public final fun getErrorEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getPaginationState ()Landroidx/lifecycle/LiveData;
 	public final fun getState ()Landroidx/lifecycle/LiveData;
@@ -4378,8 +4386,9 @@ public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListVi
 	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;I)V
 	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;II)V
 	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;III)V
-	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIILio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIIZ)V
+	public fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIIZLio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;IIIZLio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 
@@ -4388,6 +4397,7 @@ public final class io/getstream/chat/android/ui/viewmodel/channels/ChannelListVi
 	public final fun build ()Landroidx/lifecycle/ViewModelProvider$Factory;
 	public final fun chatEventHandlerFactory (Lio/getstream/chat/android/state/event/handler/chat/factory/ChatEventHandlerFactory;)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun filter (Lio/getstream/chat/android/models/FilterObject;)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
+	public final fun isDraftMessageEnabled (Z)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun limit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun memberLimit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
 	public final fun messageLimit (I)Lio/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory$Builder;
@@ -5028,7 +5038,8 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;Z)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZ)V
 	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZ)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZ)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;IZIZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -199,7 +199,7 @@ public object ChatUI {
      * Whether draft messages are enabled.
      */
     @JvmStatic
-    public var draftMessageEnabled: Boolean = false
+    public var draftMessagesEnabled: Boolean = false
 
     /**
      * Sets the strategy for resizing images hosted on Stream's CDN. Disabled by default,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -196,6 +196,12 @@ public object ChatUI {
     public var videoThumbnailsEnabled: Boolean = true
 
     /**
+     * Whether draft messages are enabled.
+     */
+    @JvmStatic
+    public var draftMessageEnabled: Boolean = false
+
+    /**
      * Sets the strategy for resizing images hosted on Stream's CDN. Disabled by default,
      * set [StreamCdnImageResizing.imageResizingEnabled] to true if you wish to enable resizing images. Note that
      * resizing applies only to images hosted on Stream's CDN which contain the original width (ow) and height (oh)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/ChannelListViewStyle.kt
@@ -79,6 +79,7 @@ public data class ChannelListViewStyle(
     @ColorInt public val backgroundColor: Int,
     @ColorInt public val backgroundLayoutColor: Int,
     public val channelTitleText: TextStyle,
+    public val draftMessageLabel: TextStyle,
     public val lastMessageText: TextStyle,
     public val lastMessageDateText: TextStyle,
     public val indicatorSentIcon: Drawable,
@@ -174,6 +175,25 @@ public data class ChannelListViewStyle(
                     .color(
                         R.styleable.ChannelListView_streamUiLastMessageTextColor,
                         context.getColorCompat(R.color.stream_ui_text_color_secondary),
+                    )
+                    .font(
+                        R.styleable.ChannelListView_streamUiLastMessageFontAssets,
+                        R.styleable.ChannelListView_streamUiLastMessageTextFont,
+                    )
+                    .style(
+                        R.styleable.ChannelListView_streamUiLastMessageTextStyle,
+                        Typeface.NORMAL,
+                    )
+                    .build()
+
+                val draftMessageLabel = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.ChannelListView_streamUiLastMessageTextSize,
+                        context.getDimension(R.dimen.stream_ui_channel_item_message),
+                    )
+                    .color(
+                        R.styleable.ChannelListView_streamUiDraftMessageLabelTextColor,
+                        context.getColorCompat(R.color.stream_ui_accent_blue),
                     )
                     .font(
                         R.styleable.ChannelListView_streamUiLastMessageFontAssets,
@@ -315,6 +335,7 @@ public data class ChannelListViewStyle(
                     backgroundColor = backgroundColor,
                     backgroundLayoutColor = backgroundLayoutColor,
                     channelTitleText = channelTitleText,
+                    draftMessageLabel = draftMessageLabel,
                     lastMessageText = lastMessageText,
                     lastMessageDateText = lastMessageDateText,
                     indicatorSentIcon = indicatorSentIcon,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListItem.kt
@@ -17,10 +17,15 @@
 package io.getstream.chat.android.ui.feature.channels.list.adapter
 
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.User
 
 public sealed class ChannelListItem {
-    public data class ChannelItem(val channel: Channel, val typingUsers: List<User>) : ChannelListItem()
+    public data class ChannelItem(
+        val channel: Channel,
+        val typingUsers: List<User>,
+        val draftMessage: DraftMessage?,
+    ) : ChannelListItem()
     public object LoadingMoreItem : ChannelListItem() {
         override fun toString(): String = "LoadingMoreItem"
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/ChannelListPayloadDiff.kt
@@ -25,6 +25,7 @@ public data class ChannelListPayloadDiff(
     val unreadCountChanged: Boolean,
     val extraDataChanged: Boolean,
     val typingUsersChanged: Boolean,
+    val draftMessageChanged: Boolean,
 ) {
     public fun hasDifference(): Boolean =
         nameChanged
@@ -35,6 +36,7 @@ public data class ChannelListPayloadDiff(
             .or(unreadCountChanged)
             .or(extraDataChanged)
             .or(typingUsersChanged)
+            .or(draftMessageChanged)
 
     public operator fun plus(other: ChannelListPayloadDiff): ChannelListPayloadDiff =
         copy(
@@ -46,5 +48,6 @@ public data class ChannelListPayloadDiff(
             unreadCountChanged = unreadCountChanged || other.unreadCountChanged,
             extraDataChanged = extraDataChanged || other.extraDataChanged,
             typingUsersChanged = typingUsersChanged || other.typingUsersChanged,
+            draftMessageChanged = draftMessageChanged || other.draftMessageChanged,
         )
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemAdapter.kt
@@ -76,6 +76,7 @@ internal class ChannelListItemAdapter(
             unreadCountChanged = true,
             extraDataChanged = true,
             typingUsersChanged = true,
+            draftMessageChanged = true,
         )
 
         val EMPTY_CHANNEL_LIST_ITEM_PAYLOAD_DIFF: ChannelListPayloadDiff = ChannelListPayloadDiff(
@@ -87,6 +88,7 @@ internal class ChannelListItemAdapter(
             unreadCountChanged = false,
             extraDataChanged = false,
             typingUsersChanged = false,
+            draftMessageChanged = false,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/internal/ChannelListItemDiffCallback.kt
@@ -71,6 +71,7 @@ internal object ChannelListItemDiffCallback : DiffUtil.ItemCallback<ChannelListI
             unreadCountChanged = channel.currentUserUnreadCount() != other.channel.currentUserUnreadCount(),
             extraDataChanged = channel.extraData != other.channel.extraData,
             typingUsersChanged = typingUsers != other.typingUsers,
+            draftMessageChanged = draftMessage != other.draftMessage,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -27,6 +27,7 @@ import androidx.core.view.updateLayoutParams
 import io.getstream.chat.android.client.extensions.currentUserUnreadCount
 import io.getstream.chat.android.client.extensions.isAnonymousChannel
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
@@ -224,17 +225,23 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         binding.itemForegroundView.apply {
             diff.run {
                 val lastMessage = channelItem.channel.getLastMessage()
-                val anonymousNameChanged = channelItem.channel.isAnonymousChannel() && diff.usersChanged
-                if (nameChanged || typingUsersChanged || lastMessageChanged || anonymousNameChanged) {
-                    configureChannelNameLabel(lastMessage, channelItem.typingUsers)
+                if (channelNameLabelChanged(channelItem.channel.isAnonymousChannel())) {
+                    configureChannelNameLabel(lastMessage, channelItem)
                 }
 
                 if (avatarViewChanged) {
                     configureAvatarView()
                 }
-                if (lastMessageChanged || typingUsersChanged) {
-                    lastMessageLabel.isVisible = channelItem.typingUsers.isEmpty() && lastMessage.isNotNull()
-                    configureLastMessageLabelAndTimestamp(lastMessage)
+                if (lastMessageChanged || typingUsersChanged || draftMessageChanged) {
+                    lastMessageLabel.isVisible =
+                        channelItem.typingUsers.isEmpty()
+                            .and(
+                                lastMessage.isNotNull()
+                                    .or(channelItem.draftMessage.isNotNull())
+                            )
+                    draftMessageLabel.isVisible = channelItem.draftMessage.isNotNull()
+                        .and(channelItem.typingUsers.isEmpty())
+                    configureLastMessageLabelAndTimestamp(lastMessage, channelItem.draftMessage)
                     typingIndicatorView.setTypingUsers(channelItem.typingUsers)
                 }
 
@@ -251,16 +258,23 @@ internal class ChannelViewHolder @JvmOverloads constructor(
         }
     }
 
+    private fun ChannelListPayloadDiff.channelNameLabelChanged(isAnonymousChannel: Boolean): Boolean =
+        nameChanged
+            .or(typingUsersChanged)
+            .or(lastMessageChanged)
+            .or(usersChanged.and(isAnonymousChannel))
+            .or(draftMessageChanged)
+
     private fun StreamUiChannelListItemForegroundViewBinding.configureChannelNameLabel(
         lastMessage: Message?,
-        typingUsers: List<User>,
+        channelItem: ChannelListItem.ChannelItem,
     ) {
         channelNameLabel.text = ChatUI.channelNameFormatter.formatChannelName(
             channel = channel,
             currentUser = ChatUI.currentUserProvider.getCurrentUser(),
         )
 
-        if (lastMessage != null || typingUsers.isNotEmpty()) {
+        if (lastMessage != null || channelItem.typingUsers.isNotEmpty() || channelItem.draftMessage != null) {
             channelNameLabel.translationY = 0f
         } else if (channelNameLabel.height > 0) {
             channelNameLabel.translationY = yDiffBetweenCenters(channelNameLabel, foregroundView)
@@ -277,20 +291,24 @@ internal class ChannelViewHolder @JvmOverloads constructor(
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureLastMessageLabelAndTimestamp(
         lastMessage: Message?,
+        draftMessage: DraftMessage?,
     ) {
-        lastMessageTimeLabel.isVisible = lastMessage.isNotNull()
-
-        lastMessage ?: return run {
-            lastMessageLabel.text = ""
-            lastMessageTimeLabel.text = ""
-        }
-
-        lastMessageLabel.text = ChatUI.messagePreviewFormatter.formatMessagePreview(
-            channel = channel,
-            message = lastMessage,
-            currentUser = ChatUI.currentUserProvider.getCurrentUser(),
-        )
-        lastMessageTimeLabel.text = ChatUI.dateFormatter.formatDate(channel.lastMessageAt)
+        lastMessageTimeLabel.isVisible = lastMessage.isNotNull().and(draftMessage == null)
+        lastMessageTimeLabel.text =
+            lastMessage
+                ?.takeUnless { draftMessage != null }
+                ?.let { ChatUI.dateFormatter.formatDate(channel.lastMessageAt) }
+                ?: ""
+        lastMessageLabel.text =
+            draftMessage?.text
+                ?: lastMessage?.let {
+                    ChatUI.messagePreviewFormatter.formatMessagePreview(
+                        channel = channel,
+                        message = it,
+                        currentUser = ChatUI.currentUserProvider.getCurrentUser(),
+                    )
+                }
+                ?: ""
     }
 
     private fun StreamUiChannelListItemForegroundViewBinding.configureUnreadCountBadge() {
@@ -369,6 +387,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
             height = style.itemHeight
         }
         channelNameLabel.setTextStyle(style.channelTitleText)
+        draftMessageLabel.setTextStyle(style.draftMessageLabel)
         lastMessageLabel.setTextStyle(style.lastMessageText)
         lastMessageTimeLabel.setTextStyle(style.lastMessageDateText)
         unreadCountBadge.setTextStyle(style.unreadMessageCounterText)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/channels/list/adapter/viewholder/internal/ChannelViewHolder.kt
@@ -30,7 +30,6 @@ import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SyncStatus
-import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.extensions.internal.context
@@ -237,7 +236,7 @@ internal class ChannelViewHolder @JvmOverloads constructor(
                         channelItem.typingUsers.isEmpty()
                             .and(
                                 lastMessage.isNotNull()
-                                    .or(channelItem.draftMessage.isNotNull())
+                                    .or(channelItem.draftMessage.isNotNull()),
                             )
                     draftMessageLabel.isVisible = channelItem.draftMessage.isNotNull()
                         .and(channelItem.typingUsers.isEmpty())

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel.kt
@@ -73,6 +73,7 @@ import kotlinx.coroutines.launch
  * @param limit The maximum number of channels to fetch.
  * @param messageLimit The number of messages to fetch for each channel.
  * @param memberLimit The number of members to fetch per channel.
+ * @param isDraftMessagesEnabled Enables or disables draft messages.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] that will be used to create [ChatEventHandler].
  * @param chatClient Entry point for all low-level operations.
  * @param globalState Global state of OfflinePlugin. Contains information
@@ -84,7 +85,7 @@ public class ChannelListViewModel(
     private val limit: Int = 30,
     private val messageLimit: Int = 1,
     private val memberLimit: Int = 30,
-    private val isDraftMessageEnabled: Boolean,
+    private val isDraftMessagesEnabled: Boolean,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(),
     private val chatClient: ChatClient = ChatClient.instance(),
     private val globalState: GlobalState = chatClient.globalState,
@@ -111,9 +112,12 @@ public class ChannelListViewModel(
     public val typingEvents: LiveData<Map<String, TypingEvent>>
         get() = globalState.typingChannels.asLiveData()
 
+    /**
+     * Draft messages for channels.
+     */
     public val draftMessages: LiveData<Map<String, DraftMessage>>
         get() = globalState.channelDraftMessages
-            .takeIf { isDraftMessageEnabled }
+            .takeIf { isDraftMessagesEnabled }
             ?.asLiveData()
             ?: MutableLiveData(emptyMap())
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModel.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.client.errors.extractCause
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelMute
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.FilterObject
 import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.TypingEvent
@@ -83,6 +84,7 @@ public class ChannelListViewModel(
     private val limit: Int = 30,
     private val messageLimit: Int = 1,
     private val memberLimit: Int = 30,
+    private val isDraftMessageEnabled: Boolean,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(),
     private val chatClient: ChatClient = ChatClient.instance(),
     private val globalState: GlobalState = chatClient.globalState,
@@ -108,6 +110,12 @@ public class ChannelListViewModel(
      */
     public val typingEvents: LiveData<Map<String, TypingEvent>>
         get() = globalState.typingChannels.asLiveData()
+
+    public val draftMessages: LiveData<Map<String, DraftMessage>>
+        get() = globalState.channelDraftMessages
+            .takeIf { isDraftMessageEnabled }
+            ?.asLiveData()
+            ?: MutableLiveData(emptyMap())
 
     /**
      * Represents the current pagination state that is a product

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelBinding.kt
@@ -22,15 +22,10 @@ import android.app.AlertDialog
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.MediatorLiveData
 import androidx.lifecycle.distinctUntilChanged
-import io.getstream.chat.android.models.DraftMessage
-import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.state.utils.EventObserver
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.feature.channels.list.ChannelListView
 import io.getstream.chat.android.ui.feature.channels.list.adapter.ChannelListItem
-import io.getstream.chat.android.ui.utils.extensions.combineWith
-import io.getstream.chat.android.ui.viewmodel.channels.ChannelListViewModel.PaginationState
-import io.getstream.chat.android.ui.viewmodel.channels.ChannelListViewModel.State
 import io.getstream.chat.android.ui.viewmodel.channels.internal.ChannelListBindingData
 
 /**
@@ -41,6 +36,7 @@ import io.getstream.chat.android.ui.viewmodel.channels.internal.ChannelListBindi
  * before setting any additional listeners on these objects yourself.
  */
 @JvmName("bind")
+@Suppress("LongMethod")
 public fun ChannelListViewModel.bindView(
     view: ChannelListView,
     lifecycleOwner: LifecycleOwner,
@@ -68,7 +64,8 @@ public fun ChannelListViewModel.bindView(
                     ChannelListItem.ChannelItem(
                         channel = channel,
                         typingUsers = typingEvents[channel.cid]?.users ?: emptyList(),
-                        draftMessage = draftMessages[channel.cid])
+                        draftMessage = draftMessages[channel.cid],
+                    )
                 } + listOfNotNull(ChannelListItem.LoadingMoreItem.takeIf { paginationState.loadingMore })
 
                 when {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.ui.ChatUI
  * @param limit How many channels to return.
  * @param memberLimit The number of members per channel.
  * @param messageLimit The number of messages to fetch for each channel.
+ * @param isDraftMessagesEnabled Enables or disables draft messages.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] that will be used to create [ChatEventHandler].
  *
  * @see Filters
@@ -44,7 +45,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
     private val limit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
-    private val isDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled,
+    private val isDraftMessagesEnabled: Boolean = ChatUI.draftMessagesEnabled,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(),
 ) : ViewModelProvider.Factory {
 
@@ -64,7 +65,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
             messageLimit = messageLimit,
             memberLimit = memberLimit,
             chatEventHandlerFactory = chatEventHandlerFactory,
-            isDraftMessageEnabled = isDraftMessageEnabled,
+            isDraftMessagesEnabled = isDraftMessagesEnabled,
         ) as T
     }
 
@@ -79,7 +80,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         private var messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT
         private var memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT
         private var chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory()
-        private var isDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled
+        private var isDraftMessagesEnabled: Boolean = ChatUI.draftMessagesEnabled
 
         /**
          * Sets the way to filter the channels.
@@ -126,8 +127,8 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         /**
          * Enables or disables draft messages.
          */
-        public fun isDraftMessageEnabled(isDraftMessageEnabled: Boolean): Builder = apply {
-            this.isDraftMessageEnabled = isDraftMessageEnabled
+        public fun isDraftMessagesEnabled(isDraftMessagesEnabled: Boolean): Builder = apply {
+            this.isDraftMessagesEnabled = isDraftMessagesEnabled
         }
 
         /**
@@ -141,7 +142,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
                 messageLimit = messageLimit,
                 memberLimit = memberLimit,
                 chatEventHandlerFactory = chatEventHandlerFactory,
-                isDraftMessageEnabled = isDraftMessageEnabled,
+                isDraftMessagesEnabled = isDraftMessagesEnabled,
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/ChannelListViewModelFactory.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.models.FilterObject
 import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.state.event.handler.chat.factory.ChatEventHandlerFactory
+import io.getstream.chat.android.ui.ChatUI
 
 /**
  * Creates a channels view model factory.
@@ -43,6 +44,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
     private val limit: Int = ChannelListViewModel.DEFAULT_CHANNEL_LIMIT,
     private val messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT,
     private val memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT,
+    private val isDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(),
 ) : ViewModelProvider.Factory {
 
@@ -62,6 +64,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
             messageLimit = messageLimit,
             memberLimit = memberLimit,
             chatEventHandlerFactory = chatEventHandlerFactory,
+            isDraftMessageEnabled = isDraftMessageEnabled,
         ) as T
     }
 
@@ -76,6 +79,7 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         private var messageLimit: Int = ChannelListViewModel.DEFAULT_MESSAGE_LIMIT
         private var memberLimit: Int = ChannelListViewModel.DEFAULT_MEMBER_LIMIT
         private var chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory()
+        private var isDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled
 
         /**
          * Sets the way to filter the channels.
@@ -120,6 +124,13 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
         }
 
         /**
+         * Enables or disables draft messages.
+         */
+        public fun isDraftMessageEnabled(isDraftMessageEnabled: Boolean): Builder = apply {
+            this.isDraftMessageEnabled = isDraftMessageEnabled
+        }
+
+        /**
          * Builds [ChannelListViewModelFactory] instance.
          */
         public fun build(): ViewModelProvider.Factory {
@@ -129,7 +140,8 @@ public class ChannelListViewModelFactory @JvmOverloads constructor(
                 limit = limit,
                 messageLimit = messageLimit,
                 memberLimit = memberLimit,
-                chatEventHandlerFactory,
+                chatEventHandlerFactory = chatEventHandlerFactory,
+                isDraftMessageEnabled = isDraftMessageEnabled,
             )
         }
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/internal/ChannelListBindingData.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/internal/ChannelListBindingData.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.ui.viewmodel.channels.internal
 
 import io.getstream.chat.android.models.DraftMessage
@@ -5,8 +21,8 @@ import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.ui.viewmodel.channels.ChannelListViewModel
 
 internal data class ChannelListBindingData(
-        val state: ChannelListViewModel.State = ChannelListViewModel.State(false, emptyList()),
-        val paginationState: ChannelListViewModel.PaginationState = ChannelListViewModel.PaginationState(),
-        val typingEvents: Map<String, TypingEvent> = emptyMap(),
-        val draftMessages: Map<String, DraftMessage> = emptyMap(),
-    )
+    val state: ChannelListViewModel.State = ChannelListViewModel.State(false, emptyList()),
+    val paginationState: ChannelListViewModel.PaginationState = ChannelListViewModel.PaginationState(),
+    val typingEvents: Map<String, TypingEvent> = emptyMap(),
+    val draftMessages: Map<String, DraftMessage> = emptyMap(),
+)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/internal/ChannelListBindingData.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channels/internal/ChannelListBindingData.kt
@@ -1,0 +1,12 @@
+package io.getstream.chat.android.ui.viewmodel.channels.internal
+
+import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.TypingEvent
+import io.getstream.chat.android.ui.viewmodel.channels.ChannelListViewModel
+
+internal data class ChannelListBindingData(
+        val state: ChannelListViewModel.State = ChannelListViewModel.State(false, emptyList()),
+        val paginationState: ChannelListViewModel.PaginationState = ChannelListViewModel.PaginationState(),
+        val typingEvents: Map<String, TypingEvent> = emptyMap(),
+        val draftMessages: Map<String, DraftMessage> = emptyMap(),
+    )

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
@@ -94,6 +94,7 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
     private val showDateSeparatorInEmptyThread: Boolean = false,
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
+    private val isComposerDraftMessageEnabled: Boolean = false,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {
@@ -138,9 +139,12 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
                     chatClient = chatClient,
                     mediaRecorder = mediaRecorder,
                     userLookupHandler = userLookupHandler,
-                    maxAttachmentCount = maxAttachmentCount,
                     fileToUri = fileToUri,
                     channelState = channelStateFlow,
+                    config = MessageComposerController.Config(
+                        maxAttachmentCount = maxAttachmentCount,
+                        isDraftMessageEnabled = isComposerDraftMessageEnabled,
+                    ),
                 ),
             )
         },

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.client.setup.state.ClientState
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.state.extensions.watchChannelAsState
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.common.feature.messages.composer.MessageComposerController
 import io.getstream.chat.android.ui.common.feature.messages.composer.mention.CompatUserLookupHandler
 import io.getstream.chat.android.ui.common.feature.messages.composer.mention.DefaultUserLookupHandler
@@ -94,7 +95,7 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
     private val showDateSeparatorInEmptyThread: Boolean = false,
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
-    private val isComposerDraftMessageEnabled: Boolean = false,
+    private val isComposerDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelFactory.kt
@@ -67,6 +67,7 @@ import java.io.File
  * @param showThreadSeparatorInEmptyThread Configures if we show a thread separator when threads are empty.
  * Adds the separator item when the value is `true`.
  * @param threadLoadOlderToNewer Configures if the thread should be loaded from older to newer messages.
+ * @param isComposerDraftMessagesEnabled Configures if the composer should support draft messages.
  *
  * @see MessageListHeaderViewModel
  * @see MessageListViewModel
@@ -95,7 +96,7 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
     private val showDateSeparatorInEmptyThread: Boolean = false,
     private val showThreadSeparatorInEmptyThread: Boolean = false,
     private val threadLoadOlderToNewer: Boolean = false,
-    private val isComposerDraftMessageEnabled: Boolean = ChatUI.draftMessageEnabled,
+    private val isComposerDraftMessagesEnabled: Boolean = ChatUI.draftMessagesEnabled,
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {
@@ -144,7 +145,7 @@ public class MessageListViewModelFactory @JvmOverloads constructor(
                     channelState = channelStateFlow,
                     config = MessageComposerController.Config(
                         maxAttachmentCount = maxAttachmentCount,
-                        isDraftMessageEnabled = isComposerDraftMessageEnabled,
+                        isDraftMessageEnabled = isComposerDraftMessagesEnabled,
                     ),
                 ),
             )

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_channel_list_item_foreground_view.xml
@@ -75,6 +75,19 @@
         />
 
     <TextView
+        android:id="@+id/draftMessageLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="@dimen/stream_ui_spacing_tiny"
+        android:text="@string/stream_ui_channel_list_draft_message_label"
+        android:textAppearance="@style/StreamUiTextAppearance.Footnote"
+        android:textDirection="locale"
+        app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
+        app:layout_constraintEnd_toStartOf="@+id/lastMessageLabel"
+        app:layout_constraintTop_toBottomOf="@+id/spacer"
+        />
+
+    <TextView
         android:id="@+id/lastMessageLabel"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
@@ -83,7 +96,7 @@
         android:maxLines="1"
         android:textAppearance="@style/StreamUiTextAppearance.Footnote"
         android:textDirection="locale"
-        app:layout_constraintStart_toStartOf="@+id/channelNameLabel"
+        app:layout_constraintStart_toEndOf="@+id/draftMessageLabel"
         app:layout_constraintEnd_toStartOf="@+id/messageStatusImageView"
         app:layout_constraintTop_toBottomOf="@+id/spacer"
         tools:text="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Phasellus a."

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_channel_list_view.xml
@@ -57,6 +57,8 @@
         <attr name="streamUiLastMessageTextSize" format="dimension|reference" />
         <!-- A color of the last message text -->
         <attr name="streamUiLastMessageTextColor" format="color|reference" />
+        <!-- A color of the draft message label text -->
+        <attr name="streamUiDraftMessageLabelTextColor" format="color|reference" />
         <!-- Font name of the last message text -->
         <attr name="streamUiLastMessageTextFont" format="reference" />
         <!-- Font assets reference for the last message text -->

--- a/stream-chat-android-ui-components/src/main/res/values/strings_channel_list.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings_channel_list.xml
@@ -37,4 +37,5 @@
     <string name="stream_ui_channel_list_error_hide_channel">Failed to hide channel</string>
     <string name="stream_ui_channel_list_error_delete_channel">Failed to delete channel</string>
     <string name="stream_ui_channel_list_error_leave_channel">Failed to leave channel</string>
+    <string name="stream_ui_channel_list_draft_message_label">Draft:</string>
 </resources>

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/channels/ChannelListViewModelTest.kt
@@ -311,6 +311,7 @@ internal class ChannelListViewModelTest {
                 chatClient = chatClient,
                 sort = initialSort,
                 filter = initialFilters,
+                isDraftMessagesEnabled = false,
                 chatEventHandlerFactory = ChatEventHandlerFactory(
                     clientState = clientState,
                 ),

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageComposerViewModelTest.kt
@@ -439,7 +439,10 @@ internal class MessageComposerViewModelTest {
                     mediaRecorder = mock(),
                     userLookupHandler = DefaultUserLookupHandler(chatClient, channelId),
                     fileToUri = { it.path },
-                    maxAttachmentCount = maxAttachmentCount,
+                    globalState = globalState,
+                    config = MessageComposerController.Config(
+                        maxAttachmentCount = maxAttachmentCount,
+                    ),
                     channelState = MutableStateFlow(channelState),
                 ),
             )


### PR DESCRIPTION
### 🎯 Goal
Depend on: #5682

With this implementation show draft messages within the list of channels and message composer.









### 🎨 UI Changes

<table>
<thead>
<tr>
<th>XML</th>
<th>Compose</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/e41116d1-ba2b-4c54-acb3-e12a9158cf6d" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/b0410bc8-a5c9-4077-9a4d-0cef719493bb" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

To test it you will need to enable draft messages feature on Channels List and Message Composer.
The following patch add the needed flags

<details>

<summary>Provide the patch summary here</summary>

```
Subject: [PATCH] Print some logs
---
Index: stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt	(revision b6c511809d418dd52bd19605f381a966c5a35015)
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt	(date 1742545910050)
@@ -199,7 +199,7 @@
      * Whether draft messages are enabled.
      */
     @JvmStatic
-    public var draftMessageEnabled: Boolean = false
+    public var draftMessageEnabled: Boolean = true
 
     /**
      * Sets the strategy for resizing images hosted on Stream's CDN. Disabled by default,
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt	(revision b6c511809d418dd52bd19605f381a966c5a35015)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt	(date 1742546563527)
@@ -101,6 +101,7 @@
                 Filters.or(Filters.notExists(CHANNEL_ARG_DRAFT), Filters.eq(CHANNEL_ARG_DRAFT, false)),
             ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),
+            isDraftMessageEnabled = true,
         )
     }
     private val threadsViewModelFactory by lazy { ThreadsViewModelFactory() }
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision b6c511809d418dd52bd19605f381a966c5a35015)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1742546563546)
@@ -110,6 +110,7 @@
             deletedMessageVisibility = DeletedMessageVisibility.ALWAYS_VISIBLE,
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
+            isComposerDraftMessageEnabled = true,
         )
     }
 
```

</details>

