### PR TITLE
Optimizations for the default channel search logic.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@
 ### 🐞 Fixed
 
 ### ⬆️ Improved
+- Optimize default channel search query to prevent timeouts. [#5870](https://github.com/GetStream/stream-chat-android/pull/5870)
 
 ### ✅ Added
 


### PR DESCRIPTION
### 🎯 Goal
Resolves: https://linear.app/stream/issue/AND-665/optimize-default-channel-search-query-on-android-compose

The default query for the channel search in the Compose SDK is way too complicated, and could cause timeouts for customers with large amounts of data. This PR simplifies the filter and ensures the `autocomplete` query is not run unless the query is at least 3 chars long. 

### 🛠 Implementation details
- Add a guard preventing the `autocomplete` query from running unless it is 3 characters long.
- Remove the `Filters.notExists("name")`

### 🎨 UI Changes
_NA_

### 🧪 Testing
1. Set the `ChannelsScreen#searchMode` to `SearchMode.Channels`
2. Enter a query - search should not be performed for the first 2 characters
