### PR TITLE
Message members from the member bottom sheet of channel info screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@
 
 ### ✅ Added
 - Add `FileAttachmentPreviewContent`, `FileAttachmentContent`,`FileAttachmentItem`, `FileUploadContent` and `FileUploadItem` to `ChatComponentFactory`. [#5791](https://github.com/GetStream/stream-chat-android/pull/5791)
+- Introduce internal `DraftChannelViewController` and experimental classes `DraftChannelViewState`, `DraftChannelViewAction`, and `DraftChannelViewEvent`. [#5797](https://github.com/GetStream/stream-chat-android/pull/5797)
+- Message member from the member bottom sheet of the channel info screen. [#5797](https://github.com/GetStream/stream-chat-android/pull/5797)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -89,6 +89,10 @@
             android:exported="false"
             android:windowSoftInputMode="adjustResize"
             />
+        <activity
+            android:name=".feature.channel.draft.DraftChannelActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize"
+            />
     </application>
-
 </manifest>

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelActivity.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.feature.channel.draft
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.systemBarsPadding
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
+import io.getstream.chat.android.compose.sample.ui.MessagesActivity
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.ui.common.feature.channel.draft.DraftChannelViewEvent
+import kotlinx.coroutines.flow.collectLatest
+
+class DraftChannelActivity : BaseConnectedActivity() {
+
+    companion object {
+        private const val KEY_MEMBER_IDS = "memberIds"
+
+        /**
+         * Creates an [Intent] for starting the [DraftChannelActivity].
+         *
+         * @param context The calling [Context], used for building the [Intent].
+         * @param memberIds The list of member IDs to be used for creating the channel.
+         */
+        fun createIntent(context: Context, memberIds: List<String>) =
+            Intent(context, DraftChannelActivity::class.java)
+                .putExtra(KEY_MEMBER_IDS, memberIds.toTypedArray())
+    }
+
+    private val viewModelFactory by lazy {
+        DraftChannelViewModelFactory(
+            memberIds = requireNotNull(intent.getStringArrayExtra(KEY_MEMBER_IDS)).toList(),
+        )
+    }
+    private val viewModel by viewModels<DraftChannelViewModel> { viewModelFactory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ChatTheme {
+                DraftChannelScreen(
+                    modifier = Modifier.systemBarsPadding(),
+                    viewModel = viewModel,
+                    onNavigationIconClick = ::finish,
+                )
+                LaunchedEffect(viewModel) {
+                    viewModel.events.collectLatest { event ->
+                        when (event) {
+                            is DraftChannelViewEvent.NavigateToChannel -> {
+                                startActivity(
+                                    MessagesActivity.createIntent(
+                                        context = applicationContext,
+                                        channelId = event.cid,
+                                    ),
+                                )
+                                finish()
+                            }
+
+                            is DraftChannelViewEvent.DraftChannelError ->
+                                Toast.makeText(
+                                    applicationContext,
+                                    R.string.draft_channel_error,
+                                    Toast.LENGTH_SHORT,
+                                ).show()
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelScreen.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelScreen.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.feature.channel.draft
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import io.getstream.chat.android.compose.ui.components.LoadingIndicator
+import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
+import io.getstream.chat.android.compose.ui.messages.header.MessageListHeader
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.viewmodel.channel.ChannelHeaderViewModel
+import io.getstream.chat.android.compose.viewmodel.channel.ChannelHeaderViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
+import io.getstream.chat.android.compose.viewmodel.messages.MessagesViewModelFactory
+import io.getstream.chat.android.ui.common.feature.channel.draft.DraftChannelViewAction
+import io.getstream.chat.android.ui.common.state.channel.draft.DraftChannelViewState
+import io.getstream.chat.android.ui.common.state.messages.list.ChannelHeaderViewState
+
+@Composable
+fun DraftChannelScreen(
+    viewModel: DraftChannelViewModel,
+    onNavigationIconClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    DraftChannelContent(
+        modifier = modifier,
+        state = state,
+        onNavigationIconClick = onNavigationIconClick,
+        onViewAction = viewModel::onViewAction,
+    )
+}
+
+@Composable
+private fun DraftChannelContent(
+    state: DraftChannelViewState,
+    onNavigationIconClick: () -> Unit,
+    onViewAction: (action: DraftChannelViewAction) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    when (state) {
+        is DraftChannelViewState.Loading -> LoadingIndicator(
+            modifier = modifier.fillMaxSize(),
+        )
+
+        is DraftChannelViewState.Content -> Scaffold(
+            modifier = modifier,
+            topBar = {
+                DraftChannelTopBar(
+                    cid = state.channel.cid,
+                    onNavigationIconClick = onNavigationIconClick,
+                )
+            },
+            bottomBar = {
+                DraftChannelBottomBar(
+                    cid = state.channel.cid,
+                    onMessageSent = { onViewAction(DraftChannelViewAction.MessageSent) },
+                )
+            },
+            containerColor = ChatTheme.colors.appBackground,
+        ) { padding ->
+            ChatTheme.componentFactory.MessageListEmptyContent(
+                modifier = Modifier
+                    .padding(padding)
+                    .fillMaxSize(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun DraftChannelTopBar(
+    cid: String,
+    onNavigationIconClick: () -> Unit,
+) {
+    val viewModel = viewModel<ChannelHeaderViewModel>(factory = ChannelHeaderViewModelFactory(cid))
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    when (val content = state) {
+        is ChannelHeaderViewState.Loading -> LoadingIndicator(
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        is ChannelHeaderViewState.Content -> MessageListHeader(
+            channel = content.channel,
+            currentUser = content.currentUser,
+            connectionState = content.connectionState,
+            onBackPressed = onNavigationIconClick,
+        )
+    }
+}
+
+@Composable
+private fun DraftChannelBottomBar(
+    cid: String,
+    onMessageSent: () -> Unit,
+) {
+    val context = LocalContext.current
+    val viewModel = viewModel<MessageComposerViewModel>(key = cid, factory = MessagesViewModelFactory(context, cid))
+    MessageComposer(
+        viewModel = viewModel,
+        onSendMessage = { message ->
+            viewModel.sendMessage(message)
+            onMessageSent()
+        },
+    )
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelViewModel.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelViewModel.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(InternalStreamChatApi::class)
+
+package io.getstream.chat.android.compose.sample.feature.channel.draft
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.ui.common.feature.channel.draft.DraftChannelViewAction
+import io.getstream.chat.android.ui.common.feature.channel.draft.DraftChannelViewController
+import io.getstream.chat.android.ui.common.feature.channel.draft.DraftChannelViewEvent
+import io.getstream.chat.android.ui.common.state.channel.draft.DraftChannelViewState
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class DraftChannelViewModel(
+    private val memberIds: List<String>,
+    controllerProvider: ViewModel.() -> DraftChannelViewController = {
+        DraftChannelViewController(
+            memberIds = memberIds,
+            scope = viewModelScope,
+        )
+    },
+) : ViewModel() {
+
+    private val controller: DraftChannelViewController by lazy { controllerProvider() }
+
+    /**
+     * @see [DraftChannelViewController.state]
+     */
+    val state: StateFlow<DraftChannelViewState> = controller.state
+
+    /**
+     * @see [DraftChannelViewController.events]
+     */
+    val events: SharedFlow<DraftChannelViewEvent> = controller.events
+
+    /**
+     * @see [DraftChannelViewController.onViewAction]
+     */
+    fun onViewAction(action: DraftChannelViewAction) {
+        controller.onViewAction(action)
+    }
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelViewModelFactory.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/draft/DraftChannelViewModelFactory.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.feature.channel.draft
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+
+class DraftChannelViewModelFactory(private val memberIds: List<String>) : ViewModelProvider.Factory {
+    @OptIn(InternalStreamChatApi::class)
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass == DraftChannelViewModel::class.java) {
+            "DraftChannelViewModelFactory can only create instances of DraftChannelViewModel"
+        }
+        @Suppress("UNCHECKED_CAST")
+        return DraftChannelViewModel(memberIds) as T
+    }
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/DirectChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/DirectChannelInfoActivity.kt
@@ -95,10 +95,11 @@ class DirectChannelInfoActivity : BaseConnectedActivity() {
             is ChannelInfoViewEvent.NavigateToPinnedMessages ->
                 openPinnedMessages()
 
-            is ChannelInfoViewEvent.NavigateToChannel ->
-                // No need to handle this in DirectChannelInfoActivity,
-                // as it is only applicable for group channels.
-                Unit
+            // No need to handle these in DirectChannelInfoActivity,
+            // as it is only applicable for group channels.
+            is ChannelInfoViewEvent.NavigateToChannel,
+            is ChannelInfoViewEvent.NavigateToDraftChannel,
+            -> Unit
         }
     }
 
@@ -137,9 +138,6 @@ class DirectChannelInfoActivity : BaseConnectedActivity() {
 
             ChannelInfoViewEvent.UnbanMemberError,
             -> R.string.stream_ui_channel_info_unban_member_error
-
-            ChannelInfoViewEvent.NewDirectChannelError,
-            -> R.string.stream_ui_channel_info_new_direct_channel_error
         }
         Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/DirectChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/DirectChannelInfoActivity.kt
@@ -76,21 +76,29 @@ class DirectChannelInfoActivity : BaseConnectedActivity() {
             LaunchedEffect(viewModel) {
                 viewModel.events.collectLatest { event ->
                     when (event) {
-                        is ChannelInfoViewEvent.Error ->
-                            showError(event)
-
-                        is ChannelInfoViewEvent.NavigateUp -> {
-                            setResult(RESULT_OK)
-                            finish()
-                        }
-
-                        is ChannelInfoViewEvent.NavigateToPinnedMessages ->
-                            openPinnedMessages()
-
-                        else -> Unit
+                        is ChannelInfoViewEvent.Error -> showError(event)
+                        is ChannelInfoViewEvent.Navigation -> onNavigationEvent(event)
+                        is ChannelInfoViewEvent.Modal -> Unit
                     }
                 }
             }
+        }
+    }
+
+    private fun onNavigationEvent(event: ChannelInfoViewEvent.Navigation) {
+        when (event) {
+            is ChannelInfoViewEvent.NavigateUp -> {
+                setResult(RESULT_OK)
+                finish()
+            }
+
+            is ChannelInfoViewEvent.NavigateToPinnedMessages ->
+                openPinnedMessages()
+
+            is ChannelInfoViewEvent.NavigateToChannel ->
+                // No need to handle this in DirectChannelInfoActivity,
+                // as it is only applicable for group channels.
+                Unit
         }
     }
 
@@ -129,6 +137,9 @@ class DirectChannelInfoActivity : BaseConnectedActivity() {
 
             ChannelInfoViewEvent.UnbanMemberError,
             -> R.string.stream_ui_channel_info_unban_member_error
+
+            ChannelInfoViewEvent.NewDirectChannelError,
+            -> R.string.stream_ui_channel_info_new_direct_channel_error
         }
         Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
@@ -96,7 +96,7 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
                 openPinnedMessages()
 
             is ChannelInfoViewEvent.NavigateToChannel -> {
-                val intent = MessagesActivity.createIntent(context = this, channelId = event.channelId)
+                val intent = MessagesActivity.createIntent(context = this, channelId = event.cid)
                 startActivity(intent)
             }
         }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.feature.channel.draft.DraftChannelActivity
 import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
 import io.getstream.chat.android.compose.sample.ui.MessagesActivity
 import io.getstream.chat.android.compose.sample.ui.pinned.PinnedMessagesActivity
@@ -95,10 +96,11 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
             is ChannelInfoViewEvent.NavigateToPinnedMessages ->
                 openPinnedMessages()
 
-            is ChannelInfoViewEvent.NavigateToChannel -> {
-                val intent = MessagesActivity.createIntent(context = this, channelId = event.cid)
-                startActivity(intent)
-            }
+            is ChannelInfoViewEvent.NavigateToChannel ->
+                startActivity(MessagesActivity.createIntent(context = this, channelId = event.cid))
+
+            is ChannelInfoViewEvent.NavigateToDraftChannel ->
+                startActivity(DraftChannelActivity.createIntent(context = this, memberIds = listOf(event.memberId)))
         }
     }
 
@@ -137,9 +139,6 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
 
             ChannelInfoViewEvent.RemoveMemberError,
             -> R.string.stream_ui_channel_info_remove_member_error
-
-            ChannelInfoViewEvent.NewDirectChannelError,
-            -> R.string.stream_ui_channel_info_new_direct_channel_error
         }
         Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import io.getstream.chat.android.compose.sample.R
-import io.getstream.chat.android.compose.sample.feature.channel.add.AddChannelActivity
 import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
 import io.getstream.chat.android.compose.sample.ui.MessagesActivity
 import io.getstream.chat.android.compose.sample.ui.pinned.PinnedMessagesActivity
@@ -77,20 +76,16 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
             LaunchedEffect(viewModel) {
                 viewModel.events.collectLatest { event ->
                     when (event) {
-                        is ChannelInfoViewEvent.Error ->
-                            showError(event)
-
-                        is ChannelInfoViewEvent.Navigation ->
-                            handleNavigationEvent(event)
-
-                        else -> Unit
+                        is ChannelInfoViewEvent.Error -> showError(event)
+                        is ChannelInfoViewEvent.Navigation -> onNavigationEvent(event)
+                        is ChannelInfoViewEvent.Modal -> Unit
                     }
                 }
             }
         }
     }
 
-    private fun handleNavigationEvent(event: ChannelInfoViewEvent.Navigation) {
+    private fun onNavigationEvent(event: ChannelInfoViewEvent.Navigation) {
         when (event) {
             is ChannelInfoViewEvent.NavigateUp -> {
                 setResult(RESULT_OK)
@@ -101,20 +96,8 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
                 openPinnedMessages()
 
             is ChannelInfoViewEvent.NavigateToChannel -> {
-                val intent = MessagesActivity.createIntent(
-                    context = this,
-                    channelId = event.channelId,
-                )
+                val intent = MessagesActivity.createIntent(context = this, channelId = event.channelId)
                 startActivity(intent)
-            }
-
-            is ChannelInfoViewEvent.NavigateToNewChannel -> {
-                // TODO NavigateToNewChannel
-                // val intent = AddChannelActivity.createIntent(
-                //     context = this,
-                //     memberId = event.memberId,
-                // )
-                startActivity(Intent(this, AddChannelActivity::class.java))
             }
         }
     }
@@ -154,6 +137,9 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
 
             ChannelInfoViewEvent.RemoveMemberError,
             -> R.string.stream_ui_channel_info_remove_member_error
+
+            ChannelInfoViewEvent.NewDirectChannelError,
+            -> R.string.stream_ui_channel_info_new_direct_channel_error
         }
         Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/GroupChannelInfoActivity.kt
@@ -26,7 +26,9 @@ import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.feature.channel.add.AddChannelActivity
 import io.getstream.chat.android.compose.sample.ui.BaseConnectedActivity
+import io.getstream.chat.android.compose.sample.ui.MessagesActivity
 import io.getstream.chat.android.compose.sample.ui.pinned.PinnedMessagesActivity
 import io.getstream.chat.android.compose.ui.channel.info.GroupChannelInfoScreen
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -78,17 +80,41 @@ class GroupChannelInfoActivity : BaseConnectedActivity() {
                         is ChannelInfoViewEvent.Error ->
                             showError(event)
 
-                        is ChannelInfoViewEvent.NavigateUp -> {
-                            setResult(RESULT_OK)
-                            finish()
-                        }
-
-                        is ChannelInfoViewEvent.NavigateToPinnedMessages ->
-                            openPinnedMessages()
+                        is ChannelInfoViewEvent.Navigation ->
+                            handleNavigationEvent(event)
 
                         else -> Unit
                     }
                 }
+            }
+        }
+    }
+
+    private fun handleNavigationEvent(event: ChannelInfoViewEvent.Navigation) {
+        when (event) {
+            is ChannelInfoViewEvent.NavigateUp -> {
+                setResult(RESULT_OK)
+                finish()
+            }
+
+            is ChannelInfoViewEvent.NavigateToPinnedMessages ->
+                openPinnedMessages()
+
+            is ChannelInfoViewEvent.NavigateToChannel -> {
+                val intent = MessagesActivity.createIntent(
+                    context = this,
+                    channelId = event.channelId,
+                )
+                startActivity(intent)
+            }
+
+            is ChannelInfoViewEvent.NavigateToNewChannel -> {
+                // TODO NavigateToNewChannel
+                // val intent = AddChannelActivity.createIntent(
+                //     context = this,
+                //     memberId = event.memberId,
+                // )
+                startActivity(Intent(this, AddChannelActivity::class.java))
             }
         }
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -327,7 +327,7 @@ class ChatsActivity : BaseConnectedActivity() {
         onNavigationIconClick: () -> Unit,
         onNavigateUp: () -> Unit,
         onNavigateToPinnedMessages: () -> Unit,
-        onNavigateToChannel: (channelId: String) -> Unit,
+        onNavigateToChannel: (cid: String) -> Unit,
     ) {
         val viewModelFactory = ChannelInfoViewModelFactory(context = applicationContext, cid = channelId)
         val viewModel = viewModel<ChannelInfoViewModel>(key = channelId, factory = viewModelFactory)
@@ -363,7 +363,7 @@ class ChatsActivity : BaseConnectedActivity() {
     private fun ChannelInfoViewModel.handleChannelInfoEvents(
         onNavigateUp: () -> Unit,
         onNavigateToPinnedMessages: () -> Unit,
-        onNavigateToChannel: (channelId: String) -> Unit = {},
+        onNavigateToChannel: (cid: String) -> Unit = {},
     ) {
         LaunchedEffect(this) {
             events.collectLatest { event ->
@@ -371,7 +371,7 @@ class ChatsActivity : BaseConnectedActivity() {
                     is ChannelInfoViewEvent.Navigation -> when (event) {
                         is ChannelInfoViewEvent.NavigateUp -> onNavigateUp()
                         is ChannelInfoViewEvent.NavigateToPinnedMessages -> onNavigateToPinnedMessages()
-                        is ChannelInfoViewEvent.NavigateToChannel -> onNavigateToChannel(event.channelId)
+                        is ChannelInfoViewEvent.NavigateToChannel -> onNavigateToChannel(event.cid)
                     }
                     is ChannelInfoViewEvent.Error -> showError(event)
                     is ChannelInfoViewEvent.Modal -> Unit

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -372,6 +372,8 @@ class ChatsActivity : BaseConnectedActivity() {
                         is ChannelInfoViewEvent.NavigateUp -> onNavigateUp()
                         is ChannelInfoViewEvent.NavigateToPinnedMessages -> onNavigateToPinnedMessages()
                         is ChannelInfoViewEvent.NavigateToChannel -> onNavigateToChannel(event.cid)
+                        // https://linear.app/stream/issue/AND-582/compose-support-draft-messages-in-chatsactivity
+                        is ChannelInfoViewEvent.NavigateToDraftChannel -> Unit
                     }
                     is ChannelInfoViewEvent.Error -> showError(event)
                     is ChannelInfoViewEvent.Modal -> Unit
@@ -540,9 +542,6 @@ private fun Context.showError(error: ChannelInfoViewEvent.Error) {
 
         ChannelInfoViewEvent.RemoveMemberError,
         -> R.string.stream_ui_channel_info_remove_member_error
-
-        ChannelInfoViewEvent.NewDirectChannelError,
-        -> R.string.stream_ui_channel_info_new_direct_channel_error
     }
     Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
 }

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -67,4 +67,7 @@
     <string name="app_bottom_bar_chats">Chats</string>
     <string name="app_bottom_bar_mentions">Mentions</string>
     <string name="app_bottom_bar_threads">Threads</string>
+
+    <!-- Draft Channel -->
+    <string name="draft_channel_error">Failed to draft a channel</string>
 </resources>

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -33,7 +33,7 @@
     <string name="custom_login_hint_user_id">User ID</string>
     <string name="custom_login_hint_user_token">User Token</string>
     <string name="custom_login_hint_user_name">Username (optional)</string>
-    <string name="custom_login_enable_adaptive_layout">Enable adaptive layout</string>
+    <string name="custom_login_enable_adaptive_layout">Enable adaptive layout (Experimental)</string>
     <string name="custom_login_enable_adaptive_layout_description">Adjust layout based on screen sizes</string>
 
     <!-- Pinned Messages -->

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -4388,6 +4388,12 @@ public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelHe
 	public final fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 }
 
+public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelHeaderViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
+}
+
 public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelInfoMemberViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoMemberInfoModalSheet.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoMemberInfoModalSheet.kt
@@ -108,12 +108,11 @@ private fun ChannelInfoMemberInfoModalSheetContent(
 ) {
     val isLoading = state is ChannelInfoMemberViewState.Loading
     ContentBox(
-        contentAlignment = if (isLoading) Alignment.Center else Alignment.TopCenter,
+        modifier = Modifier.fillMaxWidth(),
         isLoading = isLoading,
     ) {
         val content = state as ChannelInfoMemberViewState.Content
         Column(
-            modifier = Modifier.fillMaxWidth(),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
@@ -154,11 +154,11 @@ private fun DirectChannelInfoContent(
             modifier = Modifier
                 .padding(padding)
                 .fillMaxSize(),
-            contentAlignment = if (isLoading) Alignment.Center else Alignment.TopCenter,
             isLoading = isLoading,
         ) {
             val content = state as ChannelInfoViewState.Content
             Column(
+                modifier = Modifier.matchParentSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
@@ -39,7 +39,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -195,11 +194,11 @@ private fun GroupChannelInfoContent(
     val isLoading = state is ChannelInfoViewState.Loading
     ContentBox(
         modifier = modifier.fillMaxSize(),
-        contentAlignment = if (isLoading) Alignment.Center else Alignment.TopCenter,
         isLoading = isLoading,
     ) {
         val content = state as ChannelInfoViewState.Content
         LazyColumn(
+            modifier = Modifier.matchParentSize(),
             state = listState,
         ) {
             items(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelHeaderViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelHeaderViewModelFactory.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.viewmodel.channel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+
+/**
+ * Factory for creating instances of [ChannelHeaderViewModel].
+ *
+ * @param cid The full channel identifier (e.g., "messaging:123").
+ */
+@ExperimentalStreamChatApi
+public class ChannelHeaderViewModelFactory(
+    private val cid: String,
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        require(modelClass == ChannelHeaderViewModel::class.java) {
+            "ChannelHeaderViewModelFactory can only create instances of ChannelHeaderViewModel"
+        }
+        @Suppress("UNCHECKED_CAST")
+        return ChannelHeaderViewModel(cid) as T
+    }
+}

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -67,12 +67,14 @@ public final class io/getstream/chat/android/ui/common/feature/channel/info/Chan
 
 public final class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember : io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getMemberId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -377,6 +379,30 @@ public final class io/getstream/chat/android/ui/common/feature/channel/info/Chan
 	public static final field $stable I
 	public static final field INSTANCE Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$MuteChannelError;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel : io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$Navigation {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannelId ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel : io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$Navigation {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMemberId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -15,6 +15,40 @@ public abstract interface class io/getstream/chat/android/ui/common/disposable/D
 	public abstract fun isDisposed ()Z
 }
 
+public abstract interface class io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction {
+}
+
+public final class io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction$MessageSent : io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction {
+	public static final field $stable I
+	public static final field INSTANCE Lio/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction$MessageSent;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent {
+}
+
+public final class io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$DraftChannelError : io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent {
+	public static final field $stable I
+	public static final field INSTANCE Lio/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$DraftChannelError;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$NavigateToChannel : io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent {
+	public static final field $stable I
+	public fun <init> (Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$NavigateToChannel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$NavigateToChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent$NavigateToChannel;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getCid ()Ljava/lang/String;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewAction {
 }
 
@@ -73,7 +107,7 @@ public final class io/getstream/chat/android/ui/common/feature/channel/info/Chan
 	public final fun copy (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent$MessageMember;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getDistinctCid ()Ljava/lang/String;
 	public final fun getMemberId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -390,17 +424,17 @@ public final class io/getstream/chat/android/ui/common/feature/channel/info/Chan
 	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToChannel;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getChannelId ()Ljava/lang/String;
+	public final fun getCid ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel : io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$Navigation {
+public final class io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToDraftChannel : io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$Navigation {
 	public static final field $stable I
 	public fun <init> (Ljava/lang/String;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToNewChannel;
+	public final fun copy (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToDraftChannel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToDraftChannel;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent$NavigateToDraftChannel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMemberId ()Ljava/lang/String;
 	public fun hashCode ()I
@@ -1170,6 +1204,29 @@ public final class io/getstream/chat/android/ui/common/permissions/VisualMediaTy
 	public final fun getValue ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/ui/common/permissions/VisualMediaType;
 	public static fun values ()[Lio/getstream/chat/android/ui/common/permissions/VisualMediaType;
+}
+
+public abstract interface class io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState {
+}
+
+public final class io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Content : io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState {
+	public static final field $stable I
+	public fun <init> (Lio/getstream/chat/android/models/Channel;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Lio/getstream/chat/android/models/Channel;)Lio/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Content;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Content;Lio/getstream/chat/android/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Content;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Loading : io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState {
+	public static final field $stable I
+	public static final field INSTANCE Lio/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState$Loading;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class io/getstream/chat/android/ui/common/state/channel/info/ChannelInfoMemberViewState {

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewAction.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.channel.draft
+
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+
+/**
+ * Represents actions that can be performed in the draft channel view.
+ */
+@ExperimentalStreamChatApi
+public sealed interface DraftChannelViewAction {
+
+    /**
+     * Represents the action of sending a message in the draft channel.
+     */
+    public data object MessageSent : DraftChannelViewAction
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewController.kt
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.channel.draft
+
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.query.CreateChannelParams
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.MemberData
+import io.getstream.chat.android.ui.common.state.channel.draft.DraftChannelViewState
+import io.getstream.log.taggedLogger
+import io.getstream.result.Error
+import io.getstream.result.onSuccessSuspend
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Controller responsible for managing the state and events related to the draft channel.
+ */
+@InternalStreamChatApi
+public class DraftChannelViewController(
+    private val memberIds: List<String>,
+    private val scope: CoroutineScope,
+    private val chatClient: ChatClient = ChatClient.instance(),
+) {
+    private val logger by taggedLogger("Chat:NewDirectChannelViewController")
+
+    private lateinit var cid: String
+
+    /**
+     * A [StateFlow] representing the current state of the draft channel.
+     */
+    public val state: StateFlow<DraftChannelViewState> =
+        flow { createDraftChannel(::emit) }
+            .map { channel ->
+                cid = channel.cid
+                DraftChannelViewState.Content(channel = channel)
+            }.stateIn(
+                scope = scope,
+                started = SharingStarted.WhileSubscribed(STOP_TIMEOUT_IN_MILLIS),
+                initialValue = DraftChannelViewState.Loading,
+            )
+
+    private val _events = MutableSharedFlow<DraftChannelViewEvent>(extraBufferCapacity = 1)
+
+    /**
+     * A [SharedFlow] that emits one-shot events related to the draft channel, such as navigation events.
+     */
+    public val events: SharedFlow<DraftChannelViewEvent> = _events.asSharedFlow()
+
+    /**
+     * Handles actions related to the draft channel view.
+     *
+     * @param action The [DraftChannelViewAction] representing the action to be handled.
+     */
+    public fun onViewAction(action: DraftChannelViewAction) {
+        logger.d { "[onViewAction] action: $action" }
+        when (action) {
+            DraftChannelViewAction.MessageSent -> updateChannel()
+        }
+    }
+
+    private suspend fun createDraftChannel(onSuccess: suspend (channel: Channel) -> Unit = {}) {
+        logger.d { "[createDraftChannel] memberIds: $memberIds" }
+
+        val onError: (Error) -> Unit = { error ->
+            logger.e { "[createDraftChannel] error: $error" }
+            _events.tryEmit(DraftChannelViewEvent.DraftChannelError)
+        }
+
+        runCatching {
+            requireNotNull(chatClient.getCurrentUser()?.id) { "User not connected" }
+        }.onSuccess { currentUserId ->
+            chatClient.createChannel(
+                channelType = "messaging",
+                channelId = "",
+                params = CreateChannelParams(
+                    members = (memberIds + currentUserId).map(::MemberData),
+                    extraData = mapOf("draft" to true),
+                ),
+            ).await()
+                .onSuccessSuspend(onSuccess)
+                .onError(onError)
+        }.onFailure { cause ->
+            onError(Error.ThrowableError(message = cause.message.orEmpty(), cause = cause))
+        }
+    }
+
+    private fun updateChannel() {
+        logger.d { "[updateChannel] cid: $cid" }
+        scope.launch {
+            chatClient.channel(cid)
+                .update(message = null, extraData = mapOf("draft" to false))
+                .await()
+                .onSuccess {
+                    _events.tryEmit(DraftChannelViewEvent.NavigateToChannel(cid))
+                }
+                .onError {
+                    logger.e { "[updateChannel] Failed to update channel: $cid" }
+                    _events.tryEmit(DraftChannelViewEvent.DraftChannelError)
+                }
+        }
+    }
+}
+
+private const val STOP_TIMEOUT_IN_MILLIS = 5_000L

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewEvent.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.channel.draft
+
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+
+/**
+ * Represents side-effect events related to draft channel actions.
+ */
+@ExperimentalStreamChatApi
+public sealed interface DraftChannelViewEvent {
+
+    /**
+     * Indicates an event to navigate to a specific channel.
+     *
+     * @param cid The full channel identifier (e.g., "messaging:123").
+     */
+    public data class NavigateToChannel(val cid: String) : DraftChannelViewEvent
+
+    /**
+     * Indicates an error when trying to create a draft channel.
+     */
+    public data object DraftChannelError : DraftChannelViewEvent
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
@@ -105,7 +105,7 @@ public class ChannelInfoMemberViewController(
     private val _events = MutableSharedFlow<ChannelInfoMemberViewEvent>(extraBufferCapacity = 1)
 
     /**
-     * A [SharedFlow] that emits one-time events related to channel info, such as errors or success events.
+     * A [SharedFlow] that emits one-shot events related to channel info, such as errors or success events.
      */
     public val events: SharedFlow<ChannelInfoMemberViewEvent> = _events.asSharedFlow()
 
@@ -147,7 +147,7 @@ public class ChannelInfoMemberViewController(
     /**
      * Handles actions related to channel member information view.
      *
-     * @param action The [ChannelInfoMemberViewAction] representing the action to be performed.
+     * @param action The [ChannelInfoMemberViewAction] representing the action to be handled.
      */
     public fun onViewAction(
         action: ChannelInfoMemberViewAction,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
@@ -19,15 +19,20 @@
 package io.getstream.chat.android.ui.common.feature.channel.info
 
 import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QueryChannelsRequest
 import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.ChannelCapabilities
 import io.getstream.chat.android.models.ChannelData
+import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.Member
+import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.state.extensions.watchChannelAsState
 import io.getstream.chat.android.ui.common.state.channel.info.ChannelInfoMemberViewState
 import io.getstream.log.taggedLogger
+import io.getstream.result.onErrorSuspend
+import io.getstream.result.onSuccessSuspend
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -40,6 +45,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
@@ -81,6 +87,7 @@ public class ChannelInfoMemberViewController(
     public val events: SharedFlow<ChannelInfoMemberViewEvent> = _events.asSharedFlow()
 
     private lateinit var member: Member
+    private var distinctChannelId: String? = null
 
     init {
         @Suppress("OPT_IN_USAGE")
@@ -96,21 +103,55 @@ public class ChannelInfoMemberViewController(
                     channel.members
                         .mapNotNull { members -> members.firstOrNull { it.getUserId() == memberId } }
                         .onEach { logger.d { "[onMember] name: ${it.user.name}" } },
+                    queryDistinctChannel(),
                     ::ChannelInfoMemberData,
                 )
             }
             .distinctUntilChanged()
-            .onEach { (channelData, member) ->
-                onChannelInfoData(channelData, member)
+            .onEach { (channelData, member, distinctChannelId) ->
+                onChannelInfoData(channelData, member, distinctChannelId)
             }
             .launchIn(scope)
     }
 
+    private fun queryDistinctChannel(): Flow<String?> =
+        flow {
+            val currentUserId = requireNotNull(chatClient.getCurrentUser()?.id)
+            logger.d { "[queryDistinctChannel] currentUserId: $currentUserId, memberId: $memberId" }
+            chatClient.queryChannels(
+                request = QueryChannelsRequest(
+                    filter = Filters.and(
+                        Filters.eq("type", "messaging"),
+                        Filters.distinct(listOf(memberId, currentUserId)),
+                    ),
+                    querySort = QuerySortByField.descByName("last_updated"),
+                    messageLimit = 0,
+                    limit = 1,
+                ),
+            ).await()
+                .onSuccessSuspend { channels ->
+                    if (channels.isEmpty()) {
+                        logger.w { "[queryDistinctChannel] No distinct channel found of member: $memberId" }
+                        emit(null)
+                    } else {
+                        val channel = channels.first()
+                        logger.d { "[queryDistinctChannel] Found distinct channel: ${channel.cid}" }
+                        emit(channel.cid)
+                    }
+                }
+                .onErrorSuspend {
+                    logger.e { "[queryDistinctChannel] Error querying distinct channel of member: $memberId" }
+                    emit(null)
+                }
+        }
+
     private fun onChannelInfoData(
         channelData: ChannelData,
         member: Member,
+        distinctChannelId: String?,
     ) {
         this.member = member
+        this.distinctChannelId = distinctChannelId
 
         _state.update {
             ChannelInfoMemberViewState.Content(
@@ -134,8 +175,7 @@ public class ChannelInfoMemberViewController(
         logger.d { "[onViewAction] action: $action" }
         when (action) {
             is ChannelInfoMemberViewAction.MessageMemberClick ->
-                // https://linear.app/stream/issue/AND-567/compose-navigate-to-messages-from-the-member-modal-sheet-of-channel
-                _events.tryEmit(ChannelInfoMemberViewEvent.MessageMember(channelId = ""))
+                _events.tryEmit(ChannelInfoMemberViewEvent.MessageMember(memberId, distinctChannelId))
 
             is ChannelInfoMemberViewAction.BanMemberClick ->
                 _events.tryEmit(ChannelInfoMemberViewEvent.BanMember(member))
@@ -152,11 +192,11 @@ public class ChannelInfoMemberViewController(
 private data class ChannelInfoMemberData(
     val channelData: ChannelData,
     val member: Member,
+    val distinctChannelId: String?,
 )
 
 private fun buildOptionList(member: Member, capabilities: Set<String>) = buildList {
-    // https://linear.app/stream/issue/AND-567/compose-navigate-to-messages-from-the-member-modal-sheet-of-channel
-    // add(ChannelInfoMemberViewState.Content.Option.MessageMember(member = member))
+    add(ChannelInfoMemberViewState.Content.Option.MessageMember(member = member))
     if (capabilities.contains(ChannelCapabilities.BAN_CHANNEL_MEMBERS)) {
         if (member.banned) {
             add(ChannelInfoMemberViewState.Content.Option.UnbanMember(member = member))

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewController.kt
@@ -77,33 +77,30 @@ public class ChannelInfoMemberViewController(
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     public val state: StateFlow<ChannelInfoMemberViewState> =
-        channelState
-            .flatMapLatest { channel ->
-                combine(
-                    channel.channelData,
-                    channel.members
-                        .mapNotNull { members -> members.firstOrNull { it.getUserId() == memberId } }
-                        .onEach { logger.d { "[onMember] name: ${it.user.name}" } },
-                    queryDistinctChannel(),
-                    ::ChannelInfoMemberData,
-                )
-            }
-            .map { (channelData, member, distinctChannel) ->
-                this.member = member
-                this.distinctCid = distinctChannel?.cid
-                ChannelInfoMemberViewState.Content(
-                    member = member,
-                    options = buildOptionList(
-                        member = member,
-                        capabilities = channelData.ownCapabilities,
-                    ),
-                )
-            }
-            .stateIn(
-                scope = scope,
-                started = WhileSubscribed(STOP_TIMEOUT_IN_MILLIS),
-                initialValue = ChannelInfoMemberViewState.Loading,
+        channelState.flatMapLatest { channel ->
+            combine(
+                channel.channelData,
+                channel.members
+                    .mapNotNull { members -> members.firstOrNull { it.getUserId() == memberId } }
+                    .onEach { logger.d { "[onMember] name: ${it.user.name}" } },
+                queryDistinctChannel(),
+                ::ChannelInfoMemberData,
             )
+        }.map { (channelData, member, distinctChannel) ->
+            this.member = member
+            this.distinctCid = distinctChannel?.cid
+            ChannelInfoMemberViewState.Content(
+                member = member,
+                options = buildOptionList(
+                    member = member,
+                    capabilities = channelData.ownCapabilities,
+                ),
+            )
+        }.stateIn(
+            scope = scope,
+            started = WhileSubscribed(STOP_TIMEOUT_IN_MILLIS),
+            initialValue = ChannelInfoMemberViewState.Loading,
+        )
 
     private val _events = MutableSharedFlow<ChannelInfoMemberViewEvent>(extraBufferCapacity = 1)
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent.kt
@@ -29,9 +29,9 @@ public sealed interface ChannelInfoMemberViewEvent {
      * Indicates an event to proceed with messaging a member.
      *
      * @param memberId The ID of the member to message.
-     * @param channelId The ID of the channel to navigate to. Null if there is no distinct channel.
+     * @param distinctCid The full distinct channel ID, if any.
      */
-    public data class MessageMember(val memberId: String, val channelId: String?) : ChannelInfoMemberViewEvent
+    public data class MessageMember(val memberId: String, val distinctCid: String?) : ChannelInfoMemberViewEvent
 
     /**
      * Indicates an event to proceed with banning a member.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewEvent.kt
@@ -28,9 +28,10 @@ public sealed interface ChannelInfoMemberViewEvent {
     /**
      * Indicates an event to proceed with messaging a member.
      *
-     * @param channelId The ID of the channel to navigate to.
+     * @param memberId The ID of the member to message.
+     * @param channelId The ID of the channel to navigate to. Null if there is no distinct channel.
      */
-    public data class MessageMember(val channelId: String) : ChannelInfoMemberViewEvent
+    public data class MessageMember(val memberId: String, val channelId: String?) : ChannelInfoMemberViewEvent
 
     /**
      * Indicates an event to proceed with banning a member.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
@@ -194,8 +194,13 @@ public class ChannelInfoViewController(
     public fun onMemberViewEvent(event: ChannelInfoMemberViewEvent) {
         logger.d { "[onMemberViewEvent] event: $event" }
         when (event) {
-            // https://linear.app/stream/issue/AND-567/compose-navigate-to-messages-from-the-member-modal-sheet-of-channel
-            is ChannelInfoMemberViewEvent.MessageMember -> Unit
+            is ChannelInfoMemberViewEvent.MessageMember -> {
+                event.channelId?.let { channelId ->
+                    _events.tryEmit(ChannelInfoViewEvent.NavigateToChannel(channelId))
+                } ?: {
+                    _events.tryEmit(ChannelInfoViewEvent.NavigateToNewChannel(event.memberId))
+                }
+            }
 
             is ChannelInfoMemberViewEvent.BanMember ->
                 _events.tryEmit(ChannelInfoViewEvent.BanMemberModal(event.member))

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
@@ -21,14 +21,12 @@ package io.getstream.chat.android.ui.common.feature.channel.info
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.channel.ChannelClient
 import io.getstream.chat.android.client.channel.state.ChannelState
-import io.getstream.chat.android.client.query.CreateChannelParams
 import io.getstream.chat.android.core.ExperimentalStreamChatApi
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelCapabilities
 import io.getstream.chat.android.models.ChannelData
 import io.getstream.chat.android.models.Member
-import io.getstream.chat.android.models.MemberData
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.state.extensions.watchChannelAsState
@@ -92,7 +90,7 @@ public class ChannelInfoViewController(
     private val _events = MutableSharedFlow<ChannelInfoViewEvent>(extraBufferCapacity = 1)
 
     /**
-     * A [SharedFlow] that emits one-time events related to channel info, such as errors or success events.
+     * A [SharedFlow] that emits one-shot events related to channel info, such as errors or success events.
      */
     public val events: SharedFlow<ChannelInfoViewEvent> = _events.asSharedFlow()
 
@@ -161,7 +159,7 @@ public class ChannelInfoViewController(
     /**
      * Handles actions related to channel information view.
      *
-     * @param action The [ChannelInfoViewAction] representing the action to be performed.
+     * @param action The [ChannelInfoViewAction] representing the action to be handled.
      */
     public fun onViewAction(
         action: ChannelInfoViewAction,
@@ -199,7 +197,7 @@ public class ChannelInfoViewController(
             is ChannelInfoMemberViewEvent.MessageMember -> if (event.distinctCid != null) {
                 _events.tryEmit(ChannelInfoViewEvent.NavigateToChannel(event.distinctCid))
             } else {
-                createDirectChannel(event.memberId)
+                _events.tryEmit(ChannelInfoViewEvent.NavigateToDraftChannel(event.memberId))
             }
 
             is ChannelInfoMemberViewEvent.BanMember ->
@@ -412,35 +410,6 @@ public class ChannelInfoViewController(
 
     private fun List<Member>.filterNotCurrentUser() =
         filter { member -> member.user.id != chatClient.getCurrentUser()?.id }
-
-    private fun createDirectChannel(memberId: String) {
-        logger.d { "[createDirectChannel] memberId: $memberId" }
-
-        val onError: (Error) -> Unit = { error ->
-            logger.e { "[createDirectChannel] error: ${error.message}" }
-            _events.tryEmit(ChannelInfoViewEvent.NewDirectChannelError)
-        }
-
-        runCatching {
-            requireNotNull(chatClient.getCurrentUser()?.id) { "User not connected" }
-        }.onSuccess { currentUserId ->
-            scope.launch {
-                val params = CreateChannelParams(
-                    members = listOf(memberId, currentUserId).map(::MemberData),
-                    extraData = emptyMap(),
-                )
-                chatClient
-                    .createChannel(channelType = "messaging", channelId = "", params = params)
-                    .await()
-                    .onSuccess { channel ->
-                        _events.tryEmit(ChannelInfoViewEvent.NavigateToChannel(channel.cid))
-                    }
-                    .onError(onError)
-            }
-        }.onFailure { cause ->
-            onError(Error.ThrowableError(message = cause.message.orEmpty(), cause = cause))
-        }
-    }
 }
 
 private const val MINIMUM_VISIBLE_MEMBERS = 5

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewController.kt
@@ -196,8 +196,8 @@ public class ChannelInfoViewController(
     public fun onMemberViewEvent(event: ChannelInfoMemberViewEvent) {
         logger.d { "[onMemberViewEvent] event: $event" }
         when (event) {
-            is ChannelInfoMemberViewEvent.MessageMember -> if (event.channelId != null) {
-                _events.tryEmit(ChannelInfoViewEvent.NavigateToChannel(event.channelId))
+            is ChannelInfoMemberViewEvent.MessageMember -> if (event.distinctCid != null) {
+                _events.tryEmit(ChannelInfoViewEvent.NavigateToChannel(event.distinctCid))
             } else {
                 createDirectChannel(event.memberId)
             }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
@@ -151,13 +151,6 @@ public sealed interface ChannelInfoViewEvent {
     public data class NavigateToChannel(val channelId: String) : Navigation(reason = null)
 
     /**
-     * Indicates an event to navigate to a new channel creation.
-     *
-     * @param memberId The ID of the member to be added to the new channel.
-     */
-    public data class NavigateToNewChannel(val memberId: String) : Navigation(reason = null)
-
-    /**
      * Represents error events occurred while performing an action.
      */
     public sealed interface Error : ChannelInfoViewEvent
@@ -211,4 +204,9 @@ public sealed interface ChannelInfoViewEvent {
      * Indicates an error occurred while removing a member.
      */
     public data object RemoveMemberError : Error
+
+    /**
+     * Indicates an error occurred while creating a new direct channel.
+     */
+    public data object NewDirectChannelError : Error
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
@@ -144,11 +144,11 @@ public sealed interface ChannelInfoViewEvent {
     public data object NavigateToPinnedMessages : Navigation(reason = null)
 
     /**
-     * Indicates an event to navigate to the channel with the specified [channelId].
+     * Indicates an event to navigate to the channel with the specified [cid].
      *
-     * @param channelId The ID of the channel to navigate to.
+     * @param cid The full channel ID of the channel to navigate to.
      */
-    public data class NavigateToChannel(val channelId: String) : Navigation(reason = null)
+    public data class NavigateToChannel(val cid: String) : Navigation(reason = null)
 
     /**
      * Represents error events occurred while performing an action.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
@@ -144,6 +144,20 @@ public sealed interface ChannelInfoViewEvent {
     public data object NavigateToPinnedMessages : Navigation(reason = null)
 
     /**
+     * Indicates an event to navigate to the channel with the specified [channelId].
+     *
+     * @param channelId The ID of the channel to navigate to.
+     */
+    public data class NavigateToChannel(val channelId: String) : Navigation(reason = null)
+
+    /**
+     * Indicates an event to navigate to a new channel creation.
+     *
+     * @param memberId The ID of the member to be added to the new channel.
+     */
+    public data class NavigateToNewChannel(val memberId: String) : Navigation(reason = null)
+
+    /**
      * Represents error events occurred while performing an action.
      */
     public sealed interface Error : ChannelInfoViewEvent

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoViewEvent.kt
@@ -151,6 +151,13 @@ public sealed interface ChannelInfoViewEvent {
     public data class NavigateToChannel(val cid: String) : Navigation(reason = null)
 
     /**
+     * Indicates an event to navigate to draft a channel with the specified [memberId].
+     *
+     * @param memberId The ID of the member to whom the draft channel belongs.
+     */
+    public data class NavigateToDraftChannel(val memberId: String) : Navigation(reason = null)
+
+    /**
      * Represents error events occurred while performing an action.
      */
     public sealed interface Error : ChannelInfoViewEvent
@@ -204,9 +211,4 @@ public sealed interface ChannelInfoViewEvent {
      * Indicates an error occurred while removing a member.
      */
     public data object RemoveMemberError : Error
-
-    /**
-     * Indicates an error occurred while creating a new direct channel.
-     */
-    public data object NewDirectChannelError : Error
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/channel/draft/DraftChannelViewState.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.state.channel.draft
+
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.models.Channel
+
+/**
+ * Represents the state of the draft channel in the UI.
+ *
+ * This interface defines the possible states of the draft channel view,
+ * including loading and content states.
+ */
+@ExperimentalStreamChatApi
+public sealed interface DraftChannelViewState {
+
+    /**
+     * Represents the loading state of the draft channel.
+     */
+    public data object Loading : DraftChannelViewState
+
+    /**
+     * Represents the content state of the draft channel.
+     *
+     * @param channel The [Channel] object representing the direct channel being previewed.
+     */
+    public data class Content(val channel: Channel) : DraftChannelViewState
+}

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@
     <string name="stream_ui_channel_info_ban_member_error">Failed to ban member</string>
     <string name="stream_ui_channel_info_unban_member_error">Failed to unban member</string>
     <string name="stream_ui_channel_info_remove_member_error">Failed to remove member</string>
+    <string name="stream_ui_channel_info_new_direct_channel_error">Failed to create a new direct channel</string>
 
     <string name="stream_ui_channel_info_option_mute_conversation">Mute Conversation</string>
     <string name="stream_ui_channel_info_option_mute_group">Mute Group</string>

--- a/stream-chat-android-ui-common/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-common/src/main/res/values/strings.xml
@@ -89,7 +89,6 @@
     <string name="stream_ui_channel_info_ban_member_error">Failed to ban member</string>
     <string name="stream_ui_channel_info_unban_member_error">Failed to unban member</string>
     <string name="stream_ui_channel_info_remove_member_error">Failed to remove member</string>
-    <string name="stream_ui_channel_info_new_direct_channel_error">Failed to create a new direct channel</string>
 
     <string name="stream_ui_channel_info_option_mute_conversation">Mute Conversation</string>
     <string name="stream_ui_channel_info_option_mute_group">Mute Group</string>

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/draft/DraftChannelViewControllerTest.kt
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@file:OptIn(ExperimentalStreamChatApi::class)
+
+package io.getstream.chat.android.ui.common.feature.channel.draft
+
+import app.cash.turbine.test
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.channel.ChannelClient
+import io.getstream.chat.android.client.query.CreateChannelParams
+import io.getstream.chat.android.core.ExperimentalStreamChatApi
+import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.MemberData
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.positiveRandomInt
+import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.randomGenericError
+import io.getstream.chat.android.randomString
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.test.asCall
+import io.getstream.chat.android.ui.common.state.channel.draft.DraftChannelViewState
+import io.getstream.result.Error
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+internal class DraftChannelViewControllerTest {
+
+    @Test
+    fun `initial state`() = runTest {
+        val sut = Fixture().get(backgroundScope)
+
+        assertEquals(DraftChannelViewState.Loading, sut.state.value)
+    }
+
+    @Test
+    fun `create draft channel with no connected user`() = runTest {
+        val memberIds = randomMemberIds()
+        val fixture = Fixture().givenCreateDraftChannel(memberIds)
+        val sut = fixture.get(backgroundScope)
+
+        sut.state.test {
+            skipItems(1) // Skip initial state
+
+            sut.events.test {
+                assertEquals(
+                    DraftChannelViewEvent.DraftChannelError,
+                    awaitItem(),
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `create draft channel success`() = runTest {
+        val memberIds = randomMemberIds()
+        val currentUser = randomUser()
+        val channel = randomChannel()
+        val fixture = Fixture().givenCreateDraftChannel(memberIds, currentUser, channel)
+        val sut = fixture.get(backgroundScope)
+
+        sut.state.test {
+            skipItems(1) // Skip initial state
+
+            assertEquals(
+                DraftChannelViewState.Content(channel),
+                awaitItem(),
+            )
+        }
+        launch { fixture.verifyDraftChannelCreated(memberIds, currentUser) }
+    }
+
+    @Test
+    fun `create draft channel error`() = runTest {
+        val memberIds = randomMemberIds()
+        val currentUser = randomUser()
+        val channel = randomChannel()
+        val fixture = Fixture().givenCreateDraftChannel(memberIds, currentUser, channel, error = randomGenericError())
+        val sut = fixture.get(backgroundScope)
+
+        sut.state.test {
+            skipItems(1) // Skip initial state
+
+            sut.events.test {
+                assertEquals(
+                    DraftChannelViewEvent.DraftChannelError,
+                    awaitItem(),
+                )
+            }
+        }
+
+        launch { fixture.verifyDraftChannelCreated(memberIds, currentUser) }
+    }
+
+    @Test
+    fun `message sent success`() = runTest {
+        val channel = randomChannel()
+        val currentUser = randomUser()
+        val fixture = Fixture()
+            .givenCreateDraftChannel(memberIds = randomMemberIds(), currentUser, channel)
+            .givenUpdateChannel(channel)
+        val sut = fixture.get(backgroundScope)
+
+        sut.state.test {
+            skipItems(2) // Skip initial states
+
+            sut.events.test {
+                sut.onViewAction(DraftChannelViewAction.MessageSent)
+
+                assertEquals(
+                    DraftChannelViewEvent.NavigateToChannel(channel.cid),
+                    awaitItem(),
+                )
+            }
+        }
+
+        launch { fixture.verifyChannelUpdated(channel) }
+    }
+
+    @Test
+    fun `message sent error`() = runTest {
+        val channel = randomChannel()
+        val currentUser = randomUser()
+        val fixture = Fixture()
+            .givenCreateDraftChannel(memberIds = randomMemberIds(), currentUser, channel)
+            .givenUpdateChannel(channel, error = randomGenericError())
+        val sut = fixture.get(backgroundScope)
+
+        sut.state.test {
+            skipItems(2) // Skip initial states
+
+            sut.events.test {
+                sut.onViewAction(DraftChannelViewAction.MessageSent)
+
+                assertEquals(
+                    DraftChannelViewEvent.DraftChannelError,
+                    awaitItem(),
+                )
+            }
+        }
+    }
+}
+
+private class Fixture {
+    private val chatClient: ChatClient = mock()
+    private val channelClient: ChannelClient = mock()
+    private var memberIds: List<String> = randomMemberIds()
+
+    fun givenCreateDraftChannel(
+        memberIds: List<String>,
+        currentUser: User? = null,
+        channel: Channel? = null,
+        error: Error? = null,
+    ) = apply {
+        this.memberIds = memberIds
+        if (currentUser != null) {
+            whenever(chatClient.getCurrentUser()) doReturn currentUser
+        }
+        whenever(
+            chatClient.createChannel(
+                channelType = "messaging",
+                channelId = "",
+                params = CreateChannelParams(
+                    members = (memberIds + listOfNotNull(currentUser?.id)).map(::MemberData),
+                    extraData = mapOf("draft" to true),
+                ),
+            ),
+        ) doAnswer {
+            error?.asCall() ?: channel?.asCall()
+        }
+    }
+
+    fun givenUpdateChannel(channel: Channel, error: Error? = null) = apply {
+        whenever(chatClient.channel(channel.cid)) doReturn channelClient
+        whenever(channelClient.update(message = null, extraData = mapOf("draft" to false))) doAnswer {
+            error?.asCall() ?: channel.asCall()
+        }
+    }
+
+    fun verifyDraftChannelCreated(memberIds: List<String>, currentUser: User) = apply {
+        verify(chatClient).createChannel(
+            channelType = "messaging",
+            channelId = "",
+            params = CreateChannelParams(
+                members = (memberIds + currentUser.id).map(::MemberData),
+                extraData = mapOf("draft" to true),
+            ),
+        )
+    }
+
+    fun verifyChannelUpdated(channel: Channel) = apply {
+        verify(chatClient).channel(channel.cid)
+        verify(channelClient).update(message = null, extraData = mapOf("draft" to false))
+    }
+
+    fun get(scope: CoroutineScope) = DraftChannelViewController(
+        memberIds = memberIds,
+        scope = scope,
+        chatClient = chatClient,
+    )
+}
+
+private fun randomMemberIds() = List(size = positiveRandomInt(10), init = ::randomString)

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/info/ChannelInfoMemberViewControllerTest.kt
@@ -129,7 +129,7 @@ internal class ChannelInfoMemberViewControllerTest {
                 assertEquals(
                     ChannelInfoMemberViewEvent.MessageMember(
                         memberId = member.getUserId(),
-                        channelId = null,
+                        distinctCid = null,
                     ),
                     awaitItem(),
                 )
@@ -158,7 +158,7 @@ internal class ChannelInfoMemberViewControllerTest {
                 assertEquals(
                     ChannelInfoMemberViewEvent.MessageMember(
                         memberId = member.getUserId(),
-                        channelId = distinctChannel.cid,
+                        distinctCid = distinctChannel.cid,
                     ),
                     awaitItem(),
                 )


### PR DESCRIPTION
### 🎯 Goal

Support messaging a member from the group channel info screen

### 🛠 Implementation details

Messaging a member from the group channel info screen can enter two possible funnels:
- When there is an existing direct channel between the current user and the clicked member, the app navigates directly to the messages screen.
- When there is no direct channel for those users, the app opens a draft channel screen, and after sending the first message, the channel is converted to a non-draft channel and navigates to the messages screen.

The draft view controller and its state, and events are part of the `ui-common`, so it can be reused by the `ui-components` SDK. The draft screens and view model are not.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Starting a new chat</th>
<th>Messaging an existing chat</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/f97c74eb-c295-40b1-ad56-2c2d86f3875e" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/958494c7-1d1b-4c6d-b70e-d795ffd0957d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Open a group chat
- Click on the top bar title 
- Click on a member
- Click on the `Message` option in the member bottom sheet

### 🎉 GIF

![gif](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaGh1ZHZudjBob3pqbXVvNDV5aG5rMm12MmVtazVzM3Exb3BpdmM4NSZlcD12MV9naWZzX3NlYXJjaCZjdD1n/h8DJqHZgUSFAWuYCo5/giphy.gif)
