### PR TITLE
Improve documentation: `blockedFileExtensions` seems wrongly documented as Blocked mime types

### DIFF
--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/AppSettings.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/AppSettings.kt
@@ -54,7 +54,7 @@ public data class App(
  *
  * @param allowedFileExtensions Allowed file extensions.
  * @param allowedMimeTypes Allowed mime types.
- * @param blockedFileExtensions Blocked mime types.
+ * @param blockedFileExtensions Blocked file extensions.
  * @param blockedMimeTypes Blocked mime types.
  * @param sizeLimitInBytes The size limit of the file in bytes.
  */


### PR DESCRIPTION
### 🎯 Goal

- `blockedMimeTypes` seems to be the list of blocked mime types during a file upload
- `blockedFileExtensions` should be the blocked file extensions but documented as blocked mime types

### 🛠 Implementation details

Updating documentation. Not a code change.

### 🎨 UI Changes

N/A


### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

N/A
