### PR TITLE
Fix setting channels limit to large value breaking pagination

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/logic/querychannels/internal/QueryChannelsStateLogic.kt
@@ -100,7 +100,7 @@ internal class QueryChannelsStateLogic(
     /**
      * Set the end of channels.
      *
-     * @parami isEnd Boolean
+     * @param isEnd If the end of channels is reached.
      */
     internal fun setEndOfChannels(isEnd: Boolean) {
         mutableState.setEndOfChannels(isEnd)

--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/querychannels/internal/QueryChannelsMutableState.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/plugin/state/querychannels/internal/QueryChannelsMutableState.kt
@@ -151,7 +151,7 @@ internal class QueryChannelsMutableState(
     /**
      * Set the end of channels.
      *
-     * @parami isEnd Boolean
+     * @param isEnd If the end of channels is reached.
      */
     fun setEndOfChannels(isEnd: Boolean) {
         _endOfChannels?.value = isEnd


### PR DESCRIPTION
### 🎯 Goal
Setting the `QueryChannelsRequest.limit` field to a value larger than the hard server limit (`30`) breaks the pagination. Ensure that the calculation of  `QueryChannelsState.endOfChannels` takes the hard limit into consideration as well as the passed `QueryChannelsRequest.limit`. 

### 🛠 Implementation details
Calculate `QueryChannelsState.endOfChannels` as `channels.size < min(30, request.limit)` instead of `channels.size < request.limit` because the server will always return a maximum of 30 channels. 

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/ad936b06-5ce3-4251-ad1f-380ec095ea8a" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/913352ae-249c-48fe-bb9c-bba8ea5b61e8" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### 🧪 Testing
1. Apply provided patch (sets `QueryChannelsRequest.limit = 50`)
2. Login with a user with more than 30 channels
3. Verify all channels can be loaded by scrolling downwards in the channel list

<details>

<summary>Provide the patch summary here</summary>

```
Index: stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt	(revision 6c8ce890e7729632f8c544619d00dbc1512be10b)
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt	(date 1763725166485)
@@ -125,6 +125,7 @@
             ),
             chatEventHandlerFactory = CustomChatEventHandlerFactory(),
             isDraftMessageEnabled = true,
+            channelLimit = 50,
         )
     }
 

```

</details>
