### PR TITLE
[AND-464] Provide custom `ImageLoader` to `MediaGalleryPreviewActivity`.

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -40,6 +40,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -64,8 +65,10 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewResult
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewContract
+import io.getstream.chat.android.compose.ui.attachments.preview.internal.MediaGalleryInjector
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.LocalStreamImageLoader
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
@@ -422,6 +425,12 @@ internal fun MediaAttachmentContentItem(
     }
 
     var imageState by remember { mutableStateOf<AsyncImagePainter.State>(AsyncImagePainter.State.Empty) }
+
+    // Prepare the image loader for the media gallery
+    val imageLoader = LocalStreamImageLoader.current
+    LaunchedEffect(imageLoader) {
+        MediaGalleryInjector.install(imageLoader)
+    }
 
     val mixedMediaPreviewLauncher = rememberLauncherForActivityResult(
         contract = MediaGalleryPreviewContract(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
@@ -85,6 +85,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -137,6 +138,7 @@ import io.getstream.chat.android.compose.state.mediagallerypreview.ShowInChat
 import io.getstream.chat.android.compose.state.mediagallerypreview.toMediaGalleryPreviewActivityState
 import io.getstream.chat.android.compose.state.mediagallerypreview.toMessage
 import io.getstream.chat.android.compose.ui.attachments.content.PlayButton
+import io.getstream.chat.android.compose.ui.attachments.preview.internal.MediaGalleryInjector
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.components.NetworkLoadingIndicator
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
@@ -144,6 +146,7 @@ import io.getstream.chat.android.compose.ui.components.SimpleDialog
 import io.getstream.chat.android.compose.ui.components.Timestamp
 import io.getstream.chat.android.compose.ui.components.avatar.Avatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.LocalStreamImageLoader
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
 import io.getstream.chat.android.compose.ui.util.StreamImage
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -266,13 +269,18 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
                 SetupEdgeToEdge()
 
                 val message = mediaGalleryPreviewViewModel.message
-
                 if (message.isDeleted()) {
                     finish()
                     return@ChatTheme
                 }
 
-                MediaGalleryPreviewContentWrapper(message, attachmentPosition)
+                // Take the imageLoader from the injector, which is populated by the MediaAttachmentContent. This is a
+                // workaround for the fact that the MediaGalleryPreviewActivity is not a part of the composition tree of
+                // the MessageList, so the provided imageLoaderFactory from the MessageList ChatTheme cannot be used.
+                val imageLoader = MediaGalleryInjector.imageLoader ?: LocalStreamImageLoader.current
+                CompositionLocalProvider(LocalStreamImageLoader provides imageLoader) {
+                    MediaGalleryPreviewContentWrapper(message, attachmentPosition)
+                }
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/internal/MediaGalleryInjector.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/internal/MediaGalleryInjector.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.attachments.preview.internal
+
+import coil3.ImageLoader
+
+/**
+ * Injector for non-configuration dependencies of the Media Gallery Activity.
+ * Serves a bridge the Activity/Fragment which hosts the `MessageList` and the `MediaGalleryPreviewActivity`,
+ * providing values passed in the `ChatTheme` holding the `MessageList` to the `MediaGalleryPreviewActivity`.
+ */
+internal object MediaGalleryInjector {
+
+    /**
+     * The [ImageLoader] instance.
+     */
+    @Volatile
+    var imageLoader: ImageLoader? = null
+        internal set
+
+    /**
+     * Sets the [ImageLoader] instance.
+     *
+     * @param imageLoader The [ImageLoader] instance to set.
+     */
+    internal fun install(imageLoader: ImageLoader) {
+        this.imageLoader = imageLoader
+    }
+}


### PR DESCRIPTION
### 🎯 Goal
Currently it is not possible to use custom `ImageLoader`s inside the `MediaGalleryPreviewActivity` because it is an Activity that is launched from the SDK, and it is not possible to pass custom `imageLoaderFactory`(or other customization) via the `ChatTheme`. 
With this PR, we introduce an internal way of passing the `ImageLoader` from the `MediaAttachmentContent` to the `MediaGalleryPreviewActivity`. This ensures that if a custom `StreamCoilImageLoaderFactory` is passed to the `ChatTheme` wrapping the `MediaAttachmentContent`, the same one is used in the `MediaGalleryPreviewActivity` as well.

### 🛠 Implementation details
Introduce a `MediaGalleryInjector` - a global holder for the `ImageLoader`. It is populated from the `MediaAttachmentContent`(it can be done from anywhere, but I placed it there as it is directly linked to the `MediaGalleryPreviewActivity`). It is then read from the `MediaGalleryPreviewActivity`, and is bound to the local `LocalStreamImageLoader`.

### 🧪 Testing
1. Apply the provided patch. The patch adds some logging on the `DefaultStreamCoilImageLoaderFactory`, and defines a `CustomCoilImageLoaderFactory` - which has a different logging mechanism. It then provides the new factory in the `MessagesActivity`s `ChatTheme`.
2. Open the compose sample app
3. Open Channels -> Open channel -> Open Media Gallery Activity
4. Observe the logs in LogCat with tag: `StreamImageLoader`: The logs on the channel list should originate from the default imageLoader, while the logs from the messages/mediaGallery should originate from the custom imageLoader.

<summary>Patch</summary>

```
Subject: [PATCH] [AND-464] Provide custom ImageLoader to MediaGalleryPreviewActivity.
---
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(revision 5da4a1e14e5ab7102742ff6dce6adbd0a55a9c62)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt	(date 1744970340177)
@@ -84,6 +84,7 @@
 import io.getstream.chat.android.compose.ui.theme.StreamColors
 import io.getstream.chat.android.compose.ui.theme.StreamShapes
 import io.getstream.chat.android.compose.ui.theme.StreamTypography
+import io.getstream.chat.android.compose.ui.util.CustomCoilImageLoaderFactory
 import io.getstream.chat.android.compose.ui.util.rememberMessageListState
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
@@ -174,6 +175,7 @@
                 optionVisibility = MessageOptionItemVisibility(),
             ),
             ownMessageTheme = ownMessageTheme,
+            imageLoaderFactory = CustomCoilImageLoaderFactory,
         ) {
             SetupContent()
         }
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt	(revision 5da4a1e14e5ab7102742ff6dce6adbd0a55a9c62)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StreamCoilImageLoaderFactory.kt	(date 1744976021940)
@@ -17,8 +17,11 @@
 package io.getstream.chat.android.compose.ui.util
 
 import android.content.Context
+import android.util.Log
+import coil3.EventListener
 import coil3.ImageLoader
 import coil3.SingletonImageLoader
+import coil3.request.ImageRequest
 import io.getstream.chat.android.ui.common.images.StreamImageLoaderFactory
 
 /**
@@ -43,6 +46,62 @@
     }
 }
 
+public object CustomCoilImageLoaderFactory : StreamCoilImageLoaderFactory {
+    /**
+     * Loads images in the app, with our default settings.
+     */
+    private var imageLoader: ImageLoader? = null
+
+    /**
+     * Provides an [ImageLoader] using our custom [ImageLoaderFactory].
+     */
+    private var imageLoaderFactory: SingletonImageLoader.Factory? = null
+
+    /**
+     * Returns either the currently available [ImageLoader] or builds a new one.
+     *
+     * @param context - The [Context] to build the [ImageLoader] with.
+     * @return [ImageLoader] that loads images in the app.
+     */
+    override fun imageLoader(context: Context): ImageLoader = imageLoader ?: newImageLoader(context)
+
+    /**
+     * Builds a new [ImageLoader] using the given Android [Context]. If the loader already exists, we return it.
+     *
+     * @param context - The [Context] to build the [ImageLoader] with.
+     * @return [ImageLoader] that loads images in the app.
+     */
+    @Synchronized
+    private fun newImageLoader(context: Context): ImageLoader {
+        imageLoader?.let { return it }
+
+        val imageLoaderFactory = imageLoaderFactory ?: newImageLoaderFactory()
+        return imageLoaderFactory.newImageLoader(context).apply {
+            imageLoader = this
+        }
+    }
+
+    /**
+     * Uses Android [Context] to build a new [StreamImageLoaderFactory].
+     *
+     * @return [ImageLoaderFactory] that loads all the images in the app.
+     */
+    private fun newImageLoaderFactory(): SingletonImageLoader.Factory {
+        return StreamImageLoaderFactory(
+            builder = {
+                this.eventListener(object : EventListener() {
+                    override fun onStart(request: ImageRequest) {
+                        Log.d("StreamImageLoader", "onStart [custom loader]")
+                        super.onStart(request)
+                    }
+                })
+            },
+        ).apply {
+            imageLoaderFactory = this
+        }
+    }
+}
+
 /**
  * Provides a custom image loader that uses the [StreamImageLoaderFactory] to build the default loading settings.
  *
@@ -90,7 +149,16 @@
      * @return [ImageLoaderFactory] that loads all the images in the app.
      */
     private fun newImageLoaderFactory(): SingletonImageLoader.Factory {
-        return StreamImageLoaderFactory().apply {
+        return StreamImageLoaderFactory(
+            builder = {
+                this.eventListener(object : EventListener() {
+                    override fun onStart(request: ImageRequest) {
+                        Log.d("StreamImageLoader", "onStart [default loader]")
+                        super.onStart(request)
+                    }
+                })
+            },
+        ).apply {
             imageLoaderFactory = this
         }
     }

```

</details>

