### PR TITLE
Ensure headers don't contain special characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Ensure `HeadersInterceptor` doesn't use any special character that can come from the customer integration. [#5708](https://github.com/GetStream/stream-chat-android/pull/5708)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/HeadersUtil.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/HeadersUtil.kt
@@ -131,7 +131,7 @@ internal class HeadersUtil(var context: Context, private var appName: String?, p
             append("|offline_enabled=$OFFLINE_SUPPORT_ENABLED")
             append("|app=$appNameValue")
             append("|app_version=$appVersionValue")
-        }
+        }.sanitize()
     }
 
     /**

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/HeadersUtilTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/HeadersUtilTest.kt
@@ -210,4 +210,26 @@ internal class HeadersUtilTest {
 
         assertTrue(result.contains("UnknownApp"))
     }
+
+    @Test
+    fun `given a valid appName with special characters, buildUserAgent should sanitize special characters from app name`() {
+        val appNameWithSpecialChars = "MyβAppName"
+        val sanitizedAppName = "MyAppName"
+
+        val headersUtil = HeadersUtil(context, appName = appNameWithSpecialChars, appVersion = "1.0.0")
+        val userAgent = headersUtil.buildUserAgent()
+
+        assertTrue(userAgent.contains(sanitizedAppName))
+    }
+
+    @Test
+    fun `given a valid appName with special characters, buildSdkTrackingHeaders should sanitize special characters from app name`() {
+        val appNameWithSpecialChars = "MyβAppName"
+        val sanitizedAppName = "MyAppName"
+
+        val headersUtil = HeadersUtil(context, appName = appNameWithSpecialChars, appVersion = "1.0.0")
+        val trackingHeaders = headersUtil.buildSdkTrackingHeaders()
+
+        assertTrue(trackingHeaders.contains("|app=$sanitizedAppName"))
+    }
 }


### PR DESCRIPTION
### 🎯 Goal
The `HeadersInterceptor` takes some info from the customer app as the app name. Our customers could have special characters on their app names that are not compatible with the http request. To avoid it, headers need to be sanitized

Fix: https://linear.app/stream/issue/AND-428/

### 🎉 GIF
![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExMGNmYms4aDFiam4ycjY3ZmlwcW04ZWF6Y3QxMHhvdnljZm1zejYzbSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ihw3vwUGrT9I1gJt3N/giphy.gif)