### PR TITLE
Add lambdas to be able to add a Leading and Trailing composables into…

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageList.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.compose.ui.messages.list
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -214,6 +213,8 @@ public fun MessageList(
             )
         }
     },
+    leadingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
+    trailingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
 ) {
     MessageList(
         reactionSorting = reactionSorting,
@@ -244,6 +245,8 @@ public fun MessageList(
         onClosePoll = onClosePoll,
         onAddAnswer = onAddAnswer,
         onReply = onReply,
+        leadingMessageContent = leadingMessageContent,
+        trailingMessageContent = trailingMessageContent,
     )
 }
 
@@ -497,6 +500,8 @@ public fun MessageList(
             )
         }
     },
+    leadingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
+    trailingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
 ) {
     val isLoading = currentState.isLoading
     val messages = currentState.messageItems
@@ -525,6 +530,8 @@ public fun MessageList(
                     itemContent = itemContent,
                     onMessagesEndReached = onMessagesPageEndReached,
                     onScrollToBottom = onScrollToBottom,
+                    leadingMessageContent = leadingMessageContent,
+                    trailingMessageContent = trailingMessageContent,
                 )
 
                 /** Clean up: Pause any playing audio tracks in onPause(). **/

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -120,6 +120,8 @@ public fun Messages(
         }
     },
     itemContent: @Composable LazyItemScope.(MessageListItemState) -> Unit,
+    leadingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
+    trailingMessageContent: (@Composable LazyItemScope.() -> Unit)? = null,
 ) {
     val lazyListState = messagesLazyListState.lazyListState
     val messages = messagesState.messageItems
@@ -159,6 +161,13 @@ public fun Messages(
             reverseLayout = true,
             contentPadding = contentPadding,
         ) {
+
+            leadingMessageContent?.let { leadingMessageContent ->
+                item {
+                    leadingMessageContent()
+                }
+            }
+
             if (isLoadingMoreNewMessages && !startOfMessages) {
                 item {
                     loadingMoreContent()
@@ -190,6 +199,12 @@ public fun Messages(
             if (isLoadingMoreOldMessages && !endOfMessages) {
                 item {
                     loadingMoreContent()
+                }
+            }
+
+            trailingMessageContent?.let { trailingMessageContent ->
+                item {
+                    trailingMessageContent()
                 }
             }
         }


### PR DESCRIPTION
… Message List

### 🎯 Goal

Need to add a Custom composable that scrolls along with the Messages inside the MessageList component.
I need one for Leading, to appear at the beginning of the conversation and one that appears at the end of the Conversation.
Since these Composables rely on Data that are unrelated to the Stream Chat Data and also they need to be able to handle clicks, I could not achieve this by overriding ChatComponentFactory

### 🛠 Implementation details

Added two different composable lambdas with null default values that if they exists, they will be added as children of the LazyColumn.

### 🎨 UI Changes

![image](https://github.com/user-attachments/assets/861345c4-c9c5-446e-8c0d-26aa874c378d)

![image](https://github.com/user-attachments/assets/3c9e9521-79e5-4939-adb8-750d042ee871)


### 🧪 Testing

Need to open the Conversation Screen and check if the Lambdas are properly rendered inside the LazyColumn

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

![image](https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fmedia.giphy.com%2Fmedia%2F5LU6ZcEGBbhVS%2Fgiphy.gif&f=1&nofb=1&ipt=0f35df97b441a0df39289eaa200f5fcdde4f485878022794a556480c939f7b5c)

