### PR TITLE
Bump Compose version to 1.9

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,8 @@ androidxActivityCompose = "1.9.3"
 androidxActivityKtx = "1.9.3"
 androidxAnnotations = "1.9.1"
 androidxAppcompat = "1.7.0"
-androidxCompose = "1.7.5"
+androidxCompose = "1.9.0"
+androidxComposeMaterialIcons = "1.7.8"
 androidxComposeConstraintLayout = "1.1.0"
 androidxComposeMaterial3 = "1.3.1"
 androidxComposeMaterial3Adaptive = "1.0.0"
@@ -103,8 +104,8 @@ androidx-compose-constraintlayout-compose = { module = "androidx.constraintlayou
 androidx-compose-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "androidxCompose"}
 androidx-compose-material3 = { module = "androidx.compose.material3:material3", version.ref = "androidxComposeMaterial3"}
 androidx-compose-material3-adaptive = { module = "androidx.compose.material3.adaptive:adaptive", version.ref = "androidxComposeMaterial3Adaptive"}
-androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "androidxCompose"}
-androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidxCompose"}
+androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "androidxComposeMaterialIcons"}
+androidx-compose-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "androidxComposeMaterialIcons"}
 androidx-compose-runtime = { module = "androidx.compose.runtime:runtime", version.ref = "androidxCompose"}
 androidx-compose-ui = { module = "androidx.compose.ui:ui", version.ref = "androidxCompose"}
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidxCompose"}


### PR DESCRIPTION
### Goal

After some hours of fighting, I discovered the compose version we use has a bug with full screen dialogs, which I plan to use for the overlay reactions menu, so I'm bumping to get the fix.

### Implementation

- Bump compose
- Decouple Material icons version as they're not tied anymore

### 🎨 UI Changes

None

### Testing

There should be no changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  - Updated Android Compose framework to the latest stable version, ensuring the app uses the most current UI framework capabilities
  - Refreshed Material Icons library to version 1.7.8 with updated icon resources
  - Streamlined dependency version management across UI component libraries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->