### PR TITLE
Fix `CaptureMediaContract` not remembered across recompositions

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/media/CaptureMediaLauncher.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/media/CaptureMediaLauncher.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.compose.ui.messages.attachments.media
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import io.getstream.chat.android.ui.common.contract.internal.CaptureMediaContract
 import java.io.File
 
@@ -62,8 +63,10 @@ public fun rememberCaptureMediaLauncher(
     video: Boolean,
     onResult: (File) -> Unit,
 ): ManagedActivityResultLauncher<Unit, File?>? {
-    val mode = resolveMediaPickerMode(photo, video) ?: return null
-    return rememberLauncherForActivityResult(CaptureMediaContract(mode)) { file ->
+    val contract = remember(photo, video) {
+        resolveMediaPickerMode(photo, video)?.let { CaptureMediaContract(it) }
+    } ?: return null
+    return rememberLauncherForActivityResult(contract) { file ->
         file?.let(onResult)
     }
 }


### PR DESCRIPTION
### Goal

Fix a bug where `CaptureMediaContract` was being created on every recomposition in `rememberCaptureMediaLauncher`, causing unnecessary re-registration of the activity result launcher.

### Implementation

- Wrap the `CaptureMediaContract` creation in a `remember` block keyed on `photo` and `video` parameters
- Combine mode resolution and contract creation into a single remembered computation

### 🎨 UI Changes

No UI changes.

### Testing

1. Open a channel and tap the attachment picker
2. Use the camera capture functionality
3. Verify the camera launches correctly and captured media is handled properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored media capture launcher initialization in the compose UI messaging component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->