### PR TITLE
Fix ImagePicker crash and optimize changeSelectedAttachments. (#5804)

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -62,6 +63,7 @@ import io.getstream.chat.android.compose.ui.util.mirrorRtl
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMetaData
 import io.getstream.chat.android.ui.common.utils.MediaStringUtil
+import kotlinx.coroutines.launch
 
 private const val DefaultNumberOfPicturesPerRow = 3
 
@@ -119,6 +121,7 @@ internal fun DefaultImagesPickerItem(
 ) {
     val attachmentMetaData = imageItem.attachmentMetaData
     val isVideo = attachmentMetaData.type == AttachmentType.VIDEO
+    val scope = rememberCoroutineScope()
 
     val imageRequest = ImageRequest.Builder(LocalContext.current)
         .data(attachmentMetaData.uri.toString())
@@ -134,7 +137,11 @@ internal fun DefaultImagesPickerItem(
         modifier = Modifier
             .height(125.dp)
             .padding(2.dp)
-            .clickable { onImageSelected(imageItem) }
+            .clickable {
+                scope.launch {
+                    onImageSelected(imageItem)
+                }
+            }
             .testTag("Stream_AttachmentPickerSampleImage"),
     ) {
         StreamAsyncImage(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/AttachmentsPickerViewModel.kt
@@ -170,13 +170,12 @@ public class AttachmentsPickerViewModel(
     public fun changeSelectedAttachments(attachmentItem: AttachmentPickerItemState) {
         val dataSet = attachments
 
-        val itemIndex = dataSet.indexOf(attachmentItem)
+        val itemIndex = dataSet.indexOfFirst { it.attachmentMetaData == attachmentItem.attachmentMetaData }
         val newFiles = dataSet.toMutableList()
 
         val newItem = dataSet[itemIndex].copy(isSelected = !newFiles[itemIndex].isSelected)
 
-        newFiles.removeAt(itemIndex)
-        newFiles.add(itemIndex, newItem)
+        newFiles[itemIndex] = newItem
 
         if (attachmentsPickerMode == Files) {
             files = newFiles


### PR DESCRIPTION
### 🎯 Goal

Closes #5804 

### 🛠 Implementation details

Explaining...

### 🧪 Testing

Manually test by attaching a Layout Inspector to a slow device. Select and deselect as fast as you can. It won't crash.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [x] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [x] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [x] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [x] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
