### PR TITLE
[CI] Ignore offline reaction related E2E test

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/ReactionsTests.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.compose.uiautomator.seconds
 import io.getstream.chat.android.e2e.test.mockserver.ReactionType
 import io.qameta.allure.kotlin.Allure.step
 import io.qameta.allure.kotlin.AllureId
+import org.junit.Ignore
 import org.junit.Test
 
 class ReactionsTests : StreamTestCase() {
@@ -181,6 +182,7 @@ class ReactionsTests : StreamTestCase() {
     }
 
     @AllureId("5714")
+    @Ignore("https://linear.app/stream/issue/AND-578")
     @Test
     fun test_userAddsReactionWhileOffline() {
         step("GIVEN user opens the channel") {


### PR DESCRIPTION
Problem: https://github.com/GetStream/stream-chat-android/actions/runs/15264731823
Related ticket: https://linear.app/stream/issue/AND-578