### PR TITLE
6.24.0 release testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 
 ## stream-chat-android-ui-components
 ### 🐞 Fixed
+- Fix the inconsistency in the channel attachments items between XML and Compose SDKs. [#5939](https://github.com/GetStream/stream-chat-android/pull/5939)
 
 ### ⬆️ Improved
 
@@ -71,6 +72,7 @@
 
 ## stream-chat-android-compose
 ### 🐞 Fixed
+- Fix the inconsistency in the channel attachments items between XML and Compose SDKs. [#5939](https://github.com/GetStream/stream-chat-android/pull/5939) 
 
 ### ⬆️ Improved
 - Remove the fixed height modifier in `FileUploadItem`. [#5932](https://github.com/GetStream/stream-chat-android/pull/5932)

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/attachments/ChannelMediaAttachmentsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/attachments/ChannelMediaAttachmentsActivity.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.compose.viewmodel.channel.ChannelAttachmentsVie
 import io.getstream.chat.android.compose.viewmodel.channel.ChannelAttachmentsViewModelFactory
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewEvent
+import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
 import kotlinx.coroutines.flow.collectLatest
 
 class ChannelMediaAttachmentsActivity : ComponentActivity() {
@@ -49,6 +50,7 @@ class ChannelMediaAttachmentsActivity : ComponentActivity() {
         ChannelAttachmentsViewModelFactory(
             cid = requireNotNull(intent.getStringExtra(KEY_CID)),
             attachmentTypes = listOf(AttachmentType.IMAGE, AttachmentType.VIDEO),
+            localFilter = { !it.imagePreviewUrl.isNullOrEmpty() && it.titleLink.isNullOrEmpty() },
         )
     }
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -97,6 +97,7 @@ import io.getstream.chat.android.ui.common.feature.channel.info.ChannelInfoViewE
 import io.getstream.chat.android.ui.common.state.channel.info.ChannelInfoViewState
 import io.getstream.chat.android.ui.common.state.messages.list.ChannelHeaderViewState
 import io.getstream.chat.android.ui.common.state.messages.list.DeletedMessageVisibility
+import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.collectLatest
@@ -576,6 +577,7 @@ class ChatsActivity : ComponentActivity() {
         val viewModelFactory = ChannelAttachmentsViewModelFactory(
             cid = cid,
             attachmentTypes = listOf(AttachmentType.IMAGE, AttachmentType.VIDEO),
+            localFilter = { !it.imagePreviewUrl.isNullOrEmpty() && it.titleLink.isNullOrEmpty() },
         )
         val viewModel = viewModel<ChannelAttachmentsViewModel>(
             factory = viewModelFactory,

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -4751,8 +4751,8 @@ public final class io/getstream/chat/android/compose/util/KeyValuePair {
 
 public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun onViewAction (Lio/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewAction;)V
@@ -4760,7 +4760,8 @@ public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAt
 
 public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.compose.viewmodel.channel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewController
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewEvent
@@ -30,15 +31,18 @@ import kotlinx.coroutines.flow.StateFlow
  *
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
+ * @param localFilter A function to filter attachments locally after fetching.
  * @param controllerProvider The provider for [ChannelAttachmentsViewController].
  */
 public class ChannelAttachmentsViewModel(
     private val cid: String,
     private val attachmentTypes: List<String>,
+    private val localFilter: (attachment: Attachment) -> Boolean = { true },
     private val controllerProvider: ViewModel.() -> ChannelAttachmentsViewController = {
         ChannelAttachmentsViewController(
             cid = cid,
             attachmentTypes = attachmentTypes,
+            localFilter = localFilter,
             scope = viewModelScope,
         )
     },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
@@ -18,16 +18,19 @@ package io.getstream.chat.android.compose.viewmodel.channel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import io.getstream.chat.android.models.Attachment
 
 /**
  * Factory for creating instances of [ChannelAttachmentsViewModel].
  *
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
+ * @param localFilter A function to filter attachments locally after fetching.
  */
 public class ChannelAttachmentsViewModelFactory(
     private val cid: String,
     private val attachmentTypes: List<String>,
+    private val localFilter: (attachment: Attachment) -> Boolean = { true },
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -35,6 +38,6 @@ public class ChannelAttachmentsViewModelFactory(
             "ChannelAttachmentsViewModelFactory can only create instances of ChannelAttachmentsViewModel"
         }
         @Suppress("UNCHECKED_CAST")
-        return ChannelAttachmentsViewModel(cid, attachmentTypes) as T
+        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter) as T
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewController.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.ui.common.feature.channel.attachments
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Filters
 import io.getstream.chat.android.models.SearchMessagesResult
 import io.getstream.chat.android.ui.common.state.channel.attachments.ChannelAttachmentsViewState
@@ -47,6 +48,7 @@ import kotlinx.coroutines.flow.update
  *
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types to filter by.
+ * @param localFilter A function to filter attachments locally after fetching.
  * @param chatClient The [ChatClient] instance used for interacting with the chat API.
  * @param scope The [CoroutineScope] used for launching coroutines.
  */
@@ -54,6 +56,7 @@ import kotlinx.coroutines.flow.update
 public class ChannelAttachmentsViewController(
     private val cid: String,
     private val attachmentTypes: List<String>,
+    private val localFilter: (attachment: Attachment) -> Boolean = { true },
     private val chatClient: ChatClient = ChatClient.instance(),
     scope: CoroutineScope,
 ) {
@@ -120,7 +123,7 @@ public class ChannelAttachmentsViewController(
         nextPage = result.next
         val items = result.messages.flatMap { message ->
             message.attachments
-                .filter { it.type in attachmentTypes }
+                .filter(localFilter)
                 .map {
                     ChannelAttachmentsViewState.Content.Item(
                         message = message,

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/StreamFileUtil.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/StreamFileUtil.kt
@@ -262,9 +262,7 @@ public object StreamFileUtil {
                                 Success(getUri(file))
                             }
 
-                            is Failure -> response.also {
-                                println()
-                            }
+                            is Failure -> response
                         }
                     }
                 }

--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/chat/info/shared/media/ChatInfoSharedMediaFragment.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
 import io.getstream.chat.android.ui.common.state.channel.attachments.ChannelAttachmentsViewState
+import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
 import io.getstream.chat.android.ui.feature.gallery.AttachmentGalleryDestination
 import io.getstream.chat.android.ui.feature.gallery.AttachmentGalleryItem
 import io.getstream.chat.android.ui.viewmodel.channel.ChannelAttachmentsViewModel
@@ -46,8 +47,9 @@ class ChatInfoSharedMediaFragment : Fragment() {
     private val args: ChatInfoSharedMediaFragmentArgs by navArgs()
     private val viewModel: ChannelAttachmentsViewModel by viewModels {
         ChannelAttachmentsViewModelFactory(
-            args.cid!!,
+            cid = args.cid!!,
             attachmentTypes = listOf(AttachmentType.IMAGE, AttachmentType.VIDEO),
+            localFilter = { !it.imagePreviewUrl.isNullOrEmpty() && it.titleLink.isNullOrEmpty() },
         )
     }
 
@@ -122,19 +124,15 @@ class ChatInfoSharedMediaFragment : Fragment() {
                 }
 
                 is ChannelAttachmentsViewState.Content -> {
-                    val results = state.items.mapNotNull {
-                        if (!it.attachment.imageUrl.isNullOrEmpty() && it.attachment.titleLink.isNullOrEmpty()) {
-                            AttachmentGalleryItem(
-                                attachment = it.attachment,
-                                user = it.message.user,
-                                createdAt = it.message.getCreatedAtOrThrow(),
-                                messageId = it.message.id,
-                                cid = it.message.cid,
-                                isMine = it.message.user.id == user?.id,
-                            )
-                        } else {
-                            null
-                        }
+                    val results = state.items.map {
+                        AttachmentGalleryItem(
+                            attachment = it.attachment,
+                            user = it.message.user,
+                            createdAt = it.message.getCreatedAtOrThrow(),
+                            messageId = it.message.id,
+                            cid = it.message.cid,
+                            isMine = it.message.user.id == user?.id,
+                        )
                     }
                     if (results.isEmpty()) {
                         showEmptyState()

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4301,15 +4301,16 @@ public final class io/getstream/chat/android/ui/utils/extensions/UserKt {
 }
 
 public final class io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel : androidx/lifecycle/ViewModel {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getState ()Landroidx/lifecycle/LiveData;
 	public final fun onViewAction (Lio/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewAction;)V
 }
 
 public final class io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/internal/AttachmentGalleryImagePageFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/internal/AttachmentGalleryImagePageFragment.kt
@@ -22,6 +22,7 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.ui.common.utils.extensions.imagePreviewUrl
 import io.getstream.chat.android.ui.databinding.StreamUiItemAttachmentGalleryImageBinding
 import io.getstream.chat.android.ui.utils.load
 
@@ -74,7 +75,7 @@ internal class AttachmentGalleryImagePageFragment : Fragment() {
         fun create(attachment: Attachment, imageClickListener: () -> Unit = {}): Fragment {
             return AttachmentGalleryImagePageFragment().apply {
                 arguments = Bundle().apply {
-                    putString(ARG_IMAGE_URL, attachment.imageUrl)
+                    putString(ARG_IMAGE_URL, attachment.imagePreviewUrl)
                 }
                 this.imageClickListener = imageClickListener
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel.kt
@@ -20,6 +20,7 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
+import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewController
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewEvent
@@ -31,15 +32,18 @@ import io.getstream.chat.android.ui.utils.asSingleLiveEvent
  *
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
+ * @param localFilter A function to filter attachments locally after fetching.
  * @param controllerProvider The provider for [ChannelAttachmentsViewController].
  */
 public class ChannelAttachmentsViewModel(
     private val cid: String,
     private val attachmentTypes: List<String>,
+    private val localFilter: (attachment: Attachment) -> Boolean = { true },
     controllerProvider: ViewModel.() -> ChannelAttachmentsViewController = {
         ChannelAttachmentsViewController(
             cid = cid,
             attachmentTypes = attachmentTypes,
+            localFilter = localFilter,
             scope = viewModelScope,
         )
     },

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
@@ -18,16 +18,19 @@ package io.getstream.chat.android.ui.viewmodel.channel
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import io.getstream.chat.android.models.Attachment
 
 /**
  * Factory for creating instances of [ChannelAttachmentsViewModel].
  *
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
+ * @param localFilter A function to filter attachments locally after fetching.
  */
 public class ChannelAttachmentsViewModelFactory(
     private val cid: String,
     private val attachmentTypes: List<String>,
+    private val localFilter: (attachment: Attachment) -> Boolean = { true },
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -35,6 +38,6 @@ public class ChannelAttachmentsViewModelFactory(
             "ChannelAttachmentsViewModelFactory can only create instances of ChannelAttachmentsViewModel"
         }
         @Suppress("UNCHECKED_CAST")
-        return ChannelAttachmentsViewModel(cid, attachmentTypes) as T
+        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter) as T
     }
 }


### PR DESCRIPTION
### 🛠 Implementation details

- XML was not showing media attachments that contain `thumbUrl` only.
- Compose was showing link attachments where it should not.

The fix creates a unified local filter in the view controller used for both SDKs.

### 🎨 UI Changes

### Fix the inconsistency in the channel attachments items between XML and Compose SDKs.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/dba050d1-6002-4c99-8571-1e5293a8ce35" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/94cccd2f-88fd-4b4c-aa65-89a5e715409e" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

