### PR TITLE
CustomMessageLinkStyle docs

### DIFF
--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/cookbook/ui/CustomMessageLinkStyle.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/cookbook/ui/CustomMessageLinkStyle.kt
@@ -1,0 +1,74 @@
+package io.getstream.chat.docs.kotlin.cookbook.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.sp
+import io.getstream.chat.android.compose.ui.messages.list.MessageList
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.MessageTheme
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.ReactionSortingByCount
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.ui.common.state.messages.list.MessageItemState
+import io.getstream.chat.android.ui.common.state.messages.list.MessageListState
+
+/**
+ * [Custom Message Link Style](https://getstream.io/chat/docs/sdk/android/compose-cookbook/custom-message-link-style)
+ */
+@Composable
+private fun CustomMessageLinkStyle() {
+    val currentUser = User()
+    val ownMessageTheme = MessageTheme.defaultOwnTheme().copy(
+        linkStyle = TextStyle(
+            color = Color.Red,
+            fontSize = 12.sp,
+            textDecoration = TextDecoration.Underline
+        )
+    )
+    val otherMessageTheme = MessageTheme.defaultOtherTheme().copy(
+        linkStyle = TextStyle(
+            color = Color.Green,
+            fontSize = 16.sp,
+            textDecoration = TextDecoration.Underline
+        )
+    )
+    ChatTheme(
+        ownMessageTheme = ownMessageTheme,
+        otherMessageTheme = otherMessageTheme,
+    ) {
+        MessageList(
+            currentState = MessageListState(
+                messageItems = listOf(
+                    MessageItemState(
+                        currentUser = currentUser,
+                        message = Message(
+                            user = currentUser,
+                            id = "message-1",
+                            text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. www.google.com",
+                        ),
+                        isMine = true,
+                        ownCapabilities = emptySet(),
+                    ),
+                    MessageItemState(
+                        message = Message(
+                            id = "message-2",
+                            text = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. getstream.io",
+                        ),
+                        isMine = false,
+                        ownCapabilities = emptySet(),
+                    ),
+                ),
+            ),
+            reactionSorting = ReactionSortingByCount,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun CustomMessageLinkStylePreview() {
+    CustomMessageLinkStyle()
+}


### PR DESCRIPTION
### Chat Messaging / Docs / Android / Customizing Components

<img width="791" alt="Screenshot 2025-04-24 at 14 03 34" src="https://github.com/user-attachments/assets/6361ce64-dc54-4a16-8781-a27c06779008" />
<img width="825" alt="Screenshot 2025-04-24 at 14 03 43" src="https://github.com/user-attachments/assets/1c5f8e92-2ca6-4cb5-95af-3e3fe9e418c4" />

### Chat Messaging / Docs / Android / Custom Message Link Style

<img width="834" alt="Screenshot 2025-04-24 at 14 02 52" src="https://github.com/user-attachments/assets/5e5960e0-49e2-45ef-8012-dd14957228d5" />
<img width="821" alt="Screenshot 2025-04-24 at 14 03 01" src="https://github.com/user-attachments/assets/5ff130b6-3c23-4e4d-a246-bb00a7cccd2f" />
<img width="838" alt="Screenshot 2025-04-24 at 14 03 14" src="https://github.com/user-attachments/assets/d4c54ac2-7858-41fa-9d99-dcc325a2056c" />


