### PR TITLE
Add ability to cancel link previews

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/ComposerLinkPreview.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/ComposerLinkPreview.kt
@@ -82,6 +82,7 @@ public fun ComposerLinkPreview(
     modifier: Modifier = Modifier,
     linkPreview: LinkPreview,
     onClick: ((linkPreview: LinkPreview) -> Unit)? = null,
+    onCancel: () -> Unit = {},
 ) {
     var previewClosed by rememberSaveable { mutableStateOf(false) }
 
@@ -127,7 +128,10 @@ public fun ComposerLinkPreview(
             Spacer(modifier = Modifier.height(theme.titleToSubtitle))
             ComposerLinkDescription(attachment.text)
         }
-        ComposerLinkCancelIcon { previewClosed = true }
+        ComposerLinkCancelIcon {
+            onCancel()
+            previewClosed = true
+        }
     }
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -124,6 +124,7 @@ public fun MessageComposer(
     onAttachmentRemoved: (Attachment) -> Unit = { viewModel.removeSelectedAttachment(it) },
     onCancelAction: () -> Unit = { viewModel.dismissMessageActions() },
     onLinkPreviewClick: ((LinkPreview) -> Unit)? = null,
+    onCancelLinkPreviewClick: () -> Unit = { viewModel.cancelLinkPreview() },
     onMentionSelected: (User) -> Unit = { viewModel.selectMention(it) },
     onCommandSelected: (Command) -> Unit = { viewModel.selectCommand(it) },
     onAlsoSendToChannelSelected: (Boolean) -> Unit = { viewModel.setAlsoSendToChannel(it) },
@@ -134,6 +135,7 @@ public fun MessageComposer(
                 state = it,
                 onCancel = onCancelAction,
                 onLinkPreviewClick = onLinkPreviewClick,
+                onCancelLinkPreviewClick = onCancelLinkPreviewClick,
             )
         }
     },
@@ -226,6 +228,7 @@ public fun MessageComposer(
         onValueChange = onValueChange,
         onAttachmentRemoved = onAttachmentRemoved,
         onLinkPreviewClick = onLinkPreviewClick,
+        onCancelLinkPreviewClick = onCancelLinkPreviewClick,
         label = label,
     )
 }
@@ -271,6 +274,7 @@ public fun MessageComposer(
     onAttachmentRemoved: (Attachment) -> Unit = {},
     onCancelAction: () -> Unit = {},
     onLinkPreviewClick: ((LinkPreview) -> Unit)? = null,
+    onCancelLinkPreviewClick: () -> Unit = {},
     onMentionSelected: (User) -> Unit = {},
     onCommandSelected: (Command) -> Unit = {},
     onAlsoSendToChannelSelected: (Boolean) -> Unit = {},
@@ -281,6 +285,7 @@ public fun MessageComposer(
                 state = it,
                 onCancel = onCancelAction,
                 onLinkPreviewClick = onLinkPreviewClick,
+                onCancelLinkPreviewClick = onCancelLinkPreviewClick,
             )
         }
     },
@@ -410,6 +415,7 @@ public fun DefaultMessageComposerHeaderContent(
     messageComposerState: MessageComposerState,
     onCancelAction: () -> Unit,
     onLinkPreviewClick: ((LinkPreview) -> Unit)? = null,
+    onCancelLinkPreviewClick: () -> Unit = {},
 ) {
     val activeAction = messageComposerState.action
 
@@ -427,6 +433,7 @@ public fun DefaultMessageComposerHeaderContent(
             modifier = Modifier,
             linkPreview = messageComposerState.linkPreviews.first(),
             onClick = onLinkPreviewClick,
+            onCancel = onCancelLinkPreviewClick,
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -1325,6 +1325,7 @@ public interface ChatComponentFactory {
         onAttachmentRemoved: (Attachment) -> Unit,
         onCancelAction: () -> Unit,
         onLinkPreviewClick: ((LinkPreview) -> Unit)?,
+        onCancelLinkPreviewClick: () -> Unit,
         onMentionSelected: (User) -> Unit,
         onCommandSelected: (Command) -> Unit,
         onAlsoSendToChannelSelected: (Boolean) -> Unit,
@@ -1349,6 +1350,7 @@ public interface ChatComponentFactory {
             onAttachmentRemoved = onAttachmentRemoved,
             onCancelAction = onCancelAction,
             onLinkPreviewClick = onLinkPreviewClick,
+            onCancelLinkPreviewClick = onCancelLinkPreviewClick,
             onMentionSelected = onMentionSelected,
             onCommandSelected = onCommandSelected,
             onAlsoSendToChannelSelected = onAlsoSendToChannelSelected,
@@ -1379,9 +1381,15 @@ public interface ChatComponentFactory {
         state: MessageComposerState,
         onCancel: () -> Unit,
         onLinkPreviewClick: ((LinkPreview) -> Unit)?,
+        onCancelLinkPreviewClick: () -> Unit,
     ) {
         Column(modifier = Modifier.animateContentSize()) {
-            DefaultMessageComposerHeaderContent(state, onCancel, onLinkPreviewClick)
+            DefaultMessageComposerHeaderContent(
+                messageComposerState = state,
+                onCancelAction = onCancel,
+                onLinkPreviewClick = onLinkPreviewClick,
+                onCancelLinkPreviewClick = onCancelLinkPreviewClick,
+            )
         }
     }
 
@@ -1421,8 +1429,14 @@ public interface ChatComponentFactory {
         modifier: Modifier,
         linkPreview: LinkPreview,
         onClick: ((LinkPreview) -> Unit)?,
+        onCancel: () -> Unit,
     ) {
-        ComposerLinkPreview(modifier, linkPreview, onClick)
+        ComposerLinkPreview(
+            modifier = modifier,
+            linkPreview = linkPreview,
+            onClick = onClick,
+            onCancel = onCancel,
+        )
     }
 
     /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel.kt
@@ -280,4 +280,11 @@ public class MessageComposerViewModel(
         super.onCleared()
         messageComposerController.onCleared()
     }
+
+    /**
+     * @see [MessageComposerController.cancelLinkPreview]
+     */
+    public fun cancelLinkPreview() {
+        messageComposerController.cancelLinkPreview()
+    }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -712,7 +712,10 @@ public class MessageComposerController(
             chatClient.sendMessage(
                 channelType,
                 channelId,
-                message.copy(showInChannel = isInThread && alsoSendToChannel.value),
+                message.copy(
+                    showInChannel = isInThread && alsoSendToChannel.value,
+                    skipEnrichUrl = linkPreviews.value.isEmpty(),
+                ),
             ).doOnResult(scope) { result ->
                 result.onSuccessSuspend { resultMessage ->
                     chatClient.markMessageRead(
@@ -1087,5 +1090,11 @@ public class MessageComposerController(
     private fun MessageMode.emptyDraftMessage(): DraftMessage = when (this) {
         is MessageMode.MessageThread -> DraftMessage(cid = channelCid, parentId = parentMessage.id)
         else -> DraftMessage(cid = channelCid)
+    }
+
+    /**
+     */
+    public fun cancelLinkPreview() {
+        linkPreviews.value = emptyList()
     }
 }


### PR DESCRIPTION
This commit introduces the ability to cancel link previews in the message composer.

Key changes:
- Added a `cancelLinkPreview` method to `MessageComposerController` and `MessageComposerViewModel`.
- Updated `ComposerLinkPreview` to accept an `onCancel` callback.
- When sending a message, if `linkPreviews` is empty, `skipEnrichUrl` will be set to `true`.
- Connected the cancel action in the UI to the new methods.
- Updated `ChatComponentFactory` and `MessageComposer` to pass the new `onCancelLinkPreviewClick` callback.

### 🎯 Goal

_Describe why we are making this change_

### 🛠 Implementation details

_Describe the implementation_

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

_Explain how this change can be tested (or why it can't be tested)_

_Provide a patch below if it is necessary for testing_

<details>

<summary>Provide the patch summary here</summary>

```
Provide the patch code here
```

</details>

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
