### PR TITLE
Make resolveAttachmentFiles a suspend function

### DIFF
--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModelTest.kt
@@ -446,7 +446,7 @@ internal class MessageComposerViewModelTest {
         private val clientState: ClientState = mock()
         private val channelState: ChannelState = mock()
         private val storageHelper: AttachmentStorageHelper = mock {
-            on { resolveAttachmentFiles(any()) } doAnswer { it.getArgument(0) }
+            onBlocking { resolveAttachmentFiles(any()) } doAnswer { it.getArgument(0) }
         }
         private val appSettings: AppSettings = AppSettings(
             app = App(

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -746,9 +746,7 @@ public class MessageComposerController(
 
         if (resolveAttachments != null) {
             scope.launch {
-                val resolved = withContext(DispatcherProvider.IO) {
-                    resolveAttachments(preparedMessage.attachments)
-                }
+                val resolved = resolveAttachments(preparedMessage.attachments)
                 enqueueSendMessage(preparedMessage.copy(attachments = resolved), callback)
             }
         } else {
@@ -763,8 +761,7 @@ public class MessageComposerController(
     ) {
         scope.launch {
             val resolvedMessage = resolveAttachments?.let { resolve ->
-                val resolved = withContext(DispatcherProvider.IO) { resolve(message.attachments) }
-                message.copy(attachments = resolved)
+                message.copy(attachments = resolve(message.attachments))
             } ?: message
             chatClient.editMessage(channelType, channelId, resolvedMessage).enqueue(callback)
         }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentStorageHelper.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentStorageHelper.kt
@@ -24,10 +24,12 @@ import androidx.annotation.WorkerThread
 import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.core.internal.coroutines.DispatcherProvider
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.helper.internal.AttachmentStorageHelper.Companion.EXTRA_SOURCE_URI
 import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMetaData
 import io.getstream.log.taggedLogger
+import kotlinx.coroutines.withContext
 import java.io.File
 
 /**
@@ -98,37 +100,37 @@ public class AttachmentStorageHelper(
      * @param attachments The attachments to resolve.
      * @return Attachments with [Attachment.upload] populated for every entry that had a source URI.
      */
-    @WorkerThread
-    public fun resolveAttachmentFiles(
-        attachments: List<Attachment>,
-    ): List<Attachment> = attachments.mapNotNull { attachment ->
-        if (attachment.upload != null) return@mapNotNull attachment
-        val sourceUri = (attachment.extraData[EXTRA_SOURCE_URI] as? String)
-            ?.let(Uri::parse) ?: return@mapNotNull attachment
-        val metaData = AttachmentMetaData(
-            uri = sourceUri,
-            type = attachment.type,
-            mimeType = attachment.mimeType,
-            title = attachment.name,
-        ).apply { size = attachment.fileSize.toLong() }
-        val file = storageHelper.getCachedFileFromUri(context, metaData)
-        if (file == null) {
-            logger.w { "[resolveAttachmentFiles] Failed to resolve file for URI: $sourceUri" }
-            return@mapNotNull null
-        }
+    public suspend fun resolveAttachmentFiles(attachments: List<Attachment>): List<Attachment> =
+        withContext(DispatcherProvider.IO) {
+            attachments.mapNotNull { attachment ->
+                if (attachment.upload != null) return@mapNotNull attachment
+                val sourceUri = (attachment.extraData[EXTRA_SOURCE_URI] as? String)
+                    ?.let(Uri::parse) ?: return@mapNotNull attachment
+                val metaData = AttachmentMetaData(
+                    uri = sourceUri,
+                    type = attachment.type,
+                    mimeType = attachment.mimeType,
+                    title = attachment.name,
+                ).apply { size = attachment.fileSize.toLong() }
+                val file = storageHelper.getCachedFileFromUri(context, metaData)
+                if (file == null) {
+                    logger.w { "[resolveAttachmentFiles] Failed to resolve file for URI: $sourceUri" }
+                    return@mapNotNull null
+                }
 
-        val (width, height) = if (attachment.originalWidth == null && attachment.originalHeight == null) {
-            resolveLocalDimensions(file, attachment)
-        } else {
-            attachment.originalWidth to attachment.originalHeight
+                val (width, height) = if (attachment.originalWidth == null && attachment.originalHeight == null) {
+                    resolveLocalDimensions(file, attachment)
+                } else {
+                    attachment.originalWidth to attachment.originalHeight
+                }
+                attachment.copy(
+                    upload = file,
+                    extraData = attachment.extraData - EXTRA_SOURCE_URI,
+                    originalWidth = width,
+                    originalHeight = height,
+                )
+            }
         }
-        attachment.copy(
-            upload = file,
-            extraData = attachment.extraData - EXTRA_SOURCE_URI,
-            originalWidth = width,
-            originalHeight = height,
-        )
-    }
 
     /**
      * Resolves a list of file [Uri]s into [AttachmentMetaData].

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentStorageHelperTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/helper/internal/AttachmentStorageHelperTest.kt
@@ -19,13 +19,16 @@ package io.getstream.chat.android.ui.common.helper.internal
 import android.content.Context
 import android.net.Uri
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.test.TestCoroutineExtension
 import io.getstream.chat.android.ui.common.helper.internal.AttachmentStorageHelper.Companion.EXTRA_SOURCE_URI
 import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMetaData
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertSame
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.Mockito
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
@@ -166,7 +169,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles skips attachment with existing upload`() {
+    fun `resolveAttachmentFiles skips attachment with existing upload`() = runTest {
         val existingFile = mock<File>()
         val attachment = Attachment(upload = existingFile, type = "image")
 
@@ -176,7 +179,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles skips attachment without source URI`() {
+    fun `resolveAttachmentFiles skips attachment without source URI`() = runTest {
         val attachment = Attachment(type = "image", extraData = emptyMap())
 
         val result = sut.resolveAttachmentFiles(listOf(attachment))
@@ -185,7 +188,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles resolves file from source URI`() {
+    fun `resolveAttachmentFiles resolves file from source URI`() = runTest {
         val cachedFile = mock<File>()
         val sourceUri = "content://media/external/images/42"
         val parsedUri = mock<Uri>()
@@ -208,7 +211,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles reconstructs metadata from attachment fields`() {
+    fun `resolveAttachmentFiles reconstructs metadata from attachment fields`() = runTest {
         val sourceUri = "content://media/external/images/42"
         val parsedUri = mock<Uri>()
         val attachment = Attachment(
@@ -237,7 +240,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles drops attachment when file resolution fails`() {
+    fun `resolveAttachmentFiles drops attachment when file resolution fails`() = runTest {
         val sourceUri = "content://media/external/images/42"
         val parsedUri = mock<Uri>()
         val attachment = Attachment(
@@ -255,7 +258,7 @@ internal class AttachmentStorageHelperTest {
     }
 
     @Test
-    fun `resolveAttachmentFiles processes resolved, deferred, and missing-URI attachments independently`() {
+    fun `resolveAttachmentFiles processes resolved, deferred, and missing-URI attachments independently`() = runTest {
         val existingFile = mock<File>()
         val cachedFile = mock<File>()
         val parsedUri = mock<Uri>()
@@ -302,5 +305,11 @@ internal class AttachmentStorageHelperTest {
         val result = sut.resolveMetadata(emptyList())
 
         assertEquals(emptyList<AttachmentMetaData>(), result)
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutineExtension = TestCoroutineExtension()
     }
 }


### PR DESCRIPTION
### Goal

`AttachmentStorageHelper.resolveAttachmentFiles` was annotated `@WorkerThread` but passed around as a `suspend` lambda, making it look safe to call from any thread. Callers happened to wrap it in `withContext(DispatcherProvider.IO)`, but the responsibility was misplaced.

### Implementation

- Make `resolveAttachmentFiles` a `suspend` function that switches to `DispatcherProvider.IO` internally
- Remove the `@WorkerThread` annotation
- Remove `withContext(DispatcherProvider.IO)` wrappers from `MessageComposerController.sendMessage` and `enqueueEditMessage`
- Update tests to use `runTest` / `onBlocking`

### 🎨 UI Changes

None

### Testing

Existing tests updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved attachment resolution handling in the message composer by converting to asynchronous suspend-based operations. Removed explicit dispatcher switching for cleaner code while maintaining the same behavioral guarantees.

* **Tests**
  * Updated test infrastructure to support coroutine testing for attachment resolution workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->