### PR TITLE
Fix several unread separator bugs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@
 
 ## stream-chat-android-ui-common
 ### 🐞 Fixed
+- Fix unread separator showing before an uncommitted pending message. [#5945](https://github.com/GetStream/stream-chat-android/pull/5945)
+- Fix unread separator showing before a message that was sent while offline. [#5945](https://github.com/GetStream/stream-chat-android/pull/5945)
 
 ### ⬆️ Improved
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -608,7 +608,7 @@ public class MessageListController(
                     // Delegate to the calculator for the complex unread label logic
                     val unreadLabel = unreadLabelCalculator.calculateUnreadLabel(
                         channelUserRead = channelUserRead,
-                        channelState = channel,
+                        messages = channel.messages.value,
                         currentUserId = clientState.user.value?.id,
                         shouldShowButton = shouldShowButton,
                     )

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculator.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculator.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.messages.list
+
+import io.getstream.chat.android.client.channel.state.ChannelState
+import io.getstream.chat.android.client.utils.message.isDeleted
+import io.getstream.chat.android.models.ChannelUserRead
+import io.getstream.chat.android.models.Message
+
+/**
+ * Calculator responsible for determining the unread label state in a message list.
+ *
+ * This class encapsulates the complex logic for calculating when and how to display an unread
+ * messages indicator/button in a chat message list. It handles several edge cases:
+ *
+ * 1. **Standard Unread Messages**: When other users send messages after the current user's last read position.
+ * 2. **Own Messages Marked as Unread**: When a user explicitly marks their own message as unread.
+ * 3. **Multiple Own Messages Before Unread**: When the current user has sent multiple messages before
+ *    receiving new messages from others, determining the correct last read position.
+ * 4. **Uncommitted Pending Messages**: Messages awaiting server-side commit.
+ * 5. **Messages Synced After Offline**: Messages that were sent offline and later synced with the server.
+ *
+ * The calculator is designed to be stateless and pure - it performs calculations based on the provided
+ * input parameters without maintaining internal state. The caller ([MessageListController]) is responsible
+ * for determining when to invoke the calculator and managing state updates.
+ *
+ * Integrates with [ChannelState] and [ChannelUserRead] to provide accurate unread information that
+ * drives UI elements like the "jump to unread" button and unread count badges.
+ *
+ * @see MessageListController.UnreadLabel
+ * @see MessageListController.observeUnreadLabelState
+ */
+internal class UnreadLabelCalculator {
+
+    /**
+     * Calculates the [MessageListController.UnreadLabel] based on the current read state and channel messages.
+     *
+     * This method implements the core logic for determining unread message state by:
+     * - Identifying unread messages based on [ChannelUserRead.lastReadMessageId]
+     * - Detecting if the first unread message is from the current user
+     * - Handling special cases for own messages marked as unread
+     * - Finding the appropriate last read position when multiple own messages exist
+     * - Determining button visibility based on non-deleted unread messages
+     *
+     * ## Edge Cases Handled:
+     *
+     * ### Case 0: Last Read Message Not in List
+     * When the [ChannelUserRead.lastReadMessageId] is not found in the current messages list
+     * (e.g., when messages are loaded around a specific message, or the message list is filtered),
+     * the calculator skips complex ownership checks and creates a standard unread label using the
+     * provided lastReadMessageId directly. This ensures the unread indicator is displayed even when
+     * the exact last read message is not currently loaded.
+     *
+     * ### Case 1: Standard Unread Messages
+     * When messages from other users arrive after the last read position, the label is positioned
+     * after the last read message.
+     *
+     * ### Case 2: Own Message Marked as Unread
+     * When a user marks their own message as unread, the system detects this by comparing:
+     * - `firstUnreadMessage.createdAt > read.lastRead`
+     * - `read.lastRead == lastReadMessage.createdAt`
+     *
+     * This indicates an explicit "mark as unread" action on an own message.
+     *
+     * ### Case 3: Multiple Own Messages Before Other's Messages
+     * When the unread messages start with one or more of the current user's messages, followed by
+     * messages from other users, the calculator finds the last own message before the first other
+     * user's message and uses that as the lastReadMessageId. This ensures the unread indicator
+     * appears before messages from other users, not before the user's own messages. This scenario
+     * can occur when:
+     * - A message is sent offline and then synced with the server
+     * - The user sends a pending message which is not yet committed to the server
+     *
+     * ## Caller Responsibilities:
+     * The caller ([MessageListController.observeUnreadLabelState]) is responsible for:
+     * - Checking if the lastReadMessageId has changed before calling this method
+     * - Managing state updates and update triggers
+     * - Determining when calculation should be skipped (e.g., for threads)
+     *
+     * @param channelUserRead The read state for the current user, containing last read message ID and timestamp.
+     * @param channelState The current channel state, providing access to all messages.
+     * @param currentUserId The ID of the currently logged-in user.
+     * @param shouldShowButton Whether the unread button should be visible (controlled by user interactions).
+     *
+     * @return A [MessageListController.UnreadLabel] if there are unread messages that should be indicated,
+     *         or `null` if there are no unread messages or they shouldn't be shown.
+     */
+    fun calculateUnreadLabel(
+        channelUserRead: ChannelUserRead,
+        channelState: ChannelState,
+        currentUserId: String?,
+        shouldShowButton: Boolean,
+    ): MessageListController.UnreadLabel? {
+        // Step 1: Calculate the list of unread messages by folding through all messages
+        // and accumulating messages that appear after the lastReadMessageId
+        val unreadMessages = channelState.messages.value
+            .fold(emptyList<Message>()) { acc, message ->
+                when {
+                    // When we find the last read message, reset the accumulator (start fresh)
+                    channelUserRead.lastReadMessageId == message.id -> emptyList()
+                    // Otherwise, keep accumulating messages (these are unread)
+                    else -> acc + message
+                }
+            }
+
+        // Step 2: Find the actual last read message for comparison purposes
+        val lastReadMessage = channelState.messages.value
+            .firstOrNull { it.id == channelUserRead.lastReadMessageId }
+
+        // Step 2.1: If lastReadMessage is not found in the messages list, skip complex ownership
+        // checks and create a standard unread label with the provided lastReadMessageId.
+        // This handles cases where the message list was loaded around a specific message that
+        // doesn't include the actual last read message.
+        if (lastReadMessage == null) {
+            return calculateStandardUnreadLabel(
+                channelUserRead = channelUserRead,
+                unreadMessages = unreadMessages,
+                shouldShowButton = shouldShowButton,
+            )
+        }
+
+        // Step 3: Identify the first unread message and check if it belongs to the current user
+        val firstUnreadMessage = unreadMessages.firstOrNull()
+        val isFirstUnreadMessageOwn =
+            firstUnreadMessage != null && firstUnreadMessage.user.id == currentUserId
+
+        // Step 4: Determine if the user explicitly marked their own message as unread
+        // This is detected when:
+        // - The first unread message is from the current user
+        // - The first unread message was created AFTER the lastRead timestamp
+        // - The lastRead timestamp equals the lastReadMessage's creation time
+        // This pattern indicates the user performed a "mark as unread" action on their own message
+        val isOwnMessageMarkedAsUnread = isFirstUnreadMessageOwn &&
+            firstUnreadMessage.createdAt?.after(channelUserRead.lastRead) == true &&
+            channelUserRead.lastRead == lastReadMessage.createdAt
+
+        // Step 5: Calculate the unread label based on message ownership
+        return if (!isFirstUnreadMessageOwn || isOwnMessageMarkedAsUnread) {
+            // Case A: First unread message is from another user OR user marked their own message as unread
+            calculateStandardUnreadLabel(
+                channelUserRead = channelUserRead,
+                unreadMessages = unreadMessages,
+                shouldShowButton = shouldShowButton,
+            )
+        } else {
+            // Case B: First unread message(s) are from the current user, but not marked as unread
+            // This can happen when a message is sent offline and then synced with the server, or
+            // when the user sends a pending message which is not yet committed to the server.
+            calculateUnreadLabelWithOwnMessagesFirst(
+                channelUserRead = channelUserRead,
+                unreadMessages = unreadMessages,
+                currentUserId = currentUserId,
+                shouldShowButton = shouldShowButton,
+            )
+        }
+    }
+
+    /**
+     * Calculates the unread label for the standard case where the first unread message is from
+     * another user, or the current user explicitly marked their own message as unread.
+     *
+     * @param channelUserRead The read state containing unread count and last read message ID.
+     * @param unreadMessages List of all unread messages.
+     * @param shouldShowButton Whether the button should be visible.
+     *
+     * @return An [MessageListController.UnreadLabel] if conditions are met, null otherwise.
+     */
+    private fun calculateStandardUnreadLabel(
+        channelUserRead: ChannelUserRead,
+        unreadMessages: List<Message>,
+        shouldShowButton: Boolean,
+    ): MessageListController.UnreadLabel? {
+        return channelUserRead.lastReadMessageId
+            // Don't show label if there are no unread messages
+            ?.takeUnless { unreadMessages.isEmpty() }
+            // Don't show label if the last message in the list is the last read message
+            // (meaning all messages are read)
+            ?.takeUnless { unreadMessages.lastOrNull()?.id == it }
+            ?.let { lastReadMessageId ->
+                MessageListController.UnreadLabel(
+                    unreadCount = channelUserRead.unreadMessages,
+                    lastReadMessageId = lastReadMessageId,
+                    // Only show button if requested AND there are non-deleted unread messages
+                    buttonVisibility = shouldShowButton && unreadMessages.any { !it.isDeleted() },
+                )
+            }
+    }
+
+    /**
+     * Calculates the unread label when the first unread message(s) are from the current user.
+     *
+     * This method handles the scenario where:
+     * 1. The user sends one or more messages
+     * 2. Other users send messages afterward
+     * 3. The unread indicator should appear before the other users' messages, not before the
+     *    current user's own messages
+     *
+     * The algorithm finds the last message from the current user that appears before the first
+     * message from another user, and uses that as the lastReadMessageId.
+     *
+     * @param channelUserRead The read state containing unread count.
+     * @param unreadMessages List of all unread messages.
+     * @param currentUserId The ID of the current user.
+     * @param shouldShowButton Whether the button should be visible.
+     *
+     * @return An [MessageListController.UnreadLabel] if there are unread messages from others, null otherwise.
+     */
+    private fun calculateUnreadLabelWithOwnMessagesFirst(
+        channelUserRead: ChannelUserRead,
+        unreadMessages: List<Message>,
+        currentUserId: String?,
+        shouldShowButton: Boolean,
+    ): MessageListController.UnreadLabel? {
+        // If there are no unread messages at all, return null
+        if (channelUserRead.unreadMessages == 0) {
+            return null
+        }
+
+        // Find the index of the first message from another user (not the current user)
+        val firstOtherMessageIndex = unreadMessages.indexOfFirst { it.user.id != currentUserId }
+
+        // Calculate the index of the last own message before the first other user's message
+        val lastOwnMessageIndex = if (firstOtherMessageIndex > 0) {
+            // There are own messages before the first other message
+            firstOtherMessageIndex - 1
+        } else {
+            // No messages from other users found, or the first message is from another user
+            // Note: this should never happen as we guard against this case in the main method
+            -1
+        }
+
+        // Get the message at the calculated index
+        val lastOwnMessageBeforeOthers = if (lastOwnMessageIndex != -1) {
+            unreadMessages.getOrNull(lastOwnMessageIndex)
+        } else {
+            null
+        }
+
+        // Create the unread label using the last own message as the anchor point
+        return lastOwnMessageBeforeOthers?.let {
+            MessageListController.UnreadLabel(
+                unreadCount = channelUserRead.unreadMessages,
+                lastReadMessageId = it.id,
+                // Only show button if requested AND there are non-deleted unread messages
+                buttonVisibility = shouldShowButton &&
+                    unreadMessages.any { msg -> !msg.isDeleted() },
+            )
+        }
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculator.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculator.kt
@@ -92,7 +92,7 @@ internal class UnreadLabelCalculator {
      * - Determining when calculation should be skipped (e.g., for threads)
      *
      * @param channelUserRead The read state for the current user, containing last read message ID and timestamp.
-     * @param channelState The current channel state, providing access to all messages.
+     * @param messages The list of messages in the channel, ordered from oldest to newest.
      * @param currentUserId The ID of the currently logged-in user.
      * @param shouldShowButton Whether the unread button should be visible (controlled by user interactions).
      *
@@ -101,13 +101,13 @@ internal class UnreadLabelCalculator {
      */
     fun calculateUnreadLabel(
         channelUserRead: ChannelUserRead,
-        channelState: ChannelState,
+        messages: List<Message>,
         currentUserId: String?,
         shouldShowButton: Boolean,
     ): MessageListController.UnreadLabel? {
         // Step 1: Calculate the list of unread messages by folding through all messages
         // and accumulating messages that appear after the lastReadMessageId
-        val unreadMessages = channelState.messages.value
+        val unreadMessages = messages
             .fold(emptyList<Message>()) { acc, message ->
                 when {
                     // When we find the last read message, reset the accumulator (start fresh)
@@ -118,7 +118,7 @@ internal class UnreadLabelCalculator {
             }
 
         // Step 2: Find the actual last read message for comparison purposes
-        val lastReadMessage = channelState.messages.value
+        val lastReadMessage = messages
             .firstOrNull { it.id == channelUserRead.lastReadMessageId }
 
         // Step 2.1: If lastReadMessage is not found in the messages list, skip complex ownership
@@ -257,7 +257,7 @@ internal class UnreadLabelCalculator {
                 lastReadMessageId = it.id,
                 // Only show button if requested AND there are non-deleted unread messages
                 buttonVisibility = shouldShowButton &&
-                    unreadMessages.any { msg -> !msg.isDeleted() },
+                    unreadMessages.any { message -> !message.isDeleted() },
             )
         }
     }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculatorTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculatorTest.kt
@@ -16,20 +16,15 @@
 
 package io.getstream.chat.android.ui.common.feature.messages.list
 
-import io.getstream.chat.android.client.channel.state.ChannelState
 import io.getstream.chat.android.models.ChannelUserRead
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.randomChannelUserRead
 import io.getstream.chat.android.randomMessage
 import io.getstream.chat.android.randomUser
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.amshove.kluent.shouldBe
 import org.amshove.kluent.shouldBeEqualTo
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.mock
-import org.mockito.kotlin.whenever
 import java.util.Date
 
 internal class UnreadLabelCalculatorTest {
@@ -57,7 +52,6 @@ internal class UnreadLabelCalculatorTest {
             unreadMessage2,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-3",
             unreadMessages = 2,
@@ -67,7 +61,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -98,7 +92,6 @@ internal class UnreadLabelCalculatorTest {
             followUpOwnMessage,
         )
 
-        val channelState = createChannelState(messages)
         // Key: lastRead timestamp equals the lastReadMessage createdAt, but the unread message was created after
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
@@ -109,7 +102,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -145,7 +138,6 @@ internal class UnreadLabelCalculatorTest {
             otherMessage2,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 4,
@@ -155,7 +147,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -196,7 +188,6 @@ internal class UnreadLabelCalculatorTest {
             deletedMessage2,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 2,
@@ -206,7 +197,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label with shouldShowButton = true
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -238,7 +229,6 @@ internal class UnreadLabelCalculatorTest {
             activeMessage,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 2,
@@ -248,7 +238,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -273,7 +263,6 @@ internal class UnreadLabelCalculatorTest {
             unreadMessage,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 1,
@@ -283,7 +272,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label with shouldShowButton = false
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = false,
         )
@@ -305,7 +294,6 @@ internal class UnreadLabelCalculatorTest {
             createMessage(id = "msg-3", user = currentUser, createdAt = Date(300)),
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-3",
             unreadMessages = 0,
@@ -315,7 +303,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -338,7 +326,6 @@ internal class UnreadLabelCalculatorTest {
             lastMessage,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-3",
             unreadMessages = 0,
@@ -348,7 +335,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -364,7 +351,7 @@ internal class UnreadLabelCalculatorTest {
     @Test
     fun `should return null when messages list is empty`() {
         // Given: Empty messages list
-        val channelState = createChannelState(emptyList())
+        val messages = emptyList<Message>()
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-1",
             unreadMessages = 0,
@@ -374,7 +361,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -401,7 +388,6 @@ internal class UnreadLabelCalculatorTest {
             ownMessage2,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 0, // Server says no unread
@@ -411,7 +397,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -438,7 +424,6 @@ internal class UnreadLabelCalculatorTest {
             otherMessage,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 2,
@@ -448,7 +433,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -476,7 +461,6 @@ internal class UnreadLabelCalculatorTest {
             createMessage(id = "msg-3", user = otherUser, createdAt = Date(300)),
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-nonexistent",
             unreadMessages = 3,
@@ -486,7 +470,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -516,7 +500,6 @@ internal class UnreadLabelCalculatorTest {
             createMessage(id = "msg-7", user = otherUser, createdAt = Date(700)),
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 5,
@@ -526,7 +509,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -557,7 +540,6 @@ internal class UnreadLabelCalculatorTest {
             otherMessage,
         )
 
-        val channelState = createChannelState(messages)
         val channelUserRead = createChannelUserRead(
             lastReadMessageId = "msg-2",
             unreadMessages = 2,
@@ -567,7 +549,7 @@ internal class UnreadLabelCalculatorTest {
         // When: Calculate unread label
         val result = calculator.calculateUnreadLabel(
             channelUserRead = channelUserRead,
-            channelState = channelState,
+            messages = messages,
             currentUserId = currentUser.id,
             shouldShowButton = true,
         )
@@ -594,12 +576,6 @@ internal class UnreadLabelCalculatorTest {
             createdAt = createdAt,
             deletedAt = deletedAt,
         )
-    }
-
-    private fun createChannelState(messages: List<Message>): ChannelState {
-        val channelState: ChannelState = mock()
-        whenever(channelState.messages) doReturn MutableStateFlow(messages)
-        return channelState
     }
 
     private fun createChannelUserRead(

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculatorTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/UnreadLabelCalculatorTest.kt
@@ -1,0 +1,616 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.messages.list
+
+import io.getstream.chat.android.client.channel.state.ChannelState
+import io.getstream.chat.android.models.ChannelUserRead
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomChannelUserRead
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomUser
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.amshove.kluent.shouldBe
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import java.util.Date
+
+internal class UnreadLabelCalculatorTest {
+
+    private val calculator = UnreadLabelCalculator()
+    private val currentUser = randomUser(id = "current-user")
+    private val otherUser = randomUser(id = "other-user")
+
+    /**
+     * Test Case 1: Standard Unread Messages
+     * When messages from other users arrive after the last read position.
+     */
+    @Test
+    fun `should calculate unread label for standard unread messages from other users`() {
+        // Given: Messages where the last read message is followed by unread messages from other users
+        val lastReadMessage = createMessage(id = "msg-3", user = currentUser, createdAt = Date(1000))
+        val unreadMessage1 = createMessage(id = "msg-4", user = otherUser, createdAt = Date(2000))
+        val unreadMessage2 = createMessage(id = "msg-5", user = otherUser, createdAt = Date(3000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            createMessage(id = "msg-2", user = otherUser, createdAt = Date(200)),
+            lastReadMessage,
+            unreadMessage1,
+            unreadMessage2,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-3",
+            unreadMessages = 2,
+            lastRead = Date(1000),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return unread label with correct data
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 2,
+            lastReadMessageId = "msg-3",
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 2: Own Message Marked as Unread
+     * When a user explicitly marks their own message as unread.
+     */
+    @Test
+    fun `should calculate unread label when own message is marked as unread`() {
+        // Given: User's own message is marked as unread
+        val lastReadMessage = createMessage(id = "msg-2", user = otherUser, createdAt = Date(1000))
+        val ownMessageMarkedUnread = createMessage(id = "msg-3", user = currentUser, createdAt = Date(3000))
+        val followUpOwnMessage = createMessage(id = "msg-4", user = currentUser, createdAt = Date(4000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            ownMessageMarkedUnread,
+            followUpOwnMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        // Key: lastRead timestamp equals the lastReadMessage createdAt, but the unread message was created after
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 2,
+            lastRead = Date(1000), // Same as lastReadMessage.createdAt
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return unread label (own message marked as unread is treated like standard unread)
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 2,
+            lastReadMessageId = "msg-2",
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 3: Multiple Own Messages Before Other User's Messages
+     * When the user sends multiple messages, then receives messages from others.
+     * The unread indicator should appear before the other users' messages, not before the user's own messages.
+     */
+    @Test
+    fun `should calculate unread label with multiple own messages before other users messages`() {
+        // Given: User sends messages, then receives messages from others
+        val lastReadMessage = createMessage(id = "msg-2", user = otherUser, createdAt = Date(1000))
+        val ownMessage1 = createMessage(id = "msg-3", user = currentUser, createdAt = Date(2000))
+        val ownMessage2 = createMessage(id = "msg-4", user = currentUser, createdAt = Date(3000))
+        val otherMessage1 = createMessage(id = "msg-5", user = otherUser, createdAt = Date(4000))
+        val otherMessage2 = createMessage(id = "msg-6", user = otherUser, createdAt = Date(5000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            ownMessage1,
+            ownMessage2,
+            otherMessage1,
+            otherMessage2,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 4,
+            lastRead = Date(1500), // Between lastReadMessage and first own message
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should use the last own message before other users' messages as the anchor
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 4,
+            lastReadMessageId = "msg-4", // Last own message before others
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 4: Button Visibility with Deleted Messages
+     * Button should be hidden if all unread messages are deleted.
+     */
+    @Test
+    fun `should hide button when all unread messages are deleted`() {
+        // Given: Unread messages are all deleted
+        val lastReadMessage = createMessage(id = "msg-2", user = currentUser, createdAt = Date(1000))
+        val deletedMessage1 = createMessage(
+            id = "msg-3",
+            user = otherUser,
+            createdAt = Date(2000),
+            deletedAt = Date(2500),
+        )
+        val deletedMessage2 = createMessage(
+            id = "msg-4",
+            user = otherUser,
+            createdAt = Date(3000),
+            deletedAt = Date(3500),
+        )
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            deletedMessage1,
+            deletedMessage2,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 2,
+            lastRead = Date(1000),
+        )
+
+        // When: Calculate unread label with shouldShowButton = true
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Button should be hidden because all unread messages are deleted
+        result?.buttonVisibility shouldBe false
+    }
+
+    /**
+     * Test Case 5: Button Visibility with Some Deleted Messages
+     * Button should be visible if at least one unread message is not deleted.
+     */
+    @Test
+    fun `should show button when some unread messages are not deleted`() {
+        // Given: Mix of deleted and non-deleted unread messages
+        val lastReadMessage = createMessage(id = "msg-2", user = currentUser, createdAt = Date(1000))
+        val deletedMessage = createMessage(
+            id = "msg-3",
+            user = otherUser,
+            createdAt = Date(2000),
+            deletedAt = Date(2500),
+        )
+        val activeMessage = createMessage(id = "msg-4", user = otherUser, createdAt = Date(3000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            deletedMessage,
+            activeMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 2,
+            lastRead = Date(1000),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Button should be visible
+        result?.buttonVisibility shouldBe true
+    }
+
+    /**
+     * Test Case 6: shouldShowButton Parameter
+     * Button visibility should respect the shouldShowButton parameter.
+     */
+    @Test
+    fun `should hide button when shouldShowButton is false even with unread messages`() {
+        // Given: Unread messages exist
+        val lastReadMessage = createMessage(id = "msg-2", user = currentUser, createdAt = Date(1000))
+        val unreadMessage = createMessage(id = "msg-3", user = otherUser, createdAt = Date(2000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            unreadMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 1,
+            lastRead = Date(1000),
+        )
+
+        // When: Calculate unread label with shouldShowButton = false
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = false,
+        )
+
+        // Then: Button should be hidden
+        result?.buttonVisibility shouldBe false
+    }
+
+    /**
+     * Test Case 7: No Unread Messages
+     * Should return null when there are no unread messages.
+     */
+    @Test
+    fun `should return null when there are no unread messages`() {
+        // Given: All messages are read (no messages after lastReadMessage)
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            createMessage(id = "msg-2", user = otherUser, createdAt = Date(200)),
+            createMessage(id = "msg-3", user = currentUser, createdAt = Date(300)),
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-3",
+            unreadMessages = 0,
+            lastRead = Date(300),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return null (no unread label needed)
+        result shouldBe null
+    }
+
+    /**
+     * Test Case 8: Last Message is Last Read Message
+     * Should return null when the last message in the list is the last read message.
+     */
+    @Test
+    fun `should return null when last message is the last read message`() {
+        // Given: Last message in the list is the last read message
+        val lastMessage = createMessage(id = "msg-3", user = otherUser, createdAt = Date(300))
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            createMessage(id = "msg-2", user = otherUser, createdAt = Date(200)),
+            lastMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-3",
+            unreadMessages = 0,
+            lastRead = Date(300),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return null
+        result shouldBe null
+    }
+
+    /**
+     * Test Case 9: Empty Messages List
+     * Should return null when the messages list is empty.
+     */
+    @Test
+    fun `should return null when messages list is empty`() {
+        // Given: Empty messages list
+        val channelState = createChannelState(emptyList())
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-1",
+            unreadMessages = 0,
+            lastRead = Date(1000),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return null
+        result shouldBe null
+    }
+
+    /**
+     * Test Case 10: All Unread Messages Are From Current User (No Other Users)
+     * Should return null when unread messages are only from the current user and not marked as unread.
+     */
+    @Test
+    fun `should return null when all unread messages are from current user and unreadCount is zero`() {
+        // Given: Unread messages are all from current user
+        val lastReadMessage = createMessage(id = "msg-2", user = otherUser, createdAt = Date(1000))
+        val ownMessage1 = createMessage(id = "msg-3", user = currentUser, createdAt = Date(2000))
+        val ownMessage2 = createMessage(id = "msg-4", user = currentUser, createdAt = Date(3000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            ownMessage1,
+            ownMessage2,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 0, // Server says no unread
+            lastRead = Date(1500),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should return null (no messages from others)
+        result shouldBe null
+    }
+
+    /**
+     * Test Case 11: Pending/Offline Messages Scenario
+     * When user sends messages offline (pending), then receives messages from others.
+     */
+    @Test
+    fun `should handle pending messages scenario correctly`() {
+        // Given: User sends pending messages, then receives messages from others
+        val lastReadMessage = createMessage(id = "msg-2", user = otherUser, createdAt = Date(1000))
+        val pendingMessage = createMessage(id = "msg-3", user = currentUser, createdAt = Date(2000))
+        val otherMessage = createMessage(id = "msg-4", user = otherUser, createdAt = Date(3000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            pendingMessage,
+            otherMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 2,
+            lastRead = Date(1500),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should place unread indicator after the pending message, before other user's message
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 2,
+            lastReadMessageId = "msg-3", // Pending message
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 12: Last Read Message Not Found in List
+     * When lastReadMessageId is not in the messages list, should skip ownership checks
+     * and create a standard unread label using the provided lastReadMessageId.
+     * This handles cases where messages are loaded around a specific message or filtered.
+     */
+    @Test
+    fun `should handle when last read message is not in the messages list`() {
+        // Given: lastReadMessageId doesn't exist in the messages list
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            createMessage(id = "msg-2", user = otherUser, createdAt = Date(200)),
+            createMessage(id = "msg-3", user = otherUser, createdAt = Date(300)),
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-nonexistent",
+            unreadMessages = 3,
+            lastRead = Date(50), // Before all messages
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should use the provided lastReadMessageId without complex ownership checks
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 3,
+            lastReadMessageId = "msg-nonexistent",
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 13: Complex Scenario with Mixed Message Ownership
+     * Multiple messages with alternating ownership.
+     */
+    @Test
+    fun `should handle complex scenario with alternating message ownership`() {
+        // Given: Complex message pattern
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            createMessage(id = "msg-2", user = otherUser, createdAt = Date(200)), // Last read
+            createMessage(id = "msg-3", user = currentUser, createdAt = Date(300)),
+            createMessage(id = "msg-4", user = currentUser, createdAt = Date(400)),
+            createMessage(id = "msg-5", user = otherUser, createdAt = Date(500)),
+            createMessage(id = "msg-6", user = currentUser, createdAt = Date(600)),
+            createMessage(id = "msg-7", user = otherUser, createdAt = Date(700)),
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 5,
+            lastRead = Date(250),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should use msg-4 (last own message before first other user's message msg-5)
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 5,
+            lastReadMessageId = "msg-4",
+            buttonVisibility = true,
+        )
+    }
+
+    /**
+     * Test Case 14: Single Own Message After Last Read
+     * Only one own message after last read, followed by other users' messages.
+     */
+    @Test
+    fun `should handle single own message before others messages`() {
+        // Given: Single own message before others
+        val lastReadMessage = createMessage(id = "msg-2", user = otherUser, createdAt = Date(1000))
+        val ownMessage = createMessage(id = "msg-3", user = currentUser, createdAt = Date(2000))
+        val otherMessage = createMessage(id = "msg-4", user = otherUser, createdAt = Date(3000))
+
+        val messages = listOf(
+            createMessage(id = "msg-1", user = currentUser, createdAt = Date(100)),
+            lastReadMessage,
+            ownMessage,
+            otherMessage,
+        )
+
+        val channelState = createChannelState(messages)
+        val channelUserRead = createChannelUserRead(
+            lastReadMessageId = "msg-2",
+            unreadMessages = 2,
+            lastRead = Date(1500),
+        )
+
+        // When: Calculate unread label
+        val result = calculator.calculateUnreadLabel(
+            channelUserRead = channelUserRead,
+            channelState = channelState,
+            currentUserId = currentUser.id,
+            shouldShowButton = true,
+        )
+
+        // Then: Should use the single own message as anchor
+        result shouldBeEqualTo MessageListController.UnreadLabel(
+            unreadCount = 2,
+            lastReadMessageId = "msg-3",
+            buttonVisibility = true,
+        )
+    }
+
+    // Helper functions
+
+    private fun createMessage(
+        id: String,
+        user: User,
+        createdAt: Date,
+        deletedAt: Date? = null,
+    ): Message {
+        return randomMessage(
+            id = id,
+            user = user,
+            createdAt = createdAt,
+            deletedAt = deletedAt,
+        )
+    }
+
+    private fun createChannelState(messages: List<Message>): ChannelState {
+        val channelState: ChannelState = mock()
+        whenever(channelState.messages) doReturn MutableStateFlow(messages)
+        return channelState
+    }
+
+    private fun createChannelUserRead(
+        lastReadMessageId: String?,
+        unreadMessages: Int,
+        lastRead: Date,
+    ): ChannelUserRead {
+        return randomChannelUserRead(
+            lastReadMessageId = lastReadMessageId,
+            unreadMessages = unreadMessages,
+            lastRead = lastRead,
+        )
+    }
+}


### PR DESCRIPTION
### 🎯 Goal
Fixes the following bugs related to the unread separator:
- Sending a message while offline is marked as unread after syncing
- Uncommitted pending messages are marked as unread after re-entering the channel

Resolves: https://linear.app/stream/issue/AND-720/pending-messages-arent-marked-as-read-on-backend-but-adding-them-to
And related to: https://linear.app/stream/issue/AND-729/ensure-pending-message-is-marked-as-read-after-it-was-committed-server

### 🛠 Implementation details
Extracts the unread label calculation logic from the `MessageListController` to a `UnreadLabelCalculator` class
Adds specific handling for cases where the `lastReadMessageId` from the BE doesn't reflect the local state of the unread messages (syncing a message after sending it offline or having an uncommitted pending message).
The details of the implementation are described in the Docs of the new `UnreadLabelCalculator` class.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Scenario</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
Offline
</td>
<td>
<video src="https://github.com/user-attachments/assets/e37195fb-8c8d-4d6e-afe8-051be2a12ac6" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/83d0829b-1c64-4353-ae29-41f48b61939c" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
Pending (uncommitted)
</td>
<td>
<video src="https://github.com/user-attachments/assets/52f17d2e-93ad-4db5-a7fc-6266060d02f5" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/ee0f7e26-2d56-47ae-b565-0d6705025371" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
For offline bug: See steps described in video. Note: You can also send messages from different users in-between, to verify it works correctly

For pending messages: Apply the given patch to use an app where pending messages are enabled. Then send a message using any user in any channel. 
Patch: 
<details>

<summary>Patch</summary>

```
Subject: [PATCH] Unread analysis
---
Index: stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt b/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt
--- a/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt	(revision e9b0ff3c6256a786f3accd94fe5b8316e78ccda8)
+++ b/stream-chat-android-compose-sample/src/demo/java/io/getstream/chat/android/compose/sample/data/PredefinedUserCredentials.kt	(date 1759415462825)
@@ -23,186 +23,32 @@
  */
 object PredefinedUserCredentials {
 
-    const val API_KEY: String = "qx5us2v6xvmh"
+    const val API_KEY: String = "vtfx5vdrrbpy"
 
     val availableUsers: List<UserCredentials> = listOf(
         UserCredentials(
             apiKey = API_KEY,
             user = User(
-                "aapostol",
-                name = "Aleksandar Apostolov",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U05UD37MA1G-f062f8b7afc2-72",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-                ".eyJ1c2VyX2lkIjoiYWFwb3N0b2wifQ.kjeSx_Zyj84NDl37FLuEiEgZEdfpa4AKfhRFkonPP9A",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "jc",
-                name = "Jc Miñarro",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U011KEXDPB2-891dbb8df64f-128",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamMifQ.2_5Hae3LKjVSfA0gQxXlZn54Bq6xDlhjPx2J7azUNB4",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "pvelikov",
-                name = "Petar Velikov",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U07LDJZRUTG-a4129fed05b6-512",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicHZlbGlrb3YifQ." +
-                "d5eenuTIZD5gZh7rHiv3lYbE8uOqUiHfwULtUr8a-l0",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "andrerego",
-                name = "André Rêgo",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U083JCB6ZEY-2da235988b74-512",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYW5kcmVyZWdvIn0." +
-                "4sUYJXmz8H0mkClVGGPMN3mUhxg-D9cUDNJeFQ2d82I",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "thierry",
-                name = "Thierry Schellenbach",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U02RM6X6D-g28a1278a98e-128",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGhpZXJyeSJ9.hZi4pBPt2v2HSoS-7Yn7Ll2a1twhs763MlRGFAday2c",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "tommaso",
-                name = "Tommaso Barbugli",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U02U7SJP4-0f65a5997877-128",
-                language = "en",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidG9tbWFzbyJ9.lNaWC2Opyq6gmV50a2BGxK-5gm5mwCpefnUA30_k9YA",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "kanat",
-                name = "Kanat",
-                image = "https://ca.slack-edge.com/T02RM6X6B-U034NG4FPNG-688fab30cc42-72",
-                language = "fr",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXQifQ.MVoS7rCos7o3D7fkUcCFHVThKrN0sAaENupmXHYX3vw",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "kanat_ninja",
-                name = "Kanat Ninja",
-                image = "https://getstream.io/static/a4ba18b7dc1eedfa3ea4edbac74ce5e4/a3911/kanat-kiialbaev.webp",
-            ),
-
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoia2FuYXRfbmluamEifQ.s6We-MRy0ZXraiyLz8kShEPPIxXfqwUOOClfJgpTk8c",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "dnovak",
-                name = "Luke Skywalker",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/2/20/LukeTLJ.jpg",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9" +
-                ".eyJ1c2VyX2lkIjoiZG5vdmFrIn0.HuUyFkiXjHRk7hk4g2FLOg0szEi5Zq1u6CRC9t2Mwj8",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "amit",
-                name = "Leia Organa",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/f/fc/Leia_Organa_TLJ.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYW1pdCJ9.MNfrDsGkFINEZ3kCQ9hAqI38lZ6S-miHINAuH3kQy2o",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "belal",
-                name = "Han Solo",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/e/e2/TFAHanSolo.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiYmVsYWwifQ.a0DwMMb0V1Lona_1dIB7a4GtNl4oQ_WCp-W-UP3_CUQ",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "dmitrii",
-                name = "Lando Calrissian",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/8/8f/Lando_ROTJ.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZG1pdHJpaSJ9._j7pM2kqj46ztls0tG1DiUMl45l54VOLvl8jp5VCmZU",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "filip",
-                name = "Chewbacca",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/4/48/Chewbacca_TLJ.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiZmlsaXAifQ.WKqTjU6fHHjtFej-sUqS2ml3Rvdqn4Ptrf7jfKqzFgU",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "jaewoong",
-                name = "C-3PO",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/3/3f/C-3PO_TLJ_Card_Trader_Award_Card.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoiamFld29vbmcifQ.d-7AREGaSirn7TjxwLyAUvOU-nz2_LL5oMTycZvcnQc",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "oleg",
-                name = "R2-D2",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/e/eb/ArtooTFA2-Fathead.png",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoib2xlZyJ9.ZucjlxjiNewCORdCLwpKwZw2nNtRC_Bv17TjHlitdLU",
-        ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "rafal",
-                name = "Anakin Skywalker",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/6/6f/Anakin_Skywalker_RotS.png",
+                id = "test-unique-name-1",
+                name = "Unique Name",
             ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoicmFmYWwifQ.7Y4QCvc42Km8ETLdCQT5ynjiKVbZZbuN0XTiGxJNU6k",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGVzdC11bmlxdWUtbmFtZS0xIn0.Nf7N7dSik7B81Az3SejU8UpNPRjMIT_3Kn5jQA9e0sU",
         ),
         UserCredentials(
             apiKey = API_KEY,
             user = User(
-                id = "samuel",
-                name = "Obi-Wan Kenobi",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/4/4e/ObiWanHS-SWE.jpg",
+                id = "test-unique-name-2",
+                name = "Unique Name",
             ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoic2FtdWVsIn0.SusttZNc2Y0sc-JPEOPCmTa5FuKDHRcWGO_7kYrC1C0",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGVzdC11bmlxdWUtbmFtZS0yIn0.3YD0FCi5n2xOXAacC7iM0VjC4F_WKW2MFmKHNg_vVQ8",
         ),
         UserCredentials(
             apiKey = API_KEY,
             user = User(
-                id = "leandro",
-                name = "Padmé Amidala",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/b/b2/Padmegreenscrshot.jpg",
+                id = "test-unique-name-3",
+                name = "Unique Name 3",
             ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibGVhbmRybyJ9.CjlYUr79r4GopAhXIbqLBighl3meLsT4dQKzdKX7L3g",
+            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoidGVzdC11bmlxdWUtbmFtZS0zIn0.7KQIcswQejHvHJC8zOm0DhoODp5yu9LqtS4L91r252A",
         ),
-        UserCredentials(
-            apiKey = API_KEY,
-            user = User(
-                id = "marton",
-                name = "Qui-Gon Jinn",
-                image = "https://vignette.wikia.nocookie.net/starwars/images/f/f6/Qui-Gon_Jinn_Headshot_TPM.jpg",
-            ),
-            token = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoibWFydG9uIn0.22wjzwYCNdaG5FLVeTD49NqVA11UJpEwrNRjZxZrcK8",
-        ),
     )
 }

```

</details>