### PR TITLE
Fix crash when opening the ChatsScreen on tablet

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -274,7 +274,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
     unreadCountIndicator: @Composable (unreadCount: Int) -> Unit,
     readStatusIndicator: @Composable (message: Message) -> Unit,
 ) {
-    val lastMessage = channel.getLastMessage(currentUser)
+    val lastMessage = remember(channel) { channel.getLastMessage(currentUser) }
 
     if (lastMessage != null) {
         Column(
@@ -290,7 +290,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
             horizontalAlignment = Alignment.End,
             verticalArrangement = Arrangement.spacedBy(4.dp),
         ) {
-            val unreadCount = channel.currentUserUnreadCount(currentUserId = currentUser?.id)
+            val unreadCount = remember(channel) { channel.currentUserUnreadCount(currentUserId = currentUser?.id) }
 
             if (unreadCount > 0) {
                 unreadCountIndicator(unreadCount)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -54,6 +54,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.getLastMessage
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.DraftMessage
+import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.previewdata.PreviewChannelData
 import io.getstream.chat.android.previewdata.PreviewChannelUserRead
@@ -266,18 +267,12 @@ private fun UserTypingIndicator(users: List<User>) {
     }
 }
 
-/**
- * Represents the default trailing content for the channel item. By default it shows
- * the information about the last message for the channel item, such as its read state,
- * timestamp and how many unread messages the user has.
- *
- * @param channel The channel to show the info for.
- * @param currentUser The currently logged in user, used for data handling.
- */
 @Composable
 internal fun RowScope.DefaultChannelItemTrailingContent(
     channel: Channel,
     currentUser: User?,
+    unreadCountIndicator: @Composable (unreadCount: Int) -> Unit,
+    readStatusIndicator: @Composable (message: Message) -> Unit,
 ) {
     val lastMessage = channel.getLastMessage(currentUser)
 
@@ -298,10 +293,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
             val unreadCount = channel.currentUserUnreadCount(currentUserId = currentUser?.id)
 
             if (unreadCount > 0) {
-                ChatTheme.componentFactory.ChannelItemUnreadCountIndicator(
-                    unreadCount = unreadCount,
-                    modifier = Modifier,
-                )
+                unreadCountIndicator(unreadCount)
             }
 
             val isLastMessageFromCurrentUser = lastMessage.user.id == currentUser?.id
@@ -311,12 +303,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 if (isLastMessageFromCurrentUser) {
-                    ChatTheme.componentFactory.ChannelItemReadStatusIndicator(
-                        channel = channel,
-                        message = lastMessage,
-                        currentUser = currentUser,
-                        modifier = Modifier,
-                    )
+                    readStatusIndicator(lastMessage)
                 }
 
                 Timestamp(date = channel.lastMessageAt)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -440,6 +440,20 @@ public interface ChatComponentFactory {
         DefaultChannelItemTrailingContent(
             channel = channelItem.channel,
             currentUser = currentUser,
+            unreadCountIndicator = { unreadCount ->
+                ChannelItemUnreadCountIndicator(
+                    unreadCount = unreadCount,
+                    modifier = Modifier,
+                )
+            },
+            readStatusIndicator = { message ->
+                ChannelItemReadStatusIndicator(
+                    channel = channelItem.channel,
+                    message = message,
+                    currentUser = currentUser,
+                    modifier = Modifier,
+                )
+            },
         )
     }
 


### PR DESCRIPTION
### 🛠 Implementation details

It's a very strange crash that only happens when using the `ChannelsScreen` in `ChatsScreen`. 

```
FATAL EXCEPTION: main
Process: io.getstream.chat.android.compose.sample.debug, PID: 3813
java.lang.AbstractMethodError: abstract method "void io.getstream.chat.android.compose.ui.theme.ChatComponentFactory.ChannelItemUnreadCountIndicator(int, androidx.compose.ui.Modifier, androidx.compose.runtime.Composer, int)"
at io.getstream.chat.android.compose.ui.channels.list.ChannelItemKt.DefaultChannelItemTrailingContent(ChannelItem.kt:310)
at io.getstream.chat.android.compose.ui.theme.ChatComponentFactory$DefaultImpls.ChannelItemTrailingContent(ChatComponentFactory.kt:440)
```

Maybe it's because we are using compound factories for the channel item, but it does not justify it as a cause.

The fix consists of changing the internal `DefaultChannelItemTrailingContent` to have parameters in which we can define the content of the indicator using the current factories.

#### Unrelated changes

Remembering some searches that are done in the `DefaultChannelItemTrailingContent` to improve UI performance

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/1303653a-21e2-4f76-8409-690379b04798" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/742b82a7-f36e-43f6-89bb-8e7788a4f1f8" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Enable Adaptive layout in the Advance settings
- Log in with any user
