### PR TITLE
Fix the top bar up button of the messages screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@
 ### 🐞 Fixed
 - Fix `MediaGalleryPreviewActivity` overriding the `Message.attachments` of the `Message` which was passed to it. [#5863](https://github.com/GetStream/stream-chat-android/pull/5863)
 - Fix `MediaGalleryPreviewActivity` displaying the current time instead of the `Message` timestamp if the screen was opened without internet connection. [#5863](https://github.com/GetStream/stream-chat-android/pull/5863)
+- Fix the top bar up button not working when the keyboard is open in the messages screen. [#5868](https://github.com/GetStream/stream-chat-android/pull/5868)
 
 ### ⬆️ Improved
 - Add bottom padding to unread message separator. [#5855](https://github.com/GetStream/stream-chat-android/pull/5855)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/MessagesScreen.kt
@@ -48,13 +48,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
@@ -179,9 +177,6 @@ public fun MessagesScreen(
         composerViewModel.setMessageMode(messageMode)
     }
 
-    val isImeVisible by rememberUpdatedState(
-        WindowInsets.ime.getBottom(LocalDensity.current) > 0,
-    )
     val backAction: BackAction =
         {
             val isStartedForThread = listViewModel.isStartedForThread
@@ -189,7 +184,6 @@ public fun MessagesScreen(
             val isShowingOverlay = listViewModel.isShowingOverlay
 
             when {
-                isImeVisible -> Unit
                 attachmentsPickerViewModel.isShowingAttachments -> attachmentsPickerViewModel.changeAttachmentState(
                     false,
                 )


### PR DESCRIPTION
### 🎯 Goal

Previously, the back action had a check for IME visibility that would do nothing if the IME was visible, potentially making the top bar up button useless when the keyboard was open. This check has been removed.

Related to #5824

### 🧪 Testing

#### Scenario 1
- Navigate to a channel
- Click on the message compose input to open the keyboard
- Click on the top bar up button
- The user should navigate back to the channel list screen

#### Scenario 2
- Navigate to a channel
- Click on the message compose input to open the keyboard
- Use the system back button (by gesture or navigation button)
- The keyboard should close
- Use the system back button (by gesture or navigation button)
- The user should navigate back to the channel list screen

Same when entering a thread

