### PR TITLE
Expire token only when it is needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### ⬆️ Improved
 - Add `ChannelInfo` fallback to `Message` when parsing from API and/or Events. [#5813](https://github.com/GetStream/stream-chat-android/pull/5813)
+- Refresh token only during WS reconnection when the reconnection is triggered by a token issue. [#5816](https://github.com/GetStream/stream-chat-android/pull/5816)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/ChatSocket.kt
@@ -138,6 +138,7 @@ internal open class ChatSocket(
                     is State.Disconnected -> {
                         when (state) {
                             is State.Disconnected.DisconnectedByRequest -> {
+                                tokenManager.expireToken()
                                 streamWebSocket?.close()
                                 healthMonitor.stop()
                                 userScope.launch { disposeObservers() }
@@ -152,6 +153,7 @@ internal open class ChatSocket(
                                 disposeNetworkStateObserver()
                             }
                             is State.Disconnected.DisconnectedPermanently -> {
+                                tokenManager.expireToken()
                                 streamWebSocket?.close()
                                 healthMonitor.stop()
                                 userScope.launch { disposeObservers() }
@@ -160,6 +162,7 @@ internal open class ChatSocket(
                                 healthMonitor.onDisconnected()
                             }
                             is State.Disconnected.WebSocketEventLost -> {
+                                tokenManager.expireToken()
                                 streamWebSocket?.close()
                                 connectionConf?.let { chatSocketStateService.onReconnect(it, false) }
                             }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/socket/SocketFactory.kt
@@ -65,9 +65,8 @@ internal class SocketFactory(
             when (connectionConf) {
                 is ConnectionConf.AnonymousConnectionConf -> "$baseWsUrl&stream-auth-type=anonymous"
                 is ConnectionConf.UserConnectionConf -> {
+                    tokenManager.ensureTokenLoaded()
                     val token = tokenManager.getToken()
-                        .takeUnless { connectionConf.isReconnection }
-                        ?: tokenManager.loadSync()
                     "$baseWsUrl&authorization=$token&stream-auth-type=jwt"
                 }
             }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
@@ -21,6 +21,7 @@ import io.getstream.chat.android.client.parser2.ParserFactory
 import io.getstream.chat.android.client.token.FakeTokenManager
 import io.getstream.chat.android.client.utils.HeadersUtil
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomString
 import io.getstream.chat.android.randomUser
 import okhttp3.OkHttpClient
@@ -45,17 +46,18 @@ internal class SocketFactoryTest {
         whenever(this.newWebSocket(any(), any())) doReturn mock()
     }
 
-    private val socketFactory = SocketFactory(
-        chatParser,
-        FakeTokenManager(token, loadSyncToken),
-        headersUtil,
-        httpClient,
-    )
-
     /** [arguments] */
     @ParameterizedTest
     @MethodSource("arguments")
-    internal fun testCreateSocket(connectionConf: SocketFactory.ConnectionConf, expectedUrl: String) {
+    internal fun testCreateSocket(
+        expireToken: Boolean,
+        connectionConf: SocketFactory.ConnectionConf,
+        expectedUrl: String,
+    ) {
+        val socketFactory = Fixture(httpClient)
+            .withExpire(expireToken)
+            .get()
+
         socketFactory.createSocket(connectionConf)
 
         verify(httpClient, only()).newWebSocket(
@@ -63,6 +65,22 @@ internal class SocketFactoryTest {
                 it.url.toString() `should be equal to` expectedUrl
             },
             any<WebSocketListener>(),
+        )
+    }
+
+    private class Fixture(val httpClient: OkHttpClient) {
+        private val tokenManager = FakeTokenManager(token, loadSyncToken)
+
+        fun withExpire(expire: Boolean): Fixture = apply {
+            tokenManager.takeIf { expire }?.expireToken()
+            return this
+        }
+
+        fun get() = SocketFactory(
+            chatParser,
+            tokenManager,
+            headersUtil,
+            httpClient,
         )
     }
 
@@ -81,24 +99,42 @@ internal class SocketFactoryTest {
         fun arguments() = listOf(
             randomUser(image = randomString(), name = randomString(), language = randomString()).let {
                 Arguments.of(
+                    false,
                     SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it),
                     "${endpoint}connect?json=${buildFullUserJson(it, it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$token&stream-auth-type=jwt",
                 )
             },
             randomUser().let {
                 Arguments.of(
+                    false,
+                    SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
+                    "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$token&stream-auth-type=jwt",
+                )
+            },
+            randomUser(image = randomString(), name = randomString(), language = randomString()).let {
+                Arguments.of(
+                    true,
+                    SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it),
+                    "${endpoint}connect?json=${buildFullUserJson(it, it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$loadSyncToken&stream-auth-type=jwt",
+                )
+            },
+            randomUser().let {
+                Arguments.of(
+                    true,
                     SocketFactory.ConnectionConf.UserConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
                     "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&authorization=$loadSyncToken&stream-auth-type=jwt",
                 )
             },
             User("anon").let {
                 Arguments.of(
+                    randomBoolean(),
                     SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
                     "${endpoint}connect?json=${buildMinimumUserJson(it.id)}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&stream-auth-type=anonymous",
                 )
             },
             User("!anon").let {
                 Arguments.of(
+                    randomBoolean(),
                     SocketFactory.ConnectionConf.AnonymousConnectionConf(endpoint, apiKey, it).asReconnectionConf(),
                     "${endpoint}connect?json=${buildMinimumUserJson("anon")}&api_key=$apiKey&X-Stream-Client=${headersUtil.buildSdkTrackingHeaders()}&stream-auth-type=anonymous",
                 )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/socket/SocketFactoryTest.kt
@@ -73,7 +73,6 @@ internal class SocketFactoryTest {
 
         fun withExpire(expire: Boolean): Fixture = apply {
             tokenManager.takeIf { expire }?.expireToken()
-            return this
         }
 
         fun get() = SocketFactory(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/token/FakeTokenManager.kt
@@ -21,6 +21,8 @@ internal class FakeTokenManager(
     private val loadSyncToken: String = token,
 ) : TokenManager {
 
+    private var expired = false
+
     override fun loadSync(): String = loadSyncToken.also {
         token = loadSyncToken
     }
@@ -28,7 +30,10 @@ internal class FakeTokenManager(
     override fun getToken(): String = token
 
     override fun ensureTokenLoaded() {
-        // empty
+        if (expired) {
+            loadSync()
+        }
+        expired = false
     }
 
     override fun setTokenProvider(provider: CacheableTokenProvider) {
@@ -44,6 +49,6 @@ internal class FakeTokenManager(
     }
 
     override fun expireToken() {
-        // empty
+        expired = true
     }
 }


### PR DESCRIPTION
### 🎯 Goal

To ensure the WS Connection is established with a non-expired token, on #5185 we force a token refresh on any reconnection process. It was fine because ensured it, but there is a corner-case where the token doesn't need to be refreshed even if it is a reconnection process, and it is in the case the app goes to the background.

On this PR, instead of refreshing the token whenever a reconnection process is started, the previous token is expired only in the case a potential token issue happened previously, and only in the case the previous token was expired, a new one is required.

Complete AND-593

### 🎉 GIF

![](https://media3.giphy.com/media/v1.Y2lkPTc5MGI3NjExdWl2a2xzdWJydXd4d2JtZHFsdjFsZHNxM2hjMWtqNXIwZWMza2loeiZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/vTKXchNrmZ6RW/giphy.gif)