### PR TITLE
Expose `canHandle` lambda of the attachment factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Add bottom padding to unread message separator. [#5855](https://github.com/GetStream/stream-chat-android/pull/5855)
 
 ### ✅ Added
+- Expose `canHandle` lambda of the attachment factories: `AudioRecordAttachmentFactory`, `FileAttachmentFactory`, `GiphyAttachmentFactory`, `LinkAttachmentFactory`, `MediaAttachmentFactory`, `UploadAttachmentFactory`. [#5865](https://github.com/GetStream/stream-chat-android/pull/5865) 
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -620,7 +620,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Unsu
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/AudioRecordAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/compose/viewmodel/messages/AudioPlayerViewModelFactory;Lkotlin/jvm/functions/Function0;)V
+	public fun <init> (Lio/getstream/chat/android/compose/viewmodel/messages/AudioPlayerViewModelFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/compose/viewmodel/messages/AudioPlayerViewModelFactory;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/ComposableSingletons$FileAttachmentFactoryKt {
@@ -656,28 +657,28 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Comp
 public final class io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/ui/common/utils/GiphyInfoType;Lio/getstream/chat/android/ui/common/utils/GiphySizingMode;Landroidx/compose/ui/layout/ContentScale;Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
-	public fun <init> (ILkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (ILkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (ILkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
-	public synthetic fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;)V
+	public synthetic fun <init> (IZLkotlin/jvm/functions/Function8;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/factory/QuotedAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
@@ -693,8 +694,8 @@ public final class io/getstream/chat/android/compose/ui/attachments/factory/Unsu
 public final class io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory : io/getstream/chat/android/compose/ui/attachments/AttachmentFactory {
 	public static final field $stable I
 	public fun <init> ()V
-	public fun <init> (Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Lkotlin/jvm/functions/Function2;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/ComposableSingletons$MediaGalleryPreviewScreenKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/AudioRecordAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/AudioRecordAttachmentFactory.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.compose.ui.attachments.content.AudioRecordAttac
 import io.getstream.chat.android.compose.ui.attachments.content.AudioRecordAttachmentPreviewContent
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.messages.AudioPlayerViewModelFactory
+import io.getstream.chat.android.models.Attachment
 import io.getstream.log.StreamLog
 
 /**
@@ -33,11 +34,12 @@ import io.getstream.log.StreamLog
 public class AudioRecordAttachmentFactory(
     private val viewModelFactory: AudioPlayerViewModelFactory,
     private val getCurrentUserId: () -> String?,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { attachments ->
+        attachments.all(Attachment::isAudioRecording)
+    },
 ) : AttachmentFactory(
     type = Type.BuiltIn.AUDIO_RECORD,
-    canHandle = { attachments ->
-        attachments.all { it.isAudioRecording() }
-    },
+    canHandle = canHandle,
     previewContent = @Composable { modifier, attachments, onAttachmentRemoved ->
         AudioRecordAttachmentPreviewContent(
             modifier = modifier,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/FileAttachmentFactory.kt
@@ -31,7 +31,9 @@ import io.getstream.chat.android.uiutils.extension.isAnyFileType
  * An [AttachmentFactory] that validates attachments as files and uses [FileAttachmentContent] to
  * build the UI for the message.
  *
+ * @param showFileSize Lambda that determines whether to show the file size in the attachment content.
  * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param canHandle Lambda that checks if the factory can handle the given attachments.
  */
 public class FileAttachmentFactory(
     showFileSize: (Attachment) -> Boolean = { true },
@@ -39,11 +41,12 @@ public class FileAttachmentFactory(
         previewHandlers: List<AttachmentPreviewHandler>,
         attachment: Attachment,
     ) -> Unit = ::onFileAttachmentContentItemClick,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { attachments ->
+        attachments.any(Attachment::isAnyFileType)
+    },
 ) : AttachmentFactory(
     type = Type.BuiltIn.FILE,
-    canHandle = { attachments ->
-        attachments.any { it.isAnyFileType() }
-    },
+    canHandle = canHandle,
     previewContent = @Composable { modifier, attachments, onAttachmentRemoved ->
         ChatTheme.componentFactory.FileAttachmentPreviewContent(
             modifier = modifier,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/GiphyAttachmentFactory.kt
@@ -46,6 +46,7 @@ import io.getstream.chat.android.ui.common.utils.GiphySizingMode
  * Setting it to fixed size mode will make it respect all given dimensions.
  * @param contentScale Used to determine the way Giphys are scaled inside the [Image] composable.
  * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param canHandle Lambda that checks if the factory can handle the given attachments.
  *
  * @return Returns an instance of [AttachmentFactory] that is used to handle Giphys.
  */
@@ -53,10 +54,11 @@ public class GiphyAttachmentFactory(
     giphyInfoType: GiphyInfoType = GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
-    onContentItemClick: (context: Context, Url: String) -> Unit = ::onGiphyAttachmentContentClick,
+    onContentItemClick: (context: Context, url: String) -> Unit = ::onGiphyAttachmentContentClick,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { attachments -> attachments.any(Attachment::isGiphy) },
 ) : AttachmentFactory(
     type = Type.BuiltIn.GIPHY,
-    canHandle = { attachments -> attachments.any(Attachment::isGiphy) },
+    canHandle = canHandle,
     content = @Composable { modifier, state ->
         GiphyAttachmentContent(
             modifier = modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/LinkAttachmentFactory.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.compose.ui.attachments.AttachmentFactory
 import io.getstream.chat.android.compose.ui.attachments.content.LinkAttachmentContent
 import io.getstream.chat.android.compose.ui.attachments.content.onLinkAttachmentContentClick
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.uiutils.extension.hasLink
 
 /**
@@ -35,13 +36,15 @@ import io.getstream.chat.android.uiutils.extension.hasLink
  *
  * @param linkDescriptionMaxLines - The limit of how many lines we show for the link description.
  * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param canHandle Lambda that checks if the factory can handle the given attachments.
  */
 public class LinkAttachmentFactory(
     linkDescriptionMaxLines: Int,
     onContentItemClick: (context: Context, previewUrl: String) -> Unit = ::onLinkAttachmentContentClick,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { links -> links.any { it.hasLink() && !it.isGiphy() } },
 ) : AttachmentFactory(
     type = Type.BuiltIn.LINK,
-    canHandle = { links -> links.any { it.hasLink() && !it.isGiphy() } },
+    canHandle = canHandle,
     content = @Composable { modifier, state ->
         LinkAttachmentContent(
             modifier = modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/MediaAttachmentFactory.kt
@@ -39,6 +39,7 @@ import io.getstream.chat.android.compose.ui.attachments.content.MediaAttachmentP
 import io.getstream.chat.android.compose.ui.attachments.content.PlayButton
 import io.getstream.chat.android.compose.ui.attachments.content.onMediaAttachmentContentItemClick
 import io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewContract.Input
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.helper.DownloadAttachmentUriGenerator
@@ -53,6 +54,7 @@ import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizin
  * @param skipEnrichUrl Used by the media gallery. If set to true will skip enriching URLs when you update the message
  * by deleting an attachment contained within it. Set to false by default.
  * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param canHandle Lambda that checks if the factory can handle the given attachments.
  * @param itemOverlayContent Represents the content overlaid above individual items.
  * By default it is used to display a play button over video previews.
  * @param previewItemOverlayContent Represents the content overlaid above individual preview items.
@@ -71,6 +73,9 @@ public class MediaAttachmentFactory(
         streamCdnImageResizing: StreamCdnImageResizing,
         skipEnrichUrl: Boolean,
     ) -> Unit = ::onMediaAttachmentContentItemClick,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { attachments ->
+        attachments.all { it.isImage() || it.isVideo() }
+    },
     itemOverlayContent: @Composable (attachmentType: String?) -> Unit = { attachmentType ->
         if (attachmentType == AttachmentType.VIDEO) {
             DefaultItemOverlayContent()
@@ -83,9 +88,7 @@ public class MediaAttachmentFactory(
     },
 ) : AttachmentFactory(
     type = Type.BuiltIn.MEDIA,
-    canHandle = { attachments ->
-        attachments.all { it.isImage() || it.isVideo() }
-    },
+    canHandle = canHandle,
     previewContent = { modifier, attachments, onAttachmentRemoved ->
         MediaAttachmentPreviewContent(
             attachments = attachments,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/factory/UploadAttachmentFactory.kt
@@ -32,12 +32,14 @@ import io.getstream.chat.android.uiutils.extension.isUploading
  * Has no "preview content", given that this attachment only exists after being sent.
  *
  * @param onContentItemClick Lambda called when an item gets clicked.
+ * @param canHandle Lambda that checks if the factory can handle the given attachments.
  */
 public class UploadAttachmentFactory(
     onContentItemClick: (Attachment, List<AttachmentPreviewHandler>) -> Unit = ::onFileUploadContentItemClick,
+    canHandle: (attachments: List<Attachment>) -> Boolean = { attachments -> attachments.any(Attachment::isUploading) },
 ) : AttachmentFactory(
     type = Type.BuiltIn.UPLOAD,
-    canHandle = { attachments -> attachments.any { it.isUploading() } },
+    canHandle = canHandle,
     content = @Composable { modifier, state ->
         ChatTheme.componentFactory.FileUploadContent(
             modifier = modifier


### PR DESCRIPTION
### 🎯 Goal

Expose `canHandle` lambda of the attachment factories: `AudioRecordAttachmentFactory`, `FileAttachmentFactory`, `GiphyAttachmentFactory`, `LinkAttachmentFactory`, `MediaAttachmentFactory`, `UploadAttachmentFactory`
