### PR TITLE
Not show deleted poll messages

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -532,7 +532,7 @@ public fun DefaultMessageItemCenterContent(
     onAddPollOption: (poll: Poll, option: String) -> Unit,
 ) {
     val finalModifier = modifier.widthIn(max = ChatTheme.dimens.messageItemMaxWidth)
-    if (messageItem.message.isPoll()) {
+    if (messageItem.message.isPoll() && !messageItem.message.isDeleted()) {
         val poll = messageItem.message.poll
         LaunchedEffect(key1 = poll) {
             if (poll != null) {


### PR DESCRIPTION
### 🎯 Goal
Render deleted poll messages as a deleted message instead of use the "poll UI"
Fix: https://linear.app/stream/issue/AND-416/inability-to-delete-polls-in-android-app-using-streams-ui-components




<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/011fe8c9-6d4c-4f88-9dd9-3a316e82d352" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/c69332d5-6164-4436-a1fa-6cbc13e5f312" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


