### PR TITLE
Migrate release notes generation based on label

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,8 @@
-### 🎯 Goal
+### Goal
 
 _Describe why we are making this change_
 
-### 🛠 Implementation details
+### Implementation
 
 _Describe the implementation_
 
@@ -35,7 +35,7 @@ _Add relevant videos_
 </tbody>
 </table>
 
-### 🧪 Testing
+### Testing
 
 _Explain how this change can be tested (or why it can't be tested)_
 
@@ -57,11 +57,11 @@ Provide the patch code here
 #### General
 - [ ] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
 - [ ] Assigned a person / code owner group (required)
-- [ ] Thread with the PR link started in a respective Slack channel (#android-chat-core or #android-chat-ui) (required)
+- [ ] Thread with the PR link started in a respective Slack channel (required internally)
+- [ ] PR targets the `develop` branch
 - [ ] PR is linked to the GitHub issue it resolves
 
 #### Code & documentation
-- [ ] Changelog is updated with client-facing changes
 - [ ] New code is covered by unit tests
 - [ ] Comparison screenshots added for visual changes
 - [ ] Affected documentation updated (KDocs, docusaurus, tutorial)
@@ -72,7 +72,6 @@ Provide the patch code here
 - [ ] UI Changes correct (before & after images)
 - [ ] Bugs validated (bugfixes)
 - [ ] New feature tested and works
-- [ ] Release notes and docs clearly describe changes
 - [ ] All code we touched has new or updated KDocs
 - [ ] Check the SDK Size Comparison table in the CI logs
 

--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,37 @@
+changelog:
+  exclude:
+    labels:
+      - "pr:ignore-for-release"
+    authors:
+      - "github-actions[bot]"
+      - "stream-public-bot"
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - "pr:breaking-change"
+    - title: New Features 🎉
+      labels:
+        - "pr:new-feature"
+    - title: Bug Fixes 🐛
+      labels:
+        - "pr:bug"
+    - title: Improvements ✨
+      labels:
+        - "pr:improvement"
+    - title: Documentation 📚
+      labels:
+        - "pr:documentation"
+    - title: Dependencies 📦
+      labels:
+        - "pr:dependencies"
+    - title: Internal 🧪
+      labels:
+        - "pr:internal"
+        - "pr:ci"
+        - "pr:test"
+    - title: Demo App 🧩
+      labels:
+        - "pr:demo-app"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,19 @@
+name: PR checklist
+
+on:
+  pull_request:
+    types: [ opened, edited, synchronize, labeled, unlabeled, reopened ]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pr-checklist:
+    uses: GetStream/stream-build-conventions-android/.github/workflows/pr-quality.yml@v0.7.1
+    secrets: inherit


### PR DESCRIPTION
### Goal

Align stream-chat-android's release process with stream-video-android and stream-core-android by migrating to label-based release notes.

### Testing 
Will be tested on the new release

### Implementation
### Added
- `.github/release.yaml` — GitHub auto-generates release notes from PR labels
- `.github/workflows/pr-quality.yml` — Enforces PR labels via conventions workflow

### Updated
- `.github/pull_request_template.md` — Matches video SDK style, removed manual changelog requirement

### Labels Created (via GitHub API)
All 11 `pr:*` labels matching video/core:
- `pr:breaking-change`, `pr:new-feature`, `pr:bug`, `pr:improvement`
- `pr:documentation`, `pr:dependencies`, `pr:internal`, `pr:ci`, `pr:test`
- `pr:demo-app`, `pr:ignore-for-release`

### Notes
- `CHANGELOG.md` remains for history — not deleted
- Uses `stream-build-conventions-android@v0.7.1` (same version as existing `pr-checks.yml`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

### Summary by CodeRabbit

* **Chores**
  * Updated pull request template with simplified formatting and clearer submission guidance.
  * Added automated release configuration for consistent changelog categorization based on pull request labels.
  * Implemented pull request quality assurance workflow automation.
  

  

<!-- end of auto-generated comment: release notes by coderabbit.ai -->