### PR TITLE
Fix thread parent message not showing without Offline Plugin.

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/internal/LogicRegistry.kt
@@ -226,7 +226,8 @@ internal class LogicRegistry internal constructor(
             val stateLogic = ThreadStateLogic(mutableState)
             ThreadLogic(stateLogic).also { threadLogic ->
                 coroutineScope.launch {
-                    repos.selectMessage(messageId)?.let { threadLogic.upsertMessage(it) }
+                    val parentMessage = getMessageById(messageId) ?: repos.selectMessage(messageId)
+                    parentMessage?.let { threadLogic.upsertMessage(it) }
                     repos.selectMessagesForThread(messageId, MESSAGE_LIMIT).let { threadLogic.upsertMessages(it) }
                 }
             }


### PR DESCRIPTION
### 🎯 Goal
Fixes the case where the parent message is not shown when creating a new thread, when the Offline Plugin is disabled.

Resolves find: https://www.notion.so/Android-Livestream-2486a5d7f9f68023a779f64f46a49e20?d=2486a5d7f9f680d7b495001c05edd259&source=copy_link#2486a5d7f9f680ab9370dc655a98c043

### 🛠 Implementation details
- Fetch the thread parent message from the local state before checking the DB

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/7a1e13be-3240-4156-8f8d-cdb0d4cfb0f5" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/4c38b8ad-0261-456d-9c44-e89f8f63a5d3" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Disable offline support
2. Open a channel
3. Create a new thread from a message
4. The parent message should be shown
