### PR TITLE
Capitalize constant fields and remove redundant declarations.

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -111,7 +111,7 @@ public class MessageComposerController(
     mediaRecorder: StreamMediaRecorder,
     private val userLookupHandler: UserLookupHandler,
     fileToUri: (File) -> String,
-    private val config: MessageComposerController.Config = MessageComposerController.Config(),
+    private val config: Config = Config(),
     private val globalState: Flow<GlobalState> = chatClient.globalStateFlow,
 ) {
 
@@ -363,7 +363,7 @@ public class MessageComposerController(
     private val selectedMentions: MutableSet<User> = mutableSetOf()
 
     private val mentionSuggester = TypingSuggester(
-        TypingSuggestionOptions(symbol = MentionStartSymbol),
+        TypingSuggestionOptions(symbol = MENTION_START_SYMBOL),
     )
 
     /**
@@ -914,7 +914,7 @@ public class MessageComposerController(
     /**
      * Shows the mention suggestion list popup if necessary.
      */
-    private suspend fun handleMentionSuggestions() {
+    private fun handleMentionSuggestions() {
         val messageInput = messageInput.value
         if (messageInput.source == MessageInput.Source.MentionSelected) {
             logger.v { "[handleMentionSuggestions] rejected (messageInput came from mention selection)" }
@@ -976,7 +976,7 @@ public class MessageComposerController(
                 cooldownTimerJob = scope.launch {
                     for (timeRemaining in cooldownInterval - elapsedTime downTo 0) {
                         updateCooldownTime(timeRemaining.toInt())
-                        delay(OneSecond)
+                        delay(ONE_SECOND)
                     }
                 }
             } else {
@@ -1043,7 +1043,7 @@ public class MessageComposerController(
         /**
          * The character used to start a mention.
          */
-        private const val MentionStartSymbol: String = "@"
+        private const val MENTION_START_SYMBOL: String = "@"
 
         /**
          * The regex pattern used to check if the message ends with incomplete command.
@@ -1054,7 +1054,7 @@ public class MessageComposerController(
             "(http://|https://)?([a-zA-Z0-9]+(\\.[a-zA-Z0-9-]+)*\\.([a-zA-Z]{2,}))(/[\\w-./?%&=]*)?",
         )
 
-        private const val OneSecond = 1000L
+        private const val ONE_SECOND = 1000L
 
         /**
          * The amount of time we debounce computing mention suggestions and link previews.


### PR DESCRIPTION
### 🎯 Goal

Perform a small cleanup of the codebase for better readability and adherence to Kotlin conventions:
- Capitalize constant field names to follow naming conventions.
- Remove redundant suspend keyword where it was unnecessary.
- Simplify the constructor parameter by removing redundant class name reference.
