### PR TITLE
Remove hardcoded heights from attachment content components

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -24,7 +24,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
@@ -144,7 +143,6 @@ public fun FileAttachmentItem(
         Row(
             Modifier
                 .fillMaxWidth()
-                .height(50.dp)
                 .padding(vertical = 8.dp, horizontal = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -201,6 +199,8 @@ internal fun RowScope.FileAttachmentDescription(
                 modifier = Modifier.testTag("Stream_FileAttachmentSize"),
                 text = MediaStringUtil.convertFileSizeByteCount(attachment.fileSize.toLong()),
                 style = fileAttachmentTheme.fileMetadataTextStyle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentPreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentPreviewContent.kt
@@ -20,7 +20,6 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
@@ -73,7 +72,6 @@ public fun FileAttachmentPreviewContent(
                 Row(
                     modifier = Modifier
                         .width(200.dp)
-                        .height(50.dp)
                         .padding(vertical = 8.dp, horizontal = 8.dp),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -107,6 +105,8 @@ public fun FileAttachmentPreviewContent(
                                 text = fileSize,
                                 style = ChatTheme.typography.footnote,
                                 color = ChatTheme.colors.textLowEmphasis,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
                             )
                         }
                     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileUploadContent.kt
@@ -138,6 +138,8 @@ public fun FileUploadItem(
                             text = MediaStringUtil.convertFileSizeByteCount(attachment.upload?.length() ?: 0L),
                             style = ChatTheme.typography.footnote,
                             color = ChatTheme.colors.textLowEmphasis,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                 }


### PR DESCRIPTION
### 🎯 Goal

Remove hardcoded heights from attachment content components and adjust typography sizes

### 🎨 UI Changes

| Before | After |
| --- | --- |
| <img src=https://github.com/user-attachments/assets/033d71e4-eaec-46e5-8e6d-5c0155b866e4 /> | <img  src="https://github.com/user-attachments/assets/af5b507a-348e-4ec4-9b4c-91ee02cb7d16" />
| <img src="https://github.com/user-attachments/assets/c1085439-be0d-432e-b37d-9d478c55d2e9" /> | <img src="https://github.com/user-attachments/assets/7187c96d-ec73-4dd6-97f8-b0df1dd74599" /> | 