### PR TITLE
Fix recompositions of MessageListStartOfTheChannelItemContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 ## stream-chat-android-compose
 ### 🐞 Fixed
 - Fix mute/unmute instant command icons. [#5938](https://github.com/GetStream/stream-chat-android/pull/5938)
+- Fix recompositions of `MessageListStartOfTheChannelItemContent`. [#5944](https://github.com/GetStream/stream-chat-android/pull/5944) 
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -171,9 +171,7 @@ public fun Messages(
 
             itemsIndexed(
                 items = messages,
-                key = { _, item ->
-                    if (item is HasMessageListItemState) item.message.id else item.toString()
-                },
+                key = { _, item -> item.id },
             ) { index, item ->
                 val messageItemModifier =
                     if (item is MessageItemState && item.focusState == MessageFocused) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel.kt
@@ -46,6 +46,7 @@ import io.getstream.log.taggedLogger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 
@@ -70,6 +71,7 @@ public class MessageListViewModel(
         messageListController.messageListState,
         messageListController.threadListState,
     ) { messageListState, threadListState -> if (isInThread) threadListState else messageListState }
+        .distinctUntilChanged() // Only emit when the state actually changes
         .map { it.copy(messageItems = it.messageItems.reversed()) }
         .asState(viewModelScope, MessageListState())
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemState.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemState.kt
@@ -26,7 +26,21 @@ import java.util.Date
 /**
  * Represents a list item inside a message list.
  */
-public sealed class MessageListItemState
+public sealed class MessageListItemState {
+    /**
+     * A unique identifier for this item.
+     */
+    @InternalStreamChatApi
+    public val id: String get() = when (this) {
+        is HasMessageListItemState -> message.id
+        is DateSeparatorItemState -> "date-separator-${date.time}"
+        is ThreadDateSeparatorItemState -> "thread-date-separator-${date.time}"
+        is TypingItemState -> "typing-indicator"
+        is EmptyThreadPlaceholderItemState -> "empty-thread-placeholder"
+        is UnreadSeparatorItemState -> "unread-separator"
+        is StartOfTheChannelItemState -> "start-of-the-channel"
+    }
+}
 
 /**
  * Represents either regular or system message item inside a message list.

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemStateTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/state/messages/list/MessageListItemStateTest.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2014-2025 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.state.messages.list
+
+import io.getstream.chat.android.randomChannel
+import io.getstream.chat.android.randomChannelCapabilities
+import io.getstream.chat.android.randomDate
+import io.getstream.chat.android.randomInt
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomUser
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class MessageListItemStateTest {
+
+    @Test
+    fun `id for MessageItemState should return message id`() {
+        val message = randomMessage()
+        val item = MessageItemState(message = message, ownCapabilities = randomChannelCapabilities())
+        assertEquals(message.id, item.id)
+    }
+
+    @Test
+    fun `id for DateSeparatorItemState should return formatted date id`() {
+        val date = randomDate()
+        val item = DateSeparatorItemState(date)
+        assertEquals("date-separator-${date.time}", item.id)
+    }
+
+    @Test
+    fun `id for ThreadDateSeparatorItemState should return formatted thread date id`() {
+        val date = randomDate()
+        val item = ThreadDateSeparatorItemState(date, replyCount = randomInt())
+        assertEquals("thread-date-separator-${date.time}", item.id)
+    }
+
+    @Test
+    fun `id for TypingItemState should return typing-indicator`() {
+        val item = TypingItemState(typingUsers = listOf(randomUser()))
+        assertEquals("typing-indicator", item.id)
+    }
+
+    @Test
+    fun `id for EmptyThreadPlaceholderItemState should return empty-thread-placeholder`() {
+        assertEquals("empty-thread-placeholder", EmptyThreadPlaceholderItemState.id)
+    }
+
+    @Test
+    fun `id for UnreadSeparatorItemState should return unread-separator`() {
+        val item = UnreadSeparatorItemState(unreadCount = randomInt())
+        assertEquals("unread-separator", item.id)
+    }
+
+    @Test
+    fun `id for StartOfTheChannelItemState should return start-of-the-channel`() {
+        val channel = randomChannel()
+        val item = StartOfTheChannelItemState(channel)
+        assertEquals("start-of-the-channel", item.id)
+    }
+}


### PR DESCRIPTION
### 🛠 Implementation details

- Add a unique identifier for `MessageListItemState`.
- Add `distinctUntilChanged` before mapping the message list state to ensure that the reversed message list is only recreated when the actual state changes, not on every emission.

### 🧪 Testing

Apply the provided patch and look for log entries of `alor: MessageListStartOfTheChannelItemContent` when entering a channel, scrolling to the very first sent message.

<details>

<summary>MessageListStartOfTheChannelItemContent recompositions</summary>

```
Subject: [PATCH] MessageListStartOfTheChannelItemContent recompositions
---
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt	(revision 58eca85b0fd27686866ef68bcf708dc18a57edc6)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt	(date 1759409581641)
@@ -989,6 +989,8 @@
     public fun LazyItemScope.MessageListStartOfTheChannelItemContent(
         startOfTheChannelItem: StartOfTheChannelItemState,
     ) {
+        println("alor: MessageListStartOfTheChannelItemContent")
+        Text("MessageListStartOfTheChannelItemContent")
     }
 
     /**
```

</details>


