### PR TITLE
Align default `Message.id` format

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2522,7 +2522,7 @@ internal constructor(
         message: Message,
         isRetrying: Boolean = false,
     ): Call<Message> {
-        val messageWithId = message.ensureId(getCurrentUser() ?: getStoredUser())
+        val messageWithId = message.ensureId()
         return CoroutineCall(userScope) {
             messageWithId.ensureCreatedLocallyAt(cid = "$channelType:$channelId")
                 .let { messageWithLocalDate ->
@@ -2573,7 +2573,7 @@ internal constructor(
         channelId: String,
         message: DraftMessage,
     ): Call<DraftMessage> {
-        return message.ensureId(getCurrentUser() ?: getStoredUser()).let { processedDraftMessage ->
+        return message.ensureId().let { processedDraftMessage ->
             api.createDraftMessage(channelType, channelId, processedDraftMessage)
                 .retry(userScope, retryPolicy)
                 .doOnResult(userScope) { result ->

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/interceptor/message/internal/PrepareMessageLogicImpl.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/interceptor/message/internal/PrepareMessageLogicImpl.kt
@@ -63,7 +63,7 @@ internal class PrepareMessageLogicImpl(
                 )
             }
         }
-        return message.ensureId(user).copy(
+        return message.ensureId().copy(
             user = user,
             attachments = attachments,
             type = getMessageType(message),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/message/MessageUtils.kt
@@ -29,7 +29,6 @@ import io.getstream.chat.android.models.MessageModerationAction
 import io.getstream.chat.android.models.MessageType
 import io.getstream.chat.android.models.ModerationAction
 import io.getstream.chat.android.models.SyncStatus
-import io.getstream.chat.android.models.User
 import java.util.UUID
 
 private const val ITEM_COUNT_OF_TWO: Int = 2
@@ -207,23 +206,21 @@ public fun Message.isModerationError(currentUserId: String?): Boolean = isMine(c
 
 /**
  * Ensures the message has an id.
- * If the message doesn't have an id, a unique message id is generated.
+ * If the message doesn't have an id, a unique message id is generated (lowercase UUID).
  * @return the message with an id.
  */
-internal fun Message.ensureId(currentUser: User?): Message =
-    copy(id = id.takeIf { it.isNotBlank() } ?: generateMessageId(currentUser))
+internal fun Message.ensureId(): Message =
+    copy(id = id.takeIf { it.isNotBlank() } ?: fallbackMessageId())
 
 /**
  * Ensures the draft message has an id.
- * If the draft message doesn't have an id, a unique message id is generated.
+ * If the draft message doesn't have an id, a unique message id is generated (lowercase UUID).
  * @return the draft message with an id.
  */
-internal fun DraftMessage.ensureId(currentUser: User?): DraftMessage =
-    copy(id = id.takeIf { it.isNotBlank() } ?: generateMessageId(currentUser))
+internal fun DraftMessage.ensureId(): DraftMessage =
+    copy(id = id.takeIf { it.isNotBlank() } ?: fallbackMessageId())
 
 /**
- * Returns a unique message id prefixed with user id.
+ * Generates a fallback message id (lowercase UUID).
  */
-private fun generateMessageId(user: User?): String {
-    return "${user?.id}-${UUID.randomUUID()}"
-}
+internal fun fallbackMessageId(): String = UUID.randomUUID().toString().lowercase()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/message/MessageUtilsTest.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import java.util.Date
 
@@ -554,33 +555,35 @@ internal class MessageUtilsTest {
     fun `ensureId should return message with existing id`() {
         val messageId = randomString()
         val message = randomMessage(id = messageId)
-        val result = message.ensureId(randomUser())
-        result.id shouldBeEqualTo messageId
+        val messageWithId = message.ensureId()
+        Assertions.assertEquals(messageId, messageWithId.id)
     }
 
     @Test
     fun `ensureId should generate id for message without id`() {
-        val userId = randomString()
-        val user = randomUser(id = userId)
         val message = randomMessage(id = "")
-        val result = message.ensureId(user)
-        result.id.startsWith(userId) shouldBeEqualTo true
+        val messageWithId = message.ensureId()
+        Assertions.assertTrue(UuidRegex.matches(messageWithId.id))
     }
 
     @Test
     fun `ensureId should return draft message with existing id`() {
         val draftId = randomString()
-        val draftMessage = randomDraftMessage(id = draftId)
-        val result = draftMessage.ensureId(null)
-        result.id shouldBeEqualTo draftId
+        val draft = randomDraftMessage(id = draftId)
+        val draftWithId = draft.ensureId()
+        Assertions.assertEquals(draftId, draftWithId.id)
     }
 
     @Test
     fun `ensureId should generate id for draft message without id`() {
-        val userId = randomString()
-        val user = User(id = userId)
-        val draftMessage = randomDraftMessage(id = "")
-        val result = draftMessage.ensureId(user)
-        result.id.startsWith(userId) shouldBeEqualTo true
+        val draft = randomDraftMessage(id = "")
+        val draftWithId = draft.ensureId()
+        Assertions.assertTrue(UuidRegex.matches(draftWithId.id))
+    }
+
+    private companion object {
+
+        // Regex matching lowercase UUID format
+        private val UuidRegex = "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$".toRegex()
     }
 }


### PR DESCRIPTION
### 🎯 Goal
The Android SDK is misaligned from the other frontend SDKs: We use `"<userId>-<UUID>"` instead of `"UUID"`. This PR aligns this with the other SDKs. 
See iOS `Chat#sendMessage()`: https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/StateLayer/Chat.swift#L519 and
`UniqueId`: https://github.com/GetStream/stream-chat-swift/blob/develop/Sources/StreamChat/Utils/UniqueId.swift

### 🛠 Implementation details
- Changes the default MessageId format

### 🎨 UI Changes
_NA_

### 🧪 Testing
Sending messages / creating drafts should work as expected.
