### PR TITLE
fix(README): remove duplicate word 'by' in Chat Tutorial link description

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The Android SDK supports both Kotlin and Java, but *we strongly recommend using 
 ### 🔗 Quick Links
 
 * [Register](https://getstream.io/chat/trial/): Create an account and get an API key for Stream Chat
-* [Chat Tutorial](https://getstream.io/tutorials/android-chat/#kotlin): Learn the basics of the SDK by by building a simple messaging app (Kotlin or Java)
+* [Chat Tutorial](https://getstream.io/tutorials/android-chat/#kotlin): Learn the basics of the SDK by building a simple messaging app (Kotlin or Java)
 * [UI Components sample app](/stream-chat-android-ui-components-sample): Full messaging app with threads, reactions, optimistic UI updates and offline storage
 * [Compose UI Components sample app](/stream-chat-android-compose-sample): Messaging sample app built with Jetpack Compose!
 * [Client Documentation](https://getstream.io/chat/docs/android/?language=kotlin)


### PR DESCRIPTION
This PR fixes a small typo in the README file where the phrase

"Learn the basics of the SDK by by building a simple messaging app"

contains a duplicated word **"by"**. This change removes the duplicate to improve readability.

### 🎯 Goal

Improve documentation clarity by fixing a minor typo.

### 🛠 Implementation details

Removed the duplicated word **"by"** in the README file.

### 🧪 Testing

No testing required, as this change only affects documentation.

### ☑️ Contributor Checklist

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (if required)
- [x] PR is linked to the GitHub issue it resolves (if any)
- [x] Affected documentation updated
