### PR TITLE
Fix local only message deletion 

### DIFF
--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DeleteMessageListenerDatabaseTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/plugin/listener/internal/DeleteMessageListenerDatabaseTest.kt
@@ -19,12 +19,19 @@ package io.getstream.chat.android.offline.plugin.listener.internal
 import io.getstream.chat.android.client.persistance.repository.MessageRepository
 import io.getstream.chat.android.client.persistance.repository.UserRepository
 import io.getstream.chat.android.client.setup.state.ClientState
+import io.getstream.chat.android.models.MessageType
+import io.getstream.chat.android.models.ModerationAction
 import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomModeration
+import io.getstream.chat.android.randomUser
 import io.getstream.result.Error
 import io.getstream.result.Result
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -37,11 +44,16 @@ internal class DeleteMessageListenerDatabaseTest {
 
     private val clientState: ClientState = mock()
 
-    private val messageRepository: MessageRepository = mock()
+    private lateinit var messageRepository: MessageRepository
     private val userRepository: UserRepository = mock()
 
-    private val deleteMessageListenerState: DeleteMessageListenerDatabase =
-        DeleteMessageListenerDatabase(clientState, messageRepository, userRepository)
+    private lateinit var deleteMessageListenerState: DeleteMessageListenerDatabase
+
+    @BeforeEach
+    fun setUp() {
+        messageRepository = mock()
+        deleteMessageListenerState = DeleteMessageListenerDatabase(clientState, messageRepository, userRepository)
+    }
 
     @Test
     fun `when internet is available, the message should be updated as in progress before the request`() = runTest {
@@ -121,5 +133,136 @@ internal class DeleteMessageListenerDatabaseTest {
                 message.id == testMessage.id && message.syncStatus == SyncStatus.SYNC_NEEDED
             },
         )
+    }
+
+    @Test
+    fun `onMessageDeletePrecondition when message not found locally should return Success`() = runTest {
+        val currentUser = randomUser()
+
+        whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+        whenever(messageRepository.selectMessage(any())) doReturn null
+
+        val result = deleteMessageListenerState.onMessageDeletePrecondition("unknown-message-id")
+
+        assertTrue(result is Result.Success)
+    }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has moderation bounce should return Failure and delete from repo`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                user = currentUser,
+                type = MessageType.ERROR,
+                moderation = randomModeration(action = ModerationAction.bounce),
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(messageRepository).deleteChannelMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is error type should return Failure and delete from repo`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.ERROR,
+                syncStatus = SyncStatus.COMPLETED,
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(messageRepository).deleteChannelMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is ephemeral type should return Failure and delete from repo`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.EPHEMERAL,
+                syncStatus = SyncStatus.COMPLETED,
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(messageRepository).deleteChannelMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has SYNC_NEEDED should return Failure and delete from repo`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.REGULAR,
+                syncStatus = SyncStatus.SYNC_NEEDED,
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(messageRepository).deleteChannelMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has FAILED_PERMANENTLY should return Failure and delete from repo`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.REGULAR,
+                syncStatus = SyncStatus.FAILED_PERMANENTLY,
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(messageRepository).deleteChannelMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is COMPLETED regular should return Success`() = runTest {
+        val currentUser = randomUser()
+        val testMessage = randomMessage(
+            id = "msg-1",
+            cid = randomCID(),
+            type = MessageType.REGULAR,
+            syncStatus = SyncStatus.COMPLETED,
+        )
+
+        whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+        whenever(messageRepository.selectMessage(any())) doReturn testMessage
+
+        val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+        assertTrue(result is Result.Success)
     }
 }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DeleteMessageListenerStateTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/plugin/listener/internal/DeleteMessageListenerStateTest.kt
@@ -17,9 +17,12 @@
 package io.getstream.chat.android.state.plugin.listener.internal
 
 import io.getstream.chat.android.client.setup.state.ClientState
+import io.getstream.chat.android.models.MessageType
+import io.getstream.chat.android.models.ModerationAction
 import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomModeration
 import io.getstream.chat.android.randomUser
 import io.getstream.chat.android.state.plugin.logic.channel.internal.ChannelLogic
 import io.getstream.chat.android.state.plugin.logic.channel.internal.ChannelStateLogic
@@ -30,6 +33,7 @@ import io.getstream.result.Error
 import io.getstream.result.Result
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -167,5 +171,144 @@ internal class DeleteMessageListenerStateTest {
                 message.id == testMessage.id && message.syncStatus == SyncStatus.SYNC_NEEDED
             },
         )
+    }
+
+    @Test
+    fun `onMessageDeletePrecondition when message not found locally should return Success`() = runTest {
+        whenever(logicRegistry.channelFromMessageId(any())) doReturn null
+
+        val result = deleteMessageListenerState.onMessageDeletePrecondition("unknown-message-id")
+
+        assertTrue(result is Result.Success)
+    }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has moderation bounce should return Failure and delete locally`() =
+        runTest {
+            val currentUser = randomUser()
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                user = currentUser,
+                type = MessageType.ERROR,
+                moderation = randomModeration(action = ModerationAction.bounce),
+            )
+
+            whenever(clientState.user) doReturn MutableStateFlow(currentUser)
+            whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+            whenever(logicRegistry.channelFromMessage(any())) doReturn channelLogic
+            whenever(logicRegistry.getActiveQueryThreadsLogic()) doReturn activeThreadsLogic
+            whenever(logicRegistry.threadFromMessage(any())) doReturn null
+            whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(channelLogic).deleteMessage(argThat { id == testMessage.id })
+            verify(threadsLogic).deleteMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is error type should return Failure and delete locally`() = runTest {
+        val testMessage = randomMessage(
+            id = "msg-1",
+            cid = randomCID(),
+            type = MessageType.ERROR,
+            syncStatus = SyncStatus.COMPLETED,
+        )
+
+        whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+        whenever(logicRegistry.channelFromMessage(any())) doReturn channelLogic
+        whenever(logicRegistry.getActiveQueryThreadsLogic()) doReturn activeThreadsLogic
+        whenever(logicRegistry.threadFromMessage(any())) doReturn null
+        whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+        val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+        assertTrue(result is Result.Failure)
+        verify(channelLogic).deleteMessage(argThat { id == testMessage.id })
+    }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is ephemeral type should return Failure and delete locally`() =
+        runTest {
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.EPHEMERAL,
+                syncStatus = SyncStatus.COMPLETED,
+            )
+
+            whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+            whenever(logicRegistry.channelFromMessage(any())) doReturn channelLogic
+            whenever(logicRegistry.getActiveQueryThreadsLogic()) doReturn activeThreadsLogic
+            whenever(logicRegistry.threadFromMessage(any())) doReturn null
+            whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(channelLogic).deleteMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has SYNC_NEEDED should return Failure and delete locally`() =
+        runTest {
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.REGULAR,
+                syncStatus = SyncStatus.SYNC_NEEDED,
+            )
+
+            whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+            whenever(logicRegistry.channelFromMessage(any())) doReturn channelLogic
+            whenever(logicRegistry.getActiveQueryThreadsLogic()) doReturn activeThreadsLogic
+            whenever(logicRegistry.threadFromMessage(any())) doReturn null
+            whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(channelLogic).deleteMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message has FAILED_PERMANENTLY should return Failure and delete locally`() =
+        runTest {
+            val testMessage = randomMessage(
+                id = "msg-1",
+                cid = randomCID(),
+                type = MessageType.REGULAR,
+                syncStatus = SyncStatus.FAILED_PERMANENTLY,
+            )
+
+            whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+            whenever(logicRegistry.channelFromMessage(any())) doReturn channelLogic
+            whenever(logicRegistry.getActiveQueryThreadsLogic()) doReturn activeThreadsLogic
+            whenever(logicRegistry.threadFromMessage(any())) doReturn null
+            whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+            val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+            assertTrue(result is Result.Failure)
+            verify(channelLogic).deleteMessage(argThat { id == testMessage.id })
+        }
+
+    @Test
+    fun `onMessageDeletePrecondition when message is COMPLETED regular should return Success`() = runTest {
+        val testMessage = randomMessage(
+            id = "msg-1",
+            cid = randomCID(),
+            type = MessageType.REGULAR,
+            syncStatus = SyncStatus.COMPLETED,
+        )
+
+        whenever(logicRegistry.channelFromMessageId(any())) doReturn channelLogic
+        whenever(channelLogic.getMessage(any())) doReturn testMessage
+
+        val result = deleteMessageListenerState.onMessageDeletePrecondition(testMessage.id)
+
+        assertTrue(result is Result.Success)
     }
 }


### PR DESCRIPTION
### Goal

When deleting messages that were never synced to the server (e.g. `SYNC_NEEDED`, `FAILED_PERMANENTLY`, error/ephemeral types, moderation bounce), we should delete them locally only and skip the Delete API call.
Additionally, this fixes a case where we have a local-only error message (rejected by pre-send [webhook](https://getstream.io/chat/docs/java/before_message_send_webhook/#discarding-messages)) cannot be deleted - `type = error`, and `Delete` fails because the message is not present on BE

### Implementation

- Extended `Message.shouldDeleteRemote()` to return `Failure` (skip API) for `SYNC_NEEDED` and `FAILED_PERMANENTLY` in addition to `IN_PROGRESS`, error, ephemeral, and moderation bounce
- `DeleteMessageListenerState` and `DeleteMessageListenerDatabase` use `shouldDeleteRemote` in `onMessageDeletePrecondition` to delete locally when the message is local-only
- Simplified `onMessageDeleteRequest` (removed redundant `isModerationError` check) since precondition already gates the request

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/5874416a-6aff-4ee5-a78e-de0d9f169077" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/276832c2-c370-4816-9db9-f1580a70c136" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Testing
This a simulated scenario, not really testable in regular case. The idea is to attempt to delete a message with `type=error`

<details>

<summary>Patch</summary>

```
Subject: [PATCH] Mark plugin-related classes as internal.
---
Index: stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt	(revision 227ec0754a4af9b194eac4fbef9618630220f734)
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt	(date 1771247854276)
@@ -56,6 +56,7 @@
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults
 import androidx.compose.material3.pulltorefresh.PullToRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -75,6 +76,7 @@
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.channels.list.ChannelOptionState
@@ -964,6 +966,10 @@
     @Composable
     public fun LazyItemScope.MessageListModeratedItemContent(moderatedMessageItem: ModeratedMessageItemState) {
         DefaultMessageModeratedContent(moderatedMessageItemState = moderatedMessageItem)
+        LaunchedEffect(moderatedMessageItem.message.id) {
+            val client = ChatClient.instance()
+            client.deleteMessage(moderatedMessageItem.message.id).enqueue {}
+        }
     }
 
     /**

```

</details>

1. Apply the provided patch (deletes the `type=error` message as soon as it appears)
2. Open a channel
3. Write a threat (should be bounced)
4. Tap send anyway
5. The message should be posted AND deleted immediately

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved message deletion handling to properly manage moderation errors and prevent deletion of messages in inconsistent sync states, ensuring they are deleted locally instead of from the server.

* **Tests**
  * Added comprehensive test coverage for message deletion scenarios across moderation cases, sync states, and message types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->