### PR TITLE
Add focus request handling to MessageComposer for improved user exper…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Added the `focusRequestFlow` that emits one-shot focus events used to request focus on the message input field.
 
 ### ⚠️ Changed
 
@@ -72,6 +73,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Introduce `focusRequestFlow` in `MessageComposerViewModel` to request focus on the message input field triggered by certain `MessageAction`.
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -48,8 +48,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Alignment.Companion.Bottom
 import androidx.compose.ui.Alignment.Companion.Center
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
@@ -171,7 +174,16 @@ public fun MessageComposer(
     },
     input: @Composable RowScope.(MessageComposerState) -> Unit = {
         with(ChatTheme.componentFactory) {
+            val focusRequester = remember { FocusRequester() }
+            val keyboardController = LocalSoftwareKeyboardController.current
+            LaunchedEffect(Unit) {
+                viewModel.focusRequestFlow.collect {
+                    focusRequester.requestFocus()
+                    keyboardController?.show()
+                }
+            }
             MessageComposerInput(
+                modifier = Modifier.focusRequester(focusRequester),
                 state = it,
                 onInputChanged = onValueChange,
                 onAttachmentRemoved = onAttachmentRemoved,
@@ -319,6 +331,7 @@ public fun MessageComposer(
     input: @Composable RowScope.(MessageComposerState) -> Unit = {
         with(ChatTheme.componentFactory) {
             MessageComposerInput(
+                modifier = Modifier,
                 state = it,
                 onInputChanged = onValueChange,
                 onAttachmentRemoved = onAttachmentRemoved,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -1644,6 +1644,7 @@ public interface ChatComponentFactory {
     /**
      * The default input content of the message composer.
      *
+     * @param modifier The modifier to apply to the composable.
      * @param state The current state of the message composer.
      * @param onInputChanged The action to perform when the input changes.
      * @param onAttachmentRemoved The action to perform when an attachment is removed.
@@ -1651,13 +1652,14 @@ public interface ChatComponentFactory {
      */
     @Composable
     public fun RowScope.MessageComposerInput(
+        modifier: Modifier,
         state: MessageComposerState,
         onInputChanged: (String) -> Unit,
         onAttachmentRemoved: (Attachment) -> Unit,
         label: @Composable (MessageComposerState) -> Unit,
     ) {
         DefaultComposerInputContent(
-            modifier = Modifier.animateContentSize(),
+            modifier = modifier.animateContentSize(),
             messageComposerState = state,
             onValueChange = onInputChanged,
             onAttachmentRemoved = onAttachmentRemoved,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.ui.common.utils.typing.TypingUpdatesBuffer
 import io.getstream.result.call.Call
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
 
 /**
@@ -49,6 +50,11 @@ import kotlinx.coroutines.flow.StateFlow
 public class MessageComposerViewModel(
     private val messageComposerController: MessageComposerController,
 ) : ViewModel() {
+
+    /**
+     * One-shot focus events used to request focus on the message input field.
+     */
+    public val focusRequestFlow: SharedFlow<Unit> = messageComposerController.focusRequestFlow
 
     /**
      * The full UI state that has all the required data.

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -64,7 +64,9 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -242,6 +244,13 @@ public class MessageComposerController(
      * Full message composer state holding all the required information.
      */
     public val state: MutableStateFlow<MessageComposerState> = MutableStateFlow(MessageComposerState())
+
+    /**
+     * Emits one-shot focus events used to request focus on the message input field.
+     */
+    private val _focusRequestFlow: MutableSharedFlow<Unit> = MutableSharedFlow()
+    public val focusRequestFlow: SharedFlow<Unit>
+        get() = _focusRequestFlow
 
     /**
      * UI state of the current composer input.
@@ -598,6 +607,10 @@ public class MessageComposerController(
             else -> {
                 // no op, custom user action
             }
+        }
+
+        scope.launch {
+            _focusRequestFlow.emit(Unit)
         }
     }
 


### PR DESCRIPTION
### 🎯 Goal

Introduce a mechanism to programmatically request focus on the message input field when a MessageAction is triggered, improving UX in actions like replying, editing, or thread replies.

### 🛠 Implementation details

- Introduced a `focusRequestFlow` in `MessageComposerViewModel` to emit one-shot focus events.
- Collected this flow in the default input = `MessageComposer` composable using LaunchedEffect to request focus and show the keyboard.
- Used FocusRequester and LocalSoftwareKeyboardController to programmatically focus and open the keyboard.
- Applied the FocusRequester to the message input using a Modifier.

This can be further improved by passing a focusRequester as a parameter in the input (along with the state), but that would require changes in many places, which is why I avoided it and added the mechanism only to the default input.

### 🎨 UI Changes

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/1579d3fc-1d9a-40e8-9633-73cd045d8193
" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/3ed91335-e46e-42e8-8b2d-e63e5e9c9d1b" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

- Manually verified that when a MessageAction like Reply, Edit, or ThreadReply is triggered, the message input gains focus and the keyboard opens.
- Tested in both default and custom input configurations.

### ☑️Contributor Checklist

#### General
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [x] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [x] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [x] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
