### PR TITLE
Fix unread counts not updating without OfflinePlugin.

### DIFF
--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/TotalUnreadCountTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/TotalUnreadCountTest.kt
@@ -158,8 +158,8 @@ internal class TotalUnreadCountTest {
 
         fun givenChannel(channel: Channel) = apply {
             runTest {
-                whenever(repos.selectChannels(eq(listOf(channel.cid)), any())) doReturn listOf(channel)
-                whenever(repos.selectChannels(eq(listOf(channel.cid)))) doReturn listOf(channel)
+                whenever(repos.selectChannel(eq(channel.cid))) doReturn channel
+                whenever(repos.selectChannel(eq(channel.cid))) doReturn channel
             }
         }
 

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequentialTest.kt
@@ -162,8 +162,8 @@ internal class EventHandlerSequentialTest {
         fun withReadEventsCapability(cid: String) = apply {
             repos.stub {
                 onBlocking {
-                    selectChannels(listOf(cid))
-                } doReturn listOf(randomChannel(ownCapabilities = setOf(ChannelCapabilities.READ_EVENTS)))
+                    selectChannel(cid)
+                } doReturn randomChannel(ownCapabilities = setOf(ChannelCapabilities.READ_EVENTS))
             }
         }
 


### PR DESCRIPTION
### 🎯 Goal
Resolves: https://linear.app/stream/issue/AND-644/globalstatetotalunreadcount-not-updated-without-offlineplugin

Due to a faulty check in the `EventHandlerSequential`, the global unread counts were not updated for the `MessageNewEvent` in the absence of the offline plugin. We currently check if the relevant channel has the `read-events` capability before updating the unread count from the `MessageNewEvent`, but we check the channel data stored in the DB. So if the offline plugin is not present, the channel will never be written in the storage, and the check for the `read-events` capability will always fail. 
In this PR, we introduce a fallback to the current logic: If the channel is not present in the DB (or there is no DB), check for the channel capabilities from the in-memory state. 

### 🛠 Implementation details
- Add fallback to the `EventHandlerSequential.hasReadEventsCapability` method to check the local in-memory state, if the channel is not found in the DB.

### 🎨 UI Changes
<table>
<thead>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Unread channels</td>
<td>
<video src="https://github.com/user-attachments/assets/97e5db0a-5451-480b-b29d-05efafc3f87b" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/35b8e757-e867-4e9b-b677-7eec202ed579" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>Unread messages</td>
<td>
<video src="https://github.com/user-attachments/assets/12141ab8-8a40-410d-89da-8c842fb16884" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/a9e97481-1fe0-448a-933a-685801da554f" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Disable offline support (remove `OfflinePlugin` from `ChannelClient.Builder().withPlugins()`)
2. Build app
3. Open channels screen
4. Write a message from a different user
5. The unread channels badge should update to reflect the total number of unread channels