### PR TITLE
Fix MediaGallery not opened (closed automatically).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 ### 🐞 Fixed
 - Fix media gallery screen not closed after all attachments are deleted from the message. [#5884](https://github.com/GetStream/stream-chat-android/pull/5884)
 - Fix the poll creation button to disable when multiple answers has a wrong input. [#5885](https://github.com/GetStream/stream-chat-android/pull/5885)
+- Fix media gallery not opened (closed automatically) when clicking on a media attachment in the message list. [#5892](https://github.com/GetStream/stream-chat-android/pull/5892)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaGalleryPreviewActivity.kt
@@ -36,14 +36,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.PermissionState
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.client.utils.message.isDeleted
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.mediagallerypreview.Delete
 import io.getstream.chat.android.compose.state.mediagallerypreview.MediaGalleryPreviewAction
@@ -162,12 +163,6 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
             ) {
                 SetupEdgeToEdge()
 
-                val message = mediaGalleryPreviewViewModel.message
-                if (message.isDeleted() || message.attachments.isEmpty()) {
-                    finish()
-                    return@ChatTheme
-                }
-
                 val (writePermissionState, downloadPayload) = attachmentDownloadState()
                 val downloadAttachmentUriGenerator = ChatTheme.streamDownloadAttachmentUriGenerator
                 val downloadRequestInterceptor = ChatTheme.streamDownloadRequestInterceptor
@@ -195,6 +190,13 @@ public class MediaGalleryPreviewActivity : AppCompatActivity() {
                         onRequestShareAttachment = ::onRequestShareAttachment,
                         onConfirmShareAttachment = ::shareAttachment,
                     )
+                }
+            }
+            // Close the activity when the closeScreen state is true (message deleted or no more attachments).
+            val closeScreen by mediaGalleryPreviewViewModel.closeScreen.collectAsStateWithLifecycle(false)
+            LaunchedEffect(closeScreen) {
+                if (closeScreen) {
+                    finish()
                 }
             }
         }


### PR DESCRIPTION
### 🎯 Goal
Fixes a bug where the gallery could not always be opened (introduced in this [PR](https://github.com/GetStream/stream-chat-android/pull/5884)).
When opening the screen, if the UI is rendered before the `viewModel.message` emits the new `Message` with its attachment, the activity would be automatically closed
Resolves: https://linear.app/stream/issue/AND-695/media-gallery-not-opening-when-clicking-on-channel

### 🛠 Implementation details
- Removes the check for `message.isDeleted() || message.attachments.isEmpty()` to close the screen from the Compose code
- Introduce a new event-triggered screen closing logic, triggered only after deleting the attachments/message.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/f382ab8a-4cb6-40fc-9ef6-164c967e799a" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/8ae4b4a6-5512-4e8f-8fb7-69436dd3aff5" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Open channel (Compose)
2. Send attachment
3. Click on the sent attachment (or a different attachment)
4. The attachment should be opened