### PR TITLE
Fix message menu preview colors and quoted message icon size

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1486,7 +1486,7 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Mess
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooterKt {
-	public static final fun MessageThreadFooter (Ljava/util/List;Ljava/lang/String;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
+	public static final fun MessageThreadFooter-yrwZFoE (Ljava/util/List;Ljava/lang/String;Lio/getstream/chat/android/compose/state/messages/MessageAlignment;Landroidx/compose/ui/Modifier;JLandroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/PollMessageContentKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -74,10 +74,16 @@ public fun MessageFooter(
                     message.replyCount,
                 )
             }
+            val threadFooterTextColor = if (messageItem.isPreviewMode) {
+                ChatTheme.colors.textOnAccent
+            } else {
+                ChatTheme.colors.chatTextLink
+            }
             MessageThreadFooter(
                 participants = message.threadParticipants,
                 messageAlignment = alignment,
                 text = threadFooterText,
+                textColor = threadFooterTextColor,
             )
         }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
@@ -48,6 +48,7 @@ import kotlin.math.round
  * @param text Text of the label.
  * @param messageAlignment The alignment of the message, used for the content orientation.
  * @param modifier Modifier for styling.
+ * @param textColor Color of the thread replies label text.
  */
 @Composable
 public fun MessageThreadFooter(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageThreadFooter.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.StrokeJoin
@@ -54,6 +55,7 @@ public fun MessageThreadFooter(
     text: String,
     messageAlignment: MessageAlignment,
     modifier: Modifier = Modifier,
+    textColor: Color = ChatTheme.colors.chatTextLink,
 ) {
     Row(
         modifier = modifier,
@@ -69,7 +71,7 @@ public fun MessageThreadFooter(
             modifier = Modifier.testTag("Stream_ThreadRepliesLabel"),
             text = text,
             style = ChatTheme.typography.captionEmphasis,
-            color = ChatTheme.colors.chatTextLink,
+            color = textColor,
         )
 
         if (messageAlignment == MessageAlignment.End) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
@@ -167,6 +167,7 @@ private fun QuotedMessageText(body: QuotedMessageBody, color: Color) {
                 painter = painterResource(iconId),
                 contentDescription = null,
                 tint = color,
+                modifier = Modifier.size(12.dp),
             )
         }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
@@ -114,7 +114,7 @@ public fun SelectedMessageMenu(
     currentUser: User? = null,
     onDismiss: () -> Unit = {},
 ) {
-    val selectedMessageSnapshot = LocalSelectedMessageSnapshot.current.value
+    val selectedMessageSnapshot by LocalSelectedMessageSnapshot.current
     val messageItemState = MessageItemState(
         message = message,
         isMine = message.user.id == currentUser?.id,
@@ -267,7 +267,7 @@ private fun Modifier.unclippedVerticalScroll(state: UnclippedScrollState): Modif
 }
 
 private const val BackgroundBlur = 50
-private const val DimAmount = 0.6f
+private const val DimAmount = 0.7f
 
 /**
  * Holds the animation state for the [SelectedMessageMenu] pop-out effect.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -414,7 +414,7 @@ private fun ShowInChannelAnnotation(item: MessageItemState, onThreadClick: (Mess
             text = stringResource(alsoSendToChannelTextRes),
             trailingText = stringResource(R.string.stream_compose_message_list_view),
             contentColor = item.annotationContentColor(),
-            trailingTextColor = ChatTheme.colors.chatTextLink,
+            trailingTextColor = item.annotationContentColor(default = ChatTheme.colors.chatTextLink),
             onClick = { onThreadClick(item.message) },
         )
     }


### PR DESCRIPTION
### Goal

Fix message appearance issues in the selected message menu (preview mode) and fix the quoted message icon size.

### Implementation

- Update thread footer text and annotations colors to use the correct tint in preview mode (selected message menu)
- Increase the dim amount behind the selected message menu to increase contrast
- Set explicit size on the quoted message type icon to match the designs

### 🎨 UI Changes

| Before | After |
|--------|-------|
| <img width="540" height="1200" alt="Screenshot_20260408_104226" src="https://github.com/user-attachments/assets/f8d3c1e6-fc7c-45df-a9e4-41863e5ba480" /> | <img width="540" height="1200" alt="Screenshot_20260408_104110" src="https://github.com/user-attachments/assets/7a7dd28a-766c-42b6-8089-fb569fc8b20f" /> |
| <img width="540" height="193" alt="Screenshot_20260408_104245" src="https://github.com/user-attachments/assets/7adf9c92-0332-4117-8220-31b48ec0c3f7" /> | <img width="540" height="192" alt="Screenshot_20260408_104144" src="https://github.com/user-attachments/assets/90af20e5-e14c-4589-aab5-fd9462073c64" /> |



### Testing

1. Open a channel with threaded messages
2. Long-press a message that has thread replies → verify the thread footer text and annotation colors look correct on the dimmed preview
3. Reply to a message with a quoted message → verify the quote icon is properly sized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Message thread footer text now dynamically adjusts colors based on message context
  * Quoted message icons display with consistent fixed sizing
  * Message annotation colors better adapt to preview mode requirements
  * Message selection menu features enhanced visibility through improved dialog dimming

<!-- end of auto-generated comment: release notes by coderabbit.ai -->