### PR TITLE
Introduce more customizable colors to the `AttachmentPickerTheme`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@
 - Introduce `ChannelFilesAttachmentsScreen` to display the channel files attachments. [#5882](https://github.com/GetStream/stream-chat-android/pull/5882)
 - Introduce `ChannelMediaAttachmentsScreen` to display the channel media (photos & videos) attachments. [#5882](https://github.com/GetStream/stream-chat-android/pull/5882)
 - Introduce `ChannelMediaAttachmentsPreview`, a full-screen pager that allows users to swipe through media attachments in a channel. [#5882](https://github.com/GetStream/stream-chat-android/pull/5882)
+- Introduce `checkIconBackgroundColor`, `checkIconTintColor`, and `contentColor` to `AttachmentPickerTheme`. [#5903](https://github.com/GetStream/stream-chat-android/pull/5903)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -80,7 +80,6 @@ import io.getstream.chat.android.compose.ui.messages.attachments.factory.Attachm
 import io.getstream.chat.android.compose.ui.messages.attachments.factory.AttachmentsPickerTabFactories
 import io.getstream.chat.android.compose.ui.messages.composer.MessageComposer
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
-import io.getstream.chat.android.compose.ui.theme.AttachmentPickerTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageComposerTheme
 import io.getstream.chat.android.compose.ui.theme.MessageOptionsTheme
@@ -175,11 +174,6 @@ class MessagesActivity : ComponentActivity() {
                     ),
                 )
             },
-            attachmentPickerTheme = AttachmentPickerTheme.defaultTheme(colors).copy(
-                backgroundOverlay = colors.overlayDark,
-                backgroundSecondary = colors.inputBackground,
-                backgroundPrimary = colors.barsBackground,
-            ),
             reactionOptionsTheme = ReactionOptionsTheme.defaultTheme(),
             messageOptionsTheme = MessageOptionsTheme.defaultTheme(
                 optionVisibility = MessageOptionItemVisibility(),

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2155,6 +2155,7 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/fac
 	public final fun defaultFactoriesWithoutStoragePermissions (ZZZZZ)Ljava/util/List;
 	public static synthetic fun defaultFactoriesWithoutStoragePermissions$default (Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerTabFactories;ZZZZZILjava/lang/Object;)Ljava/util/List;
 	public final fun systemAttachmentsPickerTabFactories (Lio/getstream/chat/android/ui/common/permissions/SystemAttachmentsPickerConfig;)Ljava/util/List;
+	public static synthetic fun systemAttachmentsPickerTabFactories$default (Lio/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerTabFactories;Lio/getstream/chat/android/ui/common/permissions/SystemAttachmentsPickerConfig;ILjava/lang/Object;)Ljava/util/List;
 }
 
 public abstract interface class io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerTabFactory {
@@ -2600,17 +2601,23 @@ public final class io/getstream/chat/android/compose/ui/pinned/PinnedMessageList
 public final class io/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme {
 	public static final field $stable I
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme$Companion;
-	public synthetic fun <init> (JJJZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component2-0d7_KjU ()J
 	public final fun component3-0d7_KjU ()J
-	public final fun component4 ()Z
-	public final fun copy-qwTeutE (JJJZ)Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;
-	public static synthetic fun copy-qwTeutE$default (Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;JJJZILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;
+	public final fun component4-0d7_KjU ()J
+	public final fun component5-0d7_KjU ()J
+	public final fun component6-0d7_KjU ()J
+	public final fun component7 ()Z
+	public final fun copy-nl4AeYM (JJJJJJZ)Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;
+	public static synthetic fun copy-nl4AeYM$default (Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;JJJJJJZILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBackgroundOverlay-0d7_KjU ()J
 	public final fun getBackgroundPrimary-0d7_KjU ()J
 	public final fun getBackgroundSecondary-0d7_KjU ()J
+	public final fun getCheckIconBackgroundColor-0d7_KjU ()J
+	public final fun getCheckIconTintColor-0d7_KjU ()J
+	public final fun getContentColor-0d7_KjU ()J
 	public final fun getSaveAttachmentsOnDismiss ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentPreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentPreviewContent.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Alignment
@@ -104,7 +103,7 @@ private fun MediaAttachmentPreviewItem(
     Box(
         modifier = Modifier
             .size(95.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(ChatTheme.shapes.attachment)
             .testTag("Stream_MediaAttachmentPreviewItem"),
         contentAlignment = Alignment.Center,
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -152,7 +152,7 @@ internal fun DefaultImagesPickerItem(
                     .size(24.dp)
                     .background(
                         shape = CircleShape,
-                        color = ChatTheme.attachmentPickerTheme.checkIconBackgroundColor
+                        color = ChatTheme.attachmentPickerTheme.checkIconBackgroundColor,
                     ),
             ) {
                 Icon(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -150,13 +150,16 @@ internal fun DefaultImagesPickerItem(
                     .align(Alignment.TopEnd)
                     .padding(4.dp)
                     .size(24.dp)
-                    .background(shape = CircleShape, color = ChatTheme.colors.overlayDark),
+                    .background(
+                        shape = CircleShape,
+                        color = ChatTheme.attachmentPickerTheme.checkIconBackgroundColor
+                    ),
             ) {
                 Icon(
                     modifier = Modifier.align(Alignment.Center),
                     painter = painterResource(id = R.drawable.stream_compose_ic_checkmark),
                     contentDescription = null,
-                    tint = ChatTheme.colors.appBackground,
+                    tint = ChatTheme.attachmentPickerTheme.checkIconTintColor,
                 )
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerSystemTabFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerSystemTabFactory.kt
@@ -475,7 +475,7 @@ private fun RoundedIconButton(
     iconPainter: Painter,
     contentDescription: String,
     text: String,
-    iconTint: Color = ChatTheme.colors.overlayDark,
+    contentColor: Color = ChatTheme.attachmentPickerTheme.contentColor,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -501,7 +501,7 @@ private fun RoundedIconButton(
                 Icon(
                     painter = iconPainter,
                     contentDescription = contentDescription,
-                    tint = iconTint,
+                    tint = contentColor,
                     modifier = Modifier
                         .size(48.dp)
                         .padding(12.dp),
@@ -512,7 +512,7 @@ private fun RoundedIconButton(
         Text(
             text = text,
             style = ChatTheme.typography.footnote,
-            color = ChatTheme.colors.textLowEmphasis,
+            color = contentColor,
             modifier = Modifier.padding(top = 4.dp),
         )
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerTabFactories.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentsPickerTabFactories.kt
@@ -73,7 +73,7 @@ public object AttachmentsPickerTabFactories {
      * @param config The configuration for the system attachment picker.
      */
     public fun systemAttachmentsPickerTabFactories(
-        config: SystemAttachmentsPickerConfig,
+        config: SystemAttachmentsPickerConfig = SystemAttachmentsPickerConfig(),
     ): List<AttachmentsPickerTabFactory> {
         val factory = AttachmentsPickerSystemTabFactory(config)
         return listOf(factory)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.graphics.Color
  * @param backgroundOverlay The overlay background color.
  * @param backgroundSecondary The secondary background color.
  * @param backgroundPrimary The primary background color.
+ * @param checkIconBackgroundColor The background color of the check icon.
+ * @param checkIconTintColor The tint color of the check icon.
  * @param saveAttachmentsOnDismiss If the selected attachments should be saved when the picker is dismissed.
  */
 @Immutable
@@ -34,6 +36,8 @@ public data class AttachmentPickerTheme(
     val backgroundOverlay: Color,
     val backgroundSecondary: Color,
     val backgroundPrimary: Color,
+    val checkIconBackgroundColor: Color,
+    val checkIconTintColor: Color,
     val saveAttachmentsOnDismiss: Boolean,
 ) {
 
@@ -55,6 +59,8 @@ public data class AttachmentPickerTheme(
                 backgroundOverlay = colors.overlay,
                 backgroundSecondary = colors.inputBackground,
                 backgroundPrimary = colors.barsBackground,
+                checkIconBackgroundColor = colors.overlayDark,
+                checkIconTintColor = colors.textHighEmphasisInverse,
                 saveAttachmentsOnDismiss = false,
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/AttachmentPickerTheme.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.graphics.Color
  * @param backgroundPrimary The primary background color.
  * @param checkIconBackgroundColor The background color of the check icon.
  * @param checkIconTintColor The tint color of the check icon.
+ * @param contentColor The content color used for text and icons.
  * @param saveAttachmentsOnDismiss If the selected attachments should be saved when the picker is dismissed.
  */
 @Immutable
@@ -38,6 +39,7 @@ public data class AttachmentPickerTheme(
     val backgroundPrimary: Color,
     val checkIconBackgroundColor: Color,
     val checkIconTintColor: Color,
+    val contentColor: Color,
     val saveAttachmentsOnDismiss: Boolean,
 ) {
 
@@ -61,6 +63,7 @@ public data class AttachmentPickerTheme(
                 backgroundPrimary = colors.barsBackground,
                 checkIconBackgroundColor = colors.overlayDark,
                 checkIconTintColor = colors.textHighEmphasisInverse,
+                contentColor = colors.overlayDark,
                 saveAttachmentsOnDismiss = false,
             )
         }


### PR DESCRIPTION
### 🎯 Goal

- Introduce `checkIconBackgroundColor`, `checkIconTintColor`, and `contentColor` to `AttachmentPickerTheme`. 


