### PR TITLE
Fix token generation failure test flakiness

### DIFF
--- a/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/JwtTestActivity.kt
+++ b/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/JwtTestActivity.kt
@@ -188,9 +188,9 @@ class JwtTestActivity : AppCompatActivity() {
 
             OkHttpClient().newCall(request).execute().use { response ->
                 if (!response.isSuccessful) {
-                    throw Exception("Failed to fetch token: ${response.code}")
+                    return@withContext ""
                 }
-                response.body?.string() ?: throw Exception("Empty response body")
+                response.body?.string() ?: ""
             }
         }
     }


### PR DESCRIPTION
### Goal

`test_tokenGenerationFails` intermittently fails in CI. That's because the token generator used in the test app throws when the backend response is unsuccessful, but that's incorrect. `TokenProvider.loadToken` is supposed to return an empty string if the token can't be generated.

### Implementation

Return empty string instead of throwing

### 🎨 UI Changes

None

### Testing

Running `test_tokenGenerationFails` should not fail

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling in token authentication processes. The system now gracefully manages failed requests and empty responses by returning safe defaults instead of throwing exceptions, enhancing application stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->