### PR TITLE
Fix publishing to GitHub pages

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ plugins {
     alias(libs.plugins.gitversioner)
     alias(libs.plugins.gradle.versions)
     alias(libs.plugins.binary.compatibility.validator)
+    alias(libs.plugins.dokka)
     alias(libs.plugins.maven.publish)
 }
 


### PR DESCRIPTION
### 🎯 Goal

I noticed by chance that we have a release-docs workflow that started failing because I removed the dokka plugin when migrating publishing to Central Portal. Fixing that.

This makes me think that we don't have a good system for noticing these CI failures. I'm adding a task for myself to address that.

### 🛠 Implementation details

Apply the plugin

### 🎨 UI Changes

None

### 🧪 Testing

Run `./gradlew dokkaHtmlMultimodule` and verify it succeeds. This is the task that we run in that workflow.

### ☑️Contributor Checklist

#### General
- [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] Assigned a person / code owner group (required)
- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
- [ ] PR is linked to the GitHub issue it resolves

#### Code & documentation
- [ ] Changelog is updated with client-facing changes
- [ ] New code is covered by unit tests
- [ ] Comparison screenshots added for visual changes
- [ ] Affected documentation updated (KDocs, docusaurus, tutorial)

### ☑️Reviewer Checklist
- [ ] UI Components sample runs & works
- [ ] Compose sample runs & works
- [ ] UI Changes correct (before & after images)
- [ ] Bugs validated (bugfixes)
- [ ] New feature tested and works
- [ ] Release notes and docs clearly describe changes
- [ ] All code we touched has new or updated KDocs
- [ ] Check the SDK Size Comparison table in the CI logs

### 🎉 GIF

_Please provide a suitable gif that describes your work on this pull request_
