### PR TITLE
Fix composer attachment preview animation on removal

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -218,6 +218,7 @@ private fun MessageInputTop(
             if (showAttachments) {
                 ChatTheme.componentFactory.MessageComposerAttachments(
                     params = MessageComposerAttachmentsParams(
+                        modifier = Modifier.fillMaxWidth(),
                         attachments = attachments,
                         onAttachmentRemoved = onAttachmentRemoved,
                     ),


### PR DESCRIPTION
### Goal

Fix attachment preview sliding animation when removing attachments from the composer.

When two images are picked and the first one is removed, the second one animates as if it's entering
the layout from right to left instead of just sliding into place.

### Implementation

The `LazyRow` in `MessageComposerAttachments` wasn't full width, so removing an attachment caused it to shrink horizontally. So the fix is to pass `Modifier.fillMaxWidth()`
 

### 🎨 UI Changes

| Before | After |
|--------|-------|
| <video src="https://github.com/user-attachments/assets/06931202-9f6e-46f0-bde8-e2085d97c40e" controls="controls" muted="muted" /> | <video src="https://github.com/user-attachments/assets/26509b04-fb05-4419-9cd8-87737c9dc19a" controls="controls" muted="muted" /> |




### Testing

1. Open a channel and tap the attachment button
2. Pick two images
3. Remove the first one
4. Verify the second image slides smoothly to the left without a resize/entry animation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Message composer attachments now properly fill available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->