### PR TITLE
[AND-498] Fix new token not sent with the request after refreshing it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ## stream-chat-android-client
 ### 🐞 Fixed
 - Fix `NullPointerException` in `SubscriptionImpl` when subscription is disposed concurrently while being filtered. [#5738](https://github.com/GetStream/stream-chat-android/pull/5738)
+- Fix new Stream token not sent with the request after refreshing it. [#5757](https://github.com/GetStream/stream-chat-android/pull/5757)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/TokenAuthInterceptor.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/interceptor/TokenAuthInterceptor.kt
@@ -49,16 +49,18 @@ internal class TokenAuthInterceptor internal constructor(
 
             tokenManager.ensureTokenLoaded()
 
-            val request: Request = addTokenHeader(chain.request())
+            val request: Request = addTokenHeader(chain.request(), token = tokenManager.getToken())
             var response: Response = chain.proceed(request)
 
             if (!response.isSuccessful) {
                 val err = parser.toError(response)
                 if (err.serverErrorCode == ChatErrorCode.TOKEN_EXPIRED.code) {
                     tokenManager.expireToken()
-                    tokenManager.loadSync()
+                    val freshToken = tokenManager.loadSync()
                     response.close()
-                    response = chain.proceed(request)
+                    // Rebuild the request with the new token and retry the request.
+                    val requestWithFreshToken = addTokenHeader(chain.request(), token = freshToken)
+                    response = chain.proceed(requestWithFreshToken)
                 } else {
                     throw ChatRequestError(err.message, err.serverErrorCode, err.statusCode, err.cause)
                 }
@@ -67,17 +69,15 @@ internal class TokenAuthInterceptor internal constructor(
         }
     }
 
-    private fun addTokenHeader(request: Request): Request = tokenManager.getToken().let { token ->
-        try {
-            request.newBuilder().header(AUTH_HEADER, token).build()
-        } catch (e: IllegalArgumentException) {
-            throw ChatRequestError(
-                "${ChatErrorCode.INVALID_TOKEN.description}: '$token'",
-                ChatErrorCode.INVALID_TOKEN.code,
-                -1,
-                e,
-            )
-        }
+    private fun addTokenHeader(request: Request, token: String): Request = try {
+        request.newBuilder().header(AUTH_HEADER, token).build()
+    } catch (e: IllegalArgumentException) {
+        throw ChatRequestError(
+            "${ChatErrorCode.INVALID_TOKEN.description}: '$token'",
+            ChatErrorCode.INVALID_TOKEN.code,
+            -1,
+            e,
+        )
     }
 
     companion object {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
@@ -17,10 +17,14 @@
 package io.getstream.chat.android.client.token
 
 internal class FakeTokenManager(
-    private val token: String,
+    private var token: String,
     private val loadSyncToken: String = token,
 ) : TokenManager {
-    override fun loadSync(): String = loadSyncToken
+
+    override fun loadSync(): String = loadSyncToken.also {
+        token = loadSyncToken
+    }
+
     override fun getToken(): String = token
 
     override fun ensureTokenLoaded() {


### PR DESCRIPTION
### 🎯 Goal
The `AuthTokenInterceptor` detects when the BE returns a token expired error, and automatically calls the `TokenProvider` to fetch a new token. Afterwards, it re-performs the call, but still uses the old token, and NOT the refreshed one. This causes the re-performed call to always fail, even though we have a new valid token.

With this PR, we ensure that the newly fetched token is used for the repeated invocation of the failed call.

### 🛠 Implementation details
- Adds the newly fetched token from the `TokenProvider` as a header to the `Request` before re-performing it.

### 🧪 Testing
1. Use the app until the Stream token expires
2. Do some action that would trigger a BE call
3. You should observe only one failed call in the logs (the first 'Invalid token' response) instead of 2
