### PR TITLE
Change `AttachmentPickerAction` from sealed interface to interface

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerAction.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/factory/AttachmentPickerAction.kt
@@ -23,7 +23,7 @@ import io.getstream.chat.android.models.PollConfig
  * An user action event that occurs inside the attachment picker screen.
  */
 @Stable
-public sealed interface AttachmentPickerAction
+public interface AttachmentPickerAction
 
 /**
  * An user action that indicates a back button event.


### PR DESCRIPTION
### 🎯 Goal
Change `AttachmentPickerAction` from sealed interface to interface to allow custom implementations.
Resolves: https://linear.app/stream/issue/AND-758/expose-attachmentpickeraction-interface-for-custom-actions

### 🛠 Implementation details
Change `AttachmentPickerAction` from `sealed interface` to `interface`

### 🎨 UI Changes
_NA_

### 🧪 Testing
Create a class which implements the `AttachmentPickerAction` to verify that it is now extensible outside its own module.