### PR TITLE
Add `Channel` entity to `ChannelHiddenEvent` and `ChannelVisibleEvent`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@
 - New Silent messages are not increasing the unread count. [#5910](https://github.com/GetStream/stream-chat-android/pull/5910)
 
 ### ✅ Added
+- Add `channel` entity to `ChannelHiddenEvent`. [#5912](https://github.com/GetStream/stream-chat-android/pull/5912)
+- Add `channel` entity to `ChannelVisibleEvent`. [#5912](https://github.com/GetStream/stream-chat-android/pull/5912)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
@@ -116,7 +116,7 @@ public fun randomChannelVisibleEvent(
     channelType: String = randomString(),
     channelId: String = randomString(),
     user: User = randomUser(),
-
+    channel: Channel = randomChannel(),
 ): ChannelVisibleEvent = ChannelVisibleEvent(
     type = EventType.CHANNEL_VISIBLE,
     createdAt = createdAt,
@@ -125,6 +125,7 @@ public fun randomChannelVisibleEvent(
     channelType = channelType,
     channelId = channelId,
     user = user,
+    channel = channel,
 )
 
 public fun randomUserStartWatchingEvent(
@@ -152,6 +153,7 @@ public fun randomChannelHiddenEvent(
     channelId: String = randomString(),
     user: User = randomUser(),
     clearHistory: Boolean = randomBoolean(),
+    channel: Channel = randomChannel(),
 ): ChannelHiddenEvent = ChannelHiddenEvent(
     type = EventType.CHANNEL_HIDDEN,
     createdAt = createdAt,
@@ -160,6 +162,7 @@ public fun randomChannelHiddenEvent(
     channelType = channelType,
     channelId = channelId,
     user = user,
+    channel = channel,
     clearHistory = clearHistory,
 )
 

--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
@@ -512,6 +512,7 @@ public class TestDataHelper {
             channelType = channel2.type,
             channelId = channel2.id,
             user = user1,
+            channel = channel2,
             clearHistory = false,
         )
     }
@@ -525,6 +526,7 @@ public class TestDataHelper {
             cid = channel2.cid,
             channelType = channel2.type,
             channelId = channel2.id,
+            channel = channel2,
             user = user1,
         )
     }

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -1087,8 +1087,8 @@ public final class io/getstream/chat/android/client/events/ChannelDeletedEvent :
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/client/events/ChannelHiddenEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/UserEvent {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Z)V
+public final class io/getstream/chat/android/client/events/ChannelHiddenEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasChannel, io/getstream/chat/android/client/events/UserEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;Z)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
@@ -1096,10 +1096,12 @@ public final class io/getstream/chat/android/client/events/ChannelHiddenEvent : 
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lio/getstream/chat/android/models/User;
-	public final fun component8 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Z)Lio/getstream/chat/android/client/events/ChannelHiddenEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelHiddenEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;ZILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelHiddenEvent;
+	public final fun component8 ()Lio/getstream/chat/android/models/Channel;
+	public final fun component9 ()Z
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;Z)Lio/getstream/chat/android/client/events/ChannelHiddenEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelHiddenEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;ZILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelHiddenEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChannel ()Lio/getstream/chat/android/models/Channel;
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;
@@ -1241,8 +1243,8 @@ public final class io/getstream/chat/android/client/events/ChannelUserUnbannedEv
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class io/getstream/chat/android/client/events/ChannelVisibleEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/UserEvent {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;)V
+public final class io/getstream/chat/android/client/events/ChannelVisibleEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasChannel, io/getstream/chat/android/client/events/UserEvent {
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
@@ -1250,9 +1252,11 @@ public final class io/getstream/chat/android/client/events/ChannelVisibleEvent :
 	public final fun component5 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/String;
 	public final fun component7 ()Lio/getstream/chat/android/models/User;
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;)Lio/getstream/chat/android/client/events/ChannelVisibleEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelVisibleEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelVisibleEvent;
+	public final fun component8 ()Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;)Lio/getstream/chat/android/client/events/ChannelVisibleEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/ChannelVisibleEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Channel;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/ChannelVisibleEvent;
 	public fun equals (Ljava/lang/Object;)Z
+	public fun getChannel ()Lio/getstream/chat/android/models/Channel;
 	public fun getChannelId ()Ljava/lang/String;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -259,6 +259,7 @@ internal class EventMapping(
             channelType = channel_type,
             channelId = channel_id,
             user = user.toDomain(),
+            channel = channel.toDomain(),
             clearHistory = clear_history,
         )
     }
@@ -325,6 +326,7 @@ internal class EventMapping(
             channelType = channel_type,
             channelId = channel_id,
             user = user.toDomain(),
+            channel = channel.toDomain(),
         )
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -42,6 +42,7 @@ internal data class ChannelHiddenEventDto(
     val channel_type: String,
     val channel_id: String,
     val user: DownstreamUserDto,
+    val channel: DownstreamChannelDto,
     val clear_history: Boolean,
 ) : ChatEventDto()
 
@@ -88,6 +89,7 @@ internal data class ChannelVisibleEventDto(
     val channel_type: String,
     val channel_id: String,
     val user: DownstreamUserDto,
+    val channel: DownstreamChannelDto,
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -148,8 +148,9 @@ public data class ChannelHiddenEvent(
     override val channelType: String,
     override val channelId: String,
     override val user: User,
+    override val channel: Channel,
     val clearHistory: Boolean,
-) : CidEvent(), UserEvent
+) : CidEvent(), UserEvent, HasChannel
 
 /**
  * Triggered when a channels' history is truncated. Could contain system [message].
@@ -206,7 +207,8 @@ public data class ChannelVisibleEvent(
     override val channelType: String,
     override val channelId: String,
     override val user: User,
-) : CidEvent(), UserEvent
+    override val channel: Channel,
+) : CidEvent(), UserEvent, HasChannel
 
 /**
  * Triggered every 30 second to confirm that the client connection is still alive

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -40,6 +40,7 @@ internal fun createChannelHiddenEventStringJson() =
             "channel_id": "channelId",
             "cid": "channelType:channelId",
             "clear_history": true,
+            "channel": ${createChannelJsonString()},
             "channel_last_message_at": "2020-06-29T06:14:28.000Z"
         """.trimIndent(),
     )
@@ -104,6 +105,7 @@ internal fun createChannelVisibleEventStringJson() =
             "channel_id": "channelId",
             "cid": "channelType:channelId",
             "user": ${createUserJsonString()},
+            "channel": ${createChannelJsonString()},
             "channel_last_message_at": "2020-06-29T06:14:28.000Z"
         """.trimIndent(),
     )

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/EventMappingTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/EventMappingTestArguments.kt
@@ -243,6 +243,7 @@ internal object EventMappingTestArguments {
         channel_type = CHANNEL_TYPE,
         channel_id = CHANNEL_ID,
         user = USER,
+        channel = CHANNEL,
         clear_history = CLEAR_HISTORY,
     )
 
@@ -304,6 +305,7 @@ internal object EventMappingTestArguments {
         cid = CID,
         channel_type = CHANNEL_TYPE,
         channel_id = CHANNEL_ID,
+        channel = CHANNEL,
         user = USER,
     )
 
@@ -813,6 +815,7 @@ internal object EventMappingTestArguments {
         cid = channelHiddenDto.cid,
         channelType = channelHiddenDto.channel_type,
         channelId = channelHiddenDto.channel_id,
+        channel = with(domainMapping) { channelHiddenDto.channel.toDomain() },
         clearHistory = channelHiddenDto.clear_history,
     )
 
@@ -886,6 +889,7 @@ internal object EventMappingTestArguments {
         user = with(domainMapping) { channelVisibleDto.user.toDomain() },
         cid = channelVisibleDto.cid,
         channelType = channelVisibleDto.channel_type,
+        channel = with(domainMapping) { channelVisibleDto.channel.toDomain() },
         channelId = channelVisibleDto.channel_id,
     )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ChannelExtensionsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/internal/ChannelExtensionsTests.kt
@@ -97,7 +97,7 @@ internal class ChannelExtensionsTests {
             lastReadMessageId = null,
         )
         val existingMessage = randomMessage(id = "existing", createdAt = Date(1000), deletedAt = null)
-        val newMessage = randomMessage(id = "new", createdAt = Date(2000), deletedAt = null)
+        val newMessage = randomMessage(id = "new", createdAt = Date(2000), deletedAt = null, silent = false)
         val receivedEventDate = Date(2500)
 
         val channel = randomChannel(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -248,6 +248,7 @@ internal object EventArguments {
         channelType = channelType,
         channelId = channelId,
         user = user,
+        channel = channel,
         clearHistory = true,
     )
 
@@ -301,6 +302,7 @@ internal object EventArguments {
         cid = cid,
         channelType = channelType,
         channelId = channelId,
+        channel = channel,
         user = user,
     )
     private val memberAddedEvent = MemberAddedEvent(

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/chat/ChatEventHandler.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/chat/ChatEventHandler.kt
@@ -103,6 +103,8 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
         return when (event) {
             is ChannelDeletedEvent -> EventHandlingResult.Remove(event.cid)
             is NotificationChannelDeletedEvent -> EventHandlingResult.Remove(event.cid)
+            is ChannelHiddenEvent -> EventHandlingResult.Remove(event.cid)
+            is ChannelVisibleEvent -> EventHandlingResult.WatchAndAdd(event.cid)
             else -> EventHandlingResult.Skip
         }
     }
@@ -120,13 +122,7 @@ public abstract class BaseChatEventHandler : ChatEventHandler {
         event: CidEvent,
         filter: FilterObject,
         cachedChannel: Channel?,
-    ): EventHandlingResult {
-        return when (event) {
-            is ChannelHiddenEvent -> EventHandlingResult.Remove(event.cid)
-            is ChannelVisibleEvent -> EventHandlingResult.WatchAndAdd(event.cid)
-            else -> EventHandlingResult.Skip
-        }
-    }
+    ): EventHandlingResult = EventHandlingResult.Skip
 
     /**
      * Computes the event handling result.


### PR DESCRIPTION
### 🎯 Goal
The `ChannelHiddenEvent` and `ChannelVisibleEvent` now contains a `Channel` entity.
When an userA block another userB, any 1:1 channel they both have are blocked and `ChannelHiddenEvent` is received. With the new change the customer can know if the channel is hidden because the "block action" or because "hide action" and configure different behavior.

Complete: AND-716

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
