### PR TITLE
Infer layout direction from message alignment

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -112,7 +112,8 @@ public fun PollMessageContent(
     val message = messageItem.message
     val ownsMessage = messageItem.isMine
 
-    val messageBubbleShape = MessageStyling.shape(messageItem.groupPosition, outgoing = ownsMessage)
+    val messageAlignment = ChatTheme.messageAlignmentProvider.provideMessageAlignment(messageItem)
+    val messageBubbleShape = MessageStyling.shape(messageItem.groupPosition, messageAlignment)
     val messageBubbleColor = MessageStyling.backgroundColor(messageItem.isMine)
 
     val poll = message.poll

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -179,7 +179,6 @@ import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageItem
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageListEmptyContent
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageListLoadingIndicator
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageModeratedContent
-import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageSpacer
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageThreadSeparatorContent
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageTop
 import io.getstream.chat.android.compose.ui.messages.list.DefaultMessageUnreadSeparatorContent
@@ -1191,7 +1190,6 @@ public interface ChatComponentFactory {
     public fun RowScope.MessageSpacer(
         messageItem: MessageItemState,
     ) {
-        DefaultMessageSpacer(messageItem = messageItem)
     }
 
     /**

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageStyling.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageStyling.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
+import io.getstream.chat.android.compose.state.messages.MessageAlignment
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.state.messages.list.MessagePosition
@@ -121,20 +122,23 @@ internal object MessageStyling {
     )
 
     private val roundBubble = RoundedCornerShape(StreamTokens.radius2xl)
-    private val outgoingBubble = RoundedCornerShape(
+    private val rightPointingBubble = RoundedCornerShape(
         topStart = StreamTokens.radius2xl,
         topEnd = StreamTokens.radius2xl,
         bottomStart = StreamTokens.radius2xl,
         bottomEnd = ZeroCornerSize,
     )
-    private val incomingBubble = RoundedCornerShape(
+    private val leftPointingBubble = RoundedCornerShape(
         topStart = StreamTokens.radius2xl,
         topEnd = StreamTokens.radius2xl,
         bottomStart = ZeroCornerSize,
         bottomEnd = StreamTokens.radius2xl,
     )
 
-    fun shape(position: MessagePosition, outgoing: Boolean): Shape {
+    fun shape(
+        position: MessagePosition,
+        messageAlignment: MessageAlignment,
+    ): Shape {
         return when (position) {
             MessagePosition.TOP,
             MessagePosition.MIDDLE,
@@ -142,9 +146,9 @@ internal object MessageStyling {
 
             MessagePosition.BOTTOM,
             MessagePosition.NONE,
-            -> when {
-                outgoing -> outgoingBubble
-                else -> incomingBubble
+            -> when (messageAlignment) {
+                MessageAlignment.End -> rightPointingBubble
+                MessageAlignment.Start -> leftPointingBubble
             }
         }
     }


### PR DESCRIPTION
### Goal

Update rendering logic to automatically select the correct layout order & bubble shape based on `MessageAlignment`, e.g. `avatar - bubble` vs `bubble - avatar`. 

### Implementation

Check `MessageAlignment` to determine where to position avatar vs bubble and what shape the bubble should have. Before, we were only doing partial alignment.

### 🎨 UI Changes

These examples are for the case where an integrator swaps the alignment vs the default, so outgoing to the left and incoming to the right.

| Before | After |
| --- | --- |
| <img width="540" height="1200" alt="Screenshot_20260212_161648" src="https://github.com/user-attachments/assets/c35a6e2f-629f-4209-b657-045c89df1413" /> | <img width="540" height="1200" alt="Screenshot_20260212_161604" src="https://github.com/user-attachments/assets/c30e86d1-62f9-44bf-8a22-7a5311820827" /> |



### Testing

You can test the sample where you customize the message alignment and verify that it looks as you expect

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated message bubble shape calculation to use alignment-based approach instead of direction flags.
  * Refactored message layout system to be alignment-aware, improving how message components (author, spacer) are positioned.
  * Simplified avatar display logic with clearer conditions for visibility.
  * Removed unnecessary spacer rendering from message composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->