### PR TITLE
Show last snapshot update on Workflow

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   publish:
     name: Snapshot build and publish
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3.1.0
@@ -28,4 +28,8 @@ jobs:
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
+          SNAPSHOT: true
+      - name: Show snapshot version
+        run: ./scripts/show-last-snapshot-update.sh
+        env:
           SNAPSHOT: true

--- a/scripts/publish-root.gradle
+++ b/scripts/publish-root.gradle
@@ -47,3 +47,23 @@ nexusPublishing {
 tasks.withType(dokkaHtmlMultiModule.getClass()) {
     includes.from("DokkaRoot.md")
 }
+
+tasks.register("printAllArtifacts") {
+    group = "publishing"
+
+    doLast {
+        subprojects.each { subproject ->
+            subproject.plugins.withId("maven-publish") {
+                def publishingExtension = subproject.extensions.findByType(PublishingExtension)
+                publishingExtension?.publications?.all { publication ->
+                    if (publication instanceof MavenPublication) {
+                        def groupId = publication.groupId
+                        def artifactId = publication.artifactId
+                        def version = publication.version
+                        println("$groupId:$artifactId:$version")
+                    }
+                }
+            }
+        }
+    }
+}

--- a/scripts/show-last-snapshot-update.sh
+++ b/scripts/show-last-snapshot-update.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Run the Gradle task to get the artifact list and process the output line by line
+./gradlew -q printAllArtifacts | while IFS= read -r artifact; do
+    # Extract groupId, artifactId, and snapshot version from the artifact string
+    groupId=$(echo $artifact | cut -d: -f1)
+    artifactId=$(echo $artifact | cut -d: -f2)
+    snapshotVersion=$(echo $artifact | cut -d: -f3)
+
+    # Format the URL for the maven-metadata.xml file in the Nexus repository
+    url="https://oss.sonatype.org/content/repositories/snapshots/$(echo $groupId | tr '.' '/')/$artifactId/$snapshotVersion/maven-metadata.xml"
+
+    # Fetch the maven-metadata.xml using curl and extract the latest release version using sed
+    latest_version=$(curl -s "$url" | sed -n 's|.*<value>\(.*\)</value>.*|\1|p' | head -n 1)
+
+    # Print the result with the latest stable version
+    if [ -n "$latest_version" ]; then
+        echo "$groupId:$artifactId:$latest_version"
+    else
+        echo "No version found for $artifact"
+    fi
+done


### PR DESCRIPTION
### 🎯 Goal

Create an scripts that fetch the "last snapshot update" that was pushed to maven showing this information within the workflow logs allowing us to share a concrete snapshot version

Complete: AND-526
![image (6)](https://github.com/user-attachments/assets/4e899341-a0e4-46ca-a767-6f2aaca82b90)
![image (5)](https://github.com/user-attachments/assets/7b02f063-035e-4909-b4a8-e151a516a5ee)