### PR TITLE
[AND-552] Fix UninitializedPropertyAccessException in AttachmentsPickerSystemFragment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
 - Fix audio recording attachments not paused when the app goes to the background or the screen is covered with another one. [#5685](https://github.com/GetStream/stream-chat-android/pull/5685)
+- Fix `UninitializedPropertyAccessException` in `AttachmentsPickerSystemFragment`. [#5778](https://github.com/GetStream/stream-chat-android/pull/5778)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/AttachmentsPickerDialogFragment.kt
@@ -99,7 +99,7 @@ public class AttachmentsPickerDialogFragment : BottomSheetDialogFragment() {
     }
 
     override fun onDismiss(dialog: DialogInterface) {
-        if (style.saveAttachmentsOnDismiss) {
+        if (::style.isInitialized && style.saveAttachmentsOnDismiss) {
             attachmentSelectionListener?.onAttachmentsSelected(selectedAttachments)
         }
         super.onDismiss(dialog)


### PR DESCRIPTION
### 🎯 Goal

Fix #5760 

### 🛠 Implementation details

- `AttachmentsPickerSystemFragment`:
    - Changed `config` property to be passed as fragment arguments, making it state-restorable.
    - Removed the fragment in `onViewCreated` if `style` is not initialized or `savedInstanceState` is not null, preventing crashes when the fragment is recreated without necessary data.
- `AttachmentsPickerDialogFragment`:
    - Added a check in `onDismiss` to ensure `style` is initialized before accessing its properties.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/20440df5-e074-4b5a-93c7-ab0758b8678b" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/1fffcdd1-07f3-47f7-b2b6-565d4ae81e8e" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Comment out these lines in the HostActivity of the `ui-components-sample`

```kotlin
// if (savedInstanceState != null && lastNonConfigurationInstance == null) {
//     // the application process was killed by the OS
//     startActivity(packageManager.getLaunchIntentForPackage(packageName))
//     finishAffinity()
// }
```
- Enable system attachments picker in `fragment_chat.xml` layout

```xml
app:streamUiMessageComposerAttachmentsPickerSystemPickerEnabled="true"
```

- In phone Developer options, enable `Don't keep activities`.
- Open `ui-components` sample app, click on a channel and click to add a attachment.
- Minimize the app.
- Open the app from history.

### 🎉 GIF

![gif](https://media1.giphy.com/media/v1.Y2lkPTc5MGI3NjExejU3ZmxsaTFjYzV4bG92ZjlqNDNkN2kwZ3gzY25xa2xvN3Nyd3loayZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/10MlVunnRFnQ2Y/giphy.gif)
