### PR TITLE
Expose Channel Messages Count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 ### ❌ Removed
 
+## stream-chat-android-core
+### ✅ Added
+- Add `Channel.messagesCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
+
 ## stream-chat-android-client
 ### 🐞 Fixed
 
@@ -22,6 +26,8 @@
 ### ✅ Added
 - Add `ChatClient.getPendingMessage` to fetch a pending message (and its metadata) by its ID. [#5784](https://github.com/GetStream/stream-chat-android/pull/5784)
 - Introduce `ChatClient.uploadFile`, `ChatClient.deleteFile`, `ChatClient.uploadImage`, and `ChatClient.deleteImage`, to upload/delete files/images that are not related to any channel. [#5909](https://github.com/GetStream/stream-chat-android/pull/5909)
+- Add `NewMessageEvent.channelMessageCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
+- Add `MessageDeletedEvent.channelMessageCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
 
 ### ⚠️ Changed
 
@@ -44,6 +50,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
+- Add `ChannelState.messagesCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
 
 ### ⚠️ Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ## stream-chat-android-core
 ### ✅ Added
-- Add `Channel.messagesCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
+- Add `Channel.messageCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
 
 ## stream-chat-android-client
 ### 🐞 Fixed
@@ -50,7 +50,7 @@
 ### ⬆️ Improved
 
 ### ✅ Added
-- Add `ChannelState.messagesCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
+- Add `ChannelState.messageCount` field representing the total number of messages in the channel. [#5918](https://github.com/GetStream/stream-chat-android/pull/5918)
 
 ### ⚠️ Changed
 

--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/Mother.kt
@@ -62,6 +62,7 @@ import io.getstream.chat.android.models.Reaction
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.querysort.QuerySortByField
 import io.getstream.chat.android.models.querysort.QuerySorter
+import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomChannel
@@ -486,6 +487,7 @@ public fun randomNewMessageEvent(
     watcherCount: Int = randomInt(),
     totalUnreadCount: Int = randomInt(),
     unreadChannels: Int = randomInt(),
+    channelMessageCount: Int? = positiveRandomInt(),
 ): NewMessageEvent {
     return NewMessageEvent(
         type = EventType.MESSAGE_NEW,
@@ -499,6 +501,7 @@ public fun randomNewMessageEvent(
         watcherCount = watcherCount,
         totalUnreadCount = totalUnreadCount,
         unreadChannels = unreadChannels,
+        channelMessageCount = channelMessageCount,
     )
 }
 

--- a/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
+++ b/stream-chat-android-client-test/src/main/java/io/getstream/chat/android/client/test/utils/TestDataHelper.kt
@@ -296,6 +296,7 @@ public class TestDataHelper {
             watcherCount = 1,
             totalUnreadCount = 0,
             unreadChannels = 0,
+            channelMessageCount = 1,
         )
     }
 
@@ -314,6 +315,7 @@ public class TestDataHelper {
             watcherCount = 1,
             totalUnreadCount = 0,
             unreadChannels = 0,
+            channelMessageCount = 1,
         )
     }
     public val newMessageFromUser2: NewMessageEvent by lazy {
@@ -331,6 +333,7 @@ public class TestDataHelper {
             watcherCount = 1,
             totalUnreadCount = 0,
             unreadChannels = 0,
+            channelMessageCount = 1,
         )
     }
 
@@ -379,6 +382,7 @@ public class TestDataHelper {
             channelId = channel1.id,
             message = message1Deleted,
             hardDelete = false,
+            channelMessageCount = 1,
         )
     }
 
@@ -395,6 +399,7 @@ public class TestDataHelper {
             channelId = channel1.id,
             message = message1Deleted,
             hardDelete = true,
+            channelMessageCount = 1,
         )
     }
 

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -782,8 +782,8 @@ public abstract interface class io/getstream/chat/android/client/channel/state/C
 	public abstract fun getMembers ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMembersCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMessageById (Ljava/lang/String;)Lio/getstream/chat/android/models/Message;
+	public abstract fun getMessageCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMessages ()Lkotlinx/coroutines/flow/StateFlow;
-	public abstract fun getMessagesCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMessagesState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMuted ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getOldMessages ()Lkotlinx/coroutines/flow/StateFlow;

--- a/stream-chat-android-client/api/stream-chat-android-client.api
+++ b/stream-chat-android-client/api/stream-chat-android-client.api
@@ -783,6 +783,7 @@ public abstract interface class io/getstream/chat/android/client/channel/state/C
 	public abstract fun getMembersCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMessageById (Ljava/lang/String;)Lio/getstream/chat/android/models/Message;
 	public abstract fun getMessages ()Lkotlinx/coroutines/flow/StateFlow;
+	public abstract fun getMessagesCount ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMessagesState ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getMuted ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getOldMessages ()Lkotlinx/coroutines/flow/StateFlow;
@@ -1564,8 +1565,9 @@ public final class io/getstream/chat/android/client/events/MemberUpdatedEvent : 
 }
 
 public final class io/getstream/chat/android/client/events/MessageDeletedEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasMessage {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;Z)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;ZLjava/lang/Integer;)V
 	public final fun component1 ()Ljava/lang/String;
+	public final fun component10 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -1574,10 +1576,11 @@ public final class io/getstream/chat/android/client/events/MessageDeletedEvent :
 	public final fun component7 ()Lio/getstream/chat/android/models/Message;
 	public final fun component8 ()Lio/getstream/chat/android/models/User;
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;Z)Lio/getstream/chat/android/client/events/MessageDeletedEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/MessageDeletedEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;ZILjava/lang/Object;)Lio/getstream/chat/android/client/events/MessageDeletedEvent;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;ZLjava/lang/Integer;)Lio/getstream/chat/android/client/events/MessageDeletedEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/MessageDeletedEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;ZLjava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/MessageDeletedEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ljava/lang/String;
+	public final fun getChannelMessageCount ()Ljava/lang/Integer;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;
 	public fun getCreatedAt ()Ljava/util/Date;
@@ -1644,11 +1647,12 @@ public final class io/getstream/chat/android/client/events/MessageUpdatedEvent :
 }
 
 public final class io/getstream/chat/android/client/events/NewMessageEvent : io/getstream/chat/android/client/events/CidEvent, io/getstream/chat/android/client/events/HasMessage, io/getstream/chat/android/client/events/HasUnreadCounts, io/getstream/chat/android/client/events/HasWatcherCount, io/getstream/chat/android/client/events/UserEvent {
-	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;III)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIILjava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIILjava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()I
 	public final fun component11 ()I
+	public final fun component12 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/util/Date;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Lio/getstream/chat/android/models/User;
@@ -1657,10 +1661,11 @@ public final class io/getstream/chat/android/client/events/NewMessageEvent : io/
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Lio/getstream/chat/android/models/Message;
 	public final fun component9 ()I
-	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;III)Lio/getstream/chat/android/client/events/NewMessageEvent;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/NewMessageEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIIILjava/lang/Object;)Lio/getstream/chat/android/client/events/NewMessageEvent;
+	public final fun copy (Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIILjava/lang/Integer;)Lio/getstream/chat/android/client/events/NewMessageEvent;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/client/events/NewMessageEvent;Ljava/lang/String;Ljava/util/Date;Ljava/lang/String;Lio/getstream/chat/android/models/User;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/Message;IIILjava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/client/events/NewMessageEvent;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun getChannelId ()Ljava/lang/String;
+	public final fun getChannelMessageCount ()Ljava/lang/Integer;
 	public fun getChannelType ()Ljava/lang/String;
 	public fun getCid ()Ljava/lang/String;
 	public fun getCreatedAt ()Ljava/util/Date;

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -174,7 +174,7 @@ internal class DomainMapping(
             ownCapabilities = own_capabilities.toSet(),
             membership = membership?.toDomain(),
             activeLiveLocations = active_live_locations.map { it.toDomain() },
-            messagesCount = message_count,
+            messageCount = message_count,
             extraData = extraData.toMutableMap(),
         ).syncUnreadCountWithReads(currentUserIdProvider())
             .let(channelTransformer::transform)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -174,6 +174,7 @@ internal class DomainMapping(
             ownCapabilities = own_capabilities.toSet(),
             membership = membership?.toDomain(),
             activeLiveLocations = active_live_locations.map { it.toDomain() },
+            messagesCount = message_count,
             extraData = extraData.toMutableMap(),
         ).syncUnreadCountWithReads(currentUserIdProvider())
             .let(channelTransformer::transform)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/EventMapping.kt
@@ -398,6 +398,7 @@ internal class EventMapping(
             channelId = channel_id,
             message = message.toDomain(),
             hardDelete = hard_delete ?: false,
+            channelMessageCount = channel_message_count,
         )
     }
 
@@ -450,6 +451,7 @@ internal class EventMapping(
             watcherCount = watcher_count,
             totalUnreadCount = total_unread_count,
             unreadChannels = unread_channels,
+            channelMessageCount = channel_message_count,
         )
     }
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ChannelDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/ChannelDtos.kt
@@ -77,5 +77,6 @@ internal data class DownstreamChannelDto(
     val own_capabilities: List<String> = emptyList(),
     val membership: DownstreamMemberDto?,
     val active_live_locations: List<DownstreamLocationDto> = emptyList(),
+    val message_count: Int? = null,
     val extraData: Map<String, Any>,
 ) : ExtraDataDto

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/EventDtos.kt
@@ -142,6 +142,7 @@ internal data class MessageDeletedEventDto(
     val channel_id: String,
     val message: DownstreamMessageDto,
     val hard_delete: Boolean?,
+    val channel_message_count: Int? = null,
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)
@@ -179,6 +180,7 @@ internal data class NewMessageEventDto(
     val watcher_count: Int = 0,
     val total_unread_count: Int = 0,
     val unread_channels: Int = 0,
+    val channel_message_count: Int? = null,
 ) : ChatEventDto()
 
 @JsonClass(generateAdapter = true)

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
@@ -124,6 +124,9 @@ public interface ChannelState {
     /** Live locations that are currently active in this channel. */
     public val activeLiveLocations: StateFlow<List<Location>>
 
+    /** Number of messages in the channel. */
+    public val messagesCount: StateFlow<Int?>
+
     /** Function that builds a channel based on data from StateFlows. */
     public fun toChannel(): Channel
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/channel/state/ChannelState.kt
@@ -125,7 +125,7 @@ public interface ChannelState {
     public val activeLiveLocations: StateFlow<List<Location>>
 
     /** Number of messages in the channel. */
-    public val messagesCount: StateFlow<Int?>
+    public val messageCount: StateFlow<Int?>
 
     /** Function that builds a channel based on data from StateFlows. */
     public fun toChannel(): Channel

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/events/ChatEvent.kt
@@ -275,6 +275,7 @@ public data class MessageDeletedEvent(
     override val message: Message,
     val user: User?,
     val hardDelete: Boolean,
+    val channelMessageCount: Int?,
 ) : CidEvent(), HasMessage
 
 /**
@@ -335,6 +336,7 @@ public data class NewMessageEvent(
     override val watcherCount: Int = 0,
     override val totalUnreadCount: Int = 0,
     override val unreadChannels: Int = 0,
+    val channelMessageCount: Int?,
 ) : CidEvent(), UserEvent, HasMessage, HasWatcherCount, HasUnreadCounts
 
 /**

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/EventChatJsonProvider.kt
@@ -159,7 +159,8 @@ internal fun createMessageDeletedEventStringJson() =
             "cid": "channelType:channelId",
             "watcher_count": 3,
             "message": ${createMessageJsonString()},
-            "channel_last_message_at": "2020-06-29T06:14:28.000Z"
+            "channel_last_message_at": "2020-06-29T06:14:28.000Z",
+            "channel_message_count": 1
         """.trimIndent(),
     )
 
@@ -172,7 +173,8 @@ internal fun createMessageDeletedServerSideEventStringJson() =
             "cid": "channelType:channelId",
             "message": ${createMessageJsonString()},
             "hard_delete": true,
-            "channel_last_message_at": "2020-06-29T06:14:28.000Z"
+            "channel_last_message_at": "2020-06-29T06:14:28.000Z",
+            "channel_message_count": 1
         """.trimIndent(),
     )
 
@@ -556,7 +558,8 @@ internal fun createNewMessageEventStringJson() =
             "total_unread_count": 4,
             "unread_channels": 5,
             "message": ${createMessageJsonString()},
-            "channel_last_message_at": "2020-06-29T06:14:28.000Z"
+            "channel_last_message_at": "2020-06-29T06:14:28.000Z",
+            "channel_message_count": 1
         """.trimIndent(),
     )
 
@@ -570,7 +573,8 @@ internal fun createNewMessageWithoutUnreadCountsEventStringJson() =
             "cid": "channelType:channelId",
             "watcher_count": 3,
             "message": ${createMessageJsonString()},
-            "channel_last_message_at": "2020-06-29T06:14:28.000Z"
+            "channel_last_message_at": "2020-06-29T06:14:28.000Z",
+            "channel_message_count": 1
         """.trimIndent(),
     )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/EventMappingTestArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/EventMappingTestArguments.kt
@@ -780,6 +780,7 @@ internal object EventMappingTestArguments {
         watcherCount = newMessageDto.watcher_count,
         totalUnreadCount = newMessageDto.total_unread_count,
         unreadChannels = newMessageDto.unread_channels,
+        channelMessageCount = newMessageDto.channel_message_count,
     )
 
     private val draftMessageUpdatedEvent = DraftMessageUpdatedEvent(
@@ -999,6 +1000,7 @@ internal object EventMappingTestArguments {
         user = with(domainMapping) { messageDeletedDto.user?.toDomain() },
         message = with(domainMapping) { messageDeletedDto.message.toDomain() },
         hardDelete = messageDeletedDto.hard_delete ?: false,
+        channelMessageCount = messageDeletedDto.channel_message_count,
     )
 
     private val messageRead = MessageReadEvent(

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/channel/ChannelClientSubscribeTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/channel/ChannelClientSubscribeTest.kt
@@ -73,6 +73,7 @@ internal class ChannelClientSubscribeTest {
             watcherCount = 0,
             totalUnreadCount = 0,
             unreadChannels = 0,
+            channelMessageCount = 1,
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/ChatEventEnrichmentsTests.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/extensions/ChatEventEnrichmentsTests.kt
@@ -27,6 +27,7 @@ import io.getstream.chat.android.client.events.ReactionDeletedEvent
 import io.getstream.chat.android.client.events.ReactionNewEvent
 import io.getstream.chat.android.client.events.ReactionUpdateEvent
 import io.getstream.chat.android.client.extensions.internal.enrichIfNeeded
+import io.getstream.chat.android.positiveRandomInt
 import io.getstream.chat.android.randomBoolean
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomChannel
@@ -54,6 +55,7 @@ internal class ChatEventEnrichmentsTests {
             user = randomUser(),
             channelType = randomString(),
             channelId = randomString(),
+            channelMessageCount = positiveRandomInt(),
         )
         val enrichedEvent = event.enrichIfNeeded() as NewMessageEvent
         enrichedEvent.message.cid shouldBeEqualTo cid
@@ -71,6 +73,7 @@ internal class ChatEventEnrichmentsTests {
             channelType = randomString(),
             channelId = randomString(),
             hardDelete = randomBoolean(),
+            channelMessageCount = positiveRandomInt(),
         )
         val enrichedEvent = event.enrichIfNeeded() as MessageDeletedEvent
         enrichedEvent.message.cid shouldBeEqualTo cid

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser/EventArguments.kt
@@ -345,6 +345,7 @@ internal object EventArguments {
         channelId = channelId,
         message = message,
         hardDelete = false,
+        channelMessageCount = 1,
     )
     private val messageDeletedServerSideEvent = MessageDeletedEvent(
         type = EventType.MESSAGE_DELETED,
@@ -356,6 +357,7 @@ internal object EventArguments {
         channelId = channelId,
         message = message,
         hardDelete = true,
+        channelMessageCount = 1,
     )
     private val messageReadEvent = MessageReadEvent(
         type = EventType.MESSAGE_READ,
@@ -649,6 +651,7 @@ internal object EventArguments {
         watcherCount = watcherCount,
         totalUnreadCount = totalUnreadCount,
         unreadChannels = unreadChannels,
+        channelMessageCount = 1,
     )
     private val newMessageWithoutUnreadCountsEvent = NewMessageEvent(
         type = EventType.MESSAGE_NEW,
@@ -660,6 +663,7 @@ internal object EventArguments {
         channelId = channelId,
         message = message,
         watcherCount = watcherCount,
+        channelMessageCount = 1,
     )
     private val unknownEvent = UnknownEvent(
         type = EventType.UNKNOWN,

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -412,8 +412,8 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun getMemberCount ()I
 	public final fun getMembers ()Ljava/util/List;
 	public final fun getMembership ()Lio/getstream/chat/android/models/Member;
+	public final fun getMessageCount ()Ljava/lang/Integer;
 	public final fun getMessages ()Ljava/util/List;
-	public final fun getMessagesCount ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwnCapabilities ()Ljava/util/Set;
 	public final fun getPendingMessages ()Ljava/util/List;
@@ -455,8 +455,8 @@ public final class io/getstream/chat/android/models/Channel$Builder {
 	public final fun withMemberCount (I)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withMembers (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withMembership (Lio/getstream/chat/android/models/Member;)Lio/getstream/chat/android/models/Channel$Builder;
+	public final fun withMessageCount (Ljava/lang/Integer;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withMessages (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
-	public final fun withMessagesCount (Ljava/lang/Integer;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withName (Ljava/lang/String;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withOwnCapabilities (Ljava/util/Set;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withPinnedMessages (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
@@ -556,7 +556,7 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun getImage ()Ljava/lang/String;
 	public final fun getMemberCount ()I
 	public final fun getMembership ()Lio/getstream/chat/android/models/Member;
-	public final fun getMessagesCount ()Ljava/lang/Integer;
+	public final fun getMessageCount ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwnCapabilities ()Ljava/util/Set;
 	public final fun getTeam ()Ljava/lang/String;

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -352,8 +352,8 @@ public final class io/getstream/chat/android/models/BannedUsersSort : io/getstre
 
 public final class io/getstream/chat/android/models/Channel : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/lang/Integer;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/lang/Integer;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lio/getstream/chat/android/models/SyncStatus;
 	public final fun component11 ()I
@@ -378,15 +378,16 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun component29 ()Lio/getstream/chat/android/models/DraftMessage;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component30 ()Ljava/util/List;
-	public final fun component31 ()Ljava/util/Map;
+	public final fun component31 ()Ljava/lang/Integer;
+	public final fun component32 ()Ljava/util/Map;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()I
 	public final fun component6 ()Z
 	public final fun component7 ()Ljava/util/Date;
 	public final fun component8 ()Ljava/util/Date;
 	public final fun component9 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/util/Map;)Lio/getstream/chat/android/models/Channel;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/Channel;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/lang/Integer;Ljava/util/Map;)Lio/getstream/chat/android/models/Channel;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/Channel;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;Lio/getstream/chat/android/models/SyncStatus;ILjava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lio/getstream/chat/android/models/Config;Lio/getstream/chat/android/models/User;ILjava/lang/String;Ljava/lang/Boolean;Ljava/util/Date;ILjava/util/List;Ljava/util/List;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Ljava/util/List;ZLio/getstream/chat/android/models/DraftMessage;Ljava/util/List;Ljava/lang/Integer;Ljava/util/Map;ILjava/lang/Object;)Lio/getstream/chat/android/models/Channel;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getActiveLiveLocations ()Ljava/util/List;
 	public final fun getCachedLatestMessages ()Ljava/util/List;
@@ -412,6 +413,7 @@ public final class io/getstream/chat/android/models/Channel : io/getstream/chat/
 	public final fun getMembers ()Ljava/util/List;
 	public final fun getMembership ()Lio/getstream/chat/android/models/Member;
 	public final fun getMessages ()Ljava/util/List;
+	public final fun getMessagesCount ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwnCapabilities ()Ljava/util/Set;
 	public final fun getPendingMessages ()Ljava/util/List;
@@ -454,6 +456,7 @@ public final class io/getstream/chat/android/models/Channel$Builder {
 	public final fun withMembers (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withMembership (Lio/getstream/chat/android/models/Member;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withMessages (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
+	public final fun withMessagesCount (Ljava/lang/Integer;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withName (Ljava/lang/String;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withOwnCapabilities (Ljava/util/Set;)Lio/getstream/chat/android/models/Channel$Builder;
 	public final fun withPinnedMessages (Ljava/util/List;)Lio/getstream/chat/android/models/Channel$Builder;
@@ -519,8 +522,8 @@ public final class io/getstream/chat/android/models/ChannelConfig {
 
 public final class io/getstream/chat/android/models/ChannelData {
 	public fun <init> (Lio/getstream/chat/android/models/Channel;Ljava/util/Set;)V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Ljava/util/Date;
 	public final fun component11 ()I
@@ -529,6 +532,7 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun component14 ()Ljava/util/Set;
 	public final fun component15 ()Lio/getstream/chat/android/models/Member;
 	public final fun component16 ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun component17 ()Ljava/lang/Integer;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -537,8 +541,8 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun component7 ()Z
 	public final fun component8 ()Ljava/util/Date;
 	public final fun component9 ()Ljava/util/Date;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;)Lio/getstream/chat/android/models/ChannelData;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;ILjava/lang/Object;)Lio/getstream/chat/android/models/ChannelData;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/Integer;)Lio/getstream/chat/android/models/ChannelData;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/ChannelData;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/models/User;IZLjava/util/Date;Ljava/util/Date;Ljava/util/Date;ILjava/lang/String;Ljava/util/Map;Ljava/util/Set;Lio/getstream/chat/android/models/Member;Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/models/ChannelData;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getCid ()Ljava/lang/String;
 	public final fun getCooldown ()I
@@ -552,6 +556,7 @@ public final class io/getstream/chat/android/models/ChannelData {
 	public final fun getImage ()Ljava/lang/String;
 	public final fun getMemberCount ()I
 	public final fun getMembership ()Lio/getstream/chat/android/models/Member;
+	public final fun getMessagesCount ()Ljava/lang/Integer;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOwnCapabilities ()Ljava/util/Set;
 	public final fun getTeam ()Ljava/lang/String;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
@@ -100,6 +100,7 @@ public data class Channel(
     val isInsideSearch: Boolean = false,
     val draftMessage: DraftMessage? = null,
     val activeLiveLocations: List<Location> = emptyList(),
+    val messagesCount: Int? = null,
     override val extraData: Map<String, Any> = mapOf(),
 ) : CustomObject, ComparableFieldProvider {
 
@@ -193,6 +194,7 @@ public data class Channel(
         private var isInsideSearch: Boolean = false
         private var draft: DraftMessage? = null
         private var activeLiveLocations: List<Location> = emptyList()
+        private var messagesCount: Int? = null
         private var extraData: Map<String, Any> = mapOf()
 
         public constructor(channel: Channel) : this() {
@@ -225,6 +227,7 @@ public data class Channel(
             isInsideSearch = channel.isInsideSearch
             draft = channel.draftMessage
             activeLiveLocations = channel.activeLiveLocations
+            messagesCount = channel.messagesCount
             extraData = channel.extraData
         }
 
@@ -269,6 +272,9 @@ public data class Channel(
         public fun withActiveLiveLocations(activeLiveLocations: List<Location>): Builder = apply {
             this.activeLiveLocations = activeLiveLocations
         }
+        public fun withMessagesCount(messagesCount: Int?): Builder = apply {
+            this.messagesCount = messagesCount
+        }
         public fun withExtraData(extraData: Map<String, Any>): Builder = apply { this.extraData = extraData }
 
         @Deprecated(
@@ -309,6 +315,7 @@ public data class Channel(
             isInsideSearch = isInsideSearch,
             draftMessage = draft,
             activeLiveLocations = activeLiveLocations,
+            messagesCount = messagesCount,
             extraData = extraData,
         )
     }
@@ -336,6 +343,7 @@ public fun Channel.mergeChannelFromEvent(that: Channel): Channel {
         createdAt = that.createdAt,
         updatedAt = that.updatedAt,
         deletedAt = that.deletedAt,
+        messagesCount = that.messagesCount ?: messagesCount,
         /* Do not merge (messages, watcherCount, watchers, read, ownCapabilities, membership, unreadCount) fields.
         messages = that.messages,
         watcherCount = that.watcherCount,
@@ -369,5 +377,6 @@ public fun Channel.toChannelData(): ChannelData {
         ownCapabilities = ownCapabilities,
         membership = membership,
         draft = draftMessage,
+        messagesCount = messagesCount,
     )
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/Channel.kt
@@ -100,7 +100,7 @@ public data class Channel(
     val isInsideSearch: Boolean = false,
     val draftMessage: DraftMessage? = null,
     val activeLiveLocations: List<Location> = emptyList(),
-    val messagesCount: Int? = null,
+    val messageCount: Int? = null,
     override val extraData: Map<String, Any> = mapOf(),
 ) : CustomObject, ComparableFieldProvider {
 
@@ -194,7 +194,7 @@ public data class Channel(
         private var isInsideSearch: Boolean = false
         private var draft: DraftMessage? = null
         private var activeLiveLocations: List<Location> = emptyList()
-        private var messagesCount: Int? = null
+        private var messageCount: Int? = null
         private var extraData: Map<String, Any> = mapOf()
 
         public constructor(channel: Channel) : this() {
@@ -227,7 +227,7 @@ public data class Channel(
             isInsideSearch = channel.isInsideSearch
             draft = channel.draftMessage
             activeLiveLocations = channel.activeLiveLocations
-            messagesCount = channel.messagesCount
+            messageCount = channel.messageCount
             extraData = channel.extraData
         }
 
@@ -272,8 +272,8 @@ public data class Channel(
         public fun withActiveLiveLocations(activeLiveLocations: List<Location>): Builder = apply {
             this.activeLiveLocations = activeLiveLocations
         }
-        public fun withMessagesCount(messagesCount: Int?): Builder = apply {
-            this.messagesCount = messagesCount
+        public fun withMessageCount(messageCount: Int?): Builder = apply {
+            this.messageCount = messageCount
         }
         public fun withExtraData(extraData: Map<String, Any>): Builder = apply { this.extraData = extraData }
 
@@ -315,7 +315,7 @@ public data class Channel(
             isInsideSearch = isInsideSearch,
             draftMessage = draft,
             activeLiveLocations = activeLiveLocations,
-            messagesCount = messagesCount,
+            messageCount = messageCount,
             extraData = extraData,
         )
     }
@@ -343,7 +343,7 @@ public fun Channel.mergeChannelFromEvent(that: Channel): Channel {
         createdAt = that.createdAt,
         updatedAt = that.updatedAt,
         deletedAt = that.deletedAt,
-        messagesCount = that.messagesCount ?: messagesCount,
+        messageCount = that.messageCount ?: messageCount,
         /* Do not merge (messages, watcherCount, watchers, read, ownCapabilities, membership, unreadCount) fields.
         messages = that.messages,
         watcherCount = that.watcherCount,
@@ -377,6 +377,6 @@ public fun Channel.toChannelData(): ChannelData {
         ownCapabilities = ownCapabilities,
         membership = membership,
         draft = draftMessage,
-        messagesCount = messagesCount,
+        messageCount = messageCount,
     )
 }

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
@@ -59,6 +59,7 @@ public data class ChannelData(
     val ownCapabilities: Set<String> = setOf(),
     val membership: Member? = null,
     val draft: DraftMessage? = null,
+    val messagesCount: Int? = null,
 ) {
 
     /**
@@ -100,6 +101,7 @@ public data class ChannelData(
             ?: currentOwnCapabilities,
         membership = channel.membership,
         draft = channel.draftMessage,
+        messagesCount = channel.messagesCount,
     )
 
     @Deprecated(
@@ -176,6 +178,7 @@ public data class ChannelData(
             isInsideSearch = insideSearch,
             draftMessage = draft,
             activeLiveLocations = emptyList(),
+            messagesCount = messagesCount,
         )
     }
 
@@ -210,6 +213,7 @@ public fun ChannelData.mergeFromEvent(that: ChannelData): ChannelData {
         updatedAt = that.updatedAt,
         deletedAt = that.deletedAt,
         createdBy = that.createdBy,
+        messagesCount = messagesCount ?: this.messagesCount,
         /* Do not merge (ownCapabilities, membership) fields.
         ownCapabilities = that.ownCapabilities,
         membership = that.membership,

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/ChannelData.kt
@@ -40,6 +40,8 @@ import java.util.Date
  * @param ownCapabilities Channel's capabilities available for the current user. Note that the field is not provided
  * in the events.
  * @param membership Represents relationship of the current user to the channel.
+ * @param draft The current user's draft message for this channel, if any.
+ * @param messageCount The total number of messages in the channel, if known.
  */
 @Immutable
 public data class ChannelData(
@@ -59,7 +61,7 @@ public data class ChannelData(
     val ownCapabilities: Set<String> = setOf(),
     val membership: Member? = null,
     val draft: DraftMessage? = null,
-    val messagesCount: Int? = null,
+    val messageCount: Int? = null,
 ) {
 
     /**
@@ -101,7 +103,7 @@ public data class ChannelData(
             ?: currentOwnCapabilities,
         membership = channel.membership,
         draft = channel.draftMessage,
-        messagesCount = channel.messagesCount,
+        messageCount = channel.messageCount,
     )
 
     @Deprecated(
@@ -178,7 +180,7 @@ public data class ChannelData(
             isInsideSearch = insideSearch,
             draftMessage = draft,
             activeLiveLocations = emptyList(),
-            messagesCount = messagesCount,
+            messageCount = messageCount,
         )
     }
 
@@ -213,7 +215,7 @@ public fun ChannelData.mergeFromEvent(that: ChannelData): ChannelData {
         updatedAt = that.updatedAt,
         deletedAt = that.deletedAt,
         createdBy = that.createdBy,
-        messagesCount = messagesCount ?: this.messagesCount,
+        messageCount = messageCount ?: this.messageCount,
         /* Do not merge (ownCapabilities, membership) fields.
         ownCapabilities = that.ownCapabilities,
         membership = that.membership,

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -429,6 +429,7 @@ public fun randomChannel(
     isInsideSearch: Boolean = randomBoolean(),
     draftMessage: DraftMessage? = randomDraftMessageOrNull(),
     activeLiveLocations: List<Location> = emptyList(),
+    messagesCount: Int? = positiveRandomInt().takeIf { randomBoolean() },
 ): Channel = Channel(
     id = id,
     name = name,
@@ -457,6 +458,7 @@ public fun randomChannel(
     isInsideSearch = isInsideSearch,
     draftMessage = draftMessage,
     activeLiveLocations = activeLiveLocations,
+    messagesCount = messagesCount,
 )
 
 public fun randomChannelUserRead(

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -429,7 +429,7 @@ public fun randomChannel(
     isInsideSearch: Boolean = randomBoolean(),
     draftMessage: DraftMessage? = randomDraftMessageOrNull(),
     activeLiveLocations: List<Location> = emptyList(),
-    messagesCount: Int? = positiveRandomInt().takeIf { randomBoolean() },
+    messageCount: Int? = positiveRandomInt().takeIf { randomBoolean() },
 ): Channel = Channel(
     id = id,
     name = name,
@@ -458,7 +458,7 @@ public fun randomChannel(
     isInsideSearch = isInsideSearch,
     draftMessage = draftMessage,
     activeLiveLocations = activeLiveLocations,
-    messagesCount = messagesCount,
+    messageCount = messageCount,
 )
 
 public fun randomChannelUserRead(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/internal/ChatDatabase.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/database/internal/ChatDatabase.kt
@@ -86,7 +86,7 @@ import io.getstream.chat.android.offline.repository.domain.user.internal.UserEnt
         ThreadOrderEntity::class,
         DraftMessageEntity::class,
     ],
-    version = 90,
+    version = 91,
     exportSchema = false,
 )
 @TypeConverters(

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntity.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelEntity.kt
@@ -54,6 +54,7 @@ import java.util.Date
  * @param ownCapabilities Channel's capabilities available for the current user. Note that the field is not provided in the events.
  * @param membership Represents relationship of the current user to this channel.
  * @param activeLiveLocations List of active live locations in the channel.
+ * @param messageCount The total number of messages in the channel, if known.
  */
 @Entity(tableName = CHANNEL_ENTITY_TABLE_NAME, indices = [Index(value = ["syncStatus"])])
 internal data class ChannelEntity(
@@ -82,6 +83,7 @@ internal data class ChannelEntity(
     val ownCapabilities: Set<String>,
     val membership: MemberEntity?,
     val activeLiveLocations: List<LocationEntity>,
+    val messageCount: Int?,
 ) {
     /**
      * The channel id in the format messaging:123.

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channel/internal/ChannelMapper.kt
@@ -60,6 +60,7 @@ internal fun Channel.toEntity(): ChannelEntity {
         ownCapabilities = ownCapabilities,
         membership = membership?.toEntity(),
         activeLiveLocations = activeLiveLocations.map { it.toEntity() },
+        messageCount = messageCount,
     )
 }
 
@@ -93,4 +94,5 @@ internal suspend fun ChannelEntity.toModel(
     membership = membership?.toModel(getUser),
     draftMessage = getDraftMessage(channelId),
     activeLiveLocations = activeLiveLocations.map { it.toModel() },
+    messageCount = messageCount,
 ).syncUnreadCountWithReads()

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -520,7 +520,7 @@ internal class EventHandlerSequential(
                     val updatedChannel = channel.copy(
                         hidden = channel.hidden.takeIf { enrichedMessage.shadowed } ?: false,
                         messages = channel.messages + listOf(enrichedMessage),
-                        messagesCount = event.channelMessageCount ?: channel.messagesCount,
+                        messageCount = event.channelMessageCount ?: channel.messageCount,
                     )
                     batch.addChannel(updatedChannel)
                     // Update thread data in DB if the new message is added to a thread
@@ -538,7 +538,7 @@ internal class EventHandlerSequential(
                     (batch.getCurrentChannel(event.cid) ?: repos.selectChannel(event.cid))
                         ?.let {
                             batch.addChannel(
-                                it.copy(messagesCount = event.channelMessageCount ?: it.messagesCount),
+                                it.copy(messageCount = event.channelMessageCount ?: it.messageCount),
                             )
                         }
                 }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/event/handler/internal/EventHandlerSequential.kt
@@ -520,6 +520,7 @@ internal class EventHandlerSequential(
                     val updatedChannel = channel.copy(
                         hidden = channel.hidden.takeIf { enrichedMessage.shadowed } ?: false,
                         messages = channel.messages + listOf(enrichedMessage),
+                        messagesCount = event.channelMessageCount ?: channel.messagesCount,
                     )
                     batch.addChannel(updatedChannel)
                     // Update thread data in DB if the new message is added to a thread
@@ -534,6 +535,12 @@ internal class EventHandlerSequential(
                     )
                     // Update thread data in DB if deleted message is related to a thread
                     batch.addThreadIfExists(enrichedMessage)
+                    (batch.getCurrentChannel(event.cid) ?: repos.selectChannel(event.cid))
+                        ?.let {
+                            batch.addChannel(
+                                it.copy(messagesCount = event.channelMessageCount ?: it.messagesCount),
+                            )
+                        }
                 }
                 is MessageUpdatedEvent -> {
                     val enrichedMessage = event.message.enrichWithOwnReactions(batch, currentUserId, event.user)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
@@ -544,7 +544,7 @@ internal class ChannelLogic(
                         upsertEventMessage(event.message)
                         channelStateLogic.updateCurrentUserRead(event.createdAt, event.message)
                         channelStateLogic.takeUnless { event.message.shadowed }?.toggleHidden(false)
-                        event.channelMessageCount?.let(channelStateLogic::udpateMessagesCount)
+                        event.channelMessageCount?.let(channelStateLogic::udpateMessageCount)
                     }
 
                     is MessageUpdatedEvent -> {
@@ -563,7 +563,7 @@ internal class ChannelLogic(
                             upsertEventMessage(event.message)
                         }
                         channelStateLogic.toggleHidden(false)
-                        event.channelMessageCount?.let(channelStateLogic::udpateMessagesCount)
+                        event.channelMessageCount?.let(channelStateLogic::udpateMessageCount)
                     }
 
                     is NotificationMessageNewEvent -> {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelLogic.kt
@@ -544,6 +544,7 @@ internal class ChannelLogic(
                         upsertEventMessage(event.message)
                         channelStateLogic.updateCurrentUserRead(event.createdAt, event.message)
                         channelStateLogic.takeUnless { event.message.shadowed }?.toggleHidden(false)
+                        event.channelMessageCount?.let(channelStateLogic::udpateMessagesCount)
                     }
 
                     is MessageUpdatedEvent -> {
@@ -562,6 +563,7 @@ internal class ChannelLogic(
                             upsertEventMessage(event.message)
                         }
                         channelStateLogic.toggleHidden(false)
+                        event.channelMessageCount?.let(channelStateLogic::udpateMessagesCount)
                     }
 
                     is NotificationMessageNewEvent -> {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -827,6 +827,9 @@ internal class ChannelStateLogic(
     }
 
     fun getPoll(pollId: String): Poll? = polls[pollId]
+    fun udpateMessagesCount(channelMessagesCount: Int) {
+        updateChannelData { it?.copy(messagesCount = channelMessagesCount) }
+    }
 
     private companion object {
         private const val TAG = "Chat:ChannelStateLogic"

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/channel/internal/ChannelStateLogic.kt
@@ -827,8 +827,8 @@ internal class ChannelStateLogic(
     }
 
     fun getPoll(pollId: String): Poll? = polls[pollId]
-    fun udpateMessagesCount(channelMessagesCount: Int) {
-        updateChannelData { it?.copy(messagesCount = channelMessagesCount) }
+    fun udpateMessageCount(channelMessageCount: Int) {
+        updateChannelData { it?.copy(messageCount = channelMessageCount) }
     }
 
     private companion object {

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableState.kt
@@ -40,6 +40,7 @@ import io.getstream.chat.android.state.utils.internal.mapState
 import io.getstream.log.taggedLogger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.mapNotNull
 import java.util.Date
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -120,6 +121,7 @@ internal class ChannelMutableState(
     override val endOfOlderMessages: StateFlow<Boolean> = _endOfOlderMessages!!
 
     override val endOfNewerMessages: StateFlow<Boolean> = _endOfNewerMessages!!
+    override val messagesCount: StateFlow<Int?> = _channelData!!.mapState { it?.messagesCount }
     override val activeLiveLocations: StateFlow<List<Location>> = activeLiveLocations.mapState { locations ->
         locations.filter { it.cid == cid }
     }

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/channel/internal/ChannelMutableState.kt
@@ -121,7 +121,7 @@ internal class ChannelMutableState(
     override val endOfOlderMessages: StateFlow<Boolean> = _endOfOlderMessages!!
 
     override val endOfNewerMessages: StateFlow<Boolean> = _endOfNewerMessages!!
-    override val messagesCount: StateFlow<Int?> = _channelData!!.mapState { it?.messagesCount }
+    override val messageCount: StateFlow<Int?> = _channelData!!.mapState { it?.messageCount }
     override val activeLiveLocations: StateFlow<List<Location>> = activeLiveLocations.mapState { locations ->
         locations.filter { it.cid == cid }
     }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/logic/querythreads/internal/QueryThreadsLogicTest.kt
@@ -524,6 +524,7 @@ internal class QueryThreadsLogicTest {
             channelType = "messaging",
             channelId = "123",
             message = Message(id = "mId4", parentId = "mId1", text = "New reply"),
+            channelMessageCount = 1,
         )
         val stateLogic = mock<QueryThreadsStateLogic>()
         val databaseLogic = mock<QueryThreadsDatabaseLogic>()
@@ -598,6 +599,7 @@ internal class QueryThreadsLogicTest {
             channelId = "123",
             message = Message(id = "mId1", text = "Deleted thread parent"),
             hardDelete = false,
+            channelMessageCount = 1,
         )
         val stateLogic = mock<QueryThreadsStateLogic>()
         val databaseLogic = mock<QueryThreadsDatabaseLogic>()
@@ -624,6 +626,7 @@ internal class QueryThreadsLogicTest {
             channelId = "123",
             message = Message(id = "mId2", text = "Deleted thread reply"),
             hardDelete = false,
+            channelMessageCount = 1,
         )
         val stateLogic = mock<QueryThreadsStateLogic>()
         val databaseLogic = mock<QueryThreadsDatabaseLogic>()


### PR DESCRIPTION
### 🎯 Goal
Expose Channel Messages Count.
This property has been added to multiple entities:
- `NewMessageEvent.channelMessageCount`
-  MessageDeletedEvent.channelMessageCount`
- `ChannelState.messagesCount`
- `Channel.messagesCount`

Complete: AND-721