### PR TITLE
Apply IME padding in create poll screen

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.rememberScrollState
@@ -73,7 +74,9 @@ public fun CreatePollScreen(
         }
     }
     Scaffold(
-        modifier = Modifier.systemBarsPadding(),
+        modifier = Modifier
+            .systemBarsPadding()
+            .imePadding(),
         containerColor = ChatTheme.colors.backgroundCoreApp,
         topBar = {
             PollCreationHeader(
@@ -96,9 +99,9 @@ public fun CreatePollScreen(
         Column(
             modifier = Modifier
                 .padding(padding)
+                .verticalScroll(rememberScrollState())
                 .padding(StreamTokens.spacingMd)
-                .fillMaxSize()
-                .verticalScroll(rememberScrollState()),
+                .fillMaxSize(),
         ) {
             // Poll question input
             PollQuestionInput(


### PR DESCRIPTION
### Goal

The create poll screen is not fully scrollable when the keyboard is open

### Implementation

We apply `imePadding` so that the content effectively resizes when the keyboard is open and can scroll. This also solves the problem occurring when adding an option that goes outside of the visible content portion -> after the changes, the column will auto scroll to show the focused input.

### 🎨 UI Changes

None

### Testing

Open the create poll screen, open the keyboard, and verify that you can scroll to the bottom. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed poll creation screen layout to properly adjust when the keyboard appears, preventing content overlap and improving user interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->