### PR TITLE
Support User Average Response Time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 ### ✅ Added
 - Add `NotificationhandlerFactory.notificationBuilderTransformer` parameter to allow customization of the notification builder. [#5881](https://github.com/GetStream/stream-chat-android/pull/5881)
+- Support User Average Response Time. [#5893](https://github.com/GetStream/stream-chat-android/pull/5893)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -290,7 +290,7 @@ internal class DomainMapping(
             teamsRole = teams_role.orEmpty(),
             channelMutes = channel_mutes.orEmpty().map { it.toDomain() },
             blockedUserIds = blocked_user_ids.orEmpty(),
-            avgResponseTime = avg_response_time ?: 0,
+            avgResponseTime = avg_response_time,
             extraData = extraData.toMutableMap(),
         ).let(userTransformer::transform)
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -290,6 +290,7 @@ internal class DomainMapping(
             teamsRole = teams_role.orEmpty(),
             channelMutes = channel_mutes.orEmpty().map { it.toDomain() },
             blockedUserIds = blocked_user_ids.orEmpty(),
+            avgResponseTime = avg_response_time ?: 0,
             extraData = extraData.toMutableMap(),
         ).let(userTransformer::transform)
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/UserDtos.kt
@@ -78,7 +78,7 @@ internal data class DownstreamUserDto(
     val teams_role: Map<String, String>?,
     val channel_mutes: List<DownstreamChannelMuteDto>?,
     val blocked_user_ids: List<String>?,
-
+    val avg_response_time: Long?,
     val extraData: Map<String, Any>,
 ) : ExtraDataDto
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -351,6 +351,7 @@ internal object Mother {
         teamsRole: Map<String, String> = emptyMap(),
         channel_mutes: List<DownstreamChannelMuteDto>? = emptyList(),
         blocked_user_ids: List<String>? = emptyList(),
+        avg_response_time: Long? = null,
         extraData: Map<String, Any> = emptyMap(),
     ): DownstreamUserDto = DownstreamUserDto(
         id = id,
@@ -376,6 +377,7 @@ internal object Mother {
         teams_role = teamsRole,
         channel_mutes = channel_mutes,
         blocked_user_ids = blocked_user_ids,
+        avg_response_time = avg_response_time,
         extraData = extraData,
     )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/UserDtoTestData.kt
@@ -76,6 +76,7 @@ internal object UserDtoTestData {
             teams_role = null,
             channel_mutes = emptyList(),
             blocked_user_ids = null,
+            avg_response_time = null,
             extraData = emptyMap(),
         )
 
@@ -126,6 +127,7 @@ internal object UserDtoTestData {
             teams_role = null,
             channel_mutes = emptyList(),
             blocked_user_ids = null,
+            avg_response_time = null,
             extraData = emptyMap(),
         )
 
@@ -175,7 +177,8 @@ internal object UserDtoTestData {
             },
             "channel_mutes": [],
             "name": "username",
-            "image": "image"
+            "image": "image",
+            "avg_response_time": 1000
          }"""
     val downstreamUser =
         DownstreamUserDto(
@@ -221,6 +224,7 @@ internal object UserDtoTestData {
             ),
             channel_mutes = emptyList(),
             blocked_user_ids = null,
+            avg_response_time = 1000L,
             extraData = emptyMap(),
         )
 

--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -98,5 +98,6 @@
             android:windowSoftInputMode="adjustResize"
             />
         <activity android:name=".feature.reminders.MessageRemindersActivity" />
+        <activity android:name=".ui.profile.UserProfileActivity" />
     </application>
 </manifest>

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
@@ -71,6 +71,7 @@ import io.getstream.chat.android.compose.sample.ui.component.AppBottomBar
 import io.getstream.chat.android.compose.sample.ui.component.AppBottomBarOption
 import io.getstream.chat.android.compose.sample.ui.component.CustomChatComponentFactory
 import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
+import io.getstream.chat.android.compose.sample.ui.profile.UserProfileActivity
 import io.getstream.chat.android.compose.state.channels.list.ItemState
 import io.getstream.chat.android.compose.state.channels.list.SearchQuery
 import io.getstream.chat.android.compose.ui.channels.ChannelsScreen
@@ -169,6 +170,10 @@ class ChannelsActivity : ComponentActivity() {
                         ) {
                             ChannelsScreenNavigationDrawer(
                                 currentUser = user,
+                                onUserClick = {
+                                    openUserProfile()
+                                    coroutineScope.launch { drawerState.close() }
+                                },
                                 onNewDirectMessageClick = {
                                     openAddChannel()
                                     coroutineScope.launch { drawerState.close() }
@@ -410,6 +415,10 @@ class ChannelsActivity : ComponentActivity() {
                 parentMessageId = thread.parentMessageId,
             ),
         )
+    }
+
+    private fun openUserProfile() {
+        startActivity(Intent(this, UserProfileActivity::class.java))
     }
 
     private fun openAddChannel() {

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsScreenNavigationDrawer.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsScreenNavigationDrawer.kt
@@ -17,12 +17,12 @@
 package io.getstream.chat.android.compose.sample.feature.channel.list
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -47,9 +47,11 @@ import io.getstream.chat.android.compose.ui.components.avatar.UserAvatar
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.User
 
+@Suppress("LongParameterList")
 @Composable
 fun ChannelsScreenNavigationDrawer(
     currentUser: User?,
+    onUserClick: () -> Unit,
     onNewDirectMessageClick: () -> Unit,
     onNewGroupClick: () -> Unit,
     onRemindersClick: () -> Unit,
@@ -61,8 +63,11 @@ fun ChannelsScreenNavigationDrawer(
             .wrapContentWidth(),
     ) {
         // Currently logged in User
-        currentUser?.let {
-            LoggedInUserHeader(it)
+        currentUser?.let { user ->
+            LoggedInUserHeader(
+                user = user,
+                onClick = onUserClick,
+            )
         }
         // New Direct Message
         NavigationDrawerItem(
@@ -95,21 +100,32 @@ fun ChannelsScreenNavigationDrawer(
     }
 }
 
+@Suppress("LongMethod")
 @Composable
-private fun LoggedInUserHeader(user: User) {
-    Column {
+private fun LoggedInUserHeader(
+    user: User,
+    onClick: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(
+                interactionSource = null,
+                indication = ripple(),
+                onClick = onClick,
+            )
+            .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
         // Avatar and name
         Row(
-            modifier = Modifier
-                .height(64.dp)
-                .padding(horizontal = 8.dp, vertical = 12.dp),
             verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             UserAvatar(
                 modifier = Modifier.size(40.dp),
                 user = user,
             )
-            Spacer(modifier = Modifier.size(12.dp))
             Text(
                 text = user.name,
                 fontWeight = FontWeight.Bold,
@@ -124,28 +140,24 @@ private fun LoggedInUserHeader(user: User) {
             val text = remember(user.teams, user.teamsRole) {
                 val builder = StringBuilder()
                 builder.appendLine("Member of:")
-                user.teams.forEach { team ->
+                user.teams.forEachIndexed { index, team ->
                     builder.append(" - $team")
                     if (user.teamsRole[team] != null) {
                         builder.append(" (role = ${user.teamsRole[team]})")
                     }
-                    builder.appendLine()
+                    if (index != user.teams.lastIndex) {
+                        builder.appendLine()
+                    }
                 }
                 builder.toString()
             }
             Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
                 text = text,
                 fontSize = 12.sp,
                 color = ChatTheme.colors.textLowEmphasis,
             )
         } else {
             Text(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 8.dp),
                 text = "No teams",
                 fontSize = 12.sp,
                 color = ChatTheme.colors.textLowEmphasis,

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileActivity.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.sample.ui.profile
 
+import android.content.res.Resources
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -32,16 +33,17 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.ui.components.BackButton
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.components.avatar.UserAvatar
@@ -64,7 +66,7 @@ class UserProfileActivity : ComponentActivity() {
     @Composable
     private fun UserProfileScreen() {
         val viewModel = viewModel<UserProfileViewModel>()
-        val user by viewModel.user.collectAsState()
+        val user by viewModel.user.collectAsStateWithLifecycle()
         Scaffold(
             topBar = {
                 TopAppBar(
@@ -86,67 +88,71 @@ class UserProfileActivity : ComponentActivity() {
             UserProfileScreenContent(user, paddingValues)
         }
     }
-}
 
-@Composable
-private fun UserProfileScreenContent(
-    user: User?,
-    paddingValues: PaddingValues,
-) {
-    when (user) {
-        null -> {
-            LoadingIndicator(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .padding(16.dp)
-                    .fillMaxWidth(),
-            )
-        }
-
-        else -> {
-            Column(
-                modifier = Modifier
-                    .padding(paddingValues)
-                    .fillMaxWidth()
-                    .padding(start = 16.dp),
-                verticalArrangement = Arrangement.spacedBy(4.dp),
-            ) {
-                UserAvatar(
+    @Suppress("LongMethod")
+    @Composable
+    private fun UserProfileScreenContent(
+        user: User?,
+        paddingValues: PaddingValues,
+    ) {
+        when (user) {
+            null -> {
+                LoadingIndicator(
                     modifier = Modifier
-                        .align(Alignment.CenterHorizontally)
-                        .padding(bottom = 16.dp)
-                        .size(72.dp),
-                    user = user,
-                    showOnlineIndicator = false,
-                    onClick = null,
+                        .padding(paddingValues)
+                        .padding(16.dp)
+                        .fillMaxWidth(),
                 )
-                Text(
-                    text = "Name",
-                    style = ChatTheme.typography.title3,
-                    color = ChatTheme.colors.textHighEmphasis,
-                )
-                Text(
-                    text = user.name.takeIf(String::isNotBlank) ?: user.id,
-                    style = ChatTheme.typography.body,
-                    color = ChatTheme.colors.textHighEmphasis,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Divider()
-                val avgResponseTimeInSeconds = user.avgResponseTime ?: 0
-                if (avgResponseTimeInSeconds > 0) {
+            }
+
+            else -> {
+                Column(
+                    modifier = Modifier
+                        .padding(paddingValues)
+                        .fillMaxWidth()
+                        .padding(start = 16.dp),
+                    verticalArrangement = Arrangement.spacedBy(4.dp),
+                ) {
+                    UserAvatar(
+                        modifier = Modifier
+                            .align(Alignment.CenterHorizontally)
+                            .padding(bottom = 16.dp)
+                            .size(72.dp),
+                        user = user,
+                        showOnlineIndicator = false,
+                        onClick = null,
+                    )
                     Text(
-                        text = "Average Response Time",
+                        text = "Name",
                         style = ChatTheme.typography.title3,
                         color = ChatTheme.colors.textHighEmphasis,
                     )
                     Text(
-                        text = "$avgResponseTimeInSeconds seconds",
+                        text = user.name.takeIf(String::isNotBlank) ?: user.id,
                         style = ChatTheme.typography.body,
                         color = ChatTheme.colors.textHighEmphasis,
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
                     )
+                    Divider()
+                    val avgResponseTimeInSeconds = user.avgResponseTime ?: 0
+                    if (avgResponseTimeInSeconds > 0) {
+                        Text(
+                            text = "Average Response Time",
+                            style = ChatTheme.typography.title3,
+                            color = ChatTheme.colors.textHighEmphasis,
+                        )
+                        Text(
+                            text = formatTime(
+                                resources = LocalContext.current.resources,
+                                seconds = avgResponseTimeInSeconds,
+                            ),
+                            style = ChatTheme.typography.body,
+                            color = ChatTheme.colors.textHighEmphasis,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
                 }
             }
         }
@@ -156,4 +162,22 @@ private fun UserProfileScreenContent(
 @Composable
 private fun Divider() {
     HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+}
+
+@Suppress("MagicNumber")
+private fun formatTime(
+    resources: Resources,
+    seconds: Long,
+): String {
+    val minutes = (seconds / 60).toInt()
+    val remainingSeconds = (seconds % 60).toInt()
+    return buildString {
+        if (minutes > 0) {
+            append(resources.getQuantityString(R.plurals.time_minutes, minutes, minutes))
+        }
+        if (remainingSeconds > 0) {
+            if (isNotEmpty()) append(" ")
+            append(resources.getQuantityString(R.plurals.time_seconds, remainingSeconds, remainingSeconds))
+        }
+    }
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileActivity.kt
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui.profile
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.components.BackButton
+import io.getstream.chat.android.compose.ui.components.LoadingIndicator
+import io.getstream.chat.android.compose.ui.components.avatar.UserAvatar
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.mirrorRtl
+import io.getstream.chat.android.models.User
+
+class UserProfileActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            ChatTheme {
+                UserProfileScreen()
+            }
+        }
+    }
+
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    private fun UserProfileScreen() {
+        val viewModel = viewModel<UserProfileViewModel>()
+        val user by viewModel.user.collectAsState()
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {},
+                    navigationIcon = {
+                        BackButton(
+                            modifier = Modifier.mirrorRtl(layoutDirection = LocalLayoutDirection.current),
+                            painter = painterResource(id = R.drawable.stream_compose_ic_arrow_back),
+                            onBackPressed = ::finish,
+                        )
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = ChatTheme.colors.appBackground,
+                    ),
+                )
+            },
+            containerColor = ChatTheme.colors.appBackground,
+        ) { paddingValues ->
+            UserProfileScreenContent(user, paddingValues)
+        }
+    }
+}
+
+@Composable
+private fun UserProfileScreenContent(
+    user: User?,
+    paddingValues: PaddingValues,
+) {
+    when (user) {
+        null -> {
+            LoadingIndicator(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+            )
+        }
+
+        else -> {
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxWidth()
+                    .padding(start = 16.dp),
+                verticalArrangement = Arrangement.spacedBy(4.dp),
+            ) {
+                UserAvatar(
+                    modifier = Modifier
+                        .align(Alignment.CenterHorizontally)
+                        .padding(bottom = 16.dp)
+                        .size(72.dp),
+                    user = user,
+                    showOnlineIndicator = false,
+                    onClick = null,
+                )
+                Text(
+                    text = "Name",
+                    style = ChatTheme.typography.title3,
+                    color = ChatTheme.colors.textHighEmphasis,
+                )
+                Text(
+                    text = user.name.takeIf(String::isNotBlank) ?: user.id,
+                    style = ChatTheme.typography.body,
+                    color = ChatTheme.colors.textHighEmphasis,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Divider()
+                val avgResponseTimeInSeconds = user.avgResponseTime ?: 0
+                if (avgResponseTimeInSeconds > 0) {
+                    Text(
+                        text = "Average Response Time",
+                        style = ChatTheme.typography.title3,
+                        color = ChatTheme.colors.textHighEmphasis,
+                    )
+                    Text(
+                        text = "$avgResponseTimeInSeconds seconds",
+                        style = ChatTheme.typography.body,
+                        color = ChatTheme.colors.textHighEmphasis,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Divider() {
+    HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
+}

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileViewModel.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileViewModel.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui.profile
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.api.models.QueryUsersRequest
+import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.User
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+
+class UserProfileViewModel(
+    private val chatClient: ChatClient = ChatClient.instance(),
+) : ViewModel() {
+
+    val user: StateFlow<User?> =
+        chatClient.clientState.user
+            .flatMapLatest(::queryUser)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(StopTimeout),
+                initialValue = null,
+            )
+
+    /**
+     * Query updated user information from the server.
+     */
+    private fun queryUser(user: User?) = flow {
+        if (user == null) {
+            emit(null)
+        } else {
+            val filter = Filters.eq("id", user.id)
+            val request = QueryUsersRequest(filter, offset = 0, limit = 1)
+            val result = chatClient.queryUsers(request).await()
+            emit(result.getOrNull()?.firstOrNull())
+        }
+    }
+}
+
+private const val StopTimeout = 5000L

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -111,4 +111,14 @@
     <string name="reminders_query_failed">Failed to load reminders</string>
     <string name="reminders_update_failed">Failed to update the reminder</string>
     <string name="reminders_delete_failed">Failed to delete the reminder</string>
+
+    <plurals name="time_minutes">
+        <item quantity="one">1 minute</item>
+        <item quantity="other">%d minutes</item>
+    </plurals>
+    <plurals name="time_seconds">
+        <item quantity="one">1 second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
+
 </resources>

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -2119,8 +2119,8 @@ public final class io/getstream/chat/android/models/UploadedFile {
 
 public final class io/getstream/chat/android/models/User : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/Map;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Ljava/util/Date;
@@ -2135,7 +2135,7 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/util/List;
 	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()J
+	public final fun component22 ()Ljava/lang/Long;
 	public final fun component23 ()Ljava/util/Map;
 	public final fun component24 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
@@ -2145,10 +2145,10 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/lang/Long;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getAvgResponseTime ()J
+	public final fun getAvgResponseTime ()Ljava/lang/Long;
 	public final fun getBanned ()Ljava/lang/Boolean;
 	public final fun getBlockedUserIds ()Ljava/util/List;
 	public final fun getChannelMutes ()Ljava/util/List;

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -2119,8 +2119,8 @@ public final class io/getstream/chat/android/models/UploadedFile {
 
 public final class io/getstream/chat/android/models/User : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Z
 	public final fun component11 ()Ljava/util/Date;
@@ -2135,8 +2135,9 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component20 ()Ljava/util/List;
 	public final fun component21 ()Ljava/util/List;
-	public final fun component22 ()Ljava/util/Map;
-	public final fun component23 ()Ljava/util/Date;
+	public final fun component22 ()J
+	public final fun component23 ()Ljava/util/Map;
+	public final fun component24 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Boolean;
@@ -2144,9 +2145,10 @@ public final class io/getstream/chat/android/models/User : io/getstream/chat/and
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;)Lio/getstream/chat/android/models/User;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;Lio/getstream/chat/android/PrivacySettings;Ljava/lang/String;Ljava/lang/Boolean;Ljava/util/List;ZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;IIILjava/util/List;Ljava/util/List;Ljava/util/Map;Ljava/util/List;Ljava/util/List;JLjava/util/Map;Ljava/util/Date;ILjava/lang/Object;)Lio/getstream/chat/android/models/User;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAvgResponseTime ()J
 	public final fun getBanned ()Ljava/lang/Boolean;
 	public final fun getBlockedUserIds ()Ljava/util/List;
 	public final fun getChannelMutes ()Ljava/util/List;
@@ -2185,6 +2187,7 @@ public final class io/getstream/chat/android/models/User$Builder {
 	public fun <init> ()V
 	public fun <init> (Lio/getstream/chat/android/models/User;)V
 	public final fun build ()Lio/getstream/chat/android/models/User;
+	public final fun withAvgResponseTime (J)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withBanned (Ljava/lang/Boolean;)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withBlockedUserIds (Ljava/util/List;)Lio/getstream/chat/android/models/User$Builder;
 	public final fun withChannelMutes (Ljava/util/List;)Lio/getstream/chat/android/models/User$Builder;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
@@ -45,7 +45,7 @@ import java.util.Date
  * @param teamsRole The roles of the user in the teams they are part of. Example: `["teamId": "role"]`.
  * @param channelMutes A list of channels muted by the current user.
  * @param blockedUserIds A list of user ids blocked by the current user.
- * @param avgResponseTime The average response time of the user in seconds
+ * @param avgResponseTime The average time (in seconds) the user took to respond to messages.
  * @param extraData A map of custom fields for the user.
  * @param deactivatedAt Date/time of deactivation.
  */
@@ -72,7 +72,7 @@ public data class User(
     val teamsRole: Map<String, String> = emptyMap(),
     val channelMutes: List<ChannelMute> = emptyList(),
     val blockedUserIds: List<String> = emptyList(),
-    val avgResponseTime: Long = 0,
+    val avgResponseTime: Long? = null,
     override val extraData: Map<String, Any> = mapOf(),
     val deactivatedAt: Date? = null,
 ) : CustomObject, ComparableFieldProvider {
@@ -145,7 +145,7 @@ public data class User(
         private var teamsRole: Map<String, String> = emptyMap()
         private var channelMutes: List<ChannelMute> = emptyList()
         private var blockedUserIds: List<String> = emptyList()
-        private var avgResponseTime: Long = 0
+        private var avgResponseTime: Long? = null
         private var extraData: Map<String, Any> = mutableMapOf()
         private var deactivatedAt: Date? = null
 

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
@@ -45,6 +45,7 @@ import java.util.Date
  * @param teamsRole The roles of the user in the teams they are part of. Example: `["teamId": "role"]`.
  * @param channelMutes A list of channels muted by the current user.
  * @param blockedUserIds A list of user ids blocked by the current user.
+ * @param avgResponseTime The average response time of the user in seconds
  * @param extraData A map of custom fields for the user.
  * @param deactivatedAt Date/time of deactivation.
  */

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/User.kt
@@ -71,6 +71,7 @@ public data class User(
     val teamsRole: Map<String, String> = emptyMap(),
     val channelMutes: List<ChannelMute> = emptyList(),
     val blockedUserIds: List<String> = emptyList(),
+    val avgResponseTime: Long = 0,
     override val extraData: Map<String, Any> = mapOf(),
     val deactivatedAt: Date? = null,
 ) : CustomObject, ComparableFieldProvider {
@@ -112,6 +113,7 @@ public data class User(
             "deactivated_at", "deactivatedAt" -> deactivatedAt
             "updated_at", "updatedAt" -> updatedAt
             "last_active", "lastActive" -> lastActive
+            "avg_response_time", "avgResponseTime" -> avgResponseTime
             else -> extraData[fieldName] as? Comparable<*>
         }
     }
@@ -142,6 +144,7 @@ public data class User(
         private var teamsRole: Map<String, String> = emptyMap()
         private var channelMutes: List<ChannelMute> = emptyList()
         private var blockedUserIds: List<String> = emptyList()
+        private var avgResponseTime: Long = 0
         private var extraData: Map<String, Any> = mutableMapOf()
         private var deactivatedAt: Date? = null
 
@@ -167,6 +170,7 @@ public data class User(
             teamsRole = user.teamsRole
             channelMutes = user.channelMutes
             blockedUserIds = user.blockedUserIds
+            avgResponseTime = user.avgResponseTime
             extraData = user.extraData
             deactivatedAt = user.deactivatedAt
         }
@@ -198,6 +202,9 @@ public data class User(
         public fun withBlockedUserIds(blockedUserIds: List<String>): Builder = apply {
             this.blockedUserIds = blockedUserIds
         }
+        public fun withAvgResponseTime(avgResponseTime: Long): Builder = apply {
+            this.avgResponseTime = avgResponseTime
+        }
         public fun withExtraData(extraData: Map<String, Any>): Builder = apply { this.extraData = extraData }
         public fun withDeactivatedAt(deactivatedAt: Date?): Builder = apply { this.deactivatedAt = deactivatedAt }
 
@@ -224,6 +231,7 @@ public data class User(
                 teamsRole = teamsRole,
                 channelMutes = channelMutes,
                 blockedUserIds = blockedUserIds,
+                avgResponseTime = avgResponseTime,
                 extraData = extraData.toMutableMap(),
                 deactivatedAt = deactivatedAt,
             )

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/internal/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/internal/ChatDatabase.kt
@@ -86,7 +86,7 @@ import io.getstream.chat.android.offline.repository.domain.user.internal.UserEnt
         ThreadOrderEntity::class,
         DraftMessageEntity::class,
     ],
-    version = 88,
+    version = 89,
     exportSchema = false,
 )
 @TypeConverters(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
@@ -131,6 +131,7 @@ internal class DatabaseUserRepository(
             mutes = mutes.map { mute -> mute.target?.id.orEmpty() },
             teams = teams,
             teamsRole = teamsRole,
+            avgResponseTime = avgResponseTime,
             extraData = extraData,
         )
 
@@ -148,6 +149,7 @@ internal class DatabaseUserRepository(
             banned = banned,
             teams = teams,
             teamsRole = teamsRole,
+            avgResponseTime = avgResponseTime ?: 0,
             extraData = extraData.toMutableMap(),
         )
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
@@ -149,7 +149,7 @@ internal class DatabaseUserRepository(
             banned = banned,
             teams = teams,
             teamsRole = teamsRole,
-            avgResponseTime = avgResponseTime ?: 0,
+            avgResponseTime = avgResponseTime,
             extraData = extraData.toMutableMap(),
         )
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/UserEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/UserEntity.kt
@@ -62,6 +62,7 @@ internal data class UserEntity(
     val teams: List<String> = emptyList(),
     val teamsRole: Map<String, String> = emptyMap(),
     val extraData: Map<String, Any> = emptyMap(),
+    val avgResponseTime: Long? = null,
 )
 
 internal const val USER_ENTITY_TABLE_NAME = "stream_chat_user"


### PR DESCRIPTION
### 🎯 Goal

Support [User Average Response Time](https://www.notion.so/stream-wiki/Display-User-Average-Response-Time-2386a5d7f9f680f497a4f7346a38736b)

### 🛠 Implementation details

Introduces the `avgResponseTime` field to the `User` model and related DTOs and entities.

- Added `avg_response_time` to `DownstreamUserDto`.
- Added `avgResponseTime` to the `User` model, its `Builder`, and the `compareTo` logic.
- Added `avgResponseTime` to `UserEntity`.
- Updated database version to `89`.
- Mapped `avg_response_time` in `DomainMapping` and `DatabaseUserRepository`.
- Included `avg_response_time` in test data for `UserDtoTestData`.

Introduces the User Profile screen to the sample app, which shows the Average Response Time.

### 🧪 Testing

> [!IMPORTANT]
>  `User response time` must be enabled in Nessy (already enabled in the app used by the sample)

- Create a new channel
- Send a few messages
- Check the user profile screen

[Screen_recording_20250811_112201.webm](https://github.com/user-attachments/assets/d3302d3e-122c-49ea-a663-ab221574531c)
