### PR TITLE
(Demo app) Ensure user connection on app initialization after a configuration change

### DIFF
--- a/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
+++ b/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
@@ -22,13 +22,15 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.TaskStackBuilder
 import androidx.lifecycle.lifecycleScope
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.sample.BuildConfig
 import io.getstream.chat.android.compose.sample.ChatApp
-import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.list.ChannelsActivity
 import io.getstream.chat.android.compose.sample.ui.chats.ChatsActivity
 import io.getstream.chat.android.compose.sample.ui.login.UserLoginActivity
+import io.getstream.chat.android.models.InitializationState
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 
 /**
@@ -49,8 +51,9 @@ class StartupActivity : AppCompatActivity() {
         lifecycleScope.launch {
             val userCredentials = ChatApp.credentialsRepository.loadUserCredentials()
             if (userCredentials != null && !BuildConfig.BENCHMARK) {
-                // Ensure that the user is connected
-                ChatHelper.connectUser(userCredentials)
+                // Await for the client to be initialized
+                ChatClient.instance().clientState.initializationState
+                    .first { it == InitializationState.COMPLETE }
 
                 if (intent.hasExtra(KEY_CHANNEL_ID)) {
                     // Navigating from push, route to the messages screen

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
@@ -23,6 +23,8 @@ import io.getstream.chat.android.compose.sample.data.UserCredentialsRepository
 import io.getstream.chat.android.compose.sample.service.SharedLocationService
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.ui.common.helper.DateFormatter
+import kotlinx.coroutines.MainScope
+import kotlinx.coroutines.launch
 
 class ChatApp : Application() {
 
@@ -37,6 +39,14 @@ class ChatApp : Application() {
 
         // Initialize Stream SDK
         ChatHelper.initializeSdk(this, getApiKey())
+
+        MainScope().launch {
+            val userCredentials = credentialsRepository.loadUserCredentials()
+            if (userCredentials != null && !BuildConfig.BENCHMARK) {
+                // Ensure that the user is connected
+                ChatHelper.connectUser(userCredentials)
+            }
+        }
     }
 
     private fun getApiKey(): String {


### PR DESCRIPTION
### 🛠 Implementation details

(Demo app) Ensure that the user is connected in the application creation, not in the `StartupActivity`

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/6c808a88-aa13-46df-859a-ffdd290807e8" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/bb2db432-a9e5-4cba-a964-0ff4642f882d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing

Trigger a configuration change (for example, by removing a permission), and resume the app from the recent apps.


