### PR TITLE
Expose `StorageHelper` and `AttachmentFilter` to fix `StorageHelperWrapper` not instantiable

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -4653,6 +4653,7 @@ public final class io/getstream/chat/android/compose/ui/util/SearchResultNameFor
 public final class io/getstream/chat/android/compose/ui/util/StorageHelperWrapper {
 	public static final field $stable I
 	public fun <init> (Landroid/content/Context;Lio/getstream/chat/android/ui/common/helper/internal/StorageHelper;Lio/getstream/chat/android/ui/common/helper/internal/AttachmentFilter;)V
+	public synthetic fun <init> (Landroid/content/Context;Lio/getstream/chat/android/ui/common/helper/internal/StorageHelper;Lio/getstream/chat/android/ui/common/helper/internal/AttachmentFilter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAttachmentsForUpload (Ljava/util/List;)Ljava/util/List;
 	public final fun getAttachmentsFromUris (Ljava/util/List;)Ljava/util/List;
 	public final fun getAttachmentsMetadataFromUris (Ljava/util/List;)Ljava/util/List;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StorageHelperWrapper.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/StorageHelperWrapper.kt
@@ -35,8 +35,8 @@ import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMet
  */
 public class StorageHelperWrapper(
     private val context: Context,
-    private val storageHelper: StorageHelper,
-    private val attachmentFilter: AttachmentFilter,
+    private val storageHelper: StorageHelper = StorageHelper(),
+    private val attachmentFilter: AttachmentFilter = AttachmentFilter(),
 ) {
 
     /**

--- a/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
+++ b/stream-chat-android-ui-common/api/stream-chat-android-ui-common.api
@@ -1105,6 +1105,27 @@ public abstract interface class io/getstream/chat/android/ui/common/helper/Video
 	public abstract fun getVideoRequestHeaders (Ljava/lang/String;)Ljava/util/Map;
 }
 
+public final class io/getstream/chat/android/ui/common/helper/internal/AttachmentFilter {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/chat/android/client/ChatClient;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/client/ChatClient;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun filterAttachments (Ljava/util/List;)Ljava/util/List;
+	public final fun getSupportedMimeTypes ()Ljava/util/List;
+}
+
+public final class io/getstream/chat/android/ui/common/helper/internal/StorageHelper {
+	public static final field $stable I
+	public static final field Companion Lio/getstream/chat/android/ui/common/helper/internal/StorageHelper$Companion;
+	public static final field FILE_NAME_PREFIX Ljava/lang/String;
+	public static final field TIME_FORMAT Ljava/lang/String;
+	public fun <init> ()V
+	public final fun getAttachmentsFromUriList (Landroid/content/Context;Ljava/util/List;)Ljava/util/List;
+	public final fun getCachedFileFromUri (Landroid/content/Context;Lio/getstream/chat/android/ui/common/state/messages/composer/AttachmentMetaData;)Ljava/io/File;
+	public final fun getFileAttachments (Landroid/content/Context;)Ljava/util/List;
+	public final fun getMediaAttachments (Landroid/content/Context;)Ljava/util/List;
+}
+
 public final class io/getstream/chat/android/ui/common/helper/internal/StorageHelper$Companion {
 }
 

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentFilter.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentFilter.kt
@@ -18,7 +18,6 @@ package io.getstream.chat.android.ui.common.helper.internal
 
 import androidx.core.content.MimeTypeFilter
 import io.getstream.chat.android.client.ChatClient
-import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMetaData
 import io.getstream.log.taggedLogger
@@ -31,7 +30,6 @@ import io.getstream.log.taggedLogger
  *
  * @param chatClient An instance of the low level chat client to fetch upload config.
  */
-@InternalStreamChatApi
 public class AttachmentFilter(
     private val chatClient: ChatClient = ChatClient.instance(),
 ) {


### PR DESCRIPTION
### 🎯 Goal
The public `StorageHelperWrapper` cannot be instantiated because it has constructor dependencies on 2 classes marked as `@InternalStreamChatApi`:
- `StorageHelper`
- `AttachmentFilter`

This PR exposes both `StorageHelper` and `AttachmentFilter` as `public`, as it is the only way to allow instantiation of `StorageHelperWrapper`

### 🛠 Implementation details
- Expose `StorageHelper` and `AttachmentFilter` as `public`.
- Add missing KDocs on the new public API

### 🎨 UI Changes
_NA_

### 🧪 Testing
- Instantiate `StorageHelperWrapper` outside of the SDK modules (ex. in `stream-chat-android-compose-sample`)