### PR TITLE
Fix unread separator not appearing on first mark-as-unread

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -230,7 +230,7 @@ public class MessageListController(
      */
     public val unreadLabelState: MutableStateFlow<UnreadLabel?> = MutableStateFlow(null)
     private val showUnreadButtonState = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
-    private val updateUnreadLabelState = MutableStateFlow(true)
+    private var lastProcessedReadMessageId: String? = null
     private val originalTranslationsStore by lazy { MessageOriginalTranslationsStore.forChannel(cid) }
 
     /**
@@ -586,44 +586,32 @@ public class MessageListController(
     /**
      * Observes and updates the unread label state by combining multiple data sources:
      * - Button visibility preference ([showUnreadButtonState])
-     * - Update trigger state ([updateUnreadLabelState])
      * - Channel state with all messages
      * - User read state ([ChannelUserRead])
      *
-     * The unread label is only calculated when all of the following conditions are met:
-     * 1. Updates are enabled ([updateUnreadLabelState] is true)
-     * 2. Not started for a thread ([isStartedForThread] is false)
-     * 3. The last read message ID has changed from the previous state
+     * The unread label is recalculated whenever [ChannelUserRead.lastReadMessageId] changes,
+     * but the result is "sticky": a null calculation never overwrites a non-null label.
+     * This ensures the separator persists when the user auto-reads messages by scrolling,
+     * while still reacting to mark-as-unread events (which move [lastReadMessageId] backward
+     * and produce a new non-null label).
      *
-     * Once conditions are met, delegates the actual calculation to [UnreadLabelCalculator] which
-     * handles the complex logic of determining unread message state, including edge cases for
-     * own messages, mark as unread functionality, and offline/pending message scenarios.
-     *
-     * After calculation, updates [unreadLabelState] and resets the update trigger to prevent
-     * unnecessary recalculations until the next state change.
+     * Delegates the actual calculation to [UnreadLabelCalculator] which handles the complex
+     * logic of determining unread message state, including edge cases for own messages,
+     * mark as unread functionality, and offline/pending message scenarios.
      */
     @Suppress("MagicNumber")
     private fun observeUnreadLabelState() {
         combine(
             showUnreadButtonState.onStart { emit(true) },
-            updateUnreadLabelState,
             channelState.filterNotNull(),
             channelState.filterNotNull().flatMapLatest { it.read },
-        ) { data ->
-            val shouldShowButton = data[0] as Boolean
-            val shouldUpdateLabelState = data[1] as Boolean
-            val channel = data[2] as ChannelState
-            val read = data[3] as ChannelUserRead?
-
-            // Only proceed with calculation if all conditions are met
+        ) { shouldShowButton, channel, read ->
             read
-                ?.takeIf { shouldUpdateLabelState }
                 ?.takeIf { !isStartedForThread }
-                ?.takeIf {
-                    val previousUnreadMessageId = unreadLabelState.value?.lastReadMessageId
-                    it.lastReadMessageId != null && previousUnreadMessageId != it.lastReadMessageId
-                }
+                ?.takeIf { it.lastReadMessageId != null && lastProcessedReadMessageId != it.lastReadMessageId }
                 ?.let { channelUserRead ->
+                    lastProcessedReadMessageId = channelUserRead.lastReadMessageId
+
                     // Delegate to the calculator for the complex unread label logic
                     val unreadLabel = unreadLabelCalculator.calculateUnreadLabel(
                         channelUserRead = channelUserRead,
@@ -632,10 +620,11 @@ public class MessageListController(
                         shouldShowButton = shouldShowButton,
                     )
 
-                    // Update the state with the calculated label
-                    unreadLabelState.value = unreadLabel
-                    // Prevent recalculation until the next trigger
-                    updateUnreadLabelState.value = false
+                    // Only update the label if the calculator produced a non-null result. This makes the label sticky:
+                    // once shown, it persists until the user leaves the channel.
+                    if (unreadLabel != null) {
+                        unreadLabelState.value = unreadLabel
+                    }
                 }
         }.launchIn(scope)
     }
@@ -1835,9 +1824,7 @@ public class MessageListController(
                         ErrorEvent.MarkUnreadError(it)
                     }
                 } else {
-                    // Emit with shouldShowButton = false
                     showUnreadButtonState.tryEmit(false)
-                    updateUnreadLabelState.value = true
                 }
             }
         }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -761,6 +761,52 @@ internal class MessageListControllerTests {
         }
 
     @Test
+    fun `Show unread label, when read state update arrives after markUnread succeeds`() = runTest {
+        val user = randomUser()
+        val messageA = randomMessage(id = "message_a")
+        val messageB = randomMessage(id = "message_b")
+        val messageC = randomMessage(id = "message_c")
+        val messages = listOf(messageA, messageB, messageC)
+        // Channel starts fully read: read state points to the last message
+        val channelUserRead = MutableStateFlow(
+            randomChannelUserRead(
+                user = user,
+                lastReadMessageId = messageC.id,
+                unreadMessages = 0,
+            ),
+        )
+        val messagesState = MutableStateFlow(messages)
+        val controller = Fixture()
+            .givenCurrentUser(user)
+            .givenChannelState(messagesState = messagesState, read = channelUserRead)
+            .givenMarkMessageUnread()
+            .get()
+
+        // Verify no unread label initially
+        controller.unreadLabelState.value.shouldBeNull()
+
+        // User marks messageB as unread: API succeeds but the server event hasn't arrived yet
+        controller.markUnread(messageB)
+
+        // The stale read state (still pointing to messageC) should not produce a label
+        controller.unreadLabelState.value.shouldBeNull()
+
+        // Now the server event arrives and updates the read state
+        channelUserRead.emit(
+            randomChannelUserRead(
+                user = user,
+                lastReadMessageId = messageA.id,
+                unreadMessages = 2,
+            ),
+        )
+
+        // The unread label should now be visible
+        val unreadLabel = controller.unreadLabelState.value
+        unreadLabel.`should not be null`()
+        unreadLabel.lastReadMessageId `should be equal to` messageA.id
+    }
+
+    @Test
     fun `When deleting message with playing audio, audio is stopped before deletion`() = runTest {
         val messageId = randomString()
         val audioRecording = randomAttachment(type = AttachmentType.AUDIO_RECORDING)
@@ -805,26 +851,27 @@ internal class MessageListControllerTests {
     }
 
     @Test
-    fun `When deleting message with audio attachment, and different audio is playing, audio is not stopped before deletion`() = runTest {
-        val messageId = randomString()
-        val audioRecording = randomAttachment(type = AttachmentType.AUDIO_RECORDING)
-        val messages = listOf(randomMessage(id = messageId, attachments = listOf(audioRecording)))
-        val messagesState = MutableStateFlow(messages)
+    fun `When deleting message with audio attachment, and different audio is playing, audio is not stopped before deletion`() =
+        runTest {
+            val messageId = randomString()
+            val audioRecording = randomAttachment(type = AttachmentType.AUDIO_RECORDING)
+            val messages = listOf(randomMessage(id = messageId, attachments = listOf(audioRecording)))
+            val messagesState = MutableStateFlow(messages)
 
-        val audioPlayer = mock<AudioPlayer>().apply {
-            whenever(currentState) doReturn AudioState.PLAYING
-            whenever(currentPlayingId) doReturn randomAttachment().audioHash
+            val audioPlayer = mock<AudioPlayer>().apply {
+                whenever(currentState) doReturn AudioState.PLAYING
+                whenever(currentPlayingId) doReturn randomAttachment().audioHash
+            }
+
+            val controller = Fixture()
+                .givenCurrentUser()
+                .givenChannelState(messagesState = messagesState)
+                .givenAudioPlayer(audioPlayer)
+                .givenDeleteMessage(callFrom { messages.first() })
+                .get()
+            controller.deleteMessage(messages.first())
+            verify(audioPlayer, times(0)).pause()
         }
-
-        val controller = Fixture()
-            .givenCurrentUser()
-            .givenChannelState(messagesState = messagesState)
-            .givenAudioPlayer(audioPlayer)
-            .givenDeleteMessage(callFrom { messages.first() })
-            .get()
-        controller.deleteMessage(messages.first())
-        verify(audioPlayer, times(0)).pause()
-    }
 
     @Test
     fun `When deleting message without attachments, audio is not stopped before deletion`() = runTest {
@@ -1001,52 +1048,54 @@ internal class MessageListControllerTests {
     }
 
     @Test
-    fun `When reactToMessage is called with skipPush set to true, sendReaction is invoked with skipPush true`() = runTest {
-        val messageId = randomString()
-        val reactionType = "love"
-        val reaction = randomReaction(messageId = messageId, type = reactionType)
-        val message = randomMessage(id = messageId, ownReactions = emptyList())
-        val messagesState = MutableStateFlow(listOf(message))
-        val chatClient = mock<ChatClient>()
-        val controller = Fixture(chatClient = chatClient)
-            .givenCurrentUser()
-            .givenChannelState(messagesState = messagesState)
-            .givenSendReaction(callFrom { reaction })
-            .get()
+    fun `When reactToMessage is called with skipPush set to true, sendReaction is invoked with skipPush true`() =
+        runTest {
+            val messageId = randomString()
+            val reactionType = "love"
+            val reaction = randomReaction(messageId = messageId, type = reactionType)
+            val message = randomMessage(id = messageId, ownReactions = emptyList())
+            val messagesState = MutableStateFlow(listOf(message))
+            val chatClient = mock<ChatClient>()
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser()
+                .givenChannelState(messagesState = messagesState)
+                .givenSendReaction(callFrom { reaction })
+                .get()
 
-        controller.reactToMessage(reaction, message, skipPush = true)
+            controller.reactToMessage(reaction, message, skipPush = true)
 
-        verify(chatClient).sendReaction(
-            enforceUnique = false,
-            reaction = reaction,
-            cid = CID,
-            skipPush = true,
-        )
-    }
+            verify(chatClient).sendReaction(
+                enforceUnique = false,
+                reaction = reaction,
+                cid = CID,
+                skipPush = true,
+            )
+        }
 
     @Test
-    fun `When reactToMessage is called with default skipPush value, sendReaction is invoked with skipPush false`() = runTest {
-        val messageId = randomString()
-        val reactionType = "love"
-        val reaction = randomReaction(messageId = messageId, type = reactionType)
-        val message = randomMessage(id = messageId, ownReactions = emptyList())
-        val messagesState = MutableStateFlow(listOf(message))
-        val chatClient = mock<ChatClient>()
-        val controller = Fixture(chatClient = chatClient)
-            .givenCurrentUser()
-            .givenChannelState(messagesState = messagesState)
-            .givenSendReaction(callFrom { reaction })
-            .get()
+    fun `When reactToMessage is called with default skipPush value, sendReaction is invoked with skipPush false`() =
+        runTest {
+            val messageId = randomString()
+            val reactionType = "love"
+            val reaction = randomReaction(messageId = messageId, type = reactionType)
+            val message = randomMessage(id = messageId, ownReactions = emptyList())
+            val messagesState = MutableStateFlow(listOf(message))
+            val chatClient = mock<ChatClient>()
+            val controller = Fixture(chatClient = chatClient)
+                .givenCurrentUser()
+                .givenChannelState(messagesState = messagesState)
+                .givenSendReaction(callFrom { reaction })
+                .get()
 
-        controller.reactToMessage(reaction, message)
+            controller.reactToMessage(reaction, message)
 
-        verify(chatClient).sendReaction(
-            enforceUnique = false,
-            reaction = reaction,
-            cid = CID,
-            skipPush = false,
-        )
-    }
+            verify(chatClient).sendReaction(
+                enforceUnique = false,
+                reaction = reaction,
+                cid = CID,
+                skipPush = false,
+            )
+        }
 
     @Test
     fun `When reactToMessage is called for existing reaction, deleteReaction is invoked`() = runTest {


### PR DESCRIPTION
### Goal

Fix unread message separator not appearing on the first mark-as-unread action. The separator only appeared if the user marked as unread a second time (and on the previously marked-as.

### Implementation

- Replace the `updateUnreadLabelState` boolean flag with a reactive approach: `observeUnreadLabelState` now recalculates whenever `lastReadMessageId` changes, using `lastProcessedReadMessageId` to skip duplicates. The flag caused a race condition: it was set in the `markUnread` success callback before the server event updated the read state, so the calculation ran on stale data and then blocked the real update.
- Make the unread label "sticky": null results (e.g. from auto-read on scroll) don't overwrite a non-null label.
- `markUnread()` no longer sets any trigger: the label appears when the `NotificationMarkUnreadEvent` updates the read state.
- Add a test covering the race condition scenario.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8c82e3f9-0516-48be-996d-7514e5eea98f" controls="controls" muted="muted" /> | <video src="https://github.com/user-attachments/assets/e653410e-64cc-4c68-87cb-8829fb4c30dd" controls="controls" muted="muted" /> |


### Testing

1. Open a channel where all messages are read
2. Long-press a message and select "Mark as unread"
3. Verify the unread separator appears immediately (not only on the second attempt)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unread label display behavior to ensure labels persist correctly when transitioning between read and unread message states, enhancing consistency in message management workflows

* **Tests**
  * Added test case for unread label visibility during mark unread operations before server state synchronization
  * Refactored existing test code for improved maintainability and readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->