### PR TITLE
Fix auto scroll to bottom when exiting a thread

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -310,7 +310,10 @@ internal fun BoxScope.DefaultMessagesHelperContent(
     // Keep track of the last new message state that triggered a scroll to bottom.
     // If a configuration change happens, we want to keep the same state
     // and not scroll to bottom again if the newMessageState is the same as before the configuration change.
-    var lastScrollToBottomOnNewMessage by rememberSaveable(saver = MutableStateNewMessageStateSaver) {
+    var lastScrollToBottomOnNewMessage by rememberSaveable(
+        isMessageInThread,
+        saver = MutableStateNewMessageStateSaver,
+    ) {
         mutableStateOf(newMessageState)
     }
 
@@ -344,9 +347,7 @@ internal fun BoxScope.DefaultMessagesHelperContent(
             count = messagesState.unreadCount,
             onClick = {
                 scrollToBottom {
-                    coroutineScope.launch {
-                        lazyListState.scrollToItem(0)
-                    }
+                    coroutineScope.launch { lazyListState.scrollToItem(0) }
                 }
             },
         )


### PR DESCRIPTION
### Goal

Fix a bug where the message list would automatically scroll to the bottom when exiting a thread, losing the user's scroll position in the main message list.

### Implementation

The issue was in `DefaultMessagesHelperContent` where `lastScrollToBottomOnNewMessage` state was shared between thread and main list contexts. When exiting a thread:

1. `lastScrollToBottomOnNewMessage` still held the thread's last state
2. The main list's `newMessageState` was different
3. This triggered the scroll-to-bottom logic inappropriately

The fix adds `isMessageInThread` as an input to `rememberSaveable`. When the context switches (thread ↔ main list):
- The state is re-initialized with the current `newMessageState`
- Since `lastScrollToBottomOnNewMessage` equals `newMessageState`, the comparison fails
- No unwanted scroll-to-bottom occurs

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/891b1bb1-f98d-4e93-89de-a29bbdb6486e" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/59ee9ea6-a51d-4c4d-a054-854f618f513d" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Testing

1. Open a channel with messages
2. Scroll up in the message list (away from the bottom)
3. Enter a thread
4. Exit the thread
5. Verify the scroll position is preserved (not scrolled to bottom)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scroll-to-bottom button behavior to correctly manage state when viewing threaded messages, ensuring proper scrolling context based on message thread status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->