### PR TITLE
Ensure `ChannelInfo` is paresed from the Channel entity when Message doesn't contains it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Add `ChannelInfo` fallback to `Message` when parsing from API and/or Events. [#5813](https://github.com/GetStream/stream-chat-android/pull/5813)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -934,6 +934,7 @@ constructor(
 
     private fun flattenChannel(response: ChannelResponse): Channel = with(domainMapping) {
         return response.channel.toDomain().let { channel ->
+            val channelInfo = response.channel.toChannelInfo()
             channel.copy(
                 watcherCount = response.watcher_count,
                 read = response.read.map {
@@ -944,10 +945,10 @@ constructor(
                 members = response.members.map { it.toDomain() },
                 membership = response.membership?.toDomain(),
                 messages = response.messages.map {
-                    it.toDomain().enrichWithCid(channel.cid)
+                    it.toDomain(channelInfo).enrichWithCid(channel.cid)
                 },
                 pinnedMessages = response.pinned_messages.map {
-                    it.toDomain().enrichWithCid(channel.cid)
+                    it.toDomain(channelInfo).enrichWithCid(channel.cid)
                 },
                 watchers = response.watchers.map {
                     it.toDomain()

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -219,7 +219,6 @@ internal class DomainMapping(
             ).let(messageTransformer::transform)
         }
 
-
     internal fun DownstreamDraftDto.toDomain(fallbackChannelInfo: ChannelInfo? = null): DraftMessage =
         DraftMessage(
             attachments = message.attachments?.map { it.toDomain() } ?: emptyList(),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -263,7 +263,7 @@ internal class EventMapping(
             channelType = channel_type,
             channelId = channel_id,
             user = user?.toDomain(),
-            message = message?.toDomain(),
+            message = message?.toDomain(channel.toChannelInfo()),
             channel = channel.toDomain(),
         )
     }
@@ -279,7 +279,7 @@ internal class EventMapping(
             cid = cid,
             channelType = channel_type,
             channelId = channel_id,
-            message = message?.toDomain(),
+            message = message?.toDomain(channel.toChannelInfo()),
             channel = channel.toDomain(),
         )
     }
@@ -296,7 +296,7 @@ internal class EventMapping(
             channelType = channel_type,
             channelId = channel_id,
             user = user.toDomain(),
-            message = message?.toDomain(),
+            message = message?.toDomain(channel.toChannelInfo()),
             channel = channel.toDomain(),
         )
     }
@@ -626,7 +626,7 @@ internal class EventMapping(
             channelType = channel_type,
             channelId = channel_id,
             channel = channel.toDomain(),
-            message = message.toDomain(),
+            message = message.toDomain(channel.toChannelInfo()),
             totalUnreadCount = total_unread_count,
             unreadChannels = unread_channels,
         )
@@ -642,7 +642,7 @@ internal class EventMapping(
                 cid = cid,
                 channelId = channel_id,
                 channelType = channel_type,
-                message = message.toDomain(),
+                message = message.toDomain(channel.toChannelInfo()),
                 channel = channel.toDomain(),
                 createdAt = created_at.date,
                 rawCreatedAt = created_at.rawDate,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -612,6 +612,7 @@ private fun createMessageJsonString() =
         {
             "id": "09afcd85-9dbb-4da8-8d85-5a6b4268d755",
             "text": "Hello",
+            "channel": ${createChannelInfoJsonString()},
             "user": ${createUserJsonString()},
             "html": "<p>Hello</p>",
             "attachments": [ ],
@@ -627,6 +628,19 @@ private fun createMessageJsonString() =
             "silent": false,
             "type": "regular",
             "cid": ""
+        }
+    """.trimIndent()
+
+@Language("JSON")
+private fun createChannelInfoJsonString() =
+    """
+        {
+            "id": "channelId",
+            "type": "channelType",
+            "cid": "channelType:channelId",
+            "member_count": 1,
+            "name": "Channel Name",
+            "image": "https://domain.io/avatars/285/channel.png"
         }
     """.trimIndent()
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -247,7 +247,7 @@ internal object Mother {
 
     fun randomDownstreamMessageDto(
         attachments: List<AttachmentDto> = emptyList(),
-        channel: ChannelInfoDto? = null,
+        channel: ChannelInfoDto? = randomChannelInfoDto(),
         cid: String = randomString(),
         command: String? = randomString(),
         created_at: Date = randomDate(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -96,7 +96,6 @@ import io.getstream.chat.android.randomString
 import io.getstream.chat.android.randomUser
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
-import org.junit.Assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -96,6 +96,7 @@ import io.getstream.chat.android.randomString
 import io.getstream.chat.android.randomUser
 import org.amshove.kluent.`should be equal to`
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.Assert
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 
@@ -651,12 +652,13 @@ internal class DomainMappingTest {
         )
         val sut = Fixture().get()
         val thread = with(sut) { downstreamThreadDto.toDomain() }
+        val fallbackChannelInfo = with(sut) { downstreamThreadDto.channel?.toChannelInfo() }
         val expected = Thread(
             activeParticipantCount = downstreamThreadDto.active_participant_count ?: 0,
             cid = downstreamThreadDto.channel_cid,
             channel = with(sut) { downstreamThreadDto.channel?.toDomain() },
             parentMessageId = downstreamThreadDto.parent_message_id,
-            parentMessage = with(sut) { downstreamThreadDto.parent_message.toDomain() },
+            parentMessage = with(sut) { downstreamThreadDto.parent_message.toDomain(fallbackChannelInfo) },
             createdByUserId = downstreamThreadDto.created_by_user_id,
             createdBy = with(sut) { downstreamThreadDto.created_by?.toDomain() },
             participantCount = downstreamThreadDto.participant_count,
@@ -670,7 +672,7 @@ internal class DomainMappingTest {
             deletedAt = downstreamThreadDto.deleted_at,
             title = downstreamThreadDto.title,
             latestReplies = with(sut) {
-                downstreamThreadDto.latest_replies.map { it.toDomain() }
+                downstreamThreadDto.latest_replies.map { it.toDomain(fallbackChannelInfo) }
             },
             read = with(sut) {
                 downstreamThreadDto.read.orEmpty().map { it.toDomain(downstreamThreadDto.last_message_at) }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -108,6 +108,7 @@ import io.getstream.chat.android.client.events.UserStopWatchingEvent
 import io.getstream.chat.android.client.events.UserUpdatedEvent
 import io.getstream.chat.android.client.parser2.adapters.internal.StreamDateFormatter
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.ChannelInfo
 import io.getstream.chat.android.models.Command
 import io.getstream.chat.android.models.Config
 import io.getstream.chat.android.models.EventType
@@ -198,6 +199,15 @@ internal object EventArguments {
         config = config,
     )
 
+    private val channelInfo = ChannelInfo(
+        cid = channel.cid,
+        memberCount = channel.memberCount,
+        id = channel.id,
+        type = channel.type,
+        name = "Channel Name",
+        image = "https://domain.io/avatars/285/channel.png",
+    )
+
     private val message = Message(
         id = "09afcd85-9dbb-4da8-8d85-5a6b4268d755",
         text = "Hello",
@@ -207,6 +217,7 @@ internal object EventArguments {
         updatedAt = date,
         cid = channel.cid,
         type = "regular",
+        channelInfo = channelInfo,
     )
 
     private val reaction = Reaction(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageMapper.kt
@@ -177,6 +177,7 @@ internal suspend fun ReplyMessageEntity.toModel(
             messageTextUpdatedAt = messageTextUpdatedAt,
             poll = pollId?.let { getPoll(it) },
             restrictedVisibility = restrictedVisibility,
+            channelInfo = channelInfo?.toModel(),
         )
     }
 }


### PR DESCRIPTION
### 🎯 Goal
Ensure `ChannelInfo` is paresed from the Channel entity when Message doesn't contains it.

Complete: AND-595

### 🎉 GIF
![giphy5-ezgif com-optimize](https://github.com/user-attachments/assets/246e2cb6-412a-4a72-8fbe-aa63af99d8d0)
