### PR TITLE
[AND-540] Fix MessageRegularContent component factory

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
@@ -92,16 +92,28 @@ public fun MessageContent(
         }
     },
     regularMessageContent: @Composable () -> Unit = {
-        DefaultMessageContent(
-            message = message,
-            currentUser = currentUser,
-            onLongItemClick = onLongItemClick,
-            messageContentFactory = messageContentFactory,
-            onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
-            onQuotedMessageClick = onQuotedMessageClick,
-            onLinkClick = onLinkClick,
-            onUserMentionClick = onUserMentionClick,
-        )
+        if (messageContentFactory == MessageContentFactory.Deprecated) {
+            ChatTheme.componentFactory.MessageRegularContent(
+                message = message,
+                currentUser = currentUser,
+                onLongItemClick = onLongItemClick,
+                onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
+                onQuotedMessageClick = onQuotedMessageClick,
+                onLinkClick = onLinkClick,
+                onUserMentionClick = onUserMentionClick,
+            )
+        } else {
+            DefaultMessageContent(
+                message = message,
+                currentUser = currentUser,
+                onLongItemClick = onLongItemClick,
+                messageContentFactory = messageContentFactory,
+                onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
+                onQuotedMessageClick = onQuotedMessageClick,
+                onLinkClick = onLinkClick,
+                onUserMentionClick = onUserMentionClick,
+            )
+        }
     },
 ) {
     when {


### PR DESCRIPTION
### 🎯 Goal

Fix the unused `MessageRegularContent` component factory.

### 🛠 Implementation details

The `MessageRegularContent` component factory was not being used in the `MessageContent` component.
Which made the component factory being ignored when using `ChatComponentFactory`.

The fixing makes the `MessageContent` use the `MessageRegularContent` component factory only if the deprecated `messageContentFactory` is not used.

### 🧪 Testing

Create a custom `ChatComponentFactory`, implement `MessageRegularContent`, and see the message regular content using the custom UI in the `MessagesScreen`
