### PR TITLE
Show original translation (XML)

### DIFF
--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -314,6 +314,7 @@ public fun randomMessage(
     poll: Poll? = null,
     moderationDetails: MessageModerationDetails? = null,
     moderation: Moderation? = null,
+    i18n: Map<String, String> = emptyMap(),
 ): Message = Message(
     id = id,
     cid = cid,
@@ -356,6 +357,7 @@ public fun randomMessage(
     poll = poll,
     moderationDetails = moderationDetails,
     moderation = moderation,
+    i18n = i18n,
 )
 
 public fun randomChannelMute(

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -745,6 +745,7 @@ public final class io/getstream/chat/android/ui/common/feature/messages/list/Mes
 	public final fun setThreadDateSeparatorHandler (Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;)V
 	public final fun shadowBanUser (Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;)V
 	public static synthetic fun shadowBanUser$default (Lio/getstream/chat/android/ui/common/feature/messages/list/MessageListController;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Integer;ILjava/lang/Object;)V
+	public final fun toggleOriginalText (Ljava/lang/String;)V
 	public final fun unbanUser (Ljava/lang/String;)V
 	public final fun unblockUser (Ljava/lang/String;)V
 	public final fun unflagUser (Ljava/lang/String;)V
@@ -2293,12 +2294,13 @@ public final class io/getstream/chat/android/ui/common/state/messages/list/Messa
 
 public final class io/getstream/chat/android/ui/common/state/messages/list/MessageItemState : io/getstream/chat/android/ui/common/state/messages/list/HasMessageListItemState {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;Ljava/util/Set;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;Ljava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;ZLjava/util/Set;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;ZLjava/util/Set;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
 	public final fun component10 ()Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;
 	public final fun component11 ()Ljava/util/List;
-	public final fun component12 ()Ljava/util/Set;
+	public final fun component12 ()Z
+	public final fun component13 ()Ljava/util/Set;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Z
 	public final fun component4 ()Z
@@ -2307,8 +2309,8 @@ public final class io/getstream/chat/android/ui/common/state/messages/list/Messa
 	public final fun component7 ()Ljava/util/List;
 	public final fun component8 ()Z
 	public final fun component9 ()Lio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;
-	public final fun copy (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;Ljava/util/Set;)Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;Ljava/util/Set;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;
+	public final fun copy (Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;ZLjava/util/Set;)Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;Lio/getstream/chat/android/models/Message;Ljava/lang/String;ZZZLio/getstream/chat/android/models/User;Ljava/util/List;ZLio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;Lio/getstream/chat/android/ui/common/state/messages/list/MessageFocusState;Ljava/util/List;ZLjava/util/Set;ILjava/lang/Object;)Lio/getstream/chat/android/ui/common/state/messages/list/MessageItemState;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCurrentUser ()Lio/getstream/chat/android/models/User;
 	public final fun getDeletedMessageVisibility ()Lio/getstream/chat/android/ui/common/state/messages/list/DeletedMessageVisibility;
@@ -2319,6 +2321,7 @@ public final class io/getstream/chat/android/ui/common/state/messages/list/Messa
 	public final fun getOwnCapabilities ()Ljava/util/Set;
 	public final fun getParentMessageId ()Ljava/lang/String;
 	public final fun getShowMessageFooter ()Z
+	public final fun getShowOriginalText ()Z
 	public fun hashCode ()I
 	public final fun isInThread ()Z
 	public final fun isMessageRead ()Z

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -141,6 +141,7 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.Date
 import io.getstream.chat.android.ui.common.state.messages.Flag as FlagMessage
@@ -223,6 +224,7 @@ public class MessageListController(
     public val unreadLabelState: MutableStateFlow<UnreadLabel?> = MutableStateFlow(null)
     private val showUnreadButtonState = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
     private val updateUnreadLabelState = MutableStateFlow(true)
+    private val messagesInOriginalLanguage = MutableStateFlow<Set<String>>(emptySet())
 
     /**
      * Holds information about the abilities the current user is able to exercise in the given channel.
@@ -469,6 +471,7 @@ public class MessageListController(
                 unreadLabelState,
                 channelState.members,
                 channelState.endOfOlderMessages,
+                messagesInOriginalLanguage,
             ) { data ->
                 val state = data[0] as MessagesState
                 val reads = data[1] as List<ChannelUserRead>
@@ -483,6 +486,7 @@ public class MessageListController(
                 val unreadLabel = data[10] as UnreadLabel?
                 val members = data[11] as List<Member>
                 val endOfOlderMessages = data[12] as Boolean
+                val messagesInOriginalLanguage = data[13] as Set<String>
 
                 when (state) {
                     is MessagesState.Loading,
@@ -517,6 +521,7 @@ public class MessageListController(
                                 read = reads,
                             ),
                             ownCapabilities = channel.ownCapabilities,
+                            messagesInOriginalLanguage = messagesInOriginalLanguage,
                         ),
                         endOfNewMessagesReached = endOfNewerMessages,
                     )
@@ -759,6 +764,7 @@ public class MessageListController(
                 focusedMessage,
                 members,
                 ownCapabilities,
+                messagesInOriginalLanguage,
             ) { data ->
                 val messages = data[0] as List<Message>
                 val reads = data[1] as List<ChannelUserRead>
@@ -771,6 +777,7 @@ public class MessageListController(
                 val focusedMessage = data[8] as Message?
                 val members = data[9] as List<Member>
                 val ownCapabilities = data[10] as Set<String>
+                val messagesInOriginalLanguage = data[11] as Set<String>
 
                 _threadListState.value.copy(
                     isLoading = false,
@@ -793,6 +800,7 @@ public class MessageListController(
                         endOfOlderMessages = false,
                         channel = null,
                         ownCapabilities = ownCapabilities,
+                        messagesInOriginalLanguage = messagesInOriginalLanguage,
                     ),
                     parentMessageId = threadId,
                     endOfNewMessagesReached = true,
@@ -856,6 +864,7 @@ public class MessageListController(
         endOfOlderMessages: Boolean,
         channel: Channel?,
         ownCapabilities: Set<String>,
+        messagesInOriginalLanguage: Set<String>,
     ): List<MessageListItemState> {
         val parentMessageId = (_mode.value as? MessageMode.MessageThread)?.parentMessage?.id
         val currentUser = user.value
@@ -949,6 +958,7 @@ public class MessageListController(
                         messageReadBy = messageReadBy,
                         focusState = if (isMessageFocused) MessageFocused else null,
                         ownCapabilities = ownCapabilities,
+                        showOriginalText = messagesInOriginalLanguage.contains(message.id),
                     ),
                 )
             }
@@ -1233,6 +1243,19 @@ public class MessageListController(
             reads = channelState.reads,
             members = channelState.members,
         )
+    }
+
+    /**
+     * Toggles between the translated and the original text of the message.
+     */
+    public fun toggleOriginalText(messageId: String) {
+        messagesInOriginalLanguage.update { it ->
+            if (it.contains(messageId)) {
+                it - messageId
+            } else {
+                it + messageId
+            }
+        }
     }
 
     /**

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemState.kt
@@ -54,6 +54,8 @@ public sealed class HasMessageListItemState : MessageListItemState() {
  * the UI.
  * @param focusState The current [MessageFocusState] of the message, used to focus the message in the ui.
  * @param messageReadBy The list of [ChannelUserRead] for the message.
+ * @param showOriginalText If the original text of the message should be shown in the UI instead of its translation (if
+ * the message was auto-translated).
  * @param ownCapabilities The capabilities of the current user in the channel.
  */
 public data class MessageItemState(
@@ -68,6 +70,7 @@ public data class MessageItemState(
     public val deletedMessageVisibility: DeletedMessageVisibility = DeletedMessageVisibility.ALWAYS_HIDDEN,
     public val focusState: MessageFocusState? = null,
     public val messageReadBy: List<ChannelUserRead> = emptyList(),
+    public val showOriginalText: Boolean = false,
     public val ownCapabilities: Set<String>,
 ) : HasMessageListItemState()
 

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -19,6 +19,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun getMimeTypeIconProvider ()Lio/getstream/chat/android/ui/helper/MimeTypeIconProvider;
 	public static final fun getNavigator ()Lio/getstream/chat/android/ui/navigation/ChatNavigator;
 	public static final fun getQuotedAttachmentFactoryManager ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager;
+	public static final fun getShowOriginalTranslationEnabled ()Z
 	public static final fun getStreamCdnImageResizing ()Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;
 	public static final fun getStyle ()Lio/getstream/chat/android/ui/font/ChatStyle;
 	public static final fun getSupportedReactions ()Lio/getstream/chat/android/ui/helper/SupportedReactions;
@@ -44,6 +45,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun setMimeTypeIconProvider (Lio/getstream/chat/android/ui/helper/MimeTypeIconProvider;)V
 	public static final fun setNavigator (Lio/getstream/chat/android/ui/navigation/ChatNavigator;)V
 	public static final fun setQuotedAttachmentFactoryManager (Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager;)V
+	public static final fun setShowOriginalTranslationEnabled (Z)V
 	public static final fun setStreamCdnImageResizing (Lio/getstream/chat/android/ui/common/images/resizing/StreamCdnImageResizing;)V
 	public static final fun setStyle (Lio/getstream/chat/android/ui/font/ChatStyle;)V
 	public static final fun setSupportedReactions (Lio/getstream/chat/android/ui/helper/SupportedReactions;)V
@@ -2274,6 +2276,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun setThreadClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ThreadClickListener;)V
 	public final fun setThreadStartHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ThreadStartHandler;)V
 	public final fun setThreadsEnabled (Z)V
+	public final fun setToggleOriginalTextHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ToggleOriginalTextHandler;)V
 	public final fun setUserClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$UserClickListener;)V
 	public final fun setUserReactionClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$UserReactionClickListener;)V
 	public final fun shouldRequestMessagesAtBottom (Z)V
@@ -2507,6 +2510,10 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 	public abstract fun onThreadClick (Lio/getstream/chat/android/models/Message;)Z
 }
 
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnTranslatedLabelClickListener {
+	public abstract fun onTranslatedLabelClick (Lio/getstream/chat/android/models/Message;)Z
+}
+
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUnreadLabelClickListener {
 	public abstract fun onUnreadLabelClick ()V
 }
@@ -2549,6 +2556,10 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$ThreadStartHandler {
 	public abstract fun onStartThread (Lio/getstream/chat/android/models/Message;)V
+}
+
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$ToggleOriginalTextHandler {
+	public abstract fun onToggleOriginalText (Lio/getstream/chat/android/models/Message;)V
 }
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$UserClickListener {
@@ -2851,8 +2862,8 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem : io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem {
-	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZ)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZZ)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Z
@@ -2860,13 +2871,15 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Z
-	public final fun copy (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZ)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;
+	public final fun component8 ()Z
+	public final fun copy (Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZZ)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;Lio/getstream/chat/android/models/Message;Ljava/util/List;ZLjava/util/List;ZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem$MessageItem;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public final fun getMessageReadBy ()Ljava/util/List;
 	public final fun getPositions ()Ljava/util/List;
 	public final fun getShowMessageFooter ()Z
+	public final fun getShowOriginalText ()Z
 	public fun hashCode ()I
 	public final fun isMessageRead ()Z
 	public final fun isMine ()Z
@@ -2936,7 +2949,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 
 public final class io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff {
 	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff$Companion;
-	public fun <init> (ZZZZZZZZZZZZZZ)V
+	public fun <init> (ZZZZZZZZZZZZZZZ)V
 	public final fun anyChanged ()Z
 	public final fun component1 ()Z
 	public final fun component10 ()Z
@@ -2944,6 +2957,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 	public final fun component12 ()Z
 	public final fun component13 ()Z
 	public final fun component14 ()Z
+	public final fun component15 ()Z
 	public final fun component2 ()Z
 	public final fun component3 ()Z
 	public final fun component4 ()Z
@@ -2952,8 +2966,8 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (ZZZZZZZZZZZZZZ)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;ZZZZZZZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;
+	public final fun copy (ZZZZZZZZZZZZZZZ)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;ZZZZZZZZZZZZZZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAttachments ()Z
 	public final fun getDeleted ()Z
@@ -2965,6 +2979,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/Me
 	public final fun getReactions ()Z
 	public final fun getReplies ()Z
 	public final fun getReplyText ()Z
+	public final fun getShowOriginalText ()Z
 	public final fun getSyncStatus ()Z
 	public final fun getText ()Z
 	public final fun getThreadMode ()Z
@@ -3040,6 +3055,7 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 	public abstract fun getOnViewPollResultClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollResultClickListener;
 	public abstract fun getReactionViewClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnReactionViewClickListener;
 	public abstract fun getThreadClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnThreadClickListener;
+	public abstract fun getTranslatedLabelClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnTranslatedLabelClickListener;
 	public abstract fun getUnreadLabelReachedListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUnreadLabelReachedListener;
 	public abstract fun getUserClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUserClickListener;
 }
@@ -4955,6 +4971,17 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ThreadModeEntered;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ThreadModeEntered;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getParentMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ToggleOriginalText : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Lio/getstream/chat/android/models/Message;)V
+	public final fun component1 ()Lio/getstream/chat/android/models/Message;
+	public final fun copy (Lio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ToggleOriginalText;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ToggleOriginalText;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$ToggleOriginalText;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -44,7 +44,7 @@ import io.getstream.chat.android.ui.helper.SupportedReactions
 import io.getstream.chat.android.ui.helper.transformer.AutoLinkableTextTransformer
 import io.getstream.chat.android.ui.helper.transformer.ChatMessageTextTransformer
 import io.getstream.chat.android.ui.navigation.ChatNavigator
-import io.getstream.chat.android.ui.utils.extensions.getTranslatedText
+import io.getstream.chat.android.ui.utils.extensions.getToggleableTranslatedText
 import io.getstream.chat.android.ui.utils.lazyVar
 import io.getstream.chat.android.ui.widgets.avatar.ChannelAvatarRenderer
 import io.getstream.chat.android.ui.widgets.avatar.UserAvatarRenderer
@@ -115,7 +115,7 @@ public object ChatUI {
     public var messageTextTransformer: ChatMessageTextTransformer by lazyVar {
         AutoLinkableTextTransformer { textView, messageItem ->
             // Customize the transformer if needed
-            val displayedText = messageItem.message.getTranslatedText()
+            val displayedText = messageItem.message.getToggleableTranslatedText(messageItem.showOriginalText)
             textView.text = displayedText
         }
     }
@@ -215,6 +215,12 @@ public object ChatUI {
      */
     @JvmStatic
     public var autoTranslationEnabled: Boolean = false
+
+    /**
+     * Whether the option to show the original translation is enabled or not.
+     */
+    @JvmStatic
+    public var showOriginalTranslationEnabled: Boolean = false
 
     /**
      * Provides a custom renderer for user avatars.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItem.kt
@@ -22,11 +22,6 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.state.messages.list.MessagePosition
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem.DateSeparatorItem
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem.LoadingMoreIndicatorItem
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem.MessageItem
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem.ThreadSeparatorItem
-import io.getstream.chat.android.ui.feature.messages.list.adapter.MessageListItem.TypingItem
 import java.util.Date
 
 /**
@@ -82,6 +77,9 @@ public sealed class MessageListItem {
      * @property isMessageRead True if the message has been read or not.
      * @property showMessageFooter True if the message footer should be displayed, otherwise false.
      * @property isTheirs True if the message is sent by another user, otherwise false.
+     * @property showMessageFooter True if the message footer should be displayed, otherwise false.
+     * @property showOriginalText If the original text of the message should be shown in the UI instead of its
+     * translation (if the message was auto-translated).
      */
     public data class MessageItem(
         val message: Message,
@@ -91,6 +89,7 @@ public sealed class MessageListItem {
         val isThreadMode: Boolean = false,
         val isMessageRead: Boolean = true,
         val showMessageFooter: Boolean = false,
+        val showOriginalText: Boolean = false,
     ) : MessageListItem() {
         public val isTheirs: Boolean
             get() = !isMine

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListItemPayloadDiff.kt
@@ -31,6 +31,7 @@ public data class MessageListItemPayloadDiff(
     val footer: Boolean,
     val poll: Boolean,
     val threadMode: Boolean,
+    val showOriginalText: Boolean,
 ) {
     public operator fun plus(other: MessageListItemPayloadDiff): MessageListItemPayloadDiff {
         return MessageListItemPayloadDiff(
@@ -48,6 +49,7 @@ public data class MessageListItemPayloadDiff(
             footer = footer || other.footer,
             poll = poll || other.poll,
             threadMode = threadMode || other.threadMode,
+            showOriginalText = showOriginalText || other.showOriginalText,
         )
     }
 
@@ -69,6 +71,7 @@ public data class MessageListItemPayloadDiff(
             footer = false,
             poll = false,
             threadMode = false,
+            showOriginalText = false,
         )
 
         public val FULL: MessageListItemPayloadDiff = MessageListItemPayloadDiff(
@@ -86,6 +89,7 @@ public data class MessageListItemPayloadDiff(
             footer = true,
             poll = true,
             threadMode = true,
+            showOriginalText = true,
         )
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainer.kt
@@ -36,6 +36,7 @@ import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnPoll
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnReactionViewClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnShowAllPollOptionClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnThreadClickListener
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnTranslatedLabelClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUnreadLabelReachedListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUserClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollResultClickListener
@@ -66,6 +67,7 @@ public sealed interface MessageListListeners {
     public val messageLongClickListener: OnMessageLongClickListener
     public val messageRetryListener: OnMessageRetryListener
     public val threadClickListener: OnThreadClickListener
+    public val translatedLabelClickListener: OnTranslatedLabelClickListener
     public val attachmentClickListener: OnAttachmentClickListener
     public val attachmentDownloadClickListener: OnAttachmentDownloadClickListener
     public val reactionViewClickListener: OnReactionViewClickListener

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainerImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainerImpl.kt
@@ -29,6 +29,7 @@ import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnPoll
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnReactionViewClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnShowAllPollOptionClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnThreadClickListener
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnTranslatedLabelClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUnreadLabelReachedListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUserClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollResultClickListener
@@ -39,8 +40,13 @@ internal class MessageListListenerContainerImpl(
     messageLongClickListener: OnMessageLongClickListener = OnMessageLongClickListener(EmptyFunctions.ONE_PARAM),
     messageRetryListener: OnMessageRetryListener = OnMessageRetryListener(EmptyFunctions.ONE_PARAM),
     threadClickListener: OnThreadClickListener = OnThreadClickListener(EmptyFunctions.ONE_PARAM),
+    translatedLabelClickListener: OnTranslatedLabelClickListener = OnTranslatedLabelClickListener(
+        EmptyFunctions.ONE_PARAM,
+    ),
     attachmentClickListener: OnAttachmentClickListener = OnAttachmentClickListener(EmptyFunctions.TWO_PARAM),
-    attachmentDownloadClickListener: OnAttachmentDownloadClickListener = OnAttachmentDownloadClickListener(EmptyFunctions.ONE_PARAM),
+    attachmentDownloadClickListener: OnAttachmentDownloadClickListener = OnAttachmentDownloadClickListener(
+        EmptyFunctions.ONE_PARAM,
+    ),
     reactionViewClickListener: OnReactionViewClickListener = OnReactionViewClickListener(EmptyFunctions.ONE_PARAM),
     userClickListener: OnUserClickListener = OnUserClickListener(EmptyFunctions.ONE_PARAM),
     mentionClickListener: OnMentionClickListener = OnMentionClickListener(EmptyFunctions.ONE_PARAM),
@@ -86,6 +92,14 @@ internal class MessageListListenerContainerImpl(
     ) { realListener ->
         OnThreadClickListener { message ->
             realListener().onThreadClick(message)
+        }
+    }
+
+    override val translatedLabelClickListener: OnTranslatedLabelClickListener by ListenerDelegate(
+        translatedLabelClickListener,
+    ) { realListener ->
+        OnTranslatedLabelClickListener { message ->
+            realListener().onTranslatedLabelClick(message)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemDiffCallback.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/internal/MessageListItemDiffCallback.kt
@@ -78,6 +78,7 @@ internal object MessageListItemDiffCallback : DiffUtil.ItemCallback<MessageListI
             footer = oldItem.showMessageFooter != newItem.showMessageFooter,
             poll = oldMessage.poll != newMessage.poll,
             threadMode = oldItem.isThreadMode != newItem.isThreadMode,
+            showOriginalText = oldItem.showOriginalText != newItem.showOriginalText,
         )
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/FootnoteView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/FootnoteView.kt
@@ -219,16 +219,43 @@ internal class FootnoteView : LinearLayoutCompat {
     }
 
     /**
+     * Sets the click listener for the "Translated to ..." label.
+     *
+     * @param onClick The click listener to be set.
+     */
+    fun setOnTranslatedLabelClickListener(onClick: (View) -> Unit) {
+        translatedLabel.setOnClickListener(onClick)
+    }
+
+    /**
      * Shows the translated label.
      *
      * @param languageName The name of the language to be shown.
      * @param style [MessageListItemStyle] The style of the MessageListItem and its items.
+     * @param showOriginalTranslationEnabled If the "Show original" option should be enabled.
+     * @param showOriginalText If the original text of the message should be shown in the UI instead of its translation.
+     * (if [showOriginalTranslationEnabled] is true).
      */
-    fun showTranslatedLabel(languageName: String, style: MessageListItemStyle) {
+    fun showTranslatedLabel(
+        languageName: String,
+        style: MessageListItemStyle,
+        showOriginalTranslationEnabled: Boolean = false,
+        showOriginalText: Boolean = false,
+    ) {
         translatedLabel.apply {
             isVisible = true
-            text = context.getString(R.string.stream_ui_message_list_translated, languageName)
             setTextStyle(style.textStyleMessageLanguage)
+        }
+        if (showOriginalTranslationEnabled) {
+            val label = if (showOriginalText) {
+                context.getString(R.string.stream_ui_message_list_show_translation)
+            } else {
+                context.getString(R.string.stream_ui_message_list_translated, languageName) +
+                    context.getString(R.string.stream_ui_message_list_show_original)
+            }
+            translatedLabel.text = label
+        } else {
+            translatedLabel.text = context.getString(R.string.stream_ui_message_list_translated, languageName)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/internal/FootnoteDecorator.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/decorator/internal/FootnoteDecorator.kt
@@ -264,6 +264,8 @@ internal class FootnoteDecorator(
     }
 
     private fun setupSimpleFootnote(footnoteView: FootnoteView, data: MessageListItem.MessageItem) {
+        // Show the "Translated to ..." label always, even if the message footer is not shown.
+        setupMessageFooterTranslatedLabel(footnoteView, data)
         if (data.showMessageFooter) {
             footnoteView.showSimpleFootnote()
         } else {
@@ -272,7 +274,6 @@ internal class FootnoteDecorator(
         }
         setupMessageFooterLabel(footnoteView.footerTextLabel, data, listViewStyle.itemStyle)
         setupMessageFooterTime(footnoteView, data)
-        setupMessageFooterTranslatedLabel(footnoteView, data)
         setupMessageFooterStatusIndicator(footnoteView, data)
         setupMessageFooterReadCounter(footnoteView, data)
     }
@@ -365,7 +366,12 @@ internal class FootnoteDecorator(
         val translatedText = data.message.getTranslation(userLanguage).ifEmpty { data.message.text }
         if (!isGiphy && !isDeleted && userLanguage != i18nLanguage && translatedText != data.message.text) {
             val languageDisplayName = getLanguageDisplayName(userLanguage)
-            footnoteView.showTranslatedLabel(languageDisplayName, listViewStyle.itemStyle)
+            footnoteView.showTranslatedLabel(
+                languageName = languageDisplayName,
+                style = listViewStyle.itemStyle,
+                showOriginalTranslationEnabled = ChatUI.showOriginalTranslationEnabled,
+                showOriginalText = data.showOriginalText,
+            )
         } else {
             footnoteView.hideTranslatedLabel()
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/CustomAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/CustomAttachmentsViewHolder.kt
@@ -127,6 +127,9 @@ public class CustomAttachmentsViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/FileAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/FileAttachmentsViewHolder.kt
@@ -118,6 +118,9 @@ public class FileAttachmentsViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/GiphyAttachmentViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/GiphyAttachmentViewHolder.kt
@@ -81,6 +81,9 @@ public class GiphyAttachmentViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/LinkAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/LinkAttachmentsViewHolder.kt
@@ -105,6 +105,9 @@ public class LinkAttachmentsViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/MediaAttachmentsViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/MediaAttachmentsViewHolder.kt
@@ -179,6 +179,9 @@ public class MediaAttachmentsViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/MessagePlainTextViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/MessagePlainTextViewHolder.kt
@@ -58,6 +58,9 @@ public class MessagePlainTextViewHolder internal constructor(
                 footnote.setOnThreadClickListener {
                     container.threadClickListener.onThreadClick(data.message)
                 }
+                footnote.setOnTranslatedLabelClickListener {
+                    container.translatedLabelClickListener.onTranslatedLabelClick(data.message)
+                }
                 messageContainer.setOnLongClickListener {
                     container.messageLongClickListener.onMessageLongClick(data.message)
                     true
@@ -84,7 +87,8 @@ public class MessagePlainTextViewHolder internal constructor(
         super.bindData(data, diff)
         val textUnchanged = !diff.text
         val mentionsUnchanged = !diff.mentions
-        if (textUnchanged && mentionsUnchanged) return
+        val showOriginalTextUnchanged = !diff.showOriginalText
+        if (textUnchanged && mentionsUnchanged && showOriginalTextUnchanged) return
 
         with(binding) {
             messageTextTransformer.transformAndApply(messageText, data)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/Message.kt
@@ -146,3 +146,39 @@ internal inline fun Message.getTranslatedText(getCurrentUser: () -> User?): Stri
 internal fun Message.getTranslatedText(currentUserProvider: CurrentUserProvider = ChatUI.currentUserProvider): String {
     return getTranslatedText(currentUserProvider::getCurrentUser)
 }
+
+/**
+ * Returns the appropriate message text based on auto-translation settings and the user's preference.
+ *
+ * If auto-translation is enabled:
+ * - Returns the original text if [showOriginalText] is true.
+ * - Otherwise, returns the translated text for the current user's language, or the original text if no translation
+ * is available or the user has no language set.
+ *
+ * If auto-translation is disabled, always returns the original message text.
+ *
+ * @param showOriginalText Whether to show the original message text instead of the translation.
+ * @param currentUserProvider Provider for the current user, used to determine the preferred language for translation.
+ * @return The text to display for the message, either original or translated.
+ */
+internal fun Message.getToggleableTranslatedText(
+    showOriginalText: Boolean,
+    currentUserProvider: CurrentUserProvider = ChatUI.currentUserProvider,
+): String {
+    return when (ChatUI.autoTranslationEnabled) {
+        true -> {
+            // If auto-translation is enabled, we check if the message is showing original text.
+            // If it is, we return the original text, otherwise we return the translated text.
+            if (showOriginalText) {
+                text
+            } else {
+                // If the message is not showing original text, we check if the current user has a language set.
+                // If they do, we return the translated text, otherwise we return the original text.
+                currentUserProvider.getCurrentUser()?.language?.let { userLanguage ->
+                    getTranslation(userLanguage).ifEmpty { text }
+                } ?: text
+            }
+        }
+        else -> text
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/MessageListItem.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/extensions/MessageListItem.kt
@@ -49,6 +49,7 @@ public fun MessageListItemCommon.toUiMessageListItem(): MessageListItem {
             isThreadMode = isInThread,
             isMessageRead = isMessageRead,
             showMessageFooter = showMessageFooter,
+            showOriginalText = showOriginalText,
         )
         is EmptyThreadPlaceholderItemState -> MessageListItem.ThreadPlaceholderItem
         is UnreadSeparatorItemState -> MessageListItem.UnreadSeparatorItem(unreadCount = unreadCount)

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -229,6 +229,7 @@ public class MessageListViewModel(
             is Event.LastMessageRead -> messageListController.markLastMessageRead()
             is Event.ThreadModeEntered -> onThreadModeEntered(event.parentMessage)
             is Event.OpenThread -> onOpenThread(event.message)
+            is Event.ToggleOriginalText -> messageListController.toggleOriginalText(event.message.id)
             is Event.BackButtonPressed -> onBackButtonPressed()
             is Event.MarkAsUnreadMessage -> messageListController.markUnread(event.message)
             is Event.DeleteMessage -> messageListController.deleteMessage(event.message, event.hard)
@@ -561,9 +562,18 @@ public class MessageListViewModel(
         public data class ThreadModeEntered(val parentMessage: Message) : Event()
 
         /**
-         * When the user
+         * When the user opens an existing thread.
+         *
+         * @param message The original message the thread was spun off from.
          */
         public data class OpenThread(val message: Message) : Event()
+
+        /**
+         * When the user wants to toggle the original text of a message (if auto-translation is enabled).
+         *
+         * @param message The message whose original text will be toggled.
+         */
+        public data class ToggleOriginalText(val message: Message) : Event()
 
         /**
          * When the user deletes a message.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.state.utils.EventObserver
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.feature.gallery.toAttachment
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView
 import io.getstream.chat.android.ui.utils.PermissionChecker
@@ -67,6 +68,9 @@ public fun MessageListViewModel.bindView(
     view.setMessageDeleteHandler { onEvent(DeleteMessage(it, hard = false)) }
     view.setThreadStartHandler { onEvent(ThreadModeEntered(it)) }
     view.setOpenThreadHandler { onEvent(MessageListViewModel.Event.OpenThread(it)) }
+    if (ChatUI.showOriginalTranslationEnabled) {
+        view.setToggleOriginalTextHandler { onEvent(MessageListViewModel.Event.ToggleOriginalText(it)) }
+    }
     view.setMessageFlagHandler {
         onEvent(
             FlagMessage(

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -141,6 +141,8 @@
     </plurals>
     <string name="stream_ui_message_list_unread_separator">Unread Messages</string>
     <string name="stream_ui_message_list_translated">Translated to %s</string>
+    <string name="stream_ui_message_list_show_original">&#160;· Show original</string>
+    <string name="stream_ui_message_list_show_translation">Show translation</string>
     <!-- Message Actions Dialog -->
     <string name="stream_ui_message_list_reply">Reply</string>
     <string name="stream_ui_message_list_thread_reply">Thread reply</string>


### PR DESCRIPTION
### 🎯 Goal

Adds a new (optional) functionality in the Message List, allowing users to quickly show the original text of an auto-translated message.
Resolves: https://linear.app/stream/issue/AND-450/show-original-translation

### 🛠 Implementation details
- Add new `ChatUI` flag which enables the feature: `showOriginalTranslationEnabled` (default: `false`)
- When this flag is set to true, the `Translated to ...` is extended with the text: ` · Show original`. Clicking on this label, will result in showing the original text of the message. When the original text is shown, a new label would be shown: Show translation. Tapping on it, will again show the translated text.
- Add new field to the `MessageItemState`- `showOriginalText` - indicating that the message was manually 'reverted' to show its original, non-translated text.
- Expose `MessageListController.toggleOriginalText(messageId:String)` method for toggling between translated and original text for the given message.
- Update the default `ChatUi.messageTextTransformer` to take the `MessageItemState.showOriginalText` into consideration before transforming the text.

**Additional changes/fixes:** 
- The `Translated to ...` label is now always visible underneath the message bubble, and is not hidden when the message item is not showing the message footer. (Aligned to the Compose SDK).

### 🎨 UI Changes

_Add relevant screenshots_

| Before | After |
| --- | --- |
| img | img |

_Add relevant videos_

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="" controls="controls" muted="muted" />
</td>
<td>
<video src="" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Apply the given patch (Sets the ChatUi. showOriginalTranslationEnabled to true, and removes the custom message formatter)
2. Write a message from a different user (with different lang from the current user)
3. The auto-translated messages in the MessageList show also have the  · Show original label

<details>

<summary>Sets the ChatUi. showOriginalTranslationEnabled to true, and removes the custom message formatter</summary>

```
Index: stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt	(revision 2e8c5212961eca11b2cf71cda7faa162bbfc63f2)
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/application/ChatInitializer.kt	(date 1750695425669)
@@ -25,7 +25,6 @@
 import io.getstream.chat.android.client.logger.ChatLogLevel
 import io.getstream.chat.android.client.notifications.handler.NotificationConfig
 import io.getstream.chat.android.client.notifications.handler.NotificationHandlerFactory
-import io.getstream.chat.android.markdown.MarkdownTextTransformer
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.ReactionSortingByLastReactionAt
@@ -110,9 +109,8 @@
             .build()
 
         // Using markdown as text transformer
-        val messageTranslator = MessageTranslator(client::getCurrentUser, autoTranslationEnabled)
         ChatUI.autoTranslationEnabled = autoTranslationEnabled
-        ChatUI.messageTextTransformer = MarkdownTextTransformer(context, messageTranslator)
+        ChatUI.showOriginalTranslationEnabled = true
         ChatUI.draftMessagesEnabled = true
 
         TransformStyle.viewReactionsStyleTransformer = StyleTransformer { defaultStyle ->

```

</details>

