### PR TITLE
Introduce `ReactionIcon` and `ReactionToggle` components

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2037,6 +2037,40 @@ public final class io/getstream/chat/android/compose/ui/components/reactionpicke
 	public static final fun ReactionsPicker-Hzv_svQ (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/graphics/Shape;JLandroidx/compose/foundation/lazy/grid/GridCells;Lkotlin/jvm/functions/Function0;Ljava/util/Map;Lkotlin/jvm/functions/Function3;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 }
 
+public final class io/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionIconKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionIconKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionToggleKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionToggleKt;
+	public static field lambda-1 Lkotlin/jvm/functions/Function2;
+	public fun <init> ()V
+	public final fun getLambda-1$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
+public final class io/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize : java/lang/Enum {
+	public static final field ExtraExtraLarge Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static final field ExtraLarge Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static final field Large Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static final field Medium Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static final field Small Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+	public static fun values ()[Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;
+}
+
+public final class io/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize : java/lang/Enum {
+	public static final field ExtraLarge Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;
+	public static final field Large Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;
+	public static final field Medium Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;
+	public static fun values ()[Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;
+}
+
 public final class io/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$SelectedMessageMenuKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$SelectedMessageMenuKt;
 	public static field lambda-1 Lkotlin/jvm/functions/Function2;
@@ -3008,9 +3042,11 @@ public abstract interface class io/getstream/chat/android/compose/ui/theme/ChatC
 	public abstract fun PinnedMessageListItemTrailingContent (Landroidx/compose/foundation/layout/RowScope;Lio/getstream/chat/android/models/Message;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun PinnedMessageListLoadingContent (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun PinnedMessageListLoadingMoreContent (Landroidx/compose/runtime/Composer;I)V
+	public abstract fun ReactionIcon (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionMenuOptionItem (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/reactionoptions/ReactionOptionItemState;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionMenuOptions (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/Message;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionMenuShowMore (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V
+	public abstract fun ReactionToggle (Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionsMenu (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionsMenuCenterContent (Landroidx/compose/ui/Modifier;Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
 	public abstract fun ReactionsMenuHeaderContent (Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/Message;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V
@@ -3201,9 +3237,11 @@ public final class io/getstream/chat/android/compose/ui/theme/ChatComponentFacto
 	public static fun PinnedMessageListItemTrailingContent (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/foundation/layout/RowScope;Lio/getstream/chat/android/models/Message;Landroidx/compose/runtime/Composer;I)V
 	public static fun PinnedMessageListLoadingContent (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public static fun PinnedMessageListLoadingMoreContent (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/runtime/Composer;I)V
+	public static fun ReactionIcon (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public static fun ReactionMenuOptionItem (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/compose/state/reactionoptions/ReactionOptionItemState;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;I)V
 	public static fun ReactionMenuOptions (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/Message;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V
 	public static fun ReactionMenuShowMore (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V
+	public static fun ReactionToggle (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Ljava/lang/String;Ljava/lang/String;Lio/getstream/chat/android/compose/ui/components/reactions/ReactionToggleSize;ZLkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)V
 	public static fun ReactionsMenu (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;Ljava/util/Set;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;I)V
 	public static fun ReactionsMenuCenterContent (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Ljava/util/List;Landroidx/compose/runtime/Composer;I)V
 	public static fun ReactionsMenuHeaderContent (Lio/getstream/chat/android/compose/ui/theme/ChatComponentFactory;Landroidx/compose/ui/Modifier;Lio/getstream/chat/android/models/Message;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function0;ILandroidx/compose/runtime/Composer;I)V

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionIcon.kt
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.reactions
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+
+/**
+ * Component for rendering reaction emojis.
+ *
+ * @param size The size of the reaction icon.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+internal fun ReactionIcon(
+    type: String,
+    emoji: String?,
+    size: ReactionIconSize,
+    modifier: Modifier = Modifier,
+) {
+    emoji?.let {
+        Text(
+            modifier = modifier.wrapContentSize(),
+            text = it,
+            fontSize = size.toFontSize(),
+        )
+    }
+}
+
+/** Defines the size class of the reaction icon. */
+public enum class ReactionIconSize {
+    Small, Medium, Large, ExtraLarge, ExtraExtraLarge
+}
+
+private fun ReactionIconSize.toFontSize() = when (this) {
+    ReactionIconSize.Small -> 16.sp
+    ReactionIconSize.Medium -> 24.sp
+    ReactionIconSize.Large -> 32.sp
+    ReactionIconSize.ExtraLarge -> 48.sp
+    ReactionIconSize.ExtraExtraLarge -> 64.sp
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReactionIconPreview() {
+    ChatTheme {
+        Row(
+            modifier = Modifier.padding(8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            ReactionIconSize.entries.forEach { size ->
+                ReactionIcon(
+                    type = "like",
+                    emoji = "👀",
+                    size = size,
+                )
+            }
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.reactions
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.util.applyIf
+import io.getstream.chat.android.compose.ui.util.clickable
+import io.getstream.chat.android.compose.ui.util.ifNotNull
+import io.getstream.chat.android.ui.common.helper.ReactionPushEmojiFactory
+
+/**
+ * Component for rendering reaction emoji toggles.
+ *
+ * @param type The string representation of the reaction.
+ * @param emoji The emoji character the [type] maps to, if any. See [ReactionPushEmojiFactory].
+ * @param size The size of the reaction toggle.
+ * @param checked Whether the toggle is checked.
+ * @param onCheckedChange Callback when the checked state of the toggle changes.
+ * @param modifier Modifier for styling.
+ */
+@Composable
+internal fun ReactionToggle(
+    type: String,
+    emoji: String?,
+    size: ReactionToggleSize,
+    checked: Boolean,
+    onCheckedChange: ((Boolean) -> Unit)?,
+    modifier: Modifier = Modifier,
+) {
+    emoji?.let {
+        val containerSize = size.toContainerSize()
+        ChatTheme.componentFactory.ReactionIcon(
+            type = type,
+            emoji = emoji,
+            size = size.toIconSize(),
+            modifier = modifier
+                .applyIf(checked) {
+                    background(ChatTheme.colors.backgroundCoreSelected, CircleShape)
+                }
+                .ifNotNull(onCheckedChange) { onChange ->
+                    clip(CircleShape).clickable { onChange(!checked) }
+                }
+                .defaultMinSize(minWidth = containerSize, minHeight = containerSize)
+                .wrapContentSize(),
+        )
+    }
+}
+
+/** Defines the size class of the reaction toggle. */
+public enum class ReactionToggleSize {
+    Medium, Large, ExtraLarge
+}
+
+private fun ReactionToggleSize.toContainerSize(): Dp = when (this) {
+    ReactionToggleSize.Medium -> 32.dp
+    ReactionToggleSize.Large -> 40.dp
+    ReactionToggleSize.ExtraLarge -> 48.dp
+}
+
+private fun ReactionToggleSize.toIconSize() = when (this) {
+    ReactionToggleSize.Medium -> ReactionIconSize.Medium
+    ReactionToggleSize.Large -> ReactionIconSize.Medium
+    ReactionToggleSize.ExtraLarge -> ReactionIconSize.Large
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ReactionTogglePreview() {
+    ChatTheme {
+        Column(Modifier.padding(8.dp)) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ReactionToggleSize.entries.forEach { size ->
+                    ReactionToggle(
+                        type = "like",
+                        emoji = "👍",
+                        size = size,
+                        checked = false,
+                        onCheckedChange = {},
+                    )
+                }
+            }
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                ReactionToggleSize.entries.forEach { size ->
+                    ReactionToggle(
+                        type = "like",
+                        emoji = "👍",
+                        size = size,
+                        checked = true,
+                        onCheckedChange = {},
+                    )
+                }
+            }
+        }
+    }
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -145,6 +145,8 @@ import io.getstream.chat.android.compose.ui.components.reactionoptions.ExtendedR
 import io.getstream.chat.android.compose.ui.components.reactionoptions.ReactionOptionItem
 import io.getstream.chat.android.compose.ui.components.reactionoptions.ReactionOptions
 import io.getstream.chat.android.compose.ui.components.reactionpicker.ReactionsPicker
+import io.getstream.chat.android.compose.ui.components.reactions.ReactionIconSize
+import io.getstream.chat.android.compose.ui.components.reactions.ReactionToggleSize
 import io.getstream.chat.android.compose.ui.components.selectedmessage.SelectedMessageMenu
 import io.getstream.chat.android.compose.ui.components.selectedmessage.SelectedReactionsMenu
 import io.getstream.chat.android.compose.ui.components.suggestions.commands.CommandSuggestionItem
@@ -227,6 +229,7 @@ import io.getstream.chat.android.ui.common.feature.channel.info.ChannelInfoMembe
 import io.getstream.chat.android.ui.common.feature.channel.info.ChannelInfoViewAction
 import io.getstream.chat.android.ui.common.feature.channel.info.ChannelInfoViewEvent
 import io.getstream.chat.android.ui.common.feature.messages.translations.MessageOriginalTranslationsStore
+import io.getstream.chat.android.ui.common.helper.ReactionPushEmojiFactory
 import io.getstream.chat.android.ui.common.model.MessageResult
 import io.getstream.chat.android.ui.common.state.channel.attachments.ChannelAttachmentsViewState
 import io.getstream.chat.android.ui.common.state.channel.info.ChannelInfoMemberViewState
@@ -2254,7 +2257,60 @@ public interface ChatComponentFactory {
         )
     }
 
-    // REGION: Reaction menu and items
+    // REGION: Reactions
+
+    /**
+     * Factory method for creating a reaction icon. By default, it only displays the emoji.
+     *
+     * @param type The string representation of the reaction.
+     * @param emoji The emoji character the [type] maps to, if any. See [ReactionPushEmojiFactory].
+     * @param size The size of the reaction button.
+     * @param modifier Modifier for styling.
+     */
+    @Composable
+    public fun ReactionIcon(
+        type: String,
+        emoji: String?,
+        size: ReactionIconSize,
+        modifier: Modifier,
+    ) {
+        io.getstream.chat.android.compose.ui.components.reactions.ReactionIcon(
+            type = type,
+            emoji = emoji,
+            size = size,
+            modifier = modifier,
+        )
+    }
+
+    /**
+     * Factory method for creating a reaction toggle. By default, it only displays the emoji.
+     *
+     * @param type The string representation of the reaction.
+     * @param emoji The emoji character the [type] maps to, if any. See [ReactionPushEmojiFactory].
+     * @param size The size of the reaction button.
+     * @param checked Whether the toggle is checked.
+     * @param onCheckedChange Callback when the checked state of the toggle changes.
+     * @param modifier Modifier for styling.
+     */
+    @Composable
+    public fun ReactionToggle(
+        type: String,
+        emoji: String?,
+        size: ReactionToggleSize,
+        checked: Boolean,
+        onCheckedChange: ((Boolean) -> Unit)?,
+        modifier: Modifier,
+    ) {
+        io.getstream.chat.android.compose.ui.components.reactions.ReactionToggle(
+            type = type,
+            emoji = emoji,
+            size = size,
+            checked = checked,
+            onCheckedChange = onCheckedChange,
+            modifier = modifier,
+        )
+    }
+
     /**
      * Factory method for creating the full content of the SelectedReactionsMenu.
      *


### PR DESCRIPTION
### Goal

Introduce `ReactionIcon` and `ReactionToggle` components. They will be used later for displaying reactions in the SDK instead of the current implementations.
 
### Implementation

They are simple components rendering an emoji (`ReactionIcon`) + a checked state (`ReactionToggle`). We only support emojis as that's the direction we're taking going forward as emojis is the standard in chat apps. If customers want image-based reactions, they will be able to replace `ReactionIcon`.

### 🎨 UI Changes

[Figma](https://www.figma.com/design/Us73erK1xFNcB5EH3hyq6Y/Chat-SDK-Design-System?node-id=132-2034&m=dev)

<img width="546" height="179" alt="Screenshot 2026-02-11 at 12 14 00" src="https://github.com/user-attachments/assets/46194785-1420-46d6-9904-21bb97c5dd02" />

[Figma](https://www.figma.com/design/Us73erK1xFNcB5EH3hyq6Y/Chat-SDK-Design-System?node-id=2201-25686&m=dev)

<img width="546" height="402" alt="Screenshot 2026-02-11 at 12 11 39" src="https://github.com/user-attachments/assets/51067942-a565-4383-b2ba-1169ae680d48" />

### Testing

They aren't in use yet, so they can only be checked in previews.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable reaction icon component for displaying emoji reactions across five size options (Small, Medium, Large, ExtraLarge, ExtraExtraLarge)
  * Added interactive reaction toggle component with three size options and visual feedback for checked/unchecked states
  * Extended theme factory to support new reaction components, ensuring design consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->