### PR TITLE
Refactor how Draft Messages are queried to avoid potential issues on the sync process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,8 @@
 # UNRELEASED CHANGELOG
 ## Common changes for all artifacts
 ### 🐞 Fixed
-- Fix JSON parsing of `Device.providerName` when calling `ChatClient.getDevices()`. [#5821](https://github.com/GetStream/stream-chat-android/pull/5821)
-- Fix JSON parsing of `Flag.targetMessageId` when calling `ChatClient.flagUser()`. [#5829](https://github.com/GetStream/stream-chat-android/pull/5829)
 
 ### ⬆️ Improved
-- Use `AAC_ADTS` as default audio recording output format. [#5825](https://github.com/GetStream/stream-chat-android/pull/5825)
 
 ### ✅ Added
 
@@ -15,8 +12,11 @@
 
 ## stream-chat-android-client
 ### 🐞 Fixed
+- Fix JSON parsing of `Device.providerName` when calling `ChatClient.getDevices()`. [#5821](https://github.com/GetStream/stream-chat-android/pull/5821)
+- Fix JSON parsing of `Flag.targetMessageId` when calling `ChatClient.flagUser()`. [#5829](https://github.com/GetStream/stream-chat-android/pull/5829)
 
 ### ⬆️ Improved
+- Refactor how Draft Messages are queried to avoid potential issues on the sync process. [#5847](https://github.com/GetStream/stream-chat-android/pull/5847)
 
 ### ✅ Added
 
@@ -50,6 +50,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Use `AAC_ADTS` as default audio recording output format. [#5825](https://github.com/GetStream/stream-chat-android/pull/5825)
 
 ### ✅ Added
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -2671,7 +2671,9 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun insertDraftMessage (Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessage (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun insertMessages (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun selectDraftMessageByParentId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectDraftMessages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun selectDraftMessagesByCid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessageBySyncState (Lio/getstream/chat/android/models/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectMessageIdsBySyncState (Lio/getstream/chat/android/models/SyncStatus;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -955,6 +955,7 @@ constructor(
                 },
                 hidden = response.hidden,
                 hiddenMessagesBefore = response.hide_messages_before,
+                draftMessage = response.draft?.toDomain(),
             ).syncUnreadCountWithReads(domainMapping.currentUserIdProvider())
         }
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -663,7 +663,7 @@ internal class DomainMapping(
                     lastReceivedEventDate = last_message_at,
                 )
             },
-            draftMessage = draft?.toDomain(channel?.toChannelInfo()),
+            draft = draft?.toDomain(channel?.toChannelInfo()),
         )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -663,7 +663,7 @@ internal class DomainMapping(
                     lastReceivedEventDate = last_message_at,
                 )
             },
-            draft = draft?.toDomain(channel?.toChannelInfo()),
+            draftMessage = draft?.toDomain(channel?.toChannelInfo()),
         )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -663,6 +663,7 @@ internal class DomainMapping(
                     lastReceivedEventDate = last_message_at,
                 )
             },
+            draft = draft?.toDomain(channel?.toChannelInfo()),
         )
 
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ThreadDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ThreadDtos.kt
@@ -58,6 +58,7 @@ internal data class DownstreamThreadDto(
     val title: String,
     val latest_replies: List<DownstreamMessageDto>,
     val read: List<DownstreamChannelUserRead>?,
+    val draft: DownstreamDraftDto?,
 )
 
 /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/ChannelResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/response/ChannelResponse.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.client.api2.model.response
 import com.squareup.moshi.JsonClass
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChannelDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamChannelUserRead
+import io.getstream.chat.android.client.api2.model.dto.DownstreamDraftDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMemberDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamMessageDto
 import io.getstream.chat.android.client.api2.model.dto.DownstreamUserDto
@@ -36,4 +37,5 @@ internal data class ChannelResponse(
     val watcher_count: Int = 0,
     val hidden: Boolean?,
     val hide_messages_before: Date?,
+    val draft: DownstreamDraftDto?,
 )

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -149,6 +149,11 @@ public interface MessageRepository {
     public suspend fun selectDraftMessagesByCid(cid: String): DraftMessage?
 
     /**
+     * Selects a draft message by its parent message ID.
+     */
+    public suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage?
+
+    /**
      * Delete a draft message.
      */
     public suspend fun deleteDraftMessage(message: DraftMessage)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/MessageRepository.kt
@@ -144,6 +144,11 @@ public interface MessageRepository {
     public suspend fun selectDraftMessages(): List<DraftMessage>
 
     /**
+     * Selects a draft message by its channel ID.
+     */
+    public suspend fun selectDraftMessagesByCid(cid: String): DraftMessage?
+
+    /**
      * Delete a draft message.
      */
     public suspend fun deleteDraftMessage(message: DraftMessage)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -200,7 +200,7 @@ public class RepositoryFacade private constructor(
         val threadUsers = threads.mapNotNull(Thread::createdBy)
         val users = threadUsers + messages.flatMap(Message::users)
         insertUsers(users)
-        threads.forEach { it.draftMessage?.let { insertDraftMessage(it) } }
+        threads.forEach { it.draft?.let { insertDraftMessage(it) } }
         messageRepository.insertMessages(messages)
         threadsRepository.insertThreads(threads)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelConfig
 import io.getstream.chat.android.models.Config
-import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Reaction
@@ -201,7 +200,7 @@ public class RepositoryFacade private constructor(
         val threadUsers = threads.mapNotNull(Thread::createdBy)
         val users = threadUsers + messages.flatMap(Message::users)
         insertUsers(users)
-        threads.forEach { it.draft?.let { insertDraftMessage(it) } }
+        threads.forEach { it.draftMessage?.let { insertDraftMessage(it) } }
         messageRepository.insertMessages(messages)
         threadsRepository.insertThreads(threads)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelConfig
 import io.getstream.chat.android.models.Config
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Reaction
@@ -101,11 +102,13 @@ public class RepositoryFacade private constructor(
 
     override suspend fun insertChannel(channel: Channel) {
         insertUsers(channel.let(Channel::users))
+        channel.draftMessage?.let { insertDraftMessage(it) }
         channelsRepository.insertChannel(channel)
     }
 
     override suspend fun insertChannels(channels: Collection<Channel>) {
         insertUsers(channels.flatMap(Channel::users))
+        channels.forEach { it.draftMessage?.let { insertDraftMessage(it) } }
         channelsRepository.insertChannels(channels)
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/RepositoryFacade.kt
@@ -201,6 +201,7 @@ public class RepositoryFacade private constructor(
         val threadUsers = threads.mapNotNull(Thread::createdBy)
         val users = threadUsers + messages.flatMap(Message::users)
         insertUsers(users)
+        threads.forEach { it.draft?.let { insertDraftMessage(it) } }
         messageRepository.insertMessages(messages)
         threadsRepository.insertThreads(threads)
     }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
@@ -25,7 +25,6 @@ import io.getstream.chat.android.client.persistance.repository.SyncStateReposito
 import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.models.Channel
-import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/factory/RepositoryFactory.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.client.persistance.repository.SyncStateReposito
 import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -42,6 +42,7 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun deleteDraftMessage(message: DraftMessage) { /* No-Op */ }
     override suspend fun selectDraftMessages(): List<DraftMessage> = emptyList()
     override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = null
+    override suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage? = null
     override suspend fun insertDraftMessage(message: DraftMessage) { /* No-Op */ }
     override suspend fun evictMessages() { /* No-Op */ }
     override suspend fun evictMessage(messageId: String) { /* No-Op */ }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpMessageRepository.kt
@@ -41,6 +41,7 @@ internal object NoOpMessageRepository : MessageRepository {
     override suspend fun selectMessagesWithPoll(pollId: String): List<Message> = emptyList()
     override suspend fun deleteDraftMessage(message: DraftMessage) { /* No-Op */ }
     override suspend fun selectDraftMessages(): List<DraftMessage> = emptyList()
+    override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = null
     override suspend fun insertDraftMessage(message: DraftMessage) { /* No-Op */ }
     override suspend fun evictMessages() { /* No-Op */ }
     override suspend fun evictMessage(messageId: String) { /* No-Op */ }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.persistance.repository.factory.RepositoryFactory
 import io.getstream.chat.android.models.Channel
-import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/persistance/repository/noop/NoOpRepositoryFactory.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.persistance.repository.factory.RepositoryFactory
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -922,6 +922,7 @@ internal object Mother {
         title: String = randomString(),
         latestReplies: List<DownstreamMessageDto> = listOf(randomDownstreamMessageDto()),
         read: List<DownstreamChannelUserRead> = listOf(randomDownstreamChannelUserRead()),
+        draft: DownstreamDraftDto? = randomDownstreamDraftDto(),
     ): DownstreamThreadDto = DownstreamThreadDto(
         active_participant_count = activeParticipantCount,
         channel_cid = channelCid,
@@ -939,6 +940,7 @@ internal object Mother {
         title = title,
         latest_replies = latestReplies,
         read = read,
+        draft = draft,
     )
 
     fun randomDownstreamThreadInfoDto(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
@@ -354,7 +354,7 @@ internal object MoshiChatApiTestArguments {
                             hidden = randomBoolean(),
                             membership = Mother.randomDownstreamMemberDto(),
                             hide_messages_before = randomDateOrNull(),
-                            draft = randomDownstreamDraftDto()
+                            draft = randomDownstreamDraftDto(),
                         ),
                     ),
                 ),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTestArguments.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.client.api2
 
 import io.getstream.chat.android.client.Mother
+import io.getstream.chat.android.client.Mother.randomDownstreamDraftDto
 import io.getstream.chat.android.client.api.FakeResponse
 import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.api2.model.dto.HealthEventDto
@@ -353,6 +354,7 @@ internal object MoshiChatApiTestArguments {
                             hidden = randomBoolean(),
                             membership = Mother.randomDownstreamMemberDto(),
                             hide_messages_before = randomDateOrNull(),
+                            draft = randomDownstreamDraftDto()
                         ),
                     ),
                 ),
@@ -511,6 +513,7 @@ internal object MoshiChatApiTestArguments {
                     hidden = randomBoolean(),
                     membership = Mother.randomDownstreamMemberDto(),
                     hide_messages_before = randomDateOrNull(),
+                    draft = randomDownstreamDraftDto(),
                 ),
             ).toRetrofitCall(),
             Result.Success::class,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -683,7 +683,7 @@ internal class DomainMappingTest {
             read = with(sut) {
                 downstreamThreadDto.read.orEmpty().map { it.toDomain(downstreamThreadDto.last_message_at) }
             },
-            draftMessage = with(sut) {
+            draft = with(sut) {
                 downstreamThreadDto.draft?.toDomain()
             },
         )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.client.Mother.randomDownstreamChannelDto
 import io.getstream.chat.android.client.Mother.randomDownstreamChannelMuteDto
 import io.getstream.chat.android.client.Mother.randomDownstreamChannelUserRead
 import io.getstream.chat.android.client.Mother.randomDownstreamDraftDto
+import io.getstream.chat.android.client.Mother.randomDownstreamDraftMessageDto
 import io.getstream.chat.android.client.Mother.randomDownstreamFlagDto
 import io.getstream.chat.android.client.Mother.randomDownstreamMemberDto
 import io.getstream.chat.android.client.Mother.randomDownstreamMessageDto
@@ -648,6 +649,12 @@ internal class DomainMappingTest {
                     user_id = user2.id,
                 ),
             ),
+            draft = randomDownstreamDraftDto(
+                message = randomDownstreamDraftMessageDto(
+                    text = "Draft message",
+                ),
+                channelCid = "messaging:123",
+            ),
         )
         val sut = Fixture().get()
         val thread = with(sut) { downstreamThreadDto.toDomain() }
@@ -675,6 +682,9 @@ internal class DomainMappingTest {
             },
             read = with(sut) {
                 downstreamThreadDto.read.orEmpty().map { it.toDomain(downstreamThreadDto.last_message_at) }
+            },
+            draftMessage = with(sut) {
+                downstreamThreadDto.draft?.toDomain()
             },
         )
         thread shouldBeEqualTo expected

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ThreadExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ThreadExtensionsTests.kt
@@ -78,7 +78,7 @@ internal class ThreadExtensionsTests {
         title = "Test Thread",
         latestReplies = listOf(replyMessage),
         read = listOf(channelUserRead1, channelUserRead2),
-        draftMessage = null,
+        draft = null,
     )
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ThreadExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ThreadExtensionsTests.kt
@@ -78,6 +78,7 @@ internal class ThreadExtensionsTests {
         title = "Test Thread",
         latestReplies = listOf(replyMessage),
         read = listOf(channelUserRead1, channelUserRead2),
+        draftMessage = null,
     )
 
     @Test

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -435,6 +435,7 @@ public final class io/getstream/chat/android/models/Channel$Builder {
 	public final fun withCreatedAt (Ljava/util/Date;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withCreatedBy (Lio/getstream/chat/android/models/User;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withDeletedAt (Ljava/util/Date;)Lio/getstream/chat/android/models/Channel$Builder;
+	public final fun withDraftMessage (Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withExtraData (Ljava/util/Map;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withFrozen (Z)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withHidden (Ljava/lang/Boolean;)Lio/getstream/chat/android/models/Channel$Builder;
@@ -537,7 +538,7 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun getCreatedAt ()Ljava/util/Date;
 	public final fun getCreatedBy ()Lio/getstream/chat/android/models/User;
 	public final fun getDeletedAt ()Ljava/util/Date;
-	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun getDraft ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun getExtraData ()Ljava/util/Map;
 	public final fun getFrozen ()Z
 	public final fun getId ()Ljava/lang/String;
@@ -1880,7 +1881,7 @@ public final class io/getstream/chat/android/models/Thread {
 	public final fun getCreatedBy ()Lio/getstream/chat/android/models/User;
 	public final fun getCreatedByUserId ()Ljava/lang/String;
 	public final fun getDeletedAt ()Ljava/util/Date;
-	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun getDraft ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun getLastMessageAt ()Ljava/util/Date;
 	public final fun getLatestReplies ()Ljava/util/List;
 	public final fun getParentMessage ()Lio/getstream/chat/android/models/Message;

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -350,8 +350,8 @@ public final class io/getstream/chat/android/models/BannedUsersSort : io/getstre
 
 public final class io/getstream/chat/android/models/Channel : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLjava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLjava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lio/getstream/chat/android/models/SyncStatus;
 	public final fun component11 ()I
@@ -372,7 +372,8 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun component25 ()Lio/getstream/chat/android/models/Member;
 	public final fun component26 ()Ljava/util/List;
 	public final fun component27 ()Z
-	public final fun component28 ()Ljava/util/Map;
+	public final fun component28 ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun component29 ()Ljava/util/Map;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()I
@@ -380,8 +381,8 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun component7 ()Ljava/util/Date;
 	public final fun component8 ()Ljava/util/Date;
 	public final fun component9 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLjava/util/Map;)Lio/getstream/chat/android/models/Channel;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLjava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/Map;)Lio/getstream/chat/android/models/Channel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/Channel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCachedLatestMessages ()Ljava/util/List;
 	public final fun getCid ()Ljava/lang/String;
@@ -391,6 +392,7 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun getCreatedAt ()Ljava/util/Date;
 	public final fun getCreatedBy ()Lio/getstream/chat/android/models/User;
 	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
 	public fun getExtraData ()Ljava/util/Map;
 	public fun getExtraValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
 	public final fun getFrozen ()Z
@@ -509,8 +511,8 @@ public final class io/getstream/chat/android/models/ChannelConfig {
 
 public final class io/getstream/chat/android/models/ChannelData {
 	public fun <init> (Lio/getstream/chat/android/models/Channel;Ljava/util/Set;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/util/Date;
 	public final fun component11 ()I
@@ -518,6 +520,7 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun component13 ()Ljava/util/Map;
 	public final fun component14 ()Ljava/util/Set;
 	public final fun component15 ()Lio/getstream/chat/android/models/Member;
+	public final fun component16 ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -526,14 +529,15 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/util/Date;
 	public final fun component9 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;)Lio/getstream/chat/android/models/ChannelData;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;ILjava/lang/Object;)Lio/getstream/chat/android/models/ChannelData;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/models/ChannelData;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;ILjava/lang/Object;)Lio/getstream/chat/android/models/ChannelData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCid ()Ljava/lang/String;
 	public final fun getCooldown ()I
 	public final fun getCreatedAt ()Ljava/util/Date;
 	public final fun getCreatedBy ()Lio/getstream/chat/android/models/User;
 	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun getExtraData ()Ljava/util/Map;
 	public final fun getFrozen ()Z
 	public final fun getId ()Ljava/lang/String;
@@ -1848,7 +1852,7 @@ public final class io/getstream/chat/android/models/SyncStatus$Companion {
 }
 
 public final class io/getstream/chat/android/models/Thread {
-	public fun <init> (ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)V
+	public fun <init> (ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;)V
 	public final fun component1 ()I
 	public final fun component10 ()Ljava/util/Date;
 	public final fun component11 ()Ljava/util/Date;
@@ -1857,6 +1861,7 @@ public final class io/getstream/chat/android/models/Thread {
 	public final fun component14 ()Ljava/lang/String;
 	public final fun component15 ()Ljava/util/List;
 	public final fun component16 ()Ljava/util/List;
+	public final fun component17 ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Lio/getstream/chat/android/models/Channel;
 	public final fun component4 ()Ljava/lang/String;
@@ -1865,8 +1870,8 @@ public final class io/getstream/chat/android/models/Thread {
 	public final fun component7 ()Lio/getstream/chat/android/models/User;
 	public final fun component8 ()I
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;)Lio/getstream/chat/android/models/Thread;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Thread;ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lio/getstream/chat/android/models/Thread;
+	public final fun copy (ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/models/Thread;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Thread;ILjava/lang/String;Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/util/List;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/util/Date;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/DraftMessage;ILjava/lang/Object;)Lio/getstream/chat/android/models/Thread;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActiveParticipantCount ()I
 	public final fun getChannel ()Lio/getstream/chat/android/models/Channel;
@@ -1875,6 +1880,7 @@ public final class io/getstream/chat/android/models/Thread {
 	public final fun getCreatedBy ()Lio/getstream/chat/android/models/User;
 	public final fun getCreatedByUserId ()Ljava/lang/String;
 	public final fun getDeletedAt ()Ljava/util/Date;
+	public final fun getDraftMessage ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun getLastMessageAt ()Ljava/util/Date;
 	public final fun getLatestReplies ()Ljava/util/List;
 	public final fun getParentMessage ()Lio/getstream/chat/android/models/Message;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
@@ -94,6 +94,7 @@ public data class Channel(
     val membership: Member? = null,
     val cachedLatestMessages: List<Message> = emptyList(),
     val isInsideSearch: Boolean = false,
+    val draftMessage: DraftMessage? = null,
     override val extraData: Map<String, Any> = mapOf(),
 ) : CustomObject, ComparableFieldProvider {
 
@@ -185,6 +186,7 @@ public data class Channel(
         private var membership: Member? = null
         private var cachedLatestMessages: List<Message> = emptyList()
         private var isInsideSearch: Boolean = false
+        private var draftMessage: DraftMessage? = null
         private var extraData: Map<String, Any> = mapOf()
 
         public constructor(channel: Channel) : this() {
@@ -215,6 +217,7 @@ public data class Channel(
             membership = channel.membership
             cachedLatestMessages = channel.cachedLatestMessages
             isInsideSearch = channel.isInsideSearch
+            draftMessage = channel.draftMessage
             extraData = channel.extraData
         }
 
@@ -291,6 +294,7 @@ public data class Channel(
             membership = membership,
             cachedLatestMessages = cachedLatestMessages,
             isInsideSearch = isInsideSearch,
+            draftMessage = draftMessage,
             extraData = extraData,
         )
     }
@@ -350,5 +354,6 @@ public fun Channel.toChannelData(): ChannelData {
         team = team,
         ownCapabilities = ownCapabilities,
         membership = membership,
+        draftMessage = draftMessage,
     )
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
@@ -186,7 +186,7 @@ public data class Channel(
         private var membership: Member? = null
         private var cachedLatestMessages: List<Message> = emptyList()
         private var isInsideSearch: Boolean = false
-        private var draftMessage: DraftMessage? = null
+        private var draft: DraftMessage? = null
         private var extraData: Map<String, Any> = mapOf()
 
         public constructor(channel: Channel) : this() {
@@ -217,7 +217,7 @@ public data class Channel(
             membership = channel.membership
             cachedLatestMessages = channel.cachedLatestMessages
             isInsideSearch = channel.isInsideSearch
-            draftMessage = channel.draftMessage
+            draft = channel.draftMessage
             extraData = channel.extraData
         }
 
@@ -256,6 +256,9 @@ public data class Channel(
             this.cachedLatestMessages = cachedLatestMessages
         }
         public fun withIsInsideSearch(isInsideSearch: Boolean): Builder = apply { this.isInsideSearch = isInsideSearch }
+        public fun withDraftMessage(draftMessage: DraftMessage?): Builder = apply {
+            this.draft = draftMessage
+        }
         public fun withExtraData(extraData: Map<String, Any>): Builder = apply { this.extraData = extraData }
 
         @Deprecated(
@@ -294,7 +297,7 @@ public data class Channel(
             membership = membership,
             cachedLatestMessages = cachedLatestMessages,
             isInsideSearch = isInsideSearch,
-            draftMessage = draftMessage,
+            draftMessage = draft,
             extraData = extraData,
         )
     }
@@ -354,6 +357,6 @@ public fun Channel.toChannelData(): ChannelData {
         team = team,
         ownCapabilities = ownCapabilities,
         membership = membership,
-        draftMessage = draftMessage,
+        draft = draftMessage,
     )
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
@@ -58,6 +58,7 @@ public data class ChannelData(
     val extraData: Map<String, Any> = mapOf(),
     val ownCapabilities: Set<String> = setOf(),
     val membership: Member? = null,
+    val draftMessage: DraftMessage? = null,
 ) {
 
     /**
@@ -98,6 +99,7 @@ public data class ChannelData(
         ownCapabilities = channel.ownCapabilities.takeIf { ownCapabilities -> ownCapabilities.isNotEmpty() }
             ?: currentOwnCapabilities,
         membership = channel.membership,
+        draftMessage = channel.draftMessage,
     )
 
     @Deprecated(
@@ -135,6 +137,7 @@ public data class ChannelData(
      * @param reads The list of read states.
      * @param watchers The list of channel's watchers.
      * @param watcherCount Number of channel watchers.
+     * @param insideSearch Whether the channel is inside a search result.
      *
      * @return A [Channel] object.
      */
@@ -171,6 +174,7 @@ public data class ChannelData(
             membership = membership,
             cachedLatestMessages = cachedLatestMessages,
             isInsideSearch = insideSearch,
+            draftMessage = draftMessage,
         )
     }
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
@@ -58,7 +58,7 @@ public data class ChannelData(
     val extraData: Map<String, Any> = mapOf(),
     val ownCapabilities: Set<String> = setOf(),
     val membership: Member? = null,
-    val draftMessage: DraftMessage? = null,
+    val draft: DraftMessage? = null,
 ) {
 
     /**
@@ -99,7 +99,7 @@ public data class ChannelData(
         ownCapabilities = channel.ownCapabilities.takeIf { ownCapabilities -> ownCapabilities.isNotEmpty() }
             ?: currentOwnCapabilities,
         membership = channel.membership,
-        draftMessage = channel.draftMessage,
+        draft = channel.draftMessage,
     )
 
     @Deprecated(
@@ -174,7 +174,7 @@ public data class ChannelData(
             membership = membership,
             cachedLatestMessages = cachedLatestMessages,
             isInsideSearch = insideSearch,
-            draftMessage = draftMessage,
+            draftMessage = draft,
         )
     }
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
@@ -40,6 +40,7 @@ import java.util.Date
  * @param title The title of the thread.
  * @param latestReplies The list of latest replies in the thread.
  * @param read Information about the read status for the participants in the thread.
+ * @param draftMessage The draft message in the thread, if any.
  */
 @Immutable
 public data class Thread(
@@ -59,7 +60,7 @@ public data class Thread(
     val title: String,
     val latestReplies: List<Message>,
     val read: List<ChannelUserRead>,
-    val draft: DraftMessage?,
+    val draftMessage: DraftMessage?,
 ) {
 
     /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
@@ -40,7 +40,7 @@ import java.util.Date
  * @param title The title of the thread.
  * @param latestReplies The list of latest replies in the thread.
  * @param read Information about the read status for the participants in the thread.
- * @param draftMessage The draft message in the thread, if any.
+ * @param draft The draft message in the thread, if any.
  */
 @Immutable
 public data class Thread(
@@ -60,7 +60,7 @@ public data class Thread(
     val title: String,
     val latestReplies: List<Message>,
     val read: List<ChannelUserRead>,
-    val draftMessage: DraftMessage?,
+    val draft: DraftMessage?,
 ) {
 
     /**

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Thread.kt
@@ -59,6 +59,7 @@ public data class Thread(
     val title: String,
     val latestReplies: List<Message>,
     val read: List<ChannelUserRead>,
+    val draft: DraftMessage?,
 ) {
 
     /**

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -240,6 +240,8 @@ public fun randomReaction(
     enforceUnique = enforceUnique,
 )
 
+
+public fun randomDraftMessageOrNull(): DraftMessage? = randomDraftMessage().takeIf { randomBoolean() }
 public fun randomDraftMessage(
     id: String = randomString(),
     cid: String = randomCID(),
@@ -396,6 +398,7 @@ public fun randomChannel(
     ownCapabilities: Set<String> = randomChannelCapabilities(),
     extraData: Map<String, Any> = emptyMap(),
     membership: Member? = randomMember(),
+    draftMessage: DraftMessage? = randomDraftMessageOrNull()
 ): Channel = Channel(
     id = id,
     name = name,
@@ -420,6 +423,7 @@ public fun randomChannel(
     ownCapabilities = ownCapabilities,
     extraData = extraData,
     membership = membership,
+    draftMessage = draftMessage,
 )
 
 public fun randomChannelUserRead(

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -894,6 +894,7 @@ public fun randomThread(
     title: String = randomString(),
     latestReplies: List<Message> = List(positiveRandomInt(5)) { randomMessage() },
     read: List<ChannelUserRead> = List(positiveRandomInt(5)) { randomChannelUserRead() },
+    draftMessage: DraftMessage? = randomDraftMessageOrNull(),
 ): Thread = Thread(
     activeParticipantCount = activeParticipantCount,
     cid = cid,
@@ -911,6 +912,7 @@ public fun randomThread(
     title = title,
     latestReplies = latestReplies,
     read = read,
+    draftMessage = draftMessage,
 )
 
 public fun randomAppSettings(

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -911,7 +911,7 @@ public fun randomThread(
     title = title,
     latestReplies = latestReplies,
     read = read,
-    draftMessage = draftMessage,
+    draft = draftMessage,
 )
 
 public fun randomAppSettings(

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -240,7 +240,6 @@ public fun randomReaction(
     enforceUnique = enforceUnique,
 )
 
-
 public fun randomDraftMessageOrNull(): DraftMessage? = randomDraftMessage().takeIf { randomBoolean() }
 public fun randomDraftMessage(
     id: String = randomString(),
@@ -398,7 +397,7 @@ public fun randomChannel(
     ownCapabilities: Set<String> = randomChannelCapabilities(),
     extraData: Map<String, Any> = emptyMap(),
     membership: Member? = randomMember(),
-    draftMessage: DraftMessage? = randomDraftMessageOrNull()
+    draftMessage: DraftMessage? = randomDraftMessageOrNull(),
 ): Channel = Channel(
     id = id,
     name = name,

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -96,6 +96,8 @@ public final class io/getstream/chat/android/offline/repository/domain/message/i
 	public fun select (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectChunked (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun selectDraftMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun selectDraftMessageByParentId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectDraftMessages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectIdsBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectMessagesWithPoll (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -96,7 +96,7 @@ public final class io/getstream/chat/android/offline/repository/domain/message/i
 	public fun select (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectChunked (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public fun selectDraftMessage (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun selectDraftMessageByCid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectDraftMessageByParentId (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectDraftMessages (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun selectIdsBySyncStatus (Lio/getstream/chat/android/models/SyncStatus;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
@@ -20,6 +20,7 @@ import io.getstream.chat.android.client.extensions.internal.lastMessage
 import io.getstream.chat.android.client.extensions.syncUnreadCountWithReads
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelUserRead
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
@@ -62,6 +63,7 @@ internal fun Channel.toEntity(): ChannelEntity {
 internal suspend fun ChannelEntity.toModel(
     getUser: suspend (userId: String) -> User,
     getMessage: suspend (messageId: String) -> Message?,
+    getDraftMessage: suspend (cid: String) -> DraftMessage?,
 ): Channel = Channel(
     cooldown = cooldown,
     type = type,
@@ -86,4 +88,5 @@ internal suspend fun ChannelEntity.toModel(
     team = team,
     ownCapabilities = ownCapabilities,
     membership = membership?.toModel(getUser),
+    draftMessage = getDraftMessage(channelId),
 ).syncUnreadCountWithReads()

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -163,6 +163,9 @@ internal class DatabaseMessageRepository(
     override suspend fun selectDraftMessages(): List<DraftMessage> = messageDao.selectDraftMessages()
         .map { it.toModel(::selectMessage) }
 
+    override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = messageDao.selectDraftMessage(cid)
+        ?.toModel(::selectMessage)
+
     /**
      * Deletes all messages before a message with passed ID.
      *

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -163,7 +163,7 @@ internal class DatabaseMessageRepository(
     override suspend fun selectDraftMessages(): List<DraftMessage> = messageDao.selectDraftMessages()
         .map { it.toModel(::selectMessage) }
 
-    override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = messageDao.selectDraftMessage(cid)
+    override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = messageDao.selectDraftMessageByCid(cid)
         ?.toModel(::selectMessage)
 
     override suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage? =

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -166,6 +166,9 @@ internal class DatabaseMessageRepository(
     override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? = messageDao.selectDraftMessage(cid)
         ?.toModel(::selectMessage)
 
+    override suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage? =
+        messageDao.selectDraftMessageByParentId(parentId)?.toModel(::selectMessage)
+
     /**
      * Deletes all messages before a message with passed ID.
      *

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -91,6 +91,9 @@ internal interface MessageDao {
     @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid")
     suspend fun selectDraftMessage(cid: String): DraftMessageEntity?
 
+    @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE parentId = :parentId")
+    suspend fun selectDraftMessageByParentId(parentId: String): DraftMessageEntity?
+
     @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE id = :messageId")
     suspend fun deleteDraftMessage(messageId: String)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -88,8 +88,8 @@ internal interface MessageDao {
     @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME")
     suspend fun selectDraftMessages(): List<DraftMessageEntity>
 
-    @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid")
-    suspend fun selectDraftMessage(cid: String): DraftMessageEntity?
+    @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid AND parentId IS NULL")
+    suspend fun selectDraftMessageByCid(cid: String): DraftMessageEntity?
 
     @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE parentId = :parentId")
     suspend fun selectDraftMessageByParentId(parentId: String): DraftMessageEntity?

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -88,6 +88,9 @@ internal interface MessageDao {
     @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME")
     suspend fun selectDraftMessages(): List<DraftMessageEntity>
 
+    @Query("SELECT * FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE cid = :cid")
+    suspend fun selectDraftMessage(cid: String): DraftMessageEntity?
+
     @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME WHERE id = :messageId")
     suspend fun deleteDraftMessage(messageId: String)
 

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.offline.repository.domain.threads.internal
 
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.ChannelUserRead
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Thread
 import io.getstream.chat.android.models.ThreadParticipant
@@ -51,6 +52,7 @@ internal suspend fun ThreadEntity.toModel(
     getUser: suspend (userId: String) -> User,
     getMessage: suspend (messageId: String) -> Message?,
     getChannel: suspend (cid: String) -> Channel?,
+    getDraftMessage: suspend (messageId: String) -> DraftMessage?,
 ) = Thread(
     parentMessageId = parentMessageId,
     parentMessage = getMessage(parentMessageId) ?: Message(),
@@ -70,4 +72,5 @@ internal suspend fun ThreadEntity.toModel(
     title = title,
     read = read.map { it.toModel(getUser) },
     latestReplies = latestReplyIds.mapNotNull { getMessage(it) },
+    draft = getDraftMessage(parentMessageId)
 )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
@@ -72,5 +72,5 @@ internal suspend fun ThreadEntity.toModel(
     title = title,
     read = read.map { it.toModel(getUser) },
     latestReplies = latestReplyIds.mapNotNull { getMessage(it) },
-    draft = getDraftMessage(parentMessageId)
+    draftMessage = getDraftMessage(parentMessageId)
 )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
@@ -72,5 +72,5 @@ internal suspend fun ThreadEntity.toModel(
     title = title,
     read = read.map { it.toModel(getUser) },
     latestReplies = latestReplyIds.mapNotNull { getMessage(it) },
-    draftMessage = getDraftMessage(parentMessageId),
+    draft = getDraftMessage(parentMessageId),
 )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/threads/internal/ThreadMapper.kt
@@ -72,5 +72,5 @@ internal suspend fun ThreadEntity.toModel(
     title = title,
     read = read.map { it.toModel(getUser) },
     latestReplies = latestReplyIds.mapNotNull { getMessage(it) },
-    draftMessage = getDraftMessage(parentMessageId)
+    draftMessage = getDraftMessage(parentMessageId),
 )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
@@ -111,6 +111,8 @@ internal class DatabaseRepositoryFactory(
         getChannel: suspend (cid: String) -> Channel?,
     ): ThreadsRepository {
         val repository = repositoriesCache[ThreadsRepository::class.java] as? ThreadsRepository?
+        val messageRepository = createMessageRepository(getUser)
+
         return repository ?: run {
             DatabaseThreadsRepository(
                 threadDao = database.threadDao(),
@@ -118,6 +120,7 @@ internal class DatabaseRepositoryFactory(
                 getUser = getUser,
                 getMessage = getMessage,
                 getChannel = getChannel,
+                getDraftMessage = messageRepository::selectDraftMessageByParentId,
             ).also {
                 repositoriesCache[ThreadsRepository::class.java] = it
             }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
@@ -26,7 +26,6 @@ import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.persistance.repository.factory.RepositoryFactory
 import io.getstream.chat.android.models.Channel
-import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.offline.repository.database.internal.ChatDatabase
@@ -86,7 +85,7 @@ internal class DatabaseRepositoryFactory(
                 getUser,
                 getMessage,
                 messageRepository::selectDraftMessagesByCid,
-                now
+                now,
             )
                 .also { repository ->
                     repositoriesCache[ChannelRepository::class.java] = repository

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/factory/internal/DatabaseRepositoryFactory.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.client.persistance.repository.ThreadsRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.persistance.repository.factory.RepositoryFactory
 import io.getstream.chat.android.models.Channel
+import io.getstream.chat.android.models.DraftMessage
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.offline.repository.database.internal.ChatDatabase
@@ -76,9 +77,17 @@ internal class DatabaseRepositoryFactory(
         getMessage: suspend (messageId: String) -> Message?,
     ): ChannelRepository {
         val databaseChannelRepository = repositoriesCache[ChannelRepository::class.java] as? DatabaseChannelRepository?
+        val messageRepository = createMessageRepository(getUser)
 
         return databaseChannelRepository ?: run {
-            DatabaseChannelRepository(scope, database.channelStateDao(), getUser, getMessage, now)
+            DatabaseChannelRepository(
+                scope,
+                database.channelStateDao(),
+                getUser,
+                getMessage,
+                messageRepository::selectDraftMessagesByCid,
+                now
+            )
                 .also { repository ->
                     repositoriesCache[ChannelRepository::class.java] = repository
                 }

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
@@ -21,6 +21,7 @@ package io.getstream.chat.android.offline.repository.domain.channel.internal
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.offline.MockChatClientBuilder
 import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.randomDraftMessageOrNull
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomUser
 import io.getstream.chat.android.test.TestCoroutineRule
@@ -55,6 +56,7 @@ internal class ChannelRepositoryImplTest {
             channelDao,
             { randomUser() },
             { randomMessage() },
+            { randomDraftMessageOrNull() }
         )
 
     @BeforeEach

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelRepositoryImplTest.kt
@@ -56,7 +56,7 @@ internal class ChannelRepositoryImplTest {
             channelDao,
             { randomUser() },
             { randomMessage() },
-            { randomDraftMessageOrNull() }
+            { randomDraftMessageOrNull() },
         )
 
     @BeforeEach

--- a/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
+++ b/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
@@ -75,6 +75,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
+        draft = null,
     )
 
     /**
@@ -113,6 +114,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
+        draft = null,
     )
 
     /**

--- a/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
+++ b/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
@@ -75,7 +75,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
-        draft = null,
+        draftMessage = null,
     )
 
     /**
@@ -114,7 +114,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
-        draft = null,
+        draftMessage = null,
     )
 
     /**

--- a/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
+++ b/stream-chat-android-previewdata/src/main/kotlin/io/getstream/chat/android/previewdata/PreviewThreadData.kt
@@ -75,7 +75,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
-        draftMessage = null,
+        draft = null,
     )
 
     /**
@@ -114,7 +114,7 @@ public object PreviewThreadData {
                 lastReadMessageId = null,
             ),
         ),
-        draftMessage = null,
+        draft = null,
     )
 
     /**

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -546,6 +546,7 @@ internal class ChannelStateLogic(
 
         mutableState.setLoadingOlderMessages(false)
         mutableState.setLoadingNewerMessages(false)
+        channel.draftMessage?.let(globalMutableState::updateDraftMessage)
     }
 
     private fun upsertCachedMessages(messages: List<Message>) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -546,7 +546,6 @@ internal class ChannelStateLogic(
 
         mutableState.setLoadingOlderMessages(false)
         mutableState.setLoadingNewerMessages(false)
-        channel.draftMessage?.let(globalMutableState::updateDraftMessage)
     }
 
     private fun upsertCachedMessages(messages: List<Message>) {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -74,6 +74,7 @@ internal class LogicRegistry internal constructor(
     private val queryThreads: QueryThreadsLogic = QueryThreadsLogic(
         stateLogic = QueryThreadsStateLogic(
             mutableState = stateRegistry.mutableQueryThreads(),
+            mutableGlobalState = mutableGlobalState,
         ),
         databaseLogic = QueryThreadsDatabaseLogic(
             repository = repos,

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogic.kt
@@ -102,7 +102,7 @@ internal class QueryThreadsStateLogic(
 
     private fun upsertDraftMessages(threads: List<Thread>) {
         threads.forEach { thread ->
-            thread.draft?.let { draft ->
+            thread.draftMessage?.let { draft ->
                 mutableGlobalState.updateDraftMessage(draft)
             }
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogic.kt
@@ -102,7 +102,7 @@ internal class QueryThreadsStateLogic(
 
     private fun upsertDraftMessages(threads: List<Thread>) {
         threads.forEach { thread ->
-            thread.draftMessage?.let { draft ->
+            thread.draft?.let { draft ->
                 mutableGlobalState.updateDraftMessage(draft)
             }
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
@@ -102,6 +102,7 @@ internal class MutableGlobalState : GlobalState {
     }
 
     fun updateDraftMessage(draftMessage: DraftMessage) {
+        println("JcLog: updateDraftMessage: $draftMessage")
         draftMessage.parentId?.let { parentId ->
             _threadDraftMessages?.let { it.value += (parentId to draftMessage) }
         }
@@ -111,6 +112,7 @@ internal class MutableGlobalState : GlobalState {
     }
 
     fun removeDraftMessage(draftMessage: DraftMessage) {
+        println("JcLog: removeDraftMessage: $draftMessage")
         draftMessage.parentId?.let { parentId ->
             _threadDraftMessages?.let { it.value -= parentId }
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/global/internal/MutableGlobalState.kt
@@ -112,7 +112,6 @@ internal class MutableGlobalState : GlobalState {
     }
 
     fun removeDraftMessage(draftMessage: DraftMessage) {
-        println("JcLog: removeDraftMessage: $draftMessage")
         draftMessage.parentId?.let { parentId ->
             _threadDraftMessages?.let { it.value -= parentId }
         }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
@@ -689,8 +689,4 @@ internal class SyncManager(
     private enum class State {
         Idle, Syncing
     }
-
-    companion object {
-        const val QUERY_DRAFT_MESSAGES_LIMIT = 100
-    }
 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
@@ -120,6 +120,9 @@ internal class SyncManager(
         eventsDisposable = chatClient.subscribe { event ->
             onEvent(event)
         }
+        syncScope.launch {
+            syncOfflineDraftMessages()
+        }
     }
 
     override fun stop() {
@@ -168,6 +171,12 @@ internal class SyncManager(
                 updateAllReadStateForDate(event.user.id, event.createdAt)
             }
             else -> Unit
+        }
+    }
+
+    private suspend fun syncOfflineDraftMessages() {
+        repos.selectDraftMessages().forEach { draftMessage ->
+            mutableGlobalState.updateDraftMessage(draftMessage)
         }
     }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/channel/controller/attachment/UploadAttachmentsIntegrationTests.kt
@@ -281,6 +281,14 @@ internal class MockMessageRepository : MessageRepository {
         TODO("Not yet implemented")
     }
 
+    override suspend fun selectDraftMessagesByCid(cid: String): DraftMessage? {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun selectDraftMessageByParentId(parentId: String): DraftMessage? {
+        TODO("Not yet implemented")
+    }
+
     override suspend fun deleteDraftMessage(message: DraftMessage) {
         TODO("Not yet implemented")
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
@@ -84,6 +84,7 @@ internal class QueryThreadsLogicTest {
                 ),
             ),
             read = emptyList(),
+            draftMessage = null,
         ),
     )
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
@@ -84,7 +84,7 @@ internal class QueryThreadsLogicTest {
                 ),
             ),
             read = emptyList(),
-            draftMessage = null,
+            draft = null,
         ),
     )
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogicTest.kt
@@ -89,7 +89,7 @@ internal class QueryThreadsStateLogicTest {
                     lastReadMessageId = null,
                 ),
             ),
-            draftMessage = null,
+            draft = null,
         ),
     )
     val mutableGlobalState = MutableGlobalState()

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsStateLogicTest.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.models.Thread
 import io.getstream.chat.android.models.ThreadInfo
 import io.getstream.chat.android.models.ThreadParticipant
 import io.getstream.chat.android.models.User
+import io.getstream.chat.android.state.plugin.state.global.internal.MutableGlobalState
 import io.getstream.chat.android.state.plugin.state.querythreads.internal.QueryThreadsMutableState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
@@ -88,15 +89,17 @@ internal class QueryThreadsStateLogicTest {
                     lastReadMessageId = null,
                 ),
             ),
+            draftMessage = null,
         ),
     )
+    val mutableGlobalState = MutableGlobalState()
 
     @Test
     fun `Given QueryThreadsStateLogic When getting isLoading Should return isLoading from mutableState`() {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.loading) doReturn MutableStateFlow(true)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val isLoading = logic.isLoading()
         // then
@@ -109,7 +112,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).setLoading(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.setLoading(true)
         // then
@@ -121,7 +124,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.loadingMore) doReturn MutableStateFlow(true)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val isLoading = logic.isLoadingMore()
         // then
@@ -134,7 +137,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).setLoadingMore(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.setLoadingMore(true)
         // then
@@ -146,7 +149,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threads) doReturn MutableStateFlow(emptyList())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val threads = logic.getThreads()
         // then
@@ -159,7 +162,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).setThreads(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.setThreads(emptyList())
         // then
@@ -171,7 +174,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).upsertThreads(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.insertThreadsIfAbsent(emptyList())
         // then
@@ -183,7 +186,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).upsertThreads(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.upsertThreads(emptyList())
         // then
@@ -195,7 +198,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).upsertThreads(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.clearThreads()
         // then
@@ -207,7 +210,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).setNext(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.setNext("nextCursor")
         // then
@@ -219,7 +222,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.unseenThreadIds) doReturn MutableStateFlow(setOf("mId1"))
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val unseenThreadIds = logic.getUnseenThreadIds()
         // then
@@ -232,7 +235,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).addUnseenThreadId(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.addUnseenThreadId("threadId")
         // then
@@ -244,7 +247,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         doNothing().whenever(mutableState).clearUnseenThreadIds()
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.clearUnseenThreadIds()
         // then
@@ -256,7 +259,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val message = logic.getMessage("mId1")
         // then
@@ -268,7 +271,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val message = logic.getMessage("mId2")
         // then
@@ -280,7 +283,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val message = logic.getMessage("mId3")
         // then
@@ -293,7 +296,7 @@ internal class QueryThreadsStateLogicTest {
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
         doNothing().whenever(mutableState).deleteThread(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val messageToDelete = threadList[0].parentMessage
         logic.deleteMessage(messageToDelete)
@@ -307,7 +310,7 @@ internal class QueryThreadsStateLogicTest {
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
         doNothing().whenever(mutableState).deleteMessageFromThread(any(), any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val messageToDelete = threadList[0].latestReplies[0]
         logic.deleteMessage(messageToDelete)
@@ -322,7 +325,7 @@ internal class QueryThreadsStateLogicTest {
         whenever(mutableState.threadMap) doReturn mapOf("mId1" to threadList[0])
         doNothing().whenever(mutableState).deleteThread(any())
         doNothing().whenever(mutableState).deleteMessageFromThread(any(), any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val messageToDelete = Message()
         logic.deleteMessage(messageToDelete)
@@ -337,7 +340,7 @@ internal class QueryThreadsStateLogicTest {
             // given
             val mutableState = mock<QueryThreadsMutableState>()
             whenever(mutableState.threads) doReturn MutableStateFlow(threadList)
-            val logic = QueryThreadsStateLogic(mutableState)
+            val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
             val parent = Message(
                 id = "mId3",
                 cid = "messaging:123",
@@ -354,7 +357,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val parent = Message(
             id = "mId1",
             cid = "messaging:123",
@@ -379,7 +382,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threads) doReturn MutableStateFlow(threadList)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val reply = Message(
             id = "mId3",
             cid = "messaging:123",
@@ -398,7 +401,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val reply = Message(
             id = "mId3",
             cid = "messaging:123",
@@ -417,7 +420,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val reply = Message(
             id = "mId2",
             cid = "messaging:123",
@@ -437,7 +440,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val reply = Message(
             id = "mId3",
             cid = "messaging:123",
@@ -465,7 +468,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         val reply = Message(
             id = "mId3",
             cid = "messaging:123",
@@ -495,7 +498,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         logic.markThreadAsReadByUser(
             threadInfo = ThreadInfo(
@@ -525,7 +528,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val threadInfo = ThreadInfo(
             activeParticipantCount = 2,
@@ -571,7 +574,7 @@ internal class QueryThreadsStateLogicTest {
         // given
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val threadId = "mId2"
         val user = User(id = "usrId2")
@@ -587,7 +590,7 @@ internal class QueryThreadsStateLogicTest {
         val mutableState = mock<QueryThreadsMutableState>()
         whenever(mutableState.threadMap) doReturn threadList.associateBy(Thread::parentMessageId)
         doNothing().whenever(mutableState).upsertThreads(any())
-        val logic = QueryThreadsStateLogic(mutableState)
+        val logic = QueryThreadsStateLogic(mutableState, mutableGlobalState)
         // when
         val threadId = "mId1"
         val user = User(id = "usrId2")

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/querythreads/internal/QueryThreadsMutableStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/querythreads/internal/QueryThreadsMutableStateTest.kt
@@ -54,7 +54,7 @@ internal class QueryThreadsMutableStateTest {
             title = "Thread 1",
             latestReplies = listOf(Message(id = "mId1")),
             read = emptyList(),
-            draftMessage = null,
+            draft = null,
         ),
     )
 
@@ -79,7 +79,7 @@ internal class QueryThreadsMutableStateTest {
             title = "Thread 2",
             latestReplies = listOf(Message()),
             read = emptyList(),
-            draftMessage = null,
+            draft = null,
         ),
     )
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/querythreads/internal/QueryThreadsMutableStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/state/querythreads/internal/QueryThreadsMutableStateTest.kt
@@ -54,6 +54,7 @@ internal class QueryThreadsMutableStateTest {
             title = "Thread 1",
             latestReplies = listOf(Message(id = "mId1")),
             read = emptyList(),
+            draftMessage = null,
         ),
     )
 
@@ -78,6 +79,7 @@ internal class QueryThreadsMutableStateTest {
             title = "Thread 2",
             latestReplies = listOf(Message()),
             read = emptyList(),
+            draftMessage = null,
         ),
     )
 


### PR DESCRIPTION
### 🎯 Goal
Refactor how Draft Messages are queried to avoid potential issues on the sync process.
Instead of fetching them when the SDK sync, they are obtained from the queryChannels.

Complete: AND-627
