### PR TITLE
Add test comment in MessagesActivity

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -136,6 +136,7 @@ class MessagesActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // Test comment. By Claude!
         setContent {
             SetupChatTheme()
         }


### PR DESCRIPTION
### 🎯 Goal

Test the Claude skill workflow automation for creating branches, commits, and draft PRs.

### 🛠 Implementation details

Added a test comment in `MessagesActivity.onCreate()` to verify the pr-chat skill workflow works correctly.

### 🎨 UI Changes

No UI changes.

### 🧪 Testing

This is a test PR to verify the Claude skill workflow. The comment can be verified in `MessagesActivity.kt` at line 139.