### PR TITLE
Support upload file/image standalone endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 ### ✅ Added
 - Add `ChatClient.getPendingMessage` to fetch a pending message (and its metadata) by its ID. [#5784](https://github.com/GetStream/stream-chat-android/pull/5784)
+- Introduce `ChatClient.uploadFile`, `ChatClient.deleteFile`, `ChatClient.uploadImage`, and `ChatClient.deleteImage`, to upload/delete files/images that are not related to any channel. [#5909](https://github.com/GetStream/stream-chat-android/pull/5909)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3344,9 +3344,9 @@ public abstract interface class io/getstream/chat/android/client/user/storage/Us
 }
 
 public abstract interface class io/getstream/chat/android/client/utils/ProgressCallback {
-	public abstract fun onError (Lio/getstream/result/Error;)V
-	public abstract fun onProgress (JJ)V
-	public abstract fun onSuccess (Ljava/lang/String;)V
+	public fun onError (Lio/getstream/result/Error;)V
+	public fun onProgress (JJ)V
+	public fun onSuccess (Ljava/lang/String;)V
 }
 
 public final class io/getstream/chat/android/client/utils/TimeProvider {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -47,13 +47,9 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun deleteDevice (Lio/getstream/chat/android/models/Device;)Lio/getstream/result/call/Call;
 	public final fun deleteDraftMessages (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/result/call/Call;
 	public final fun deleteFile (Ljava/lang/String;)Lio/getstream/result/call/Call;
-	public final fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
-	public static synthetic fun deleteFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 	public final fun deleteImage (Ljava/lang/String;)Lio/getstream/result/call/Call;
-	public final fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
-	public static synthetic fun deleteImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;Z)Lio/getstream/result/call/Call;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/result/call/Call;
@@ -238,13 +234,11 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun updateUser (Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
 	public final fun updateUsers (Ljava/util/List;)Lio/getstream/result/call/Call;
 	public final fun uploadFile (Ljava/io/File;)Lio/getstream/result/call/Call;
-	public final fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
-	public final fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
-	public static synthetic fun uploadFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
+	public final fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
+	public static synthetic fun uploadFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 	public final fun uploadImage (Ljava/io/File;)Lio/getstream/result/call/Call;
-	public final fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
-	public final fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
-	public static synthetic fun uploadImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
+	public final fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
+	public static synthetic fun uploadImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 }
 
 public final class io/getstream/chat/android/client/ChatClient$Builder : io/getstream/chat/android/client/ChatClient$ChatClientBuilder {
@@ -3307,16 +3301,16 @@ public abstract interface class io/getstream/chat/android/client/uploader/FileTr
 }
 
 public abstract interface class io/getstream/chat/android/client/uploader/FileUploader {
-	public fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public fun deleteFile (Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
-	public fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public fun deleteImage (Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadFile (Ljava/io/File;Ljava/lang/String;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadImage (Ljava/io/File;Ljava/lang/String;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 }
 
 public final class io/getstream/chat/android/client/uploader/NoOpFileTransformer : io/getstream/chat/android/client/uploader/FileTransformer {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -446,12 +446,6 @@ public class io/getstream/chat/android/client/api/models/QueryChannelRequest : i
 	public final fun membersLimit ()I
 	public final fun membersOffset ()I
 	public final fun messagesLimit ()I
-	public synthetic fun noPresence ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noPresence ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
-	public synthetic fun noState ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noState ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
-	public synthetic fun noWatch ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noWatch ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
 	public final fun pagination ()Lkotlin/Pair;
 	public fun setPresence (Z)V
 	public fun setState (Z)V
@@ -463,12 +457,6 @@ public class io/getstream/chat/android/client/api/models/QueryChannelRequest : i
 	public fun withMembers (II)Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
 	public fun withMessages (I)Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
 	public fun withMessages (Lio/getstream/chat/android/client/api/models/Pagination;Ljava/lang/String;I)Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
-	public synthetic fun withPresence ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withPresence ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
-	public synthetic fun withState ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withState ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
-	public synthetic fun withWatch ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withWatch ()Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
 	public fun withWatchers (II)Lio/getstream/chat/android/client/api/models/QueryChannelRequest;
 }
 
@@ -496,12 +484,6 @@ public final class io/getstream/chat/android/client/api/models/QueryChannelsRequ
 	public fun getWatch ()Z
 	public fun hashCode ()I
 	public final fun isFirstPage ()Z
-	public synthetic fun noPresence ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noPresence ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
-	public synthetic fun noState ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noState ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
-	public synthetic fun noWatch ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun noWatch ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
 	public final fun setLimit (I)V
 	public final fun setMemberLimit (I)V
 	public final fun setMessageLimit (I)V
@@ -513,12 +495,6 @@ public final class io/getstream/chat/android/client/api/models/QueryChannelsRequ
 	public final fun withLimit (I)Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
 	public final fun withMessages (I)Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
 	public final fun withOffset (I)Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
-	public synthetic fun withPresence ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withPresence ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
-	public synthetic fun withState ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withState ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
-	public synthetic fun withWatch ()Lio/getstream/chat/android/client/api/models/ChannelRequest;
-	public fun withWatch ()Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;
 }
 
 public final class io/getstream/chat/android/client/api/models/QueryThreadsRequest {
@@ -874,34 +850,19 @@ public final class io/getstream/chat/android/client/clientstate/DisconnectCause$
 }
 
 public abstract interface class io/getstream/chat/android/client/debugger/ChatClientDebugger {
-	public abstract fun debugSendMessage (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Z)Lio/getstream/chat/android/client/debugger/SendMessageDebugger;
-	public abstract fun onNonFatalErrorOccurred (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Error;)V
-}
-
-public final class io/getstream/chat/android/client/debugger/ChatClientDebugger$DefaultImpls {
-	public static fun debugSendMessage (Lio/getstream/chat/android/client/debugger/ChatClientDebugger;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Z)Lio/getstream/chat/android/client/debugger/SendMessageDebugger;
+	public fun debugSendMessage (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Z)Lio/getstream/chat/android/client/debugger/SendMessageDebugger;
 	public static synthetic fun debugSendMessage$default (Lio/getstream/chat/android/client/debugger/ChatClientDebugger;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;ZILjava/lang/Object;)Lio/getstream/chat/android/client/debugger/SendMessageDebugger;
-	public static fun onNonFatalErrorOccurred (Lio/getstream/chat/android/client/debugger/ChatClientDebugger;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Error;)V
+	public fun onNonFatalErrorOccurred (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Error;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/debugger/SendMessageDebugger {
-	public abstract fun onInterceptionStart (Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onInterceptionStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onInterceptionUpdate (Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onSendStart (Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onSendStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onStart (Lio/getstream/chat/android/models/Message;)V
-	public abstract fun onStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
-}
-
-public final class io/getstream/chat/android/client/debugger/SendMessageDebugger$DefaultImpls {
-	public static fun onInterceptionStart (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/chat/android/models/Message;)V
-	public static fun onInterceptionStop (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
-	public static fun onInterceptionUpdate (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/chat/android/models/Message;)V
-	public static fun onSendStart (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/chat/android/models/Message;)V
-	public static fun onSendStop (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
-	public static fun onStart (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/chat/android/models/Message;)V
-	public static fun onStop (Lio/getstream/chat/android/client/debugger/SendMessageDebugger;Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
+	public fun onInterceptionStart (Lio/getstream/chat/android/models/Message;)V
+	public fun onInterceptionStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
+	public fun onInterceptionUpdate (Lio/getstream/chat/android/models/Message;)V
+	public fun onSendStart (Lio/getstream/chat/android/models/Message;)V
+	public fun onSendStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
+	public fun onStart (Lio/getstream/chat/android/models/Message;)V
+	public fun onStop (Lio/getstream/result/Result;Lio/getstream/chat/android/models/Message;)V
 }
 
 public final class io/getstream/chat/android/client/errorhandler/ErrorHandler$Companion {
@@ -2693,12 +2654,8 @@ public abstract interface class io/getstream/chat/android/client/logger/ChatLogg
 	public abstract fun logI (Ljava/lang/Object;Ljava/lang/String;)V
 	public abstract fun logT (Ljava/lang/Object;Ljava/lang/Throwable;)V
 	public abstract fun logT (Ljava/lang/Throwable;)V
-	public abstract fun logV (Ljava/lang/Object;Ljava/lang/String;)V
+	public fun logV (Ljava/lang/Object;Ljava/lang/String;)V
 	public abstract fun logW (Ljava/lang/Object;Ljava/lang/String;)V
-}
-
-public final class io/getstream/chat/android/client/logger/ChatLoggerHandler$DefaultImpls {
-	public static fun logV (Lio/getstream/chat/android/client/logger/ChatLoggerHandler;Ljava/lang/Object;Ljava/lang/String;)V
 }
 
 public abstract class io/getstream/chat/android/client/notifications/handler/ChatNotification {
@@ -2773,19 +2730,12 @@ public final class io/getstream/chat/android/client/notifications/handler/Notifi
 public abstract interface class io/getstream/chat/android/client/notifications/handler/NotificationHandler {
 	public abstract fun dismissAllNotifications ()V
 	public abstract fun dismissChannelNotifications (Ljava/lang/String;Ljava/lang/String;)V
-	public abstract fun onChatEvent (Lio/getstream/chat/android/client/events/NewMessageEvent;)Z
+	public fun onChatEvent (Lio/getstream/chat/android/client/events/NewMessageEvent;)Z
 	public abstract fun onNotificationPermissionStatus (Lio/getstream/android/push/permissions/NotificationPermissionStatus;)V
-	public abstract fun onNotificationReminderDueEvent (Lio/getstream/chat/android/client/events/NotificationReminderDueEvent;)Z
-	public abstract fun onPushMessage (Lio/getstream/chat/android/models/PushMessage;)Z
-	public abstract fun showNotification (Lio/getstream/chat/android/client/notifications/handler/ChatNotification;)V
+	public fun onNotificationReminderDueEvent (Lio/getstream/chat/android/client/events/NotificationReminderDueEvent;)Z
+	public fun onPushMessage (Lio/getstream/chat/android/models/PushMessage;)Z
+	public fun showNotification (Lio/getstream/chat/android/client/notifications/handler/ChatNotification;)V
 	public abstract fun showNotification (Lio/getstream/chat/android/models/Channel;Lio/getstream/chat/android/models/Message;)V
-}
-
-public final class io/getstream/chat/android/client/notifications/handler/NotificationHandler$DefaultImpls {
-	public static fun onChatEvent (Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;Lio/getstream/chat/android/client/events/NewMessageEvent;)Z
-	public static fun onNotificationReminderDueEvent (Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;Lio/getstream/chat/android/client/events/NotificationReminderDueEvent;)Z
-	public static fun onPushMessage (Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;Lio/getstream/chat/android/models/PushMessage;)Z
-	public static fun showNotification (Lio/getstream/chat/android/client/notifications/handler/NotificationHandler;Lio/getstream/chat/android/client/notifications/handler/ChatNotification;)V
 }
 
 public final class io/getstream/chat/android/client/notifications/handler/NotificationHandlerFactory {
@@ -2829,8 +2779,10 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun selectAllCids (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectChannel (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectChannelCidsBySyncNeeded (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun selectChannelCidsBySyncNeeded$default (Lio/getstream/chat/android/client/persistance/repository/ChannelRepository;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun selectChannels (Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun selectChannelsSyncNeeded (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun selectChannelsSyncNeeded$default (Lio/getstream/chat/android/client/persistance/repository/ChannelRepository;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public abstract fun selectMembersForChannel (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setChannelDeletedAt (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun setHiddenForChannel (Ljava/lang/String;ZLjava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -2838,11 +2790,6 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 	public abstract fun updateChannelMessage (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateLastMessageForChannel (Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun updateMembersForChannel (Ljava/lang/String;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/getstream/chat/android/client/persistance/repository/ChannelRepository$DefaultImpls {
-	public static synthetic fun selectChannelCidsBySyncNeeded$default (Lio/getstream/chat/android/client/persistance/repository/ChannelRepository;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
-	public static synthetic fun selectChannelsSyncNeeded$default (Lio/getstream/chat/android/client/persistance/repository/ChannelRepository;ILkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/persistance/repository/MessageRepository {
@@ -2932,137 +2879,120 @@ public abstract interface class io/getstream/chat/android/client/persistance/rep
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/Plugin : io/getstream/chat/android/client/plugin/DependencyResolver, io/getstream/chat/android/client/plugin/listeners/BlockUserListener, io/getstream/chat/android/client/plugin/listeners/ChannelMarkReadListener, io/getstream/chat/android/client/plugin/listeners/CreateChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteChannelListener, io/getstream/chat/android/client/plugin/listeners/DeleteMessageListener, io/getstream/chat/android/client/plugin/listeners/DeleteReactionListener, io/getstream/chat/android/client/plugin/listeners/DraftMessageListener, io/getstream/chat/android/client/plugin/listeners/EditMessageListener, io/getstream/chat/android/client/plugin/listeners/FetchCurrentUserListener, io/getstream/chat/android/client/plugin/listeners/GetMessageListener, io/getstream/chat/android/client/plugin/listeners/HideChannelListener, io/getstream/chat/android/client/plugin/listeners/LiveLocationListener, io/getstream/chat/android/client/plugin/listeners/MarkAllReadListener, io/getstream/chat/android/client/plugin/listeners/QueryBlockedUsersListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelListener, io/getstream/chat/android/client/plugin/listeners/QueryChannelsListener, io/getstream/chat/android/client/plugin/listeners/QueryMembersListener, io/getstream/chat/android/client/plugin/listeners/QueryThreadsListener, io/getstream/chat/android/client/plugin/listeners/SendAttachmentListener, io/getstream/chat/android/client/plugin/listeners/SendGiphyListener, io/getstream/chat/android/client/plugin/listeners/SendMessageListener, io/getstream/chat/android/client/plugin/listeners/SendReactionListener, io/getstream/chat/android/client/plugin/listeners/ShuffleGiphyListener, io/getstream/chat/android/client/plugin/listeners/ThreadQueryListener, io/getstream/chat/android/client/plugin/listeners/TypingEventListener, io/getstream/chat/android/client/plugin/listeners/UnblockUserListener {
-	public abstract fun getErrorHandler ()Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
-	public abstract fun onAttachmentSendRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onBlockUserResult (Lio/getstream/result/Result;)V
-	public abstract fun onChannelMarkReadPrecondition (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onCreateChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/util/List;)Lio/getstream/result/Result;
-	public abstract fun onCreateChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onCreateChannelRequest (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onCreateChannelResult (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onCreateDraftMessageResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteChannelRequest (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteChannelResult (Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteReactionPrecondition (Lio/getstream/chat/android/models/User;)Lio/getstream/result/Result;
-	public abstract fun onDeleteReactionRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onDeleteReactionResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onFetchCurrentUserResult (Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetMessageResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetNewerRepliesRequest (Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetNewerRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetRepliesMoreRequest (Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetRepliesMoreResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetRepliesRequest (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGiphySendResult (Ljava/lang/String;Lio/getstream/result/Result;)V
-	public abstract fun onHideChannelPrecondition (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onHideChannelRequest (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onHideChannelResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMarkAllReadRequest (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageDeletePrecondition (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageDeleteRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageDeleteResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageEditRequest (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageEditResult (Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onMessageSendResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryActiveLocationsResult (Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryBlockedUsersResult (Lio/getstream/result/Result;)V
-	public abstract fun onQueryChannelPrecondition (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryChannelResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryChannelsPrecondition (Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryChannelsRequest (Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryChannelsResult (Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryMembersResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;IILio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryThreadsPrecondition (Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryThreadsRequest (Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onQueryThreadsResult (Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onSendReactionPrecondition (Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onSendReactionRequest (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onSendReactionResult (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onShuffleGiphyResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onStartLiveLocationSharingResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onStopLiveLocationSharingResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onTypingEventPrecondition (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
-	public abstract fun onTypingEventRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
-	public abstract fun onTypingEventResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
-	public abstract fun onUnblockUserResult (Ljava/lang/String;Lio/getstream/result/Result;)V
-	public abstract fun onUpdateLiveLocationPrecondition (Lio/getstream/chat/android/models/Location;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onUpdateLiveLocationResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onUserDisconnected ()V
-	public abstract fun onUserSet (Lio/getstream/chat/android/models/User;)V
-}
-
-public final class io/getstream/chat/android/client/plugin/Plugin$DefaultImpls {
-	public static fun getErrorHandler (Lio/getstream/chat/android/client/plugin/Plugin;)Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
-	public static fun onAttachmentSendRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onBlockUserResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;)V
-	public static fun onChannelMarkReadPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onCreateChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/util/List;)Lio/getstream/result/Result;
-	public static fun onCreateChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onCreateChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onCreateChannelResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onCreateDraftMessageResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteChannelResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteDraftMessagesResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteReactionPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;)Lio/getstream/result/Result;
-	public static fun onDeleteReactionRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onDeleteReactionResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onFetchCurrentUserResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetMessageResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetNewerRepliesRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetNewerRepliesResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetRepliesMoreRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetRepliesMoreResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetRepliesPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetRepliesRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGetRepliesResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onGiphySendResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;)V
-	public static fun onHideChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onHideChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onHideChannelResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMarkAllReadRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageDeletePrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageDeleteRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageDeleteResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageEditRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageEditResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onMessageSendResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryActiveLocationsResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryBlockedUsersResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;)V
-	public static fun onQueryChannelPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryChannelRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryChannelResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryChannelsPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryChannelsRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryChannelsResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryDraftMessagesResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryDraftMessagesResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryMembersResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;IILio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryThreadsPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryThreadsRequest (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onQueryThreadsResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onSendReactionPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onSendReactionPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onSendReactionRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onSendReactionResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onShuffleGiphyResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onStartLiveLocationSharingResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onStopLiveLocationSharingResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onTypingEventPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
-	public static fun onTypingEventRequest (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
-	public static fun onTypingEventResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
-	public static fun onUnblockUserResult (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;)V
-	public static fun onUpdateLiveLocationPrecondition (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onUpdateLiveLocationResult (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static fun onUserDisconnected (Lio/getstream/chat/android/client/plugin/Plugin;)V
-	public static fun onUserSet (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;)V
+	public fun getErrorHandler ()Lio/getstream/chat/android/client/errorhandler/ErrorHandler;
+	public fun onAttachmentSendRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onAttachmentSendRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onBlockUserResult (Lio/getstream/result/Result;)V
+	public fun onChannelMarkReadPrecondition (Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onChannelMarkReadPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/util/List;)Lio/getstream/result/Result;
+	public fun onCreateChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateChannelRequest (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/query/CreateChannelParams;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateChannelResult (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onCreateDraftMessageResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onCreateDraftMessageResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteChannelPrecondition (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteChannelPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteChannelRequest (Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteChannelResult (Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteDraftMessagesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteReactionPrecondition (Lio/getstream/chat/android/models/User;)Lio/getstream/result/Result;
+	public fun onDeleteReactionRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteReactionRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onDeleteReactionResult (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onDeleteReactionResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onFetchCurrentUserResult (Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onFetchCurrentUserResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetMessageResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetMessageResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetNewerRepliesRequest (Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetNewerRepliesRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetNewerRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetNewerRepliesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetRepliesMoreRequest (Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetRepliesMoreRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetRepliesMoreResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetRepliesMoreResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetRepliesRequest (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetRepliesRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetRepliesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGiphySendResult (Ljava/lang/String;Lio/getstream/result/Result;)V
+	public fun onHideChannelPrecondition (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onHideChannelPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onHideChannelRequest (Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onHideChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onHideChannelResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onHideChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ZLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMarkAllReadRequest (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMarkAllReadRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageDeletePrecondition (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageDeletePrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageDeleteRequest (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageDeleteRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageDeleteResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageDeleteResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageEditRequest (Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageEditRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageEditResult (Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageEditResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Message;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onMessageSendResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onMessageSendResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryActiveLocationsResult (Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryActiveLocationsResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryBlockedUsersResult (Lio/getstream/result/Result;)V
+	public fun onQueryChannelPrecondition (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryChannelRequest (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryChannelResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/client/api/models/QueryChannelRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryChannelsPrecondition (Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelsPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryChannelsRequest (Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelsRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryChannelsResult (Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryChannelsResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryChannelsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryDraftMessagesResult (Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryDraftMessagesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/models/FilterObject;ILjava/lang/String;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryDraftMessagesResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/Integer;Ljava/lang/Integer;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryMembersResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;IILio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryMembersResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;IILio/getstream/chat/android/models/FilterObject;Lio/getstream/chat/android/models/querysort/QuerySorter;Ljava/util/List;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryThreadsPrecondition (Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryThreadsPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryThreadsRequest (Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryThreadsRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onQueryThreadsResult (Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onQueryThreadsResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/result/Result;Lio/getstream/chat/android/client/api/models/QueryThreadsRequest;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onSendReactionPrecondition (Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onSendReactionPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onSendReactionRequest (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onSendReactionRequest$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onSendReactionResult (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onSendReactionResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onShuffleGiphyResult (Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onShuffleGiphyResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Ljava/lang/String;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onStartLiveLocationSharingResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onStartLiveLocationSharingResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onStopLiveLocationSharingResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onStopLiveLocationSharingResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onTypingEventPrecondition (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)Lio/getstream/result/Result;
+	public fun onTypingEventRequest (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
+	public fun onTypingEventResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Ljava/util/Date;)V
+	public fun onUnblockUserResult (Ljava/lang/String;Lio/getstream/result/Result;)V
+	public fun onUpdateLiveLocationPrecondition (Lio/getstream/chat/android/models/Location;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateLiveLocationPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUpdateLiveLocationResult (Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onUpdateLiveLocationResult$suspendImpl (Lio/getstream/chat/android/client/plugin/Plugin;Lio/getstream/chat/android/models/Location;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onUserDisconnected ()V
+	public fun onUserSet (Lio/getstream/chat/android/models/User;)V
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/factory/PluginFactory : io/getstream/chat/android/client/plugin/DependencyResolver {
@@ -3180,13 +3110,10 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/SendReactionListener {
 	public abstract fun onSendReactionPrecondition (Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onSendReactionPrecondition (Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onSendReactionPrecondition (Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onSendReactionPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/listeners/SendReactionListener;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onSendReactionRequest (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onSendReactionResult (Ljava/lang/String;Lio/getstream/chat/android/models/Reaction;ZLio/getstream/chat/android/models/User;Lio/getstream/result/Result;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/getstream/chat/android/client/plugin/listeners/SendReactionListener$DefaultImpls {
-	public static fun onSendReactionPrecondition (Lio/getstream/chat/android/client/plugin/listeners/SendReactionListener;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/ShuffleGiphyListener {
@@ -3198,13 +3125,10 @@ public abstract interface class io/getstream/chat/android/client/plugin/listener
 	public abstract fun onGetNewerRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILjava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onGetRepliesMoreRequest (Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onGetRepliesMoreResult (Lio/getstream/result/Result;Ljava/lang/String;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public abstract fun onGetRepliesPrecondition (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun onGetRepliesPrecondition (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun onGetRepliesPrecondition$suspendImpl (Lio/getstream/chat/android/client/plugin/listeners/ThreadQueryListener;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onGetRepliesRequest (Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun onGetRepliesResult (Lio/getstream/result/Result;Ljava/lang/String;ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
-}
-
-public final class io/getstream/chat/android/client/plugin/listeners/ThreadQueryListener$DefaultImpls {
-	public static fun onGetRepliesPrecondition (Lio/getstream/chat/android/client/plugin/listeners/ThreadQueryListener;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
 public abstract interface class io/getstream/chat/android/client/plugin/listeners/TypingEventListener {
@@ -3383,23 +3307,16 @@ public abstract interface class io/getstream/chat/android/client/uploader/FileTr
 }
 
 public abstract interface class io/getstream/chat/android/client/uploader/FileUploader {
-	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
-	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public abstract fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public abstract fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-}
-
-public final class io/getstream/chat/android/client/uploader/FileUploader$DefaultImpls {
-	public static fun deleteFile (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
-	public static fun deleteImage (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
-	public static fun uploadFile (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public static fun uploadImage (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 }
 
 public final class io/getstream/chat/android/client/uploader/NoOpFileTransformer : io/getstream/chat/android/client/uploader/FileTransformer {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -46,8 +46,14 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun deleteChannel (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteDevice (Lio/getstream/chat/android/models/Device;)Lio/getstream/result/call/Call;
 	public final fun deleteDraftMessages (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/result/call/Call;
+	public final fun deleteFile (Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public static synthetic fun deleteFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/call/Call;
+	public final fun deleteImage (Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public final fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/call/Call;
+	public static synthetic fun deleteImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;)Lio/getstream/result/call/Call;
 	public final fun deleteMessage (Ljava/lang/String;Z)Lio/getstream/result/call/Call;
 	public static synthetic fun deleteMessage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/lang/String;ZILjava/lang/Object;)Lio/getstream/result/call/Call;
@@ -231,6 +237,14 @@ public final class io/getstream/chat/android/client/ChatClient {
 	public final fun updateReminder (Ljava/lang/String;Ljava/util/Date;)Lio/getstream/result/call/Call;
 	public final fun updateUser (Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
 	public final fun updateUsers (Ljava/util/List;)Lio/getstream/result/call/Call;
+	public final fun uploadFile (Ljava/io/File;)Lio/getstream/result/call/Call;
+	public final fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
+	public final fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
+	public static synthetic fun uploadFile$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
+	public final fun uploadImage (Ljava/io/File;)Lio/getstream/result/call/Call;
+	public final fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;)Lio/getstream/result/call/Call;
+	public final fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/call/Call;
+	public static synthetic fun uploadImage$default (Lio/getstream/chat/android/client/ChatClient;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;ILjava/lang/Object;)Lio/getstream/result/call/Call;
 }
 
 public final class io/getstream/chat/android/client/ChatClient$Builder : io/getstream/chat/android/client/ChatClient$ChatClientBuilder {
@@ -3369,12 +3383,23 @@ public abstract interface class io/getstream/chat/android/client/uploader/FileTr
 }
 
 public abstract interface class io/getstream/chat/android/client/uploader/FileUploader {
+	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun deleteImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public abstract fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public abstract fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+}
+
+public final class io/getstream/chat/android/client/uploader/FileUploader$DefaultImpls {
+	public static fun deleteFile (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public static fun deleteImage (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/result/Result;
+	public static fun uploadFile (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public static fun uploadImage (Lio/getstream/chat/android/client/uploader/FileUploader;Ljava/io/File;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 }
 
 public final class io/getstream/chat/android/client/uploader/NoOpFileTransformer : io/getstream/chat/android/client/uploader/FileTransformer {

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -3309,8 +3309,8 @@ public abstract interface class io/getstream/chat/android/client/uploader/FileUp
 	public abstract fun sendFile (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;)Lio/getstream/result/Result;
 	public abstract fun sendImage (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public fun uploadFile (Ljava/io/File;Ljava/lang/String;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
-	public fun uploadImage (Ljava/io/File;Ljava/lang/String;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadFile (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
+	public fun uploadImage (Ljava/io/File;Lio/getstream/chat/android/client/utils/ProgressCallback;)Lio/getstream/result/Result;
 }
 
 public final class io/getstream/chat/android/client/uploader/NoOpFileTransformer : io/getstream/chat/android/client/uploader/FileTransformer {

--- a/stream-chat-android-client/build.gradle.kts
+++ b/stream-chat-android-client/build.gradle.kts
@@ -69,6 +69,7 @@ tasks.withType<KotlinCompile>().configureEach {
             listOf(
                 "-progressive",
                 "-Xexplicit-api=strict",
+                "-Xjvm-default=all",
                 "-opt-in=kotlin.RequiresOptIn",
                 "-opt-in=io.getstream.chat.android.core.internal.InternalStreamChatApi",
             ),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -196,6 +196,7 @@ import io.getstream.chat.android.models.UploadAttachmentsNetworkType
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -1030,6 +1031,86 @@ internal constructor(
     public fun deleteImage(channelType: String, channelId: String, url: String): Call<Unit> {
         return api.deleteImage(channelType, channelId, url)
     }
+
+    /**
+     * Uploads a file not related to any channel. Progress can be accessed via [progressCallback].
+     *
+     * @param file The file to be uploaded.
+     * @param user An optional user associated with the file. Can be null.
+     * @param progressCallback The callback to be invoked periodically to report upload progress.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [UploadedFile]
+     * if the file was successfully uploaded.
+     *
+     * @see FileUploader
+     */
+    @CheckResult
+    @JvmOverloads
+    public fun uploadFile(
+        file: File,
+        user: User? = null,
+        progressCallback: ProgressCallback? = null,
+    ): Call<UploadedFile> = api.uploadFile(file, user, progressCallback)
+
+    /**
+     * Deletes a file not related to any channel.
+     *
+     * @param url The URL of the file to be deleted.
+     * @param userId An optional ID of the user associated with the file.
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [Unit]
+     * if the file was successfully deleted.
+     *
+     * @see FileUploader
+     */
+    @CheckResult
+    @JvmOverloads
+    public fun deleteFile(
+        url: String,
+        userId: UserId? = null,
+    ): Call<Unit> = api.deleteFile(url, userId)
+
+    /**
+     * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
+     *
+     * @param file The image to be uploaded.
+     * @param user An optional user associated with the image. Can be null.
+     * @param progressCallback The callback to be invoked periodically to report upload progress.
+     * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
+     * or an exception if the upload failed.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [UploadedFile]
+     * if the file was successfully uploaded.
+     *
+     * @see FileUploader
+     */
+    @CheckResult
+    @JvmOverloads
+    public fun uploadImage(
+        file: File,
+        user: User? = null,
+        progressCallback: ProgressCallback? = null,
+    ): Call<UploadedFile> = api.uploadImage(file, user, progressCallback)
+
+    /**
+     * Deletes an image not related to any channel.
+     *
+     * @param url The URL of the image to be deleted.
+     * @param userId An optional ID of the user associated with the image.
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @return Executable async [Call] which completes with [Result] containing an instance of [Unit]
+     * if the file was successfully deleted.
+     *
+     * @see FileUploader
+     */
+    @CheckResult
+    @JvmOverloads
+    public fun deleteImage(
+        url: String,
+        userId: UserId? = null,
+    ): Call<Unit> = api.deleteImage(url, userId)
 
     //region Reactions
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -196,7 +196,6 @@ import io.getstream.chat.android.models.UploadAttachmentsNetworkType
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
-import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -1036,7 +1035,6 @@ internal constructor(
      * Uploads a file not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The file to be uploaded.
-     * @param user An optional user associated with the file. Can be null.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      *
      * @return Executable async [Call] which completes with [Result] containing an instance of [UploadedFile]
@@ -1048,15 +1046,16 @@ internal constructor(
     @JvmOverloads
     public fun uploadFile(
         file: File,
-        user: User? = null,
         progressCallback: ProgressCallback? = null,
-    ): Call<UploadedFile> = api.uploadFile(file, user, progressCallback)
+    ): Call<UploadedFile> = api.uploadFile(
+        file = file,
+        progressCallback = progressCallback,
+    )
 
     /**
      * Deletes a file not related to any channel.
      *
      * @param url The URL of the file to be deleted.
-     * @param userId An optional ID of the user associated with the file.
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @return Executable async [Call] which completes with [Result] containing an instance of [Unit]
@@ -1065,17 +1064,14 @@ internal constructor(
      * @see FileUploader
      */
     @CheckResult
-    @JvmOverloads
     public fun deleteFile(
         url: String,
-        userId: UserId? = null,
-    ): Call<Unit> = api.deleteFile(url, userId)
+    ): Call<Unit> = api.deleteFile(url)
 
     /**
      * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The image to be uploaded.
-     * @param user An optional user associated with the image. Can be null.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
      * or an exception if the upload failed.
@@ -1089,15 +1085,16 @@ internal constructor(
     @JvmOverloads
     public fun uploadImage(
         file: File,
-        user: User? = null,
         progressCallback: ProgressCallback? = null,
-    ): Call<UploadedFile> = api.uploadImage(file, user, progressCallback)
+    ): Call<UploadedFile> = api.uploadImage(
+        file = file,
+        progressCallback = progressCallback,
+    )
 
     /**
      * Deletes an image not related to any channel.
      *
      * @param url The URL of the image to be deleted.
-     * @param userId An optional ID of the user associated with the image.
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @return Executable async [Call] which completes with [Result] containing an instance of [Unit]
@@ -1109,8 +1106,7 @@ internal constructor(
     @JvmOverloads
     public fun deleteImage(
         url: String,
-        userId: UserId? = null,
-    ): Call<Unit> = api.deleteImage(url, userId)
+    ): Call<Unit> = api.deleteImage(url)
 
     //region Reactions
     /**

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -58,7 +58,6 @@ import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
-import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -100,27 +99,23 @@ internal interface ChatApi {
     @CheckResult
     fun uploadFile(
         file: File,
-        user: User?,
         progressCallback: ProgressCallback?,
     ): Call<UploadedFile>
 
     @CheckResult
     fun deleteFile(
         url: String,
-        userId: UserId?,
     ): Call<Unit>
 
     @CheckResult
     fun uploadImage(
         file: File,
-        user: User?,
         progressCallback: ProgressCallback?,
     ): Call<UploadedFile>
 
     @CheckResult
     fun deleteImage(
         url: String,
-        userId: UserId?,
     ): Call<Unit>
 
     @CheckResult

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/ChatApi.kt
@@ -58,6 +58,7 @@ import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -95,6 +96,32 @@ internal interface ChatApi {
 
     @CheckResult
     fun deleteImage(channelType: String, channelId: String, url: String): Call<Unit>
+
+    @CheckResult
+    fun uploadFile(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Call<UploadedFile>
+
+    @CheckResult
+    fun deleteFile(
+        url: String,
+        userId: UserId?,
+    ): Call<Unit>
+
+    @CheckResult
+    fun uploadImage(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Call<UploadedFile>
+
+    @CheckResult
+    fun deleteImage(
+        url: String,
+        userId: UserId?,
+    ): Call<Unit>
 
     @CheckResult
     fun addDevice(device: Device): Call<Unit>

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
@@ -67,7 +67,7 @@ internal interface RetrofitCdnApi {
     @POST("/uploads/file")
     fun uploadFile(
         @Part file: MultipartBody.Part,
-        @Part user: MultipartBody.Part?,
+        @Part user: MultipartBody.Part,
         @Tag progressCallback: ProgressCallback?,
     ): RetrofitCall<UploadFileResponse>
 
@@ -80,7 +80,7 @@ internal interface RetrofitCdnApi {
     @POST("/uploads/image")
     fun uploadImage(
         @Part file: MultipartBody.Part,
-        @Part user: MultipartBody.Part?,
+        @Part user: MultipartBody.Part,
         @Tag progressCallback: ProgressCallback?,
     ): RetrofitCall<UploadFileResponse>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
@@ -62,4 +62,30 @@ internal interface RetrofitCdnApi {
         @Path("id") channelId: String,
         @Query("url") url: String,
     ): RetrofitCall<CompletableResponse>
+
+    @Multipart
+    @POST("/uploads/file")
+    fun uploadFile(
+        @Part file: MultipartBody.Part,
+        @Part user: MultipartBody.Part?,
+        @Tag progressCallback: ProgressCallback?,
+    ): RetrofitCall<UploadFileResponse>
+
+    @DELETE("/uploads/file")
+    fun deleteFile(
+        @Query("url") url: String,
+    ): RetrofitCall<CompletableResponse>
+
+    @Multipart
+    @POST("/uploads/image")
+    fun uploadImage(
+        @Part file: MultipartBody.Part,
+        @Part user: MultipartBody.Part?,
+        @Tag progressCallback: ProgressCallback?,
+    ): RetrofitCall<UploadFileResponse>
+
+    @DELETE("/uploads/image")
+    fun deleteImage(
+        @Query("url") url: String,
+    ): RetrofitCall<CompletableResponse>
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/RetrofitCdnApi.kt
@@ -67,7 +67,6 @@ internal interface RetrofitCdnApi {
     @POST("/uploads/file")
     fun uploadFile(
         @Part file: MultipartBody.Part,
-        @Part user: MultipartBody.Part,
         @Tag progressCallback: ProgressCallback?,
     ): RetrofitCall<UploadFileResponse>
 
@@ -80,7 +79,6 @@ internal interface RetrofitCdnApi {
     @POST("/uploads/image")
     fun uploadImage(
         @Part file: MultipartBody.Part,
-        @Part user: MultipartBody.Part,
         @Tag progressCallback: ProgressCallback?,
     ): RetrofitCall<UploadFileResponse>
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/CompletableResponse.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/models/CompletableResponse.kt
@@ -16,4 +16,7 @@
 
 package io.getstream.chat.android.client.api.models
 
+import com.squareup.moshi.JsonClass
+
+@JsonClass(generateAdapter = true)
 internal data class CompletableResponse(val duration: String = "")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -137,7 +137,6 @@ import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
-import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -566,14 +565,13 @@ constructor(
 
     override fun uploadFile(
         file: File,
-        user: User?,
         progressCallback: ProgressCallback?,
     ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
         fileTransformer.transform(file)
             .let { transformedFile ->
                 fileUploader.uploadFile(
                     file = transformedFile,
-                    user = user,
+                    userId = userId,
                     progressCallback = progressCallback,
                 )
             }.onSuccess { uploadedFile ->
@@ -586,25 +584,20 @@ constructor(
 
     override fun deleteFile(
         url: String,
-        userId: UserId?,
     ): Call<Unit> =
         CoroutineCall(coroutineScope) {
-            fileUploader.deleteFile(
-                url = url,
-                userId = userId,
-            )
+            fileUploader.deleteFile(url = url)
         }
 
     override fun uploadImage(
         file: File,
-        user: User?,
         progressCallback: ProgressCallback?,
     ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
         fileTransformer.transform(file)
             .let { transformedFile ->
                 fileUploader.uploadImage(
                     file = transformedFile,
-                    user = user,
+                    userId = userId,
                     progressCallback = progressCallback,
                 )
             }.onSuccess { uploadedFile ->
@@ -617,13 +610,9 @@ constructor(
 
     override fun deleteImage(
         url: String,
-        userId: UserId?,
     ): Call<Unit> =
         CoroutineCall(coroutineScope) {
-            fileUploader.deleteImage(
-                url = url,
-                userId = userId,
-            )
+            fileUploader.deleteImage(url = url)
         }
 
     override fun flagUser(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -501,8 +501,10 @@ constructor(
                         channelId = channelId,
                         userId = userId,
                         file = transformedFile,
-                        callback,
-                    )
+                        callback = callback,
+                    ).onSuccess { uploadedFile ->
+                        callback.onSuccess(url = uploadedFile.file)
+                    }.onError(callback::onError)
                 } else {
                     fileUploader.sendFile(
                         channelType = channelType,
@@ -528,8 +530,10 @@ constructor(
                         channelId = channelId,
                         userId = userId,
                         file = transformedFile,
-                        callback,
-                    )
+                        callback = callback,
+                    ).onSuccess { uploadedFile ->
+                        callback.onSuccess(url = uploadedFile.file)
+                    }.onError(callback::onError)
                 } else {
                     fileUploader.sendImage(
                         channelType = channelType,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -576,6 +576,11 @@ constructor(
                     user = user,
                     progressCallback = progressCallback,
                 )
+            }.onSuccess { uploadedFile ->
+                progressCallback?.onSuccess(url = uploadedFile.file)
+            }
+            .onError { error ->
+                progressCallback?.onError(error)
             }
     }
 
@@ -602,6 +607,11 @@ constructor(
                     user = user,
                     progressCallback = progressCallback,
                 )
+            }.onSuccess { uploadedFile ->
+                progressCallback?.onSuccess(url = uploadedFile.file)
+            }
+            .onError { error ->
+                progressCallback?.onError(error)
             }
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -571,7 +571,6 @@ constructor(
             .let { transformedFile ->
                 fileUploader.uploadFile(
                     file = transformedFile,
-                    userId = userId,
                     progressCallback = progressCallback,
                 )
             }.onSuccess { uploadedFile ->
@@ -597,7 +596,6 @@ constructor(
             .let { transformedFile ->
                 fileUploader.uploadImage(
                     file = transformedFile,
-                    userId = userId,
                     progressCallback = progressCallback,
                 )
             }.onSuccess { uploadedFile ->

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/MoshiChatApi.kt
@@ -137,6 +137,7 @@ import io.getstream.chat.android.models.UnreadCounts
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserBlock
+import io.getstream.chat.android.models.UserId
 import io.getstream.chat.android.models.VideoCallInfo
 import io.getstream.chat.android.models.VideoCallToken
 import io.getstream.chat.android.models.Vote
@@ -562,6 +563,58 @@ constructor(
             )
         }
     }
+
+    override fun uploadFile(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
+        fileTransformer.transform(file)
+            .let { transformedFile ->
+                fileUploader.uploadFile(
+                    file = transformedFile,
+                    user = user,
+                    progressCallback = progressCallback,
+                )
+            }
+    }
+
+    override fun deleteFile(
+        url: String,
+        userId: UserId?,
+    ): Call<Unit> =
+        CoroutineCall(coroutineScope) {
+            fileUploader.deleteFile(
+                url = url,
+                userId = userId,
+            )
+        }
+
+    override fun uploadImage(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Call<UploadedFile> = CoroutineCall(coroutineScope) {
+        fileTransformer.transform(file)
+            .let { transformedFile ->
+                fileUploader.uploadImage(
+                    file = transformedFile,
+                    user = user,
+                    progressCallback = progressCallback,
+                )
+            }
+    }
+
+    override fun deleteImage(
+        url: String,
+        userId: UserId?,
+    ): Call<Unit> =
+        CoroutineCall(coroutineScope) {
+            fileUploader.deleteImage(
+                url = url,
+                userId = userId,
+            )
+        }
 
     override fun flagUser(
         userId: String,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
@@ -140,7 +140,10 @@ constructor(
     private val defaultApi by lazy { buildApi(config) }
     internal val chatSocket: ChatSocket by lazy { buildChatSocket(config) }
     private val defaultFileUploader by lazy {
-        StreamFileUploader(buildRetrofitCdnApi())
+        StreamFileUploader(
+            retrofitCdnApi = buildRetrofitCdnApi(),
+            dtoMapping = dtoMapping,
+        )
     }
 
     val lifecycleObserver: StreamLifecycleObserver by lazy { StreamLifecycleObserver(userScope, lifecycle) }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/di/BaseChatModule.kt
@@ -142,7 +142,6 @@ constructor(
     private val defaultFileUploader by lazy {
         StreamFileUploader(
             retrofitCdnApi = buildRetrofitCdnApi(),
-            dtoMapping = dtoMapping,
         )
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.client.uploader
 
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.models.UploadedFile
-import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.UserId
 import io.getstream.result.Result
 import java.io.File
@@ -130,7 +129,7 @@ public interface FileUploader {
      * Uploads a file not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The file to be uploaded.
-     * @param user An optional user associated with the file. Can be null.
+     * @param userId The ID of the user associated with the file.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
      * or an exception if the upload failed.
@@ -140,7 +139,7 @@ public interface FileUploader {
      */
     public fun uploadFile(
         file: File,
-        user: User?,
+        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = NotImplemented
 
@@ -148,7 +147,6 @@ public interface FileUploader {
      * Deletes a file not related to any channel.
      *
      * @param url The URL of the file to be deleted.
-     * @param userId An optional ID of the user associated with the file.
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @see [Result.success]
@@ -156,14 +154,13 @@ public interface FileUploader {
      */
     public fun deleteFile(
         url: String,
-        userId: UserId?,
     ): Result<Unit> = NotImplemented
 
     /**
      * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The image to be uploaded.
-     * @param user An optional user associated with the image. Can be null.
+     * @param userId The ID of the user associated with the file.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
      * or an exception if the upload failed.
@@ -173,7 +170,7 @@ public interface FileUploader {
      */
     public fun uploadImage(
         file: File,
-        user: User?,
+        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = NotImplemented
 
@@ -181,7 +178,6 @@ public interface FileUploader {
      * Deletes an image not related to any channel.
      *
      * @param url The URL of the image to be deleted.
-     * @param userId An optional ID of the user associated with the image.
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @see [Result.success]
@@ -189,7 +185,6 @@ public interface FileUploader {
      */
     public fun deleteImage(
         url: String,
-        userId: UserId?,
     ): Result<Unit> = NotImplemented
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -142,7 +142,7 @@ public interface FileUploader {
         file: File,
         user: User?,
         progressCallback: ProgressCallback?,
-    ): Result<UploadedFile> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+    ): Result<UploadedFile> = NotImplemented
 
     /**
      * Deletes a file not related to any channel.
@@ -157,7 +157,7 @@ public interface FileUploader {
     public fun deleteFile(
         url: String,
         userId: UserId?,
-    ): Result<Unit> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+    ): Result<Unit> = NotImplemented
 
     /**
      * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
@@ -175,7 +175,7 @@ public interface FileUploader {
         file: File,
         user: User?,
         progressCallback: ProgressCallback?,
-    ): Result<UploadedFile> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+    ): Result<UploadedFile> = NotImplemented
 
     /**
      * Deletes an image not related to any channel.
@@ -190,5 +190,8 @@ public interface FileUploader {
     public fun deleteImage(
         url: String,
         userId: UserId?,
-    ): Result<Unit> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+    ): Result<Unit> = NotImplemented
 }
+
+private val NotImplemented: Nothing =
+    error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -18,6 +18,8 @@ package io.getstream.chat.android.client.uploader
 
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.models.UploadedFile
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.models.UserId
 import io.getstream.result.Result
 import java.io.File
 
@@ -33,7 +35,7 @@ public interface FileUploader {
      * or an exception if the upload had failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     @Suppress("LongParameterList")
     public fun sendFile(
@@ -51,7 +53,7 @@ public interface FileUploader {
      * or an exception if the upload had failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     public fun sendFile(
         channelType: String,
@@ -67,7 +69,7 @@ public interface FileUploader {
      * or an exception if the upload had failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     @Suppress("LongParameterList")
     public fun sendImage(
@@ -85,7 +87,7 @@ public interface FileUploader {
      * or an exception if the upload had failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     public fun sendImage(
         channelType: String,
@@ -100,7 +102,7 @@ public interface FileUploader {
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     public fun deleteFile(
         channelType: String,
@@ -115,7 +117,7 @@ public interface FileUploader {
      * @return The empty [Result] object, or [Result] object with exception if the operation failed.
      *
      * @see [Result.success]
-     * @see [Result.error]
+     * @see [Result.failure]
      */
     public fun deleteImage(
         channelType: String,
@@ -123,4 +125,70 @@ public interface FileUploader {
         userId: String,
         url: String,
     ): Result<Unit>
+
+    /**
+     * Uploads a file not related to any channel. Progress can be accessed via [progressCallback].
+     *
+     * @param file The file to be uploaded.
+     * @param user An optional user associated with the file. Can be null.
+     * @param progressCallback The callback to be invoked periodically to report upload progress.
+     * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
+     * or an exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.failure]
+     */
+    public fun uploadFile(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Result<UploadedFile> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+
+    /**
+     * Deletes a file not related to any channel.
+     *
+     * @param url The URL of the file to be deleted.
+     * @param userId An optional ID of the user associated with the file.
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @see [Result.success]
+     * @see [Result.failure]
+     */
+    public fun deleteFile(
+        url: String,
+        userId: UserId?,
+    ): Result<Unit> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+
+    /**
+     * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
+     *
+     * @param file The image to be uploaded.
+     * @param user An optional user associated with the image. Can be null.
+     * @param progressCallback The callback to be invoked periodically to report upload progress.
+     * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
+     * or an exception if the upload failed.
+     *
+     * @see [Result.success]
+     * @see [Result.failure]
+     */
+    public fun uploadImage(
+        file: File,
+        user: User?,
+        progressCallback: ProgressCallback?,
+    ): Result<UploadedFile> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
+
+    /**
+     * Deletes an image not related to any channel.
+     *
+     * @param url The URL of the image to be deleted.
+     * @param userId An optional ID of the user associated with the image.
+     * @return The empty [Result] object, or [Result] object with exception if the operation failed.
+     *
+     * @see [Result.success]
+     * @see [Result.failure]
+     */
+    public fun deleteImage(
+        url: String,
+        userId: UserId?,
+    ): Result<Unit> = error("Not implemented! Have you forgotten to implement it in your custom FileUploader?")
 }

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/FileUploader.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.client.uploader
 
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.models.UploadedFile
-import io.getstream.chat.android.models.UserId
 import io.getstream.result.Result
 import java.io.File
 
@@ -129,7 +128,6 @@ public interface FileUploader {
      * Uploads a file not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The file to be uploaded.
-     * @param userId The ID of the user associated with the file.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
      * or an exception if the upload failed.
@@ -139,7 +137,6 @@ public interface FileUploader {
      */
     public fun uploadFile(
         file: File,
-        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = NotImplemented
 
@@ -160,7 +157,6 @@ public interface FileUploader {
      * Uploads an image not related to any channel. Progress can be accessed via [progressCallback].
      *
      * @param file The image to be uploaded.
-     * @param userId The ID of the user associated with the file.
      * @param progressCallback The callback to be invoked periodically to report upload progress.
      * @return The [Result] object containing an instance of [UploadedFile] in the case of a successful upload
      * or an exception if the upload failed.
@@ -170,7 +166,6 @@ public interface FileUploader {
      */
     public fun uploadImage(
         file: File,
-        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = NotImplemented
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/uploader/StreamFileUploader.kt
@@ -22,12 +22,9 @@ import io.getstream.chat.android.client.api2.mapping.toUploadedFile
 import io.getstream.chat.android.client.extensions.getMediaType
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.models.UploadedFile
-import io.getstream.chat.android.models.UserId
 import io.getstream.result.Result
-import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.MultipartBody
 import okhttp3.RequestBody.Companion.asRequestBody
-import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.File
 
 internal class StreamFileUploader(
@@ -110,11 +107,9 @@ internal class StreamFileUploader(
 
     override fun uploadFile(
         file: File,
-        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = retrofitCdnApi.uploadFile(
         file = file.asBodyPart(),
-        user = userId.asBodyPart(),
         progressCallback = progressCallback,
     ).execute().map(UploadFileResponse::toUploadedFile)
 
@@ -125,11 +120,9 @@ internal class StreamFileUploader(
 
     override fun uploadImage(
         file: File,
-        userId: UserId,
         progressCallback: ProgressCallback?,
     ): Result<UploadedFile> = retrofitCdnApi.uploadImage(
         file = file.asBodyPart(),
-        user = userId.asBodyPart(),
         progressCallback = progressCallback,
     ).execute().map(UploadFileResponse::toUploadedFile)
 
@@ -142,12 +135,6 @@ internal class StreamFileUploader(
         val body = asRequestBody(contentType = getMediaType())
         val filename = filenameSanitizer.sanitize(filename = name)
         return MultipartBody.Part.createFormData(name = "file", filename = filename, body = body)
-    }
-
-    private fun UserId.asBodyPart(): MultipartBody.Part {
-        val json = "{\"id\":\"$this\"}"
-        val body = json.toRequestBody(contentType = "application/json".toMediaType())
-        return MultipartBody.Part.createFormData(name = "user", filename = null, body = body)
     }
 }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/ProgressCallback.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/ProgressCallback.kt
@@ -24,21 +24,27 @@ import io.getstream.result.Error
 public interface ProgressCallback {
 
     /**
-     * Called when the attachment is uploaded successfully with an [url].
+     * Called when a file is uploaded successfully with an [url].
      */
-    public fun onSuccess(url: String?)
+    public fun onSuccess(url: String?) {
+        // no-op
+    }
 
     /**
-     * Called when the attachment could not be uploaded due to cancellation, network problem or timeout etc
+     * Called when a file could not be uploaded due to cancellation, network problem or timeout etc
      * with an [error].
      *
      * @see Error
      */
-    public fun onError(error: Error)
+    public fun onError(error: Error) {
+        // no-op
+    }
 
     /**
-     * Called when the attachment upload is in progress with [bytesUploaded] count
+     * Called when the file upload is in progress with [bytesUploaded] count
      * and [totalBytes] in bytes of the file.
      */
-    public fun onProgress(bytesUploaded: Long, totalBytes: Long)
+    public fun onProgress(bytesUploaded: Long, totalBytes: Long) {
+        // no-op
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientChannelFileUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientChannelFileUploaderTests.kt
@@ -36,7 +36,7 @@ import org.mockito.kotlin.whenever
 /**
  * Tests for the files functionalities of the [ChatClient].
  */
-internal class ChatClientFileUploaderTests : BaseChatClientTest() {
+internal class ChatClientChannelFileUploaderTests : BaseChatClientTest() {
 
     @Test
     fun sendFileSuccess() = runTest {

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientStandaloneFileUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientStandaloneFileUploaderTests.kt
@@ -23,7 +23,6 @@ import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.randomFile
 import io.getstream.chat.android.randomString
 import io.getstream.chat.android.randomUploadedFile
-import io.getstream.chat.android.randomUser
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -33,24 +32,23 @@ import org.mockito.kotlin.whenever
 internal class ChatClientStandaloneFileUploaderTests : BaseChatClientTest() {
 
     @Test
-    fun `upload file with user and progress callback should return success result`() = runTest {
+    fun `upload file with progress callback should return success result`() = runTest {
         val file = randomFile()
-        val user = randomUser()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
-        whenever(api.uploadFile(file, user, progressCallback)) doReturn
+        whenever(api.uploadFile(file, progressCallback)) doReturn
             RetroSuccess(uploadedFile).toRetrofitCall()
 
-        val result = chatClient.uploadFile(file, user, progressCallback).await()
+        val result = chatClient.uploadFile(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
     }
 
     @Test
-    fun `upload file without user and progress callback should return success result`() = runTest {
+    fun `upload file without progress callback should return success result`() = runTest {
         val file = randomFile()
         val uploadedFile = randomUploadedFile()
-        whenever(api.uploadFile(file, user = null, progressCallback = null)) doReturn
+        whenever(api.uploadFile(file, progressCallback = null)) doReturn
             RetroSuccess(uploadedFile).toRetrofitCall()
 
         val result = chatClient.uploadFile(file).await()
@@ -59,24 +57,23 @@ internal class ChatClientStandaloneFileUploaderTests : BaseChatClientTest() {
     }
 
     @Test
-    fun `upload image with user and progress callback should return success result`() = runTest {
+    fun `upload image with progress callback should return success result`() = runTest {
         val file = randomFile()
-        val user = randomUser()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
-        whenever(api.uploadImage(file, user, progressCallback)) doReturn
+        whenever(api.uploadImage(file, progressCallback)) doReturn
             RetroSuccess(uploadedFile).toRetrofitCall()
 
-        val result = chatClient.uploadImage(file, user, progressCallback).await()
+        val result = chatClient.uploadImage(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
     }
 
     @Test
-    fun `upload image without user and progress callback should return success result`() = runTest {
+    fun `upload image without progress callback should return success result`() = runTest {
         val file = randomFile()
         val uploadedFile = randomUploadedFile()
-        whenever(api.uploadImage(file, user = null, progressCallback = null)) doReturn
+        whenever(api.uploadImage(file, progressCallback = null)) doReturn
             RetroSuccess(uploadedFile).toRetrofitCall()
 
         val result = chatClient.uploadImage(file).await()
@@ -85,21 +82,9 @@ internal class ChatClientStandaloneFileUploaderTests : BaseChatClientTest() {
     }
 
     @Test
-    fun `delete file with user ID should return success result`() = runTest {
+    fun `delete file should return success result`() = runTest {
         val url = randomString()
-        val userId = randomString()
-        whenever(api.deleteFile(url, userId)) doReturn
-            RetroSuccess(Unit).toRetrofitCall()
-
-        val result = chatClient.deleteFile(url, userId).await()
-
-        verifySuccess(result, equalsTo = Unit)
-    }
-
-    @Test
-    fun `delete file without user ID should return success result`() = runTest {
-        val url = randomString()
-        whenever(api.deleteFile(url, userId = null)) doReturn
+        whenever(api.deleteFile(url)) doReturn
             RetroSuccess(Unit).toRetrofitCall()
 
         val result = chatClient.deleteFile(url).await()
@@ -108,21 +93,9 @@ internal class ChatClientStandaloneFileUploaderTests : BaseChatClientTest() {
     }
 
     @Test
-    fun `delete image with user ID should return success result`() = runTest {
+    fun `delete image should return success result`() = runTest {
         val url = randomString()
-        val userId = randomString()
-        whenever(api.deleteImage(url, userId)) doReturn
-            RetroSuccess(Unit).toRetrofitCall()
-
-        val result = chatClient.deleteImage(url, userId).await()
-
-        verifySuccess(result, equalsTo = Unit)
-    }
-
-    @Test
-    fun `delete image without user ID should return success result`() = runTest {
-        val url = randomString()
-        whenever(api.deleteImage(url, userId = null)) doReturn
+        whenever(api.deleteImage(url)) doReturn
             RetroSuccess(Unit).toRetrofitCall()
 
         val result = chatClient.deleteImage(url).await()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientStandaloneFileUploaderTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientStandaloneFileUploaderTests.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.client
+
+import io.getstream.chat.android.client.chatclient.BaseChatClientTest
+import io.getstream.chat.android.client.utils.ProgressCallback
+import io.getstream.chat.android.client.utils.RetroSuccess
+import io.getstream.chat.android.client.utils.verifySuccess
+import io.getstream.chat.android.randomFile
+import io.getstream.chat.android.randomString
+import io.getstream.chat.android.randomUploadedFile
+import io.getstream.chat.android.randomUser
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+
+internal class ChatClientStandaloneFileUploaderTests : BaseChatClientTest() {
+
+    @Test
+    fun `upload file with user and progress callback should return success result`() = runTest {
+        val file = randomFile()
+        val user = randomUser()
+        val progressCallback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.uploadFile(file, user, progressCallback)) doReturn
+            RetroSuccess(uploadedFile).toRetrofitCall()
+
+        val result = chatClient.uploadFile(file, user, progressCallback).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun `upload file without user and progress callback should return success result`() = runTest {
+        val file = randomFile()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.uploadFile(file, user = null, progressCallback = null)) doReturn
+            RetroSuccess(uploadedFile).toRetrofitCall()
+
+        val result = chatClient.uploadFile(file).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun `upload image with user and progress callback should return success result`() = runTest {
+        val file = randomFile()
+        val user = randomUser()
+        val progressCallback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.uploadImage(file, user, progressCallback)) doReturn
+            RetroSuccess(uploadedFile).toRetrofitCall()
+
+        val result = chatClient.uploadImage(file, user, progressCallback).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun `upload image without user and progress callback should return success result`() = runTest {
+        val file = randomFile()
+        val uploadedFile = randomUploadedFile()
+        whenever(api.uploadImage(file, user = null, progressCallback = null)) doReturn
+            RetroSuccess(uploadedFile).toRetrofitCall()
+
+        val result = chatClient.uploadImage(file).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun `delete file with user ID should return success result`() = runTest {
+        val url = randomString()
+        val userId = randomString()
+        whenever(api.deleteFile(url, userId)) doReturn
+            RetroSuccess(Unit).toRetrofitCall()
+
+        val result = chatClient.deleteFile(url, userId).await()
+
+        verifySuccess(result, equalsTo = Unit)
+    }
+
+    @Test
+    fun `delete file without user ID should return success result`() = runTest {
+        val url = randomString()
+        whenever(api.deleteFile(url, userId = null)) doReturn
+            RetroSuccess(Unit).toRetrofitCall()
+
+        val result = chatClient.deleteFile(url).await()
+
+        verifySuccess(result, equalsTo = Unit)
+    }
+
+    @Test
+    fun `delete image with user ID should return success result`() = runTest {
+        val url = randomString()
+        val userId = randomString()
+        whenever(api.deleteImage(url, userId)) doReturn
+            RetroSuccess(Unit).toRetrofitCall()
+
+        val result = chatClient.deleteImage(url, userId).await()
+
+        verifySuccess(result, equalsTo = Unit)
+    }
+
+    @Test
+    fun `delete image without user ID should return success result`() = runTest {
+        val url = randomString()
+        whenever(api.deleteImage(url, userId = null)) doReturn
+            RetroSuccess(Unit).toRetrofitCall()
+
+        val result = chatClient.deleteImage(url).await()
+
+        verifySuccess(result, equalsTo = Unit)
+    }
+}

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -114,6 +114,7 @@ import io.getstream.chat.android.client.uploader.FileUploader
 import io.getstream.chat.android.client.uploader.NoOpFileTransformer
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.RetroSuccess
+import io.getstream.chat.android.client.utils.verifySuccess
 import io.getstream.chat.android.models.BannedUsersSort
 import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.Location
@@ -140,6 +141,7 @@ import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomPollConfig
 import io.getstream.chat.android.randomReaction
 import io.getstream.chat.android.randomString
+import io.getstream.chat.android.randomUploadedFile
 import io.getstream.chat.android.randomUser
 import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.result.Result
@@ -772,6 +774,82 @@ internal class MoshiChatApiTest {
         // then
         result `should be instance of` expected
         verify(fileUploader, times(1)).deleteImage(channelType, channelId, userId, url)
+    }
+
+    @Test
+    fun testUploadStandaloneFile() = runTest {
+        val file = randomFile()
+        val user = randomUser()
+        val progressCallback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        val fileUploader = mock<FileUploader> {
+            on { uploadFile(file, user, progressCallback) } doReturn Result.Success(uploadedFile)
+        }
+        val fileTransformer = mock<FileTransformer> {
+            on { transform(file) } doReturn file
+        }
+        val sut = Fixture()
+            .withFileUploader(fileUploader)
+            .withFileTransformer(fileTransformer)
+            .get()
+
+        val result = sut.uploadFile(file, user, progressCallback).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun testDeleteStandaloneFile() = runTest {
+        val url = randomString()
+        val userId = randomString()
+        val fileUploader = mock<FileUploader> {
+            on { deleteFile(url, userId) } doReturn Result.Success(Unit)
+        }
+        val sut = Fixture()
+            .withFileUploader(fileUploader)
+            .get()
+
+        val result = sut.deleteFile(url, userId).await()
+
+        verifySuccess(result, equalsTo = Unit)
+    }
+
+    @Test
+    fun testUploadStandaloneImage() = runTest {
+        val file = randomFile()
+        val user = randomUser()
+        val progressCallback = mock<ProgressCallback>()
+        val uploadedFile = randomUploadedFile()
+        val fileUploader = mock<FileUploader> {
+            on { uploadImage(file, user, progressCallback) } doReturn Result.Success(uploadedFile)
+        }
+        val fileTransformer = mock<FileTransformer> {
+            on { transform(file) } doReturn file
+        }
+        val sut = Fixture()
+            .withFileUploader(fileUploader)
+            .withFileTransformer(fileTransformer)
+            .get()
+
+        val result = sut.uploadImage(file, user, progressCallback).await()
+
+        verifySuccess(result, equalsTo = uploadedFile)
+    }
+
+    @Test
+    fun testDeleteStandaloneImage() = runTest {
+        val url = randomString()
+        val userId = randomString()
+        val fileUploader = mock<FileUploader> {
+            on { deleteImage(url, userId) } doReturn Result.Success(Unit)
+        }
+        val sut = Fixture()
+            .withFileUploader(fileUploader)
+            .get()
+
+        val result = sut.deleteImage(url, userId).await()
+
+        verifySuccess(result, equalsTo = Unit)
     }
 
     @ParameterizedTest

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -779,11 +779,11 @@ internal class MoshiChatApiTest {
     @Test
     fun testUploadStandaloneFile() = runTest {
         val file = randomFile()
-        val user = randomUser()
+        val userId = randomString()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
         val fileUploader = mock<FileUploader> {
-            on { uploadFile(file, user, progressCallback) } doReturn Result.Success(uploadedFile)
+            on { uploadFile(file, userId, progressCallback) } doReturn Result.Success(uploadedFile)
         }
         val fileTransformer = mock<FileTransformer> {
             on { transform(file) } doReturn file
@@ -793,7 +793,8 @@ internal class MoshiChatApiTest {
             .withFileTransformer(fileTransformer)
             .get()
 
-        val result = sut.uploadFile(file, user, progressCallback).await()
+        sut.setConnection(userId = userId, connectionId = randomString())
+        val result = sut.uploadFile(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
         verify(progressCallback).onSuccess(uploadedFile.file)
@@ -802,15 +803,14 @@ internal class MoshiChatApiTest {
     @Test
     fun testDeleteStandaloneFile() = runTest {
         val url = randomString()
-        val userId = randomString()
         val fileUploader = mock<FileUploader> {
-            on { deleteFile(url, userId) } doReturn Result.Success(Unit)
+            on { deleteFile(url) } doReturn Result.Success(Unit)
         }
         val sut = Fixture()
             .withFileUploader(fileUploader)
             .get()
 
-        val result = sut.deleteFile(url, userId).await()
+        val result = sut.deleteFile(url).await()
 
         verifySuccess(result, equalsTo = Unit)
     }
@@ -818,11 +818,11 @@ internal class MoshiChatApiTest {
     @Test
     fun testUploadStandaloneImage() = runTest {
         val file = randomFile()
-        val user = randomUser()
+        val userId = randomString()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
         val fileUploader = mock<FileUploader> {
-            on { uploadImage(file, user, progressCallback) } doReturn Result.Success(uploadedFile)
+            on { uploadImage(file, userId, progressCallback) } doReturn Result.Success(uploadedFile)
         }
         val fileTransformer = mock<FileTransformer> {
             on { transform(file) } doReturn file
@@ -832,7 +832,8 @@ internal class MoshiChatApiTest {
             .withFileTransformer(fileTransformer)
             .get()
 
-        val result = sut.uploadImage(file, user, progressCallback).await()
+        sut.setConnection(userId = userId, connectionId = randomString())
+        val result = sut.uploadImage(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
         verify(progressCallback).onSuccess(uploadedFile.file)
@@ -841,15 +842,14 @@ internal class MoshiChatApiTest {
     @Test
     fun testDeleteStandaloneImage() = runTest {
         val url = randomString()
-        val userId = randomString()
         val fileUploader = mock<FileUploader> {
-            on { deleteImage(url, userId) } doReturn Result.Success(Unit)
+            on { deleteImage(url) } doReturn Result.Success(Unit)
         }
         val sut = Fixture()
             .withFileUploader(fileUploader)
             .get()
 
-        val result = sut.deleteImage(url, userId).await()
+        val result = sut.deleteImage(url).await()
 
         verifySuccess(result, equalsTo = Unit)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -779,11 +779,10 @@ internal class MoshiChatApiTest {
     @Test
     fun testUploadStandaloneFile() = runTest {
         val file = randomFile()
-        val userId = randomString()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
         val fileUploader = mock<FileUploader> {
-            on { uploadFile(file, userId, progressCallback) } doReturn Result.Success(uploadedFile)
+            on { uploadFile(file, progressCallback) } doReturn Result.Success(uploadedFile)
         }
         val fileTransformer = mock<FileTransformer> {
             on { transform(file) } doReturn file
@@ -793,7 +792,6 @@ internal class MoshiChatApiTest {
             .withFileTransformer(fileTransformer)
             .get()
 
-        sut.setConnection(userId = userId, connectionId = randomString())
         val result = sut.uploadFile(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
@@ -818,11 +816,10 @@ internal class MoshiChatApiTest {
     @Test
     fun testUploadStandaloneImage() = runTest {
         val file = randomFile()
-        val userId = randomString()
         val progressCallback = mock<ProgressCallback>()
         val uploadedFile = randomUploadedFile()
         val fileUploader = mock<FileUploader> {
-            on { uploadImage(file, userId, progressCallback) } doReturn Result.Success(uploadedFile)
+            on { uploadImage(file, progressCallback) } doReturn Result.Success(uploadedFile)
         }
         val fileTransformer = mock<FileTransformer> {
             on { transform(file) } doReturn file
@@ -832,7 +829,6 @@ internal class MoshiChatApiTest {
             .withFileTransformer(fileTransformer)
             .get()
 
-        sut.setConnection(userId = userId, connectionId = randomString())
         val result = sut.uploadImage(file, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/MoshiChatApiTest.kt
@@ -796,6 +796,7 @@ internal class MoshiChatApiTest {
         val result = sut.uploadFile(file, user, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
+        verify(progressCallback).onSuccess(uploadedFile.file)
     }
 
     @Test
@@ -834,6 +835,7 @@ internal class MoshiChatApiTest {
         val result = sut.uploadImage(file, user, progressCallback).await()
 
         verifySuccess(result, equalsTo = uploadedFile)
+        verify(progressCallback).onSuccess(uploadedFile.file)
     }
 
     @Test

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
@@ -22,14 +22,12 @@ import io.getstream.chat.android.client.Mother.randomUploadFileResponse
 import io.getstream.chat.android.client.api.RetrofitCdnApi
 import io.getstream.chat.android.client.api.models.CompletableResponse
 import io.getstream.chat.android.client.api.models.UploadFileResponse
-import io.getstream.chat.android.client.api2.mapping.DtoMapping
 import io.getstream.chat.android.client.utils.ProgressCallback
 import io.getstream.chat.android.client.utils.RetroError
 import io.getstream.chat.android.client.utils.RetroSuccess
 import io.getstream.chat.android.models.UploadedFile
 import io.getstream.chat.android.randomFile
 import io.getstream.chat.android.randomString
-import io.getstream.chat.android.randomUser
 import io.getstream.result.Error
 import io.getstream.result.Result
 import org.amshove.kluent.shouldBeEqualTo
@@ -66,13 +64,12 @@ internal class StreamFileUploaderTest {
     }
 
     private val retrofitCdnApi: RetrofitCdnApi = mock()
-    private val dtpMapping: DtoMapping = mock()
     private lateinit var streamFileUploader: StreamFileUploader
 
     @Before
     fun before() {
         shadowOf(MimeTypeMap.getSingleton())
-        streamFileUploader = StreamFileUploader(retrofitCdnApi, dtpMapping)
+        streamFileUploader = StreamFileUploader(retrofitCdnApi)
     }
 
     @Test
@@ -232,9 +229,8 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should upload file to api with user and progress callback`() {
+    fun `Should upload file to api with progress callback`() {
         val file = randomFile()
-        val user = randomUser()
         val response = randomUploadFileResponse()
         whenever(
             retrofitCdnApi.uploadFile(
@@ -244,7 +240,7 @@ internal class StreamFileUploaderTest {
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadFile(file, user, progressCallback)
+        val result = streamFileUploader.uploadFile(file, userId, progressCallback)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -253,18 +249,18 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should upload file to api with no user nor progress callback`() {
+    fun `Should upload file to api with no progress callback`() {
         val file = randomFile()
         val response = randomUploadFileResponse()
         whenever(
             retrofitCdnApi.uploadFile(
                 file = any(),
-                user = eq(null),
+                user = any(),
                 progressCallback = eq(null),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadFile(file, user = null, progressCallback = null)
+        val result = streamFileUploader.uploadFile(file, userId, progressCallback = null)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -273,9 +269,8 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should upload image to api with user and progress callback`() {
+    fun `Should upload image to api with progress callback`() {
         val file = randomFile()
-        val user = randomUser()
         val response = randomUploadFileResponse()
         whenever(
             retrofitCdnApi.uploadImage(
@@ -285,7 +280,7 @@ internal class StreamFileUploaderTest {
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadImage(file, user, progressCallback)
+        val result = streamFileUploader.uploadImage(file, userId, progressCallback)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -294,18 +289,18 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should upload image to api with no user nor progress callback`() {
+    fun `Should upload image to api with no progress callback`() {
         val file = randomFile()
         val response = randomUploadFileResponse()
         whenever(
             retrofitCdnApi.uploadImage(
                 file = any(),
-                user = eq(null),
+                user = any(),
                 progressCallback = eq(null),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadImage(file, user = null, progressCallback = null)
+        val result = streamFileUploader.uploadImage(file, userId, progressCallback = null)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -314,45 +309,23 @@ internal class StreamFileUploaderTest {
     }
 
     @Test
-    fun `Should delete file with url and userId`() {
+    fun `Should delete file with url`() {
         val url = randomString()
         whenever(retrofitCdnApi.deleteFile(url = url)) doReturn
             RetroSuccess(CompletableResponse(duration = randomString())).toRetrofitCall()
 
-        val result = streamFileUploader.deleteFile(url, userId)
+        val result = streamFileUploader.deleteFile(url)
 
         assertTrue(result is Result.Success)
     }
 
     @Test
-    fun `Should delete file with url and no userId`() {
-        val url = randomString()
-        whenever(retrofitCdnApi.deleteFile(url = url)) doReturn
-            RetroSuccess(CompletableResponse(duration = randomString())).toRetrofitCall()
-
-        val result = streamFileUploader.deleteFile(url, userId = null)
-
-        assertTrue(result is Result.Success)
-    }
-
-    @Test
-    fun `Should delete image with url and userId`() {
+    fun `Should delete image with url`() {
         val url = randomString()
         whenever(retrofitCdnApi.deleteImage(url = url)) doReturn
             RetroSuccess(CompletableResponse(duration = randomString())).toRetrofitCall()
 
-        val result = streamFileUploader.deleteImage(url, userId)
-
-        assertTrue(result is Result.Success)
-    }
-
-    @Test
-    fun `Should delete image with url and no userId`() {
-        val url = randomString()
-        whenever(retrofitCdnApi.deleteImage(url = url)) doReturn
-            RetroSuccess(CompletableResponse(duration = randomString())).toRetrofitCall()
-
-        val result = streamFileUploader.deleteImage(url, userId = null)
+        val result = streamFileUploader.deleteImage(url)
 
         assertTrue(result is Result.Success)
     }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/uploader/StreamFileUploaderTest.kt
@@ -235,12 +235,11 @@ internal class StreamFileUploaderTest {
         whenever(
             retrofitCdnApi.uploadFile(
                 file = any(),
-                user = any(),
                 progressCallback = eq(progressCallback),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadFile(file, userId, progressCallback)
+        val result = streamFileUploader.uploadFile(file, progressCallback)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -255,12 +254,11 @@ internal class StreamFileUploaderTest {
         whenever(
             retrofitCdnApi.uploadFile(
                 file = any(),
-                user = any(),
                 progressCallback = eq(null),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadFile(file, userId, progressCallback = null)
+        val result = streamFileUploader.uploadFile(file, progressCallback = null)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -275,12 +273,11 @@ internal class StreamFileUploaderTest {
         whenever(
             retrofitCdnApi.uploadImage(
                 file = any(),
-                user = any(),
                 progressCallback = eq(progressCallback),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadImage(file, userId, progressCallback)
+        val result = streamFileUploader.uploadImage(file, progressCallback)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()
@@ -295,12 +292,11 @@ internal class StreamFileUploaderTest {
         whenever(
             retrofitCdnApi.uploadImage(
                 file = any(),
-                user = any(),
                 progressCallback = eq(null),
             ),
         ) doReturn RetroSuccess(response).toRetrofitCall()
 
-        val result = streamFileUploader.uploadImage(file, userId, progressCallback = null)
+        val result = streamFileUploader.uploadImage(file, progressCallback = null)
 
         assertTrue(result is Result.Success)
         val uploadedFile = result.getOrThrow()

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileUtils.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileUtils.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.sample.ui.profile
+
+import android.content.Context
+import android.net.Uri
+import androidx.core.content.FileProvider
+import io.getstream.chat.android.compose.sample.R
+import java.io.File
+import java.util.UUID
+
+@Suppress("MagicNumber")
+internal fun Context.formatTime(seconds: Long): String {
+    val minutes = (seconds / 60).toInt()
+    val remainingSeconds = (seconds % 60).toInt()
+    return buildString {
+        if (minutes > 0) {
+            append(resources.getQuantityString(R.plurals.time_minutes, minutes, minutes))
+        }
+        if (remainingSeconds > 0) {
+            if (isNotEmpty()) append(" ")
+            append(resources.getQuantityString(R.plurals.time_seconds, remainingSeconds, remainingSeconds))
+        }
+    }
+}
+
+internal fun Uri.toCacheFile(context: Context): File {
+    val cacheFile = File(context.cacheDir, UUID.randomUUID().toString())
+    context.contentResolver.openInputStream(this).use { inputStream ->
+        cacheFile.outputStream().use { output ->
+            inputStream?.copyTo(output)
+        }
+    }
+    return cacheFile
+}
+
+internal fun Context.generateCameraImageFile(): File =
+    cacheDir.resolve(relative = "camera_${UUID.randomUUID()}.jpg")
+
+internal fun File.getUri(context: Context): Uri =
+    FileProvider.getUriForFile(
+        context,
+        "${context.packageName}.streamfileprovider",
+        this,
+    )

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileViewEvent.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/profile/UserProfileViewEvent.kt
@@ -16,15 +16,13 @@
 
 package io.getstream.chat.android.compose.sample.ui.profile
 
-import io.getstream.chat.android.models.UnreadCounts
-import io.getstream.chat.android.models.User
+import io.getstream.result.Error
 
-data class UserProfileViewState(
-    val user: User? = null,
-    val unreadCounts: UnreadCounts? = null,
-    val progressIndicator: ProgressIndicator? = null,
-) {
-    data class ProgressIndicator(
-        val progress: Float? = null, // null when indeterminate
-    )
+sealed interface UserProfileViewEvent {
+    data object UpdateProfilePictureSuccess : UserProfileViewEvent
+    sealed interface Failure : UserProfileViewEvent { val error: Error }
+    data class LoadUserError(override val error: Error) : Failure
+    data class LoadUnreadCountsError(override val error: Error) : Failure
+    data class UpdateProfilePictureError(override val error: Error) : Failure
+    data class RemoveProfilePictureError(override val error: Error) : Failure
 }


### PR DESCRIPTION
### 🎯 Goal

Support upload standalone file/image endpoints as per https://github.com/GetStream/stream-chat-js/pull/1564

### 🛠 Implementation details

Introduced `ChatClient.uploadFile`, `ChatClient.deleteFile`, `ChatClient.uploadImage`, and `ChatClient.deleteImage`, to upload/delete files/images that are not related to any channel. 

```kotlin
chatClient.uploadImage(
    file = anImageFile,
).enqueue()
```

Added a functionality to upload the profile picture to the Compose demo app.

> [!NOTE]
> All the updated profile pictures are reset on a new app cold launch or login, so that we keep the original avatars of the demo app.

> [!IMPORTANT]
> It was set `-Xjvm-default=all` to the Kotlin compiler of the client module, so that default implementations of interfaces are available in **Java**, e.g., using the `ProgressCallback` doesn't require implementing all the callback functions.

### 🎨 UI Changes

<video src="https://github.com/user-attachments/assets/b1092121-b778-4130-9712-f8f68639316d" controls="controls" muted="muted" />

