### PR TITLE
[AND-440] Fix the typing list item focus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Return a subtype of `NewMessageState` (`Typing`) for the typing indicator item, so that the UI can behave properly. [#5712](https://github.com/GetStream/stream-chat-android/pull/5712)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1618,6 +1618,34 @@ public abstract class io/getstream/chat/android/ui/common/state/messages/list/Mo
 	public abstract fun getText ()I
 }
 
+public final class io/getstream/chat/android/ui/common/state/messages/list/MyOwn : io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Long;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Long;)Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTs ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract class io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
+	public static final field $stable I
+}
+
+public final class io/getstream/chat/android/ui/common/state/messages/list/Other : io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/Long;)V
+	public final fun component1 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Long;)Lio/getstream/chat/android/ui/common/state/messages/list/Other;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/Other;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/Other;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getTs ()Ljava/lang/Long;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public final class io/getstream/chat/android/ui/common/state/messages/list/SelectedMessageFailedModerationState : io/getstream/chat/android/ui/common/state/messages/list/SelectedMessageState {
 	public static final field $stable I
 	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/Set;)V
@@ -1745,6 +1773,14 @@ public final class io/getstream/chat/android/ui/common/state/messages/list/Threa
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDate ()Ljava/util/Date;
 	public final fun getReplyCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/state/messages/list/Typing : io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
+	public static final field $stable I
+	public static final field INSTANCE Lio/getstream/chat/android/ui/common/state/messages/list/Typing;
+	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1618,34 +1618,6 @@ public abstract class io/getstream/chat/android/ui/common/state/messages/list/Mo
 	public abstract fun getText ()I
 }
 
-public final class io/getstream/chat/android/ui/common/state/messages/list/MyOwn : io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/Long;)V
-	public final fun component1 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/Long;)Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/MyOwn;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getTs ()Ljava/lang/Long;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
-public abstract class io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
-	public static final field $stable I
-}
-
-public final class io/getstream/chat/android/ui/common/state/messages/list/Other : io/getstream/chat/android/ui/common/state/messages/list/NewMessageState {
-	public static final field $stable I
-	public fun <init> (Ljava/lang/Long;)V
-	public final fun component1 ()Ljava/lang/Long;
-	public final fun copy (Ljava/lang/Long;)Lio/getstream/chat/android/ui/common/state/messages/list/Other;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/Other;Ljava/lang/Long;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/Other;
-	public fun equals (Ljava/lang/Object;)Z
-	public final fun getTs ()Ljava/lang/Long;
-	public fun hashCode ()I
-	public fun toString ()Ljava/lang/String;
-}
-
 public final class io/getstream/chat/android/ui/common/state/messages/list/SelectedMessageFailedModerationState : io/getstream/chat/android/ui/common/state/messages/list/SelectedMessageState {
 	public static final field $stable I
 	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/Set;)V

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -673,7 +673,7 @@ public class MessageListController(
         val newMessageState = getNewMessageState(
             lastMessage = newLastMessage,
             lastLoadedMessage = lastLoadedMessage,
-            typingItemState = newState.lastItemOrNull<TypingItemState>()
+            typingItemState = newState.lastItemOrNull<TypingItemState>(),
         )
         logger.v {
             "[updateMessageList] #messageList; oldLastMessage: ${oldLastMessage?.text}, " +
@@ -808,7 +808,7 @@ public class MessageListController(
                 val newMessageState = getNewMessageState(
                     lastMessage = newLastMessage,
                     lastLoadedMessage = lastLoadedThreadMessage,
-                    typingItemState = newState.lastItemOrNull<TypingItemState>()
+                    typingItemState = newState.lastItemOrNull<TypingItemState>(),
                 )
 
                 _threadListState.value = newState.copy(newMessageState = newMessageState)
@@ -1038,7 +1038,7 @@ public class MessageListController(
     private fun getNewMessageState(
         lastMessage: Message?,
         lastLoadedMessage: Message?,
-        typingItemState: TypingItemState?
+        typingItemState: TypingItemState?,
     ): NewMessageState? {
         val lastLoadedMessageDate = lastLoadedMessage?.createdAt ?: lastLoadedMessage?.createdLocallyAt
         return when {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -105,6 +105,7 @@ import io.getstream.chat.android.ui.common.state.messages.list.ShuffleGiphy
 import io.getstream.chat.android.ui.common.state.messages.list.StartOfTheChannelItemState
 import io.getstream.chat.android.ui.common.state.messages.list.SystemMessageItemState
 import io.getstream.chat.android.ui.common.state.messages.list.ThreadDateSeparatorItemState
+import io.getstream.chat.android.ui.common.state.messages.list.Typing
 import io.getstream.chat.android.ui.common.state.messages.list.TypingItemState
 import io.getstream.chat.android.ui.common.state.messages.list.UnreadSeparatorItemState
 import io.getstream.chat.android.ui.common.state.messages.list.lastItemOrNull
@@ -1042,7 +1043,7 @@ public class MessageListController(
     ): NewMessageState? {
         val lastLoadedMessageDate = lastLoadedMessage?.createdAt ?: lastLoadedMessage?.createdLocallyAt
         return when {
-            typingItemState != null -> Other(ts = null)
+            typingItemState != null -> Typing
             lastMessage == null -> null
             lastLoadedMessage == null -> getNewMessageStateForMessage(lastMessage)
             lastMessage.wasCreatedAfter(lastLoadedMessageDate) &&

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -670,7 +670,11 @@ public class MessageListController(
         val oldLastMessage = _messageListState.value.lastItemOrNull<HasMessageListItemState>()?.message
         val newLastMessage = newState.lastItemOrNull<HasMessageListItemState>()?.message
 
-        val newMessageState = getNewMessageState(newLastMessage, lastLoadedMessage)
+        val newMessageState = getNewMessageState(
+            lastMessage = newLastMessage,
+            lastLoadedMessage = lastLoadedMessage,
+            typingItemState = newState.lastItemOrNull<TypingItemState>()
+        )
         logger.v {
             "[updateMessageList] #messageList; oldLastMessage: ${oldLastMessage?.text}, " +
                 "newLastMessage: ${newLastMessage?.text}, newMessageState: $newMessageState"
@@ -801,7 +805,11 @@ public class MessageListController(
                 val newLastMessage =
                     (newState.messageItems.lastOrNull { it is MessageItemState } as? MessageItemState)?.message
 
-                val newMessageState = getNewMessageState(newLastMessage, lastLoadedThreadMessage)
+                val newMessageState = getNewMessageState(
+                    lastMessage = newLastMessage,
+                    lastLoadedMessage = lastLoadedThreadMessage,
+                    typingItemState = newState.lastItemOrNull<TypingItemState>()
+                )
 
                 _threadListState.value = newState.copy(newMessageState = newMessageState)
                 if (newMessageState != null) lastLoadedThreadMessage = newLastMessage
@@ -1025,11 +1033,16 @@ public class MessageListController(
      *
      * @param lastMessage The new last message in the list, used for comparison.
      * @param lastLoadedMessage The last currently loaded message, used for comparison.
+     * @param typingItemState The typing item state, used to determine if the other user is currently typing.
      */
-    private fun getNewMessageState(lastMessage: Message?, lastLoadedMessage: Message?): NewMessageState? {
+    private fun getNewMessageState(
+        lastMessage: Message?,
+        lastLoadedMessage: Message?,
+        typingItemState: TypingItemState?
+    ): NewMessageState? {
         val lastLoadedMessageDate = lastLoadedMessage?.createdAt ?: lastLoadedMessage?.createdLocallyAt
-
         return when {
+            typingItemState != null -> Other(ts = null)
             lastMessage == null -> null
             lastLoadedMessage == null -> getNewMessageStateForMessage(lastMessage)
             lastMessage.wasCreatedAfter(lastLoadedMessageDate) &&

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
@@ -30,3 +30,8 @@ public data class MyOwn(val ts: Long?) : NewMessageState()
  * If the message is someone else's (we didn't send it), we show a "New message" bubble.
  */
 public data class Other(val ts: Long?) : NewMessageState()
+
+/**
+ * If it is a typing message, we scroll to the bottom of the list.
+ */
+public data object Typing : NewMessageState()

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
@@ -16,28 +16,22 @@
 
 package io.getstream.chat.android.ui.common.state.messages.list
 
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
-
 /**
  * Represents the state when a new message arrives to the channel.
  */
-@InternalStreamChatApi
 public sealed class NewMessageState
 
 /**
  * If the message is our own (we sent it), we scroll to the bottom of the list.
  */
-@InternalStreamChatApi
 public data class MyOwn(val ts: Long?) : NewMessageState()
 
 /**
  * If the message is someone else's (we didn't send it), we show a "New message" bubble.
  */
-@InternalStreamChatApi
 public data class Other(val ts: Long?) : NewMessageState()
 
 /**
  * If it is a typing message, we scroll to the bottom of the list.
  */
-@InternalStreamChatApi
 public data object Typing : NewMessageState()

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/NewMessageState.kt
@@ -16,22 +16,28 @@
 
 package io.getstream.chat.android.ui.common.state.messages.list
 
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
 /**
  * Represents the state when a new message arrives to the channel.
  */
+@InternalStreamChatApi
 public sealed class NewMessageState
 
 /**
  * If the message is our own (we sent it), we scroll to the bottom of the list.
  */
+@InternalStreamChatApi
 public data class MyOwn(val ts: Long?) : NewMessageState()
 
 /**
  * If the message is someone else's (we didn't send it), we show a "New message" bubble.
  */
+@InternalStreamChatApi
 public data class Other(val ts: Long?) : NewMessageState()
 
 /**
  * If it is a typing message, we scroll to the bottom of the list.
  */
+@InternalStreamChatApi
 public data object Typing : NewMessageState()

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -131,6 +131,7 @@ internal class MessageListControllerTests {
             messageItems = listOf(
                 TypingItemState(listOf(user2)),
             ),
+            newMessageState = Other(ts = null),
         )
 
         controller.messageListState.value `should be equal to` expectedResult

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -63,6 +63,7 @@ import io.getstream.chat.android.ui.common.state.messages.list.MessageListState
 import io.getstream.chat.android.ui.common.state.messages.list.MessagePosition
 import io.getstream.chat.android.ui.common.state.messages.list.Other
 import io.getstream.chat.android.ui.common.state.messages.list.SystemMessageItemState
+import io.getstream.chat.android.ui.common.state.messages.list.Typing
 import io.getstream.chat.android.ui.common.state.messages.list.TypingItemState
 import io.getstream.result.call.Call
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -114,7 +115,6 @@ internal class MessageListControllerTests {
         controller.messageListState.value `should be equal to` expectedResult
     }
 
-    // test typing indicator logic
     @Test
     fun `Given other users are typing When there are no messages Should return only the typing indicator`() = runTest {
         val controller = Fixture()
@@ -131,7 +131,7 @@ internal class MessageListControllerTests {
             messageItems = listOf(
                 TypingItemState(listOf(user2)),
             ),
-            newMessageState = Other(ts = null),
+            newMessageState = Typing,
         )
 
         controller.messageListState.value `should be equal to` expectedResult

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/messages/viewholder/BaseMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/messages/viewholder/BaseMessagesComponentBrowserFragment.kt
@@ -21,7 +21,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem
 import io.getstream.chat.android.ui.model.MessageListItemWrapper
@@ -57,7 +56,6 @@ abstract class BaseMessagesComponentBrowserFragment : Fragment() {
             setModeratedMessageLongClickListener {}
 
             init(Channel())
-            @OptIn(InternalStreamChatApi::class)
             displayNewMessages(MessageListItemWrapper(getItems()))
         }
     }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/messages/viewholder/BaseMessagesComponentBrowserFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/messages/viewholder/BaseMessagesComponentBrowserFragment.kt
@@ -21,6 +21,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem
 import io.getstream.chat.android.ui.model.MessageListItemWrapper
@@ -56,6 +57,7 @@ abstract class BaseMessagesComponentBrowserFragment : Fragment() {
             setModeratedMessageLongClickListener {}
 
             init(Channel())
+            @OptIn(InternalStreamChatApi::class)
             displayNewMessages(MessageListItemWrapper(getItems()))
         }
     }


### PR DESCRIPTION
### 🎯 Goal

Focus on the typing item when it appears, and the scroll position is near the bottom.

### 🛠 Implementation details

Return a `NewMessageState` for the typing indicator item, so that the UI can behave properly.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/58da32e6-8aec-4460-9da9-9ccb43dffebc" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/7652a09c-66a0-4148-b975-4d5f0090f39d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Create a custom typing indicator item (the default is empty)

```kotlin
public interface ChatComponentFactory {
    @Composable
    public fun LazyItemScope.MessageListTypingIndicatorItemContent(typingItem: TypingItemState) {
        Text(modifier = Modifier.padding(10.dp), text = "Typing...")
    }
}
```
- Enter a channel and start typing from the other channel member login.

### 🎉 GIF

![gif](https://media0.giphy.com/media/v1.Y2lkPTc5MGI3NjExeWNxdXV0NTltcGR3N21iZ2VxZTh6NWk1cmU2c2x6OHU1NHRtNXlpcSZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ThrM4jEi2lBxd7X2yz/giphy.gif)
