### PR TITLE
Remove redundant use of coroutineScope inside of LaunchedEffect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Make the `MessageListHeader` support nullable `onHeaderTitleClick`, so that the ripple effect is not shown when the header is not clickable. [#5785](https://github.com/GetStream/stream-chat-android/pull/5785)
 
 ### ❌ Removed
+- Remove redundant use of coroutineScope inside of `LaunchedEffect`. [#5811](https://github.com/GetStream/stream-chat-android/pull/5811)
 
 ## stream-chat-android-markdown-transformer
 ### 🐞 Fixed

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
@@ -37,7 +37,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -60,7 +59,6 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.previewdata.PreviewPinnedMessageData
 import io.getstream.chat.android.ui.common.state.pinned.PinnedMessageListState
 import kotlinx.coroutines.flow.collectLatest
-import kotlinx.coroutines.launch
 
 /**
  * Default 'Pinned Messages List' component, which relies on [PinnedMessageListViewModel] to show and allow interactions
@@ -119,14 +117,11 @@ public fun PinnedMessageList(
     )
 
     // Error emissions
-    val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     LaunchedEffect(Unit) {
-        coroutineScope.launch {
-            viewModel.errorEvents.collectLatest {
-                val errorMessage = context.getString(R.string.stream_compose_pinned_message_list_results_error)
-                Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
-            }
+        viewModel.errorEvents.collectLatest {
+            val errorMessage = context.getString(R.string.stream_compose_pinned_message_list_results_error)
+            Toast.makeText(context, errorMessage, Toast.LENGTH_SHORT).show()
         }
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Avoid unnecessary coroutine scope creation inside a LaunchedEffect block and simplify the coroutine launch logic in the PinnedMessagesScreen. 
- This improves code readability and adheres to best practices in Compose.
-  Avoid manually launching nested coroutines when the outer scope already provides the structured, lifecycle-safe coroutine.
- Creating a CoroutineScope just to immediately launch one job inside another coroutine (LaunchedEffect) is unnecessary indirection and adds no value in our case.
- Keep coroutine usage minimal and clear.

### 🛠 Implementation details

Replaced the use of rememberCoroutineScope() within LaunchedEffect with a direct suspend call to collect from viewModel.errorEvents. Since LaunchedEffect already provides a lifecycle-aware coroutine scope, creating an additional scope was redundant.

### 🧪 Testing

This change is covered by existing UI behavior. To verify:

- Trigger a message error in PinnedMessagesScreen.
- Confirm that the Toast still shows the error message correctly.

No additional testing patch is required.


### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [x] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [x] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF
![FreshFromTheBathCuteDogGIF](https://github.com/user-attachments/assets/785b8619-e28b-43f7-b9fd-20d2d14c27fa)

