### PR TITLE
Remove pinned channel items customization from the demo

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
@@ -116,9 +116,7 @@ class ChannelsActivity : ComponentActivity() {
         val currentUserId = chatClient.getCurrentUser()?.id ?: ""
         ChannelListViewModelFactory(
             chatClient = chatClient,
-            querySort = QuerySortByField
-                .descByName<Channel>("pinned_at") // pinned channels first
-                .desc("last_updated"), // then by last updated
+            querySort = QuerySortByField.descByName("last_updated"),
             filters = Filters.and(
                 Filters.eq("type", "messaging"),
                 Filters.`in`("members", listOf(currentUserId)),

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/feature/channel/list/ChannelsActivity.kt
@@ -83,10 +83,8 @@ import io.getstream.chat.android.compose.ui.channels.info.SelectedChannelMenu
 import io.getstream.chat.android.compose.ui.channels.list.ChannelItem
 import io.getstream.chat.android.compose.ui.channels.list.ChannelList
 import io.getstream.chat.android.compose.ui.components.SearchInput
-import io.getstream.chat.android.compose.ui.components.channels.ChannelOptionItemVisibility
 import io.getstream.chat.android.compose.ui.components.channels.buildDefaultChannelActions
 import io.getstream.chat.android.compose.ui.mentions.MentionList
-import io.getstream.chat.android.compose.ui.theme.ChannelOptionsTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.threads.ThreadList
 import io.getstream.chat.android.compose.viewmodel.channels.ChannelListViewModel
@@ -157,11 +155,6 @@ class ChannelsActivity : ComponentActivity() {
                 dateFormatter = ChatApp.dateFormatter,
                 allowUIAutomationTest = true,
                 componentFactory = CustomChatComponentFactory(),
-                channelOptionsTheme = ChannelOptionsTheme.defaultTheme(
-                    optionVisibility = ChannelOptionItemVisibility(
-                        isPinChannelVisible = true,
-                    ),
-                ),
             ) {
                 val user by channelsViewModel.user.collectAsStateWithLifecycle()
                 val drawerState = rememberDrawerState(DrawerValue.Closed)

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -444,7 +444,7 @@ class ChatsActivity : ComponentActivity() {
                     is ChannelInfoViewEvent.UnmuteUser,
                     is ChannelInfoViewEvent.BlockUser,
                     is ChannelInfoViewEvent.UnblockUser,
-                        -> Unit
+                    -> Unit
                 }
             }
         }
@@ -712,37 +712,37 @@ private fun ThreePaneNavigator.navigateToChannel(
 private fun Context.showError(error: ChannelInfoViewEvent.Error) {
     val message = when (error) {
         ChannelInfoViewEvent.RenameChannelError,
-            -> UiCommonR.string.stream_ui_channel_info_rename_group_error
+        -> UiCommonR.string.stream_ui_channel_info_rename_group_error
 
         ChannelInfoViewEvent.MuteChannelError,
         ChannelInfoViewEvent.UnmuteChannelError,
-            -> UiCommonR.string.stream_ui_channel_info_mute_conversation_error
+        -> UiCommonR.string.stream_ui_channel_info_mute_conversation_error
 
         ChannelInfoViewEvent.MuteUserError,
         ChannelInfoViewEvent.UnmuteUserError,
-            -> UiCommonR.string.stream_ui_channel_info_mute_user_error
+        -> UiCommonR.string.stream_ui_channel_info_mute_user_error
 
         ChannelInfoViewEvent.BlockUserError,
         ChannelInfoViewEvent.UnblockUserError,
-            -> UiCommonR.string.stream_ui_channel_info_block_user_error
+        -> UiCommonR.string.stream_ui_channel_info_block_user_error
 
         ChannelInfoViewEvent.LeaveChannelError,
-            -> UiCommonR.string.stream_ui_channel_info_leave_conversation_error
+        -> UiCommonR.string.stream_ui_channel_info_leave_conversation_error
 
         ChannelInfoViewEvent.DeleteChannelError,
-            -> UiCommonR.string.stream_ui_channel_info_delete_conversation_error
+        -> UiCommonR.string.stream_ui_channel_info_delete_conversation_error
 
         ChannelInfoViewEvent.BanMemberError,
-            -> UiCommonR.string.stream_ui_channel_info_ban_member_error
+        -> UiCommonR.string.stream_ui_channel_info_ban_member_error
 
         ChannelInfoViewEvent.UnbanMemberError,
-            -> UiCommonR.string.stream_ui_channel_info_unban_member_error
+        -> UiCommonR.string.stream_ui_channel_info_unban_member_error
 
         ChannelInfoViewEvent.RemoveMemberError,
-            -> UiCommonR.string.stream_ui_channel_info_remove_member_error
+        -> UiCommonR.string.stream_ui_channel_info_remove_member_error
 
         ChannelInfoViewEvent.AddMembersError,
-            -> UiCommonR.string.stream_ui_channel_info_add_members_error
+        -> UiCommonR.string.stream_ui_channel_info_add_members_error
     }
     Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -165,7 +165,6 @@ class ChatsActivity : ComponentActivity() {
                 channelOptionsTheme = ChannelOptionsTheme.defaultTheme(
                     optionVisibility = ChannelOptionItemVisibility(
                         isViewInfoVisible = AdaptiveLayoutInfo.singlePaneWindow(),
-                        isPinChannelVisible = true,
                     ),
                 ),
             ) {

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -134,9 +134,7 @@ class ChatsActivity : ComponentActivity() {
         val currentUserId = chatClient.getCurrentUser()?.id ?: ""
         ChannelListViewModelFactory(
             chatClient = chatClient,
-            querySort = QuerySortByField
-                .descByName<Channel>("pinned_at") // pinned channels first
-                .desc("last_updated"), // then by last updated
+            querySort = QuerySortByField.descByName("last_updated"),
             filters = Filters.and(
                 Filters.eq("type", "messaging"),
                 Filters.`in`("members", listOf(currentUserId)),
@@ -447,7 +445,7 @@ class ChatsActivity : ComponentActivity() {
                     is ChannelInfoViewEvent.UnmuteUser,
                     is ChannelInfoViewEvent.BlockUser,
                     is ChannelInfoViewEvent.UnblockUser,
-                    -> Unit
+                        -> Unit
                 }
             }
         }
@@ -715,37 +713,37 @@ private fun ThreePaneNavigator.navigateToChannel(
 private fun Context.showError(error: ChannelInfoViewEvent.Error) {
     val message = when (error) {
         ChannelInfoViewEvent.RenameChannelError,
-        -> UiCommonR.string.stream_ui_channel_info_rename_group_error
+            -> UiCommonR.string.stream_ui_channel_info_rename_group_error
 
         ChannelInfoViewEvent.MuteChannelError,
         ChannelInfoViewEvent.UnmuteChannelError,
-        -> UiCommonR.string.stream_ui_channel_info_mute_conversation_error
+            -> UiCommonR.string.stream_ui_channel_info_mute_conversation_error
 
         ChannelInfoViewEvent.MuteUserError,
         ChannelInfoViewEvent.UnmuteUserError,
-        -> UiCommonR.string.stream_ui_channel_info_mute_user_error
+            -> UiCommonR.string.stream_ui_channel_info_mute_user_error
 
         ChannelInfoViewEvent.BlockUserError,
         ChannelInfoViewEvent.UnblockUserError,
-        -> UiCommonR.string.stream_ui_channel_info_block_user_error
+            -> UiCommonR.string.stream_ui_channel_info_block_user_error
 
         ChannelInfoViewEvent.LeaveChannelError,
-        -> UiCommonR.string.stream_ui_channel_info_leave_conversation_error
+            -> UiCommonR.string.stream_ui_channel_info_leave_conversation_error
 
         ChannelInfoViewEvent.DeleteChannelError,
-        -> UiCommonR.string.stream_ui_channel_info_delete_conversation_error
+            -> UiCommonR.string.stream_ui_channel_info_delete_conversation_error
 
         ChannelInfoViewEvent.BanMemberError,
-        -> UiCommonR.string.stream_ui_channel_info_ban_member_error
+            -> UiCommonR.string.stream_ui_channel_info_ban_member_error
 
         ChannelInfoViewEvent.UnbanMemberError,
-        -> UiCommonR.string.stream_ui_channel_info_unban_member_error
+            -> UiCommonR.string.stream_ui_channel_info_unban_member_error
 
         ChannelInfoViewEvent.RemoveMemberError,
-        -> UiCommonR.string.stream_ui_channel_info_remove_member_error
+            -> UiCommonR.string.stream_ui_channel_info_remove_member_error
 
         ChannelInfoViewEvent.AddMembersError,
-        -> UiCommonR.string.stream_ui_channel_info_add_members_error
+            -> UiCommonR.string.stream_ui_channel_info_add_members_error
     }
     Toast.makeText(applicationContext, message, Toast.LENGTH_SHORT).show()
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/component/CustomChatComponentFactory.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/component/CustomChatComponentFactory.kt
@@ -16,11 +16,9 @@
 
 package io.getstream.chat.android.compose.sample.ui.component
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import io.getstream.chat.android.client.extensions.isPinned
 import io.getstream.chat.android.compose.sample.ui.location.LocationComponentFactory
 import io.getstream.chat.android.compose.sample.vm.SharedLocationViewModelFactory
 import io.getstream.chat.android.compose.ui.channels.list.ChannelItem
@@ -40,11 +38,6 @@ class CustomChatComponentFactory(
     override fun LazyItemScope.ChannelListItemContent(params: ChannelListItemContentParams) {
         val coordinator = LocalSwipeRevealCoordinator.current
         val swipeEnabled = ChatTheme.config.channelList.swipeActionsEnabled && coordinator != null
-        val pinnedModifier = if (params.channelItem.channel.isPinned()) {
-            Modifier.background(color = ChatTheme.colors.backgroundCoreHighlight)
-        } else {
-            Modifier
-        }
 
         if (swipeEnabled) {
             SwipeableChannelItem(
@@ -54,7 +47,6 @@ class CustomChatComponentFactory(
                 swipeActions = { ChannelSwipeActions(ChannelSwipeActionsParams(params.channelItem)) },
             ) {
                 ChannelItem(
-                    modifier = pinnedModifier,
                     channelItem = params.channelItem,
                     currentUser = params.currentUser,
                     onChannelClick = params.onChannelClick,
@@ -63,7 +55,7 @@ class CustomChatComponentFactory(
             }
         } else {
             ChannelItem(
-                modifier = Modifier.animateItem().then(pinnedModifier),
+                modifier = Modifier.animateItem(),
                 channelItem = params.channelItem,
                 currentUser = params.currentUser,
                 onChannelClick = params.onChannelClick,


### PR DESCRIPTION
### Goal

Removing the custom background for pinned channels. We'll revisit it after the state is designed and bring it to the SDK.

### Implementation

Remove the background modifier.

### 🎨 UI Changes

Pinned channels now look visually identical to regular ones

### Testing

Launch the compose sample, pin a channel and verify that the corresponding channel item looks identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed visual styling previously applied to pinned channels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->