### PR TITLE
Fix Poll creation button enabling on changed change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fix media gallery screen not closed after all attachments are deleted from the message. [#5884](https://github.com/GetStream/stream-chat-android/pull/5884)
+- Fix the poll creation button to disable when multiple answers has a wrong input. [#5885](https://github.com/GetStream/stream-chat-android/pull/5885)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionInput.kt
@@ -31,7 +31,10 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,9 +45,11 @@ import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.style.TextDirection
@@ -94,6 +99,12 @@ public fun PollOptionInput(
     val colors = ChatTheme.colors
     val textColor = ChatTheme.colors.textHighEmphasis
     val focusRequester = remember { FocusRequester() }
+    // Using TextFieldValue to manage the text input state,
+    // which allows us to set the cursor position to the end of the text
+    // when the input is first drawn.
+    var textFieldValue by remember(value) {
+        mutableStateOf(TextFieldValue(text = value, selection = TextRange(value.length)))
+    }
 
     Box(modifier = modifier.height(ChatTheme.dimens.pollOptionInputHeight)) {
         BasicTextField(
@@ -104,10 +115,10 @@ public fun PollOptionInput(
                 .padding(innerPadding)
                 .focusRequester(focusRequester)
                 .semantics { contentDescription = description },
-            value = value,
+            value = textFieldValue,
             onValueChange = {
-                if (it.length <= maxLength) {
-                    onValueChange.invoke(it)
+                if (it.text.length <= maxLength) {
+                    onValueChange.invoke(it.text)
                 }
             },
             visualTransformation = {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
@@ -125,6 +125,7 @@ public fun PollSwitchList(
                             end = itemInnerPadding.calculateEndPadding(layoutDirection = layoutDirection),
                         ),
                 ) {
+                    val context = LocalContext.current
                     Row(
                         modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically,
@@ -163,7 +164,14 @@ public fun PollSwitchList(
                             onCheckedChange = { checked ->
                                 switchItemList[index] = item.copy(
                                     enabled = checked,
-                                    pollOptionError = null,
+                                    // Validate the poll switch input even on checked state change
+                                    pollOptionError = item.pollSwitchInput?.run {
+                                        if (checked) {
+                                            errorOrNull(context, value.toString())
+                                        } else {
+                                            null
+                                        }
+                                    },
                                 )
                                 onSwitchesChanged(switchItemList)
                             },
@@ -172,7 +180,6 @@ public fun PollSwitchList(
 
                     if (item.pollSwitchInput != null && item.enabled) {
                         val switchInput = item.pollSwitchInput
-                        val context = LocalContext.current
                         PollOptionInput(
                             modifier = Modifier
                                 .fillMaxWidth()


### PR DESCRIPTION
### 🎯 Goal

Fix the poll creation button to disable when multiple answers has a wrong input.

### 🛠 Implementation details

- Validate poll switch input even on checked state change.
-Using `TextFieldValue` to manage the text input state, which allows us to set the cursor position to the end of the text when the input is first drawn.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/bb28671e-1eb1-432a-a7f2-09f4862d808a" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/211c15d5-0c11-4e14-a1c0-66f6987bbd8e" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

