### PR TITLE
Fix `markDelivered` not working when switching users

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -5065,7 +5065,7 @@ internal constructor(
                 ),
                 messageReceiptManager = MessageReceiptManager(
                     now = ::Date,
-                    repositoryFacade = { instance().repositoryFacade },
+                    getRepositoryFacade = { instance().repositoryFacade },
                     messageReceiptRepository = repository,
                     api = api,
                 ),

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/receipts/MessageReceiptManager.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/receipts/MessageReceiptManager.kt
@@ -36,16 +36,19 @@ import java.util.Date
  * for later reporting to the server.
  *
  * @param now Function to provide the current date.
- * @param repositoryFacade Function to provide the [RepositoryFacade] tied to the currently logged in user.
+ * @param getRepositoryFacade Function to provide the [RepositoryFacade] tied to the currently logged in user.
  * @param messageReceiptRepository The [MessageReceiptRepository] to store the created receipts.
  * @param api The [ChatApi] to fetch data if needed.
  */
 internal class MessageReceiptManager(
     private val now: () -> Date,
-    private val repositoryFacade: () -> RepositoryFacade,
+    private val getRepositoryFacade: () -> RepositoryFacade,
     private val messageReceiptRepository: MessageReceiptRepository,
     private val api: ChatApi,
 ) {
+
+    private val repositoryFacade: RepositoryFacade
+        get() = getRepositoryFacade()
 
     private val logger by taggedLogger("Chat:MessageReceiptManager")
 
@@ -120,10 +123,10 @@ internal class MessageReceiptManager(
     }
 
     private suspend fun retrieveCurrentUser(): User? =
-        repositoryFacade().selectUser(userId = "me")
+        repositoryFacade.selectUser(userId = "me")
 
     private suspend fun retrieveChannel(cid: String): Channel? =
-        repositoryFacade().selectChannel(cid) ?: run {
+        repositoryFacade.selectChannel(cid) ?: run {
             val (channelType, channelId) = cid.cidToTypeAndId()
             val request = QueryChannelRequest()
             api.queryChannel(channelType, channelId, request)
@@ -131,7 +134,7 @@ internal class MessageReceiptManager(
         }
 
     private suspend fun retrieveMessage(id: String): Message? =
-        repositoryFacade().selectMessage(id) ?: run {
+        repositoryFacade.selectMessage(id) ?: run {
             api.getMessage(id)
                 .await().getOrNull()
         }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/receipts/MessageReceiptManagerTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/receipts/MessageReceiptManagerTest.kt
@@ -436,7 +436,7 @@ internal class MessageReceiptManagerTest {
 
         fun get() = MessageReceiptManager(
             now = { Now },
-            repositoryFacade = { mockRepositoryFacade },
+            getRepositoryFacade = { mockRepositoryFacade },
             messageReceiptRepository = mockMessageReceiptRepository,
             api = mockChatApi,
         )


### PR DESCRIPTION
### 🎯 Goal
The `MessageReceiptManager` keeps a `lazy` reference to the `RepositoryFacade`. The facade is switched with a new instance if the connected `User` changes, but the `MessageReceiptManager` is not. 
So if the connected `User` changes, the `MessageReceiptManager` by keeping a `lazy` reference to the (old) `RepositoryFacade` attempts to read outdated data (from the previously connected `User`).

### 🛠 Implementation details
- Remove the `lazy` persistence of the `RepositoryFacade` from the `MessageReceiptManager `

### 🎨 UI Changes
_NA_

### 🧪 Testing
1. Log in, log out, and log in with a different user
2. Check the logs for `Chat:MessageReceiptManager`
3. There should be no WARNING logs with text: `[markChannelsAsDelivered] Current user not found`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the markDelivered operation would not function correctly when switching between users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->