### PR TITLE
Fix messages not being sent after attachment upload completes in background

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/attachment/worker/UploadAttachmentsWorker.kt
@@ -87,6 +87,7 @@ public class UploadAttachmentsWorker(
 
         return if (!hasPendingAttachment) {
             logger.d { "[sendAttachments] #uploader; message ${message.id} doesn't have pending attachments" }
+            AttachmentsUploadStates.updateMessageAttachments(message)
             Result.Success(Unit)
         } else {
             val attachments = uploadAttachments(message)


### PR DESCRIPTION
### Goal

Fix a race condition where messages with attachments are never sent to the server after a successful CDN upload, causing them to disappear from the UI until the app is restarted.

### Implementation

The attachment upload flow uses a WorkManager worker (`UploadAttachmentsWorker`) for the actual CDN upload and an in-memory coroutine observer (`AttachmentsUploadStates`) to bridge the result back to `AttachmentsSender.waitForAttachmentsToBeSent()`, which gates the `doSendMessage` call.

When the worker finds that all attachments are already uploaded (`!hasPendingAttachment`), it returned early **without** notifying `AttachmentsUploadStates`. This left the in-memory observer hanging indefinitely, so `waitForAttachmentsToBeSent` never completed and `doSendMessage` was never called.

This happens when:
1. The worker uploads attachments successfully but is killed before calling `updateMessages()`
2. On retry (reconnect or app restart), a new worker runs, reads the message from DB, sees all attachments already have `UploadState.Success`, and takes the early-return path — without signaling the observer

The fix adds `AttachmentsUploadStates.updateMessageAttachments(message)` to the early-return branch so the observer receives the success signal and `doSendMessage` proceeds.

### UI Changes

No UI changes.

### Testing

1. Send a message with an attachment
2. While the upload is in progress, toggle airplane mode or force-kill the app
3. Reopen the app or turn off airplane mode
4. Verify the message is sent successfully and appears in the message list

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed attachment upload state tracking to ensure proper state updates in all message scenarios. Previously, when messages had no pending attachments awaiting upload, the system would not update attachment upload states. This has been corrected to maintain consistent and accurate upload status tracking across all cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->