### PR TITLE
Filter out Poll Options differing only on whitespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Filter out Poll Options differing only on whitespaces. [#5913](https://github.com/GetStream/stream-chat-android/pull/5913)
 
 ### ⬆️ Improved
 
@@ -67,6 +68,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Filter out Poll Options differing only on whitespaces. [#5913](https://github.com/GetStream/stream-chat-android/pull/5913)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollViewModel.kt
@@ -154,11 +154,17 @@ public class CreatePollViewModel : ViewModel() {
         _options.value.let { options ->
             val previousOptions = options.values
                 .filterNot { it.id == id }
-                .map { it.text }
+                .map { it.text.trim() }
                 .filter { it.isNotEmpty() }
             options[id]?.let { option ->
                 _options.value = LinkedHashMap(options).apply {
-                    put(id, option.copy(text = text, duplicateError = previousOptions.contains(text)))
+                    put(
+                        id,
+                        option.copy(
+                            text = text,
+                            duplicateError = previousOptions.any { it == text.trim() },
+                        ),
+                    )
                 }
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter.kt
@@ -62,6 +62,7 @@ public class OptionsAdapter(
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { /* no-op */ }
             override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) { /* no-op */ }
             override fun afterTextChanged(s: Editable?) {
+                pollAnswer.updateErrorState()
                 onOptionChange(pollAnswer.id, s.toString())
             }
         }
@@ -71,9 +72,13 @@ public class OptionsAdapter(
             binding.option.removeTextChangedListener(textWatcher)
             binding.option.setText(pollAnswer.text)
             binding.option.setSelection(pollAnswer.text.length)
+            pollAnswer.updateErrorState()
             binding.option.addTextChangedListener(textWatcher)
+        }
+
+        private fun PollAnswer.updateErrorState() {
             binding.option.error = when {
-                pollAnswer.duplicateError ->
+                duplicateError ->
                     binding.root.context.getString(R.string.stream_ui_poll_this_is_already_an_option)
                 else -> null
             }


### PR DESCRIPTION
### 🎯 Goal
Filter out Poll Options differing only on whitespaces
Fix: AND-717

### 🎨 UI Changes
<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/9b70b83a-69dd-431b-af26-a51b262e99cd" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/a7262bb1-ae19-4ba8-8690-873501560d23" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/211b96b7-4df2-4632-ab42-e0f427bcb2cc" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/8e86e9af-fb5f-4553-b33b-eedc783e6aae" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

