### PR TITLE
Introduce new buttons

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1477,6 +1477,13 @@ public final class io/getstream/chat/android/compose/ui/components/avatar/UserAv
 	public static final fun UserAvatar (Lio/getstream/chat/android/models/User;Landroidx/compose/ui/Modifier;ZZLandroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/components/button/ComposableSingletons$StreamButtonKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/button/ComposableSingletons$StreamButtonKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class io/getstream/chat/android/compose/ui/components/channels/ChannelMembersKt {
 	public static final fun ChannelMembers (Ljava/util/List;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/User;Landroidx/compose/runtime/Composer;II)V
 }
@@ -3539,8 +3546,8 @@ public final class io/getstream/chat/android/compose/ui/theme/ReactionOptionsThe
 public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public static final field $stable I
 	public static final field Companion Lio/getstream/chat/android/compose/ui/theme/StreamColors$Companion;
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
-	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJIIILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1-0d7_KjU ()J
 	public final fun component10-0d7_KjU ()J
 	public final fun component11-0d7_KjU ()J
@@ -3624,9 +3631,19 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun component82-0d7_KjU ()J
 	public final fun component83-0d7_KjU ()J
 	public final fun component84-0d7_KjU ()J
+	public final fun component85-0d7_KjU ()J
+	public final fun component86-0d7_KjU ()J
+	public final fun component87-0d7_KjU ()J
+	public final fun component88-0d7_KjU ()J
+	public final fun component89-0d7_KjU ()J
 	public final fun component9-0d7_KjU ()J
-	public final fun copy-Hw5wJPc (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
-	public static synthetic fun copy-Hw5wJPc$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJIIILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public final fun component90-0d7_KjU ()J
+	public final fun component91-0d7_KjU ()J
+	public final fun component92-0d7_KjU ()J
+	public final fun component93-0d7_KjU ()J
+	public final fun component94-0d7_KjU ()J
+	public final fun copy-W5JOMTU (JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJ)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
+	public static synthetic fun copy-W5JOMTU$default (Lio/getstream/chat/android/compose/ui/theme/StreamColors;JJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJJIIILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/StreamColors;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAccentError-0d7_KjU ()J
 	public final fun getAccentNeutral-0d7_KjU ()J
@@ -3643,31 +3660,41 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun getAvatarPaletteText3-0d7_KjU ()J
 	public final fun getAvatarPaletteText4-0d7_KjU ()J
 	public final fun getAvatarPaletteText5-0d7_KjU ()J
+	public final fun getBackgroundCoreDisabled-0d7_KjU ()J
+	public final fun getBackgroundCoreSurface-0d7_KjU ()J
 	public final fun getBackgroundElevationElevation0-0d7_KjU ()J
 	public final fun getBackgroundElevationElevation2-0d7_KjU ()J
 	public final fun getBarsBackground-0d7_KjU ()J
+	public final fun getBorderCoreDefault-0d7_KjU ()J
 	public final fun getBorderCoreImage-0d7_KjU ()J
 	public final fun getBorderCoreOnDark-0d7_KjU ()J
 	public final fun getBorderCorePrimary-0d7_KjU ()J
 	public final fun getBorderCoreSurfaceSubtle-0d7_KjU ()J
+	public final fun getBorderUtilityDisabled-0d7_KjU ()J
 	public final fun getBorders-0d7_KjU ()J
-	public final fun getButtonStyleGhostBg-0d7_KjU ()J
-	public final fun getButtonStyleGhostBorder-0d7_KjU ()J
-	public final fun getButtonStyleGhostTextPrimary-0d7_KjU ()J
-	public final fun getButtonStyleGhostTextSecondary-0d7_KjU ()J
-	public final fun getButtonStyleOutlineBg-0d7_KjU ()J
-	public final fun getButtonStyleOutlineBorder-0d7_KjU ()J
-	public final fun getButtonStyleOutlineText-0d7_KjU ()J
-	public final fun getButtonTypeDestructiveBg-0d7_KjU ()J
-	public final fun getButtonTypeDestructiveBorder-0d7_KjU ()J
-	public final fun getButtonTypeDestructiveText-0d7_KjU ()J
-	public final fun getButtonTypeDestructiveTextInverse-0d7_KjU ()J
-	public final fun getButtonTypePrimaryBg-0d7_KjU ()J
-	public final fun getButtonTypePrimaryBgDisabled-0d7_KjU ()J
-	public final fun getButtonTypePrimaryBorder-0d7_KjU ()J
-	public final fun getButtonTypePrimaryText-0d7_KjU ()J
-	public final fun getButtonTypePrimaryTextDisabled-0d7_KjU ()J
-	public final fun getButtonTypeSecondaryTextDisabled-0d7_KjU ()J
+	public final fun getBrand100-0d7_KjU ()J
+	public final fun getBrand150-0d7_KjU ()J
+	public final fun getBrand200-0d7_KjU ()J
+	public final fun getBrand300-0d7_KjU ()J
+	public final fun getBrand400-0d7_KjU ()J
+	public final fun getBrand50-0d7_KjU ()J
+	public final fun getBrand500-0d7_KjU ()J
+	public final fun getBrand600-0d7_KjU ()J
+	public final fun getBrand700-0d7_KjU ()J
+	public final fun getBrand800-0d7_KjU ()J
+	public final fun getBrand900-0d7_KjU ()J
+	public final fun getButtonDestructiveBg-0d7_KjU ()J
+	public final fun getButtonDestructiveBorder-0d7_KjU ()J
+	public final fun getButtonDestructiveText-0d7_KjU ()J
+	public final fun getButtonDestructiveTextOnAccent-0d7_KjU ()J
+	public final fun getButtonPrimaryBg-0d7_KjU ()J
+	public final fun getButtonPrimaryBorder-0d7_KjU ()J
+	public final fun getButtonPrimaryText-0d7_KjU ()J
+	public final fun getButtonPrimaryTextOnAccent-0d7_KjU ()J
+	public final fun getButtonSecondaryBg-0d7_KjU ()J
+	public final fun getButtonSecondaryBorder-0d7_KjU ()J
+	public final fun getButtonSecondaryText-0d7_KjU ()J
+	public final fun getButtonSecondaryTextOnAccent-0d7_KjU ()J
 	public final fun getChatBgAttachmentIncoming-0d7_KjU ()J
 	public final fun getChatBgAttachmentOutgoing-0d7_KjU ()J
 	public final fun getChatBgIncoming-0d7_KjU ()J
@@ -3700,11 +3727,11 @@ public final class io/getstream/chat/android/compose/ui/theme/StreamColors {
 	public final fun getPrimaryAccent-0d7_KjU ()J
 	public final fun getShowMoreCountText-0d7_KjU ()J
 	public final fun getShowMoreOverlay-0d7_KjU ()J
-	public final fun getStateBgDisabled-0d7_KjU ()J
-	public final fun getStateTextDisabled-0d7_KjU ()J
+	public final fun getTextDisabled-0d7_KjU ()J
 	public final fun getTextHighEmphasis-0d7_KjU ()J
 	public final fun getTextHighEmphasisInverse-0d7_KjU ()J
 	public final fun getTextLowEmphasis-0d7_KjU ()J
+	public final fun getTextOnAccent-0d7_KjU ()J
 	public final fun getTextPrimary-0d7_KjU ()J
 	public final fun getTextSecondary-0d7_KjU ()J
 	public final fun getTextTertiary-0d7_KjU ()J

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButton.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.button
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.material3.ripple
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.StreamTokens
+import io.getstream.chat.android.compose.ui.util.ifNotNull
+
+@Composable
+internal fun StreamTextButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    style: StreamButtonStyle = StreamButtonStyleDefaults.primarySolid,
+    size: StreamButtonSize = StreamButtonSize.Medium,
+    leadingIcon: Painter? = null,
+    trailingIcon: Painter? = null,
+    text: String,
+) {
+    StreamButton(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled,
+        style = style,
+        size = size,
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = StreamTokens.spacingSm),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm, Alignment.CenterHorizontally),
+        ) {
+            leadingIcon?.let { Icon(painter = it, contentDescription = null) }
+            Text(text)
+            trailingIcon?.let { Icon(painter = it, contentDescription = null) }
+        }
+    }
+}
+
+@Composable
+internal fun StreamButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    enabled: Boolean = true,
+    style: StreamButtonStyle = StreamButtonStyleDefaults.primarySolid,
+    size: StreamButtonSize = StreamButtonSize.Medium,
+    content: @Composable () -> Unit,
+) {
+    Box(
+        modifier = modifier
+            .defaultMinSize(size.minimumSize, size.minimumSize)
+            .clip(CircleShape)
+            .ifNotNull(style.containerColor(enabled), Modifier::background)
+            .ifNotNull(style.borderColor(enabled)) { border(1.dp, it, CircleShape) }
+            .clickable(
+                onClick = onClick,
+                enabled = enabled,
+                role = Role.Button,
+                interactionSource = remember(::MutableInteractionSource),
+                indication = ripple(),
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        val contentColor = style.contentColor(enabled)
+
+        CompositionLocalProvider(
+            LocalContentColor provides contentColor,
+            LocalTextStyle provides ChatTheme.typography.bodyEmphasis,
+            content = content,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun StreamButtonPreview() {
+    ChatTheme {
+        val styles = listOf(
+            StreamButtonStyleDefaults.primarySolid,
+            StreamButtonStyleDefaults.primaryOutline,
+            StreamButtonStyleDefaults.primaryGhost,
+            StreamButtonStyleDefaults.secondarySolid,
+            StreamButtonStyleDefaults.secondaryOutline,
+            StreamButtonStyleDefaults.secondaryGhost,
+            StreamButtonStyleDefaults.destructiveSolid,
+            StreamButtonStyleDefaults.destructiveOutline,
+            StreamButtonStyleDefaults.destructiveGhost,
+        )
+
+        Column(
+            modifier = Modifier.padding(StreamTokens.spacingMd),
+            verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
+        ) {
+            styles.forEach { style ->
+                Row(horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs)) {
+                    val painter = painterResource(R.drawable.stream_compose_ic_checkmark)
+                    StreamButton(onClick = {}, style = style) {
+                        Icon(painter, null)
+                    }
+                    StreamTextButton(
+                        onClick = {},
+                        style = style,
+                        leadingIcon = painter,
+                        text = "{{ label }}",
+                        trailingIcon = painter,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButtonSize.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButtonSize.kt
@@ -1,0 +1,24 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.button
+
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+internal enum class StreamButtonSize(val minimumSize: Dp) {
+    Small(32.dp), Medium(40.dp), Large(48.dp)
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButtonStyle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButtonStyle.kt
@@ -1,0 +1,163 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.button
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.graphics.Color
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+
+internal data class StreamButtonStyle(
+    val containerColor: Color?,
+    val contentColor: Color,
+    val borderColor: Color?,
+    val disabledContainerColor: Color?,
+    val disabledContentColor: Color,
+    val disabledBorderColor: Color?,
+)
+
+@Stable
+internal fun StreamButtonStyle.contentColor(enabled: Boolean) =
+    if (enabled) contentColor else disabledContentColor
+
+@Stable
+internal fun StreamButtonStyle.containerColor(enabled: Boolean) =
+    if (enabled) containerColor else disabledContainerColor
+
+@Stable
+internal fun StreamButtonStyle.borderColor(enabled: Boolean) =
+    if (enabled) borderColor else disabledBorderColor
+
+internal object StreamButtonStyleDefaults {
+    val primarySolid: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = colors.buttonPrimaryBg,
+                contentColor = colors.buttonPrimaryTextOnAccent,
+                borderColor = null,
+                disabledContainerColor = colors.backgroundCoreDisabled,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+    val primaryOutline: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonPrimaryText,
+                borderColor = colors.buttonPrimaryBorder,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = colors.borderUtilityDisabled,
+            )
+        }
+    val primaryGhost: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonPrimaryText,
+                borderColor = null,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+    val secondarySolid: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = colors.buttonSecondaryBg,
+                contentColor = colors.buttonSecondaryTextOnAccent,
+                borderColor = null,
+                disabledContainerColor = colors.backgroundCoreDisabled,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+    val secondaryOutline: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonSecondaryText,
+                borderColor = colors.buttonSecondaryBorder,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = colors.buttonSecondaryBorder,
+            )
+        }
+    val secondaryGhost: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonSecondaryText,
+                borderColor = null,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+    val destructiveSolid: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = colors.buttonDestructiveBg,
+                contentColor = colors.buttonDestructiveTextOnAccent,
+                borderColor = null,
+                disabledContainerColor = colors.backgroundCoreDisabled,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+    val destructiveOutline: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonDestructiveText,
+                borderColor = colors.buttonDestructiveBorder,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = colors.borderUtilityDisabled,
+            )
+        }
+    val destructiveGhost: StreamButtonStyle
+        @Composable
+        get() {
+            val colors = ChatTheme.colors
+            return StreamButtonStyle(
+                containerColor = null,
+                contentColor = colors.buttonDestructiveText,
+                borderColor = null,
+                disabledContainerColor = null,
+                disabledContentColor = colors.textDisabled,
+                disabledBorderColor = null,
+            )
+        }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/ContextualMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/ContextualMenu.kt
@@ -85,7 +85,7 @@ internal fun ContextualMenuItem(
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
     ) {
         val (textColor, iconColor) = when {
-            !enabled -> colors.stateTextDisabled to colors.stateTextDisabled
+            !enabled -> colors.textDisabled to colors.textDisabled
             destructive -> colors.accentError to colors.accentError
             else -> colors.textPrimary to colors.textSecondary
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/StreamColors.kt
@@ -69,32 +69,44 @@ import io.getstream.chat.android.compose.R
  * @param avatarPaletteText3 Used for avatar text color.
  * @param avatarPaletteText4 Used for avatar text color.
  * @param avatarPaletteText5 Used for avatar text color.
+ * @param backgroundCoreDisabled Used for disabled background in components like buttons.
+ * @param backgroundCoreSurface Used for surface background in components like buttons.
+ * @param backgroundElevationElevation0 Used for base elevation surface backgrounds.
  * @param borderCoreImage Used for image frame border treatment.
+ * @param borderCoreDefault Used for default border color.
  * @param borderCoreOnDark Used for borders on dark backgrounds.
  * @param borderCoreSurfaceSubtle Used for very light separators.
  * @param borderCorePrimary Used for selected or active state border.
+ * @param borderUtilityDisabled Used for disabled state borders.
+ * @param brand50 Brand color at 50 intensity level.
+ * @param brand100 Brand color at 100 intensity level.
+ * @param brand150 Brand color at 150 intensity level.
+ * @param brand200 Brand color at 200 intensity level.
+ * @param brand300 Brand color at 300 intensity level.
+ * @param brand400 Brand color at 400 intensity level.
+ * @param brand500 Brand color at 500 intensity level.
+ * @param brand600 Brand color at 600 intensity level.
+ * @param brand700 Brand color at 700 intensity level.
+ * @param brand800 Brand color at 800 intensity level.
+ * @param brand900 Brand color at 900 intensity level.
+ * @param textOnAccent Used for text displayed on accent/colored backgrounds.
  * @param textPrimary Used for main text color.
  * @param textSecondary Used for secondary text color with lower emphasis.
- * @param stateBgDisabled Used for disabled background for inputs, buttons, or chips.
- * @param stateTextDisabled Used for disabled text and icon color.
+ * @param textTertiary Used for tertiary text color with lowest emphasis.
+ * @param textDisabled Used for disabled text and icon color.
  * @param backgroundElevationElevation2 Used for elevated surface backgrounds at elevation level 2.
- * @param buttonStyleGhostBg Used for ghost button background.
- * @param buttonStyleGhostBorder Used for ghost button border.
- * @param buttonStyleGhostTextPrimary Used for primary ghost button text.
- * @param buttonStyleGhostTextSecondary Used for secondary ghost button text.
- * @param buttonStyleOutlineBg Used for outline button background.
- * @param buttonStyleOutlineBorder Used for outline button border.
- * @param buttonStyleOutlineText Used for outline button text.
- * @param buttonTypeDestructiveBg Used for destructive button background.
- * @param buttonTypeDestructiveBorder Used for destructive button border.
- * @param buttonTypeDestructiveText Used for destructive button text.
- * @param buttonTypeDestructiveTextInverse Used for destructive button inverse text.
- * @param buttonTypePrimaryBg Used for primary button background.
- * @param buttonTypePrimaryBgDisabled Used for disabled primary button background.
- * @param buttonTypePrimaryBorder Used for primary button border.
- * @param buttonTypePrimaryText Used for primary button text.
- * @param buttonTypePrimaryTextDisabled Used for disabled primary button text.
- * @param buttonTypeSecondaryTextDisabled Used for disabled secondary button text.
+ * @param buttonDestructiveBg Used for destructive button background.
+ * @param buttonDestructiveBorder Used for destructive button border.
+ * @param buttonDestructiveText Used for destructive button text.
+ * @param buttonDestructiveTextOnAccent Used for destructive button text on accent backgrounds.
+ * @param buttonPrimaryBg Used for primary button background.
+ * @param buttonPrimaryBorder Used for primary button border.
+ * @param buttonPrimaryText Used for primary button text.
+ * @param buttonPrimaryTextOnAccent Used for primary button text on accent backgrounds.
+ * @param buttonSecondaryBg Used for secondary button background.
+ * @param buttonSecondaryBorder Used for secondary button border.
+ * @param buttonSecondaryText Used for secondary button text.
+ * @param buttonSecondaryTextOnAccent Used for secondary button text on accent backgrounds.
  * @param chatBgIncoming Used for incoming message bubble background.
  * @param chatBgOutgoing Used for outgoing message bubble background.
  * @param chatBgAttachmentIncoming Used for incoming message attachment background.
@@ -153,35 +165,45 @@ public data class StreamColors(
     public val avatarPaletteText3: Color,
     public val avatarPaletteText4: Color,
     public val avatarPaletteText5: Color,
+    public val backgroundCoreDisabled: Color,
+    public val backgroundCoreSurface: Color,
     public val backgroundElevationElevation0: Color,
     public val borderCoreImage: Color,
+    public val borderCoreDefault: Color,
     public val borderCoreOnDark: Color,
     public val borderCoreSurfaceSubtle: Color,
     public val borderCorePrimary: Color,
+    public val borderUtilityDisabled: Color,
+    public val brand50: Color,
+    public val brand100: Color,
+    public val brand150: Color,
+    public val brand200: Color,
+    public val brand300: Color,
+    public val brand400: Color,
+    public val brand500: Color,
+    public val brand600: Color,
+    public val brand700: Color,
+    public val brand800: Color,
+    public val brand900: Color,
+    public val textOnAccent: Color,
     public val textPrimary: Color,
     public val textSecondary: Color,
     public val textTertiary: Color,
-    public val stateBgDisabled: Color,
-    public val stateTextDisabled: Color,
+    public val textDisabled: Color,
     public val appBackground: Color = backgroundElevationElevation0,
     public val backgroundElevationElevation2: Color,
-    public val buttonStyleGhostBg: Color,
-    public val buttonStyleGhostBorder: Color,
-    public val buttonStyleGhostTextPrimary: Color = accentPrimary,
-    public val buttonStyleGhostTextSecondary: Color = textPrimary,
-    public val buttonStyleOutlineBg: Color,
-    public val buttonStyleOutlineBorder: Color = borderCoreSurfaceSubtle,
-    public val buttonStyleOutlineText: Color = textPrimary,
-    public val buttonTypeDestructiveBg: Color = accentError,
-    public val buttonTypeDestructiveBorder: Color = accentError,
-    public val buttonTypeDestructiveText: Color,
-    public val buttonTypeDestructiveTextInverse: Color = accentError,
-    public val buttonTypePrimaryBg: Color = accentPrimary,
-    public val buttonTypePrimaryBgDisabled: Color = stateBgDisabled,
-    public val buttonTypePrimaryBorder: Color = borderCorePrimary,
-    public val buttonTypePrimaryText: Color,
-    public val buttonTypePrimaryTextDisabled: Color = stateTextDisabled,
-    public val buttonTypeSecondaryTextDisabled: Color = stateTextDisabled,
+    public val buttonDestructiveBg: Color = accentError,
+    public val buttonDestructiveBorder: Color = accentError,
+    public val buttonDestructiveText: Color = accentError,
+    public val buttonDestructiveTextOnAccent: Color = textOnAccent,
+    public val buttonPrimaryBg: Color = accentPrimary,
+    public val buttonPrimaryBorder: Color = brand200,
+    public val buttonPrimaryText: Color = accentPrimary,
+    public val buttonPrimaryTextOnAccent: Color = textOnAccent,
+    public val buttonSecondaryBg: Color = backgroundCoreSurface,
+    public val buttonSecondaryBorder: Color = borderCoreDefault,
+    public val buttonSecondaryText: Color = textPrimary,
+    public val buttonSecondaryTextOnAccent: Color = textPrimary,
     public val chatBgIncoming: Color,
     public val chatBgOutgoing: Color,
     public val chatBgAttachmentIncoming: Color,
@@ -237,24 +259,34 @@ public data class StreamColors(
 
             accentError = StreamPrimitiveColors.red500,
             accentNeutral = StreamPrimitiveColors.slate500,
-            accentSuccess = StreamPrimitiveColors.green500,
             accentPrimary = StreamPrimitiveColors.blue500,
+            accentSuccess = StreamPrimitiveColors.green500,
+            backgroundCoreDisabled = StreamPrimitiveColors.slate200,
+            backgroundCoreSurface = StreamPrimitiveColors.slate100,
             backgroundElevationElevation0 = StreamPrimitiveColors.baseWhite,
             backgroundElevationElevation2 = StreamPrimitiveColors.baseWhite,
+            borderCoreDefault = StreamPrimitiveColors.slate150,
             borderCoreImage = StreamPrimitiveColors.baseBlack.copy(alpha = .1f),
             borderCoreOnDark = StreamPrimitiveColors.baseWhite,
-            borderCoreSurfaceSubtle = StreamPrimitiveColors.slate200,
             borderCorePrimary = StreamPrimitiveColors.blue600,
+            borderCoreSurfaceSubtle = StreamPrimitiveColors.slate200,
+            borderUtilityDisabled = StreamPrimitiveColors.slate200,
+            brand50 = StreamPrimitiveColors.blue50,
+            brand100 = StreamPrimitiveColors.blue100,
+            brand150 = StreamPrimitiveColors.blue150,
+            brand200 = StreamPrimitiveColors.blue200,
+            brand300 = StreamPrimitiveColors.blue300,
+            brand400 = StreamPrimitiveColors.blue400,
+            brand500 = StreamPrimitiveColors.blue500,
+            brand600 = StreamPrimitiveColors.blue600,
+            brand700 = StreamPrimitiveColors.blue700,
+            brand800 = StreamPrimitiveColors.blue800,
+            brand900 = StreamPrimitiveColors.blue900,
+            textDisabled = StreamPrimitiveColors.slate400,
+            textOnAccent = StreamPrimitiveColors.baseWhite,
             textPrimary = StreamPrimitiveColors.slate900,
             textSecondary = StreamPrimitiveColors.slate700,
             textTertiary = StreamPrimitiveColors.slate500,
-            stateBgDisabled = StreamPrimitiveColors.slate200,
-            stateTextDisabled = StreamPrimitiveColors.slate400,
-            buttonStyleGhostBg = StreamPrimitiveColors.baseTransparent,
-            buttonStyleGhostBorder = StreamPrimitiveColors.baseTransparent,
-            buttonStyleOutlineBg = StreamPrimitiveColors.baseTransparent,
-            buttonTypeDestructiveText = StreamPrimitiveColors.baseWhite,
-            buttonTypePrimaryText = StreamPrimitiveColors.baseWhite,
             avatarPaletteBg1 = StreamPrimitiveColors.blue100,
             avatarPaletteBg2 = StreamPrimitiveColors.cyan100,
             avatarPaletteBg3 = StreamPrimitiveColors.green100,
@@ -312,25 +344,35 @@ public data class StreamColors(
             showMoreCountText = colorResource(R.color.stream_compose_show_more_text_dark),
 
             accentError = StreamPrimitiveColors.red400,
-            backgroundElevationElevation0 = StreamPrimitiveColors.baseBlack,
             accentNeutral = StreamPrimitiveColors.neutral500,
-            accentSuccess = StreamPrimitiveColors.green400,
             accentPrimary = StreamPrimitiveColors.blue400,
+            accentSuccess = StreamPrimitiveColors.green400,
+            backgroundCoreDisabled = StreamPrimitiveColors.slate800,
+            backgroundCoreSurface = StreamPrimitiveColors.neutral700,
+            backgroundElevationElevation0 = StreamPrimitiveColors.baseBlack,
             backgroundElevationElevation2 = StreamPrimitiveColors.neutral800,
+            borderCoreDefault = StreamPrimitiveColors.neutral600,
             borderCoreImage = StreamPrimitiveColors.baseWhite.copy(alpha = .2f),
             borderCoreOnDark = StreamPrimitiveColors.baseWhite,
-            borderCoreSurfaceSubtle = StreamPrimitiveColors.neutral700,
             borderCorePrimary = StreamPrimitiveColors.blue300,
+            borderCoreSurfaceSubtle = StreamPrimitiveColors.neutral700,
+            borderUtilityDisabled = StreamPrimitiveColors.neutral800,
+            brand50 = StreamPrimitiveColors.blue900,
+            brand100 = StreamPrimitiveColors.blue800,
+            brand150 = StreamPrimitiveColors.blue700,
+            brand200 = StreamPrimitiveColors.blue700,
+            brand300 = StreamPrimitiveColors.blue600,
+            brand400 = StreamPrimitiveColors.blue500,
+            brand500 = StreamPrimitiveColors.blue400,
+            brand600 = StreamPrimitiveColors.blue300,
+            brand700 = StreamPrimitiveColors.blue200,
+            brand800 = StreamPrimitiveColors.blue150,
+            brand900 = StreamPrimitiveColors.blue100,
+            textDisabled = StreamPrimitiveColors.slate600,
+            textOnAccent = StreamPrimitiveColors.baseWhite,
             textPrimary = StreamPrimitiveColors.neutral50,
             textSecondary = StreamPrimitiveColors.neutral100,
             textTertiary = StreamPrimitiveColors.neutral400,
-            stateBgDisabled = StreamPrimitiveColors.slate800,
-            stateTextDisabled = StreamPrimitiveColors.slate600,
-            buttonStyleGhostBg = StreamPrimitiveColors.baseTransparent,
-            buttonStyleGhostBorder = StreamPrimitiveColors.baseTransparent,
-            buttonStyleOutlineBg = StreamPrimitiveColors.baseTransparent,
-            buttonTypeDestructiveText = StreamPrimitiveColors.baseWhite,
-            buttonTypePrimaryText = StreamPrimitiveColors.baseWhite,
             avatarPaletteBg1 = StreamPrimitiveColors.blue800,
             avatarPaletteBg2 = StreamPrimitiveColors.cyan800,
             avatarPaletteBg3 = StreamPrimitiveColors.green800,
@@ -359,7 +401,9 @@ internal object StreamPrimitiveColors {
     val baseBlack = Color(0xFF000000)
     val baseTransparent = Color(0x00000000)
     val baseWhite = Color(0xFFFFFFFF)
+    val blue50 = Color(0xFFF3F7FF)
     val blue100 = Color(0xFFD2E3FF)
+    val blue150 = Color(0xFFC3D9FF)
     val blue200 = Color(0xFFA6C4FF)
     val blue300 = Color(0xFF7AA7FF)
     val blue400 = Color(0xFF4E8BFF)
@@ -367,6 +411,7 @@ internal object StreamPrimitiveColors {
     val blue600 = Color(0xFF0052CE)
     val blue700 = Color(0xFF0042A3)
     val blue800 = Color(0xFF003179)
+    val blue900 = Color(0xFF091A3B)
     val cyan100 = Color(0xFFD7F7FB)
     val cyan800 = Color(0xFF1C8791)
     val green100 = Color(0xFFC9FCE7)
@@ -378,6 +423,7 @@ internal object StreamPrimitiveColors {
     val neutral300 = Color(0xFFC1C1C1)
     val neutral400 = Color(0xFF8F8F8F)
     val neutral500 = Color(0xFF7F7F7F)
+    val neutral600 = Color(0xFF565656)
     val neutral700 = Color(0xFF4A4A4A)
     val neutral800 = Color(0xFF383838)
     val purple100 = Color(0xFFEBDEFD)
@@ -386,6 +432,7 @@ internal object StreamPrimitiveColors {
     val red400 = Color(0xFFE6756C)
     val red500 = Color(0xFFD92F26)
     val slate100 = Color(0xFFF2F4F6)
+    val slate150 = Color(0xFFD5DBE1)
     val slate200 = Color(0xFFE2E6EA)
     val slate400 = Color(0xFFB8BEC4)
     val slate500 = Color(0xFF9EA4AA)


### PR DESCRIPTION
### 🎯 Goal

Here we go again: here are new buttons with Stream-specific styling. They are not meant to be arbitrarily flexible. Rather, they are made to follow closely the Stream design system. Nothing is public for the time being. If we decide we actually want to expose these base buttons to integrators, we can do so later.

### 🛠 Implementation details

- Create base `StreamButton` that accept a style and size and can contain arbitrary content
- Create `StreamTextButton` that is a shortcut for the common icon-text-icon layout
- Added/updated colors

### 🎨 UI Changes

<img width="504" height="1075" alt="Screenshot 2026-02-02 at 14 04 22" src="https://github.com/user-attachments/assets/368e454f-7054-446f-9d09-6c3000c61c35" />


### 🧪 Testing

They're not in use atm, but you can check the preview