### PR TITLE
Replace ChatTheme with ChatPreviewTheme in Compose previews

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -466,39 +466,39 @@ public final class io/getstream/chat/android/compose/ui/attachments/content/Comp
 public final class io/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$FileAttachmentContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$FileAttachmentContentKt;
 	public fun <init> ()V
-	public final fun getLambda$-1438497045$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-190394655$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1709464528$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1103268560$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-158367770$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-229440939$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$GiphyAttachmentContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$GiphyAttachmentContentKt;
 	public fun <init> ()V
-	public final fun getLambda$148516783$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1129161930$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$271803750$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$LinkAttachmentContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$LinkAttachmentContentKt;
 	public fun <init> ()V
-	public final fun getLambda$-1039792722$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$711826331$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-326727309$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1342017654$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$MediaAttachmentContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$MediaAttachmentContentKt;
 	public fun <init> ()V
-	public final fun getLambda$-112484143$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1286615753$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1310088420$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1438143150$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1772229418$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$517707180$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$604805366$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$UnsupportedAttachmentContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/attachments/content/ComposableSingletons$UnsupportedAttachmentContentKt;
 	public fun <init> ()V
-	public final fun getLambda$1585511707$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$74927776$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContentKt {
@@ -719,11 +719,11 @@ public final class io/getstream/chat/android/compose/ui/channel/attachments/Comp
 public final class io/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelFilesAttachmentsScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelFilesAttachmentsScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$-1605074509$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1105952831$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1430999464$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1974083312$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$320933252$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1929160531$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-619185079$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1179308856$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$165834500$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$463499381$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelMediaAttachmentsGridKt {
@@ -740,18 +740,18 @@ public final class io/getstream/chat/android/compose/ui/channel/attachments/Comp
 public final class io/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelMediaAttachmentsPreviewScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelMediaAttachmentsPreviewScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$-1516918540$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1465845588$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1920060441$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2102936505$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelMediaAttachmentsScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/attachments/ComposableSingletons$ChannelMediaAttachmentsScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$-1530630590$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1634553890$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-2011005747$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-849534311$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1568152074$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1789652642$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-595823289$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1720295075$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$57568143$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$773377618$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ChannelInfoMemberOptionsKt {
@@ -761,82 +761,82 @@ public final class io/getstream/chat/android/compose/ui/channel/info/ChannelInfo
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$AddMembersScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$AddMembersScreenKt;
 	public fun <init> ()V
+	public final fun getLambda$-1405797700$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-153564054$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1609278116$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1754400971$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1915312793$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-416001815$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-583584479$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-386570093$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-80773330$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1302953779$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1486904705$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1885975461$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$239876316$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$579647544$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1557441282$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2101868791$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$756179806$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoMemberInfoModalSheetKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoMemberInfoModalSheetKt;
 	public fun <init> ()V
-	public final fun getLambda$-1892406114$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1862093938$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2059119949$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2063755161$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-496513353$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-983067788$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1054007122$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1693499577$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoOptionItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoOptionItemKt;
 	public fun <init> ()V
-	public final fun getLambda$-132121367$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1960660711$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-761876236$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2123306414$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoOptionKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoOptionKt;
 	public fun <init> ()V
-	public final fun getLambda$-25888197$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-374874103$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$878977789$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1867261042$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1160171714$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$255305728$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoScreenModalKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$ChannelInfoScreenModalKt;
 	public fun <init> ()V
-	public final fun getLambda$-1276733865$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1747879428$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-221195044$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1163325870$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2077810280$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$831333506$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2049244919$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-563668452$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1272363629$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1580953399$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1632291101$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1741641217$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$DirectChannelInfoScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$DirectChannelInfoScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$1370191152$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1685690876$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1581494219$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1717717761$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$621085431$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$GroupChannelEditScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$GroupChannelEditScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$-1110400167$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-12028341$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1600862874$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1661534055$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1831392551$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1839460112$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1942727980$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1996460951$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-465025143$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-831942993$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1264790270$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$343549382$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1055248884$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1145027614$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$326726436$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$GroupChannelInfoScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channel/info/ComposableSingletons$GroupChannelInfoScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$-1305793373$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1507130086$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-392871553$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$389406287$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$421433172$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$496355070$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreenKt {
@@ -867,20 +867,20 @@ public final class io/getstream/chat/android/compose/ui/channels/header/ChannelL
 public final class io/getstream/chat/android/compose/ui/channels/header/ComposableSingletons$ChannelListHeaderKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channels/header/ComposableSingletons$ChannelListHeaderKt;
 	public fun <init> ()V
-	public final fun getLambda$-1324713633$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-235659580$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$10820473$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1232866394$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1672244468$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1292686748$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1705746086$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1568094879$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$179857529$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$346048958$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$423422310$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$787072767$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$757173855$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/info/ComposableSingletons$SelectedChannelMenuKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channels/info/ComposableSingletons$SelectedChannelMenuKt;
 	public fun <init> ()V
-	public final fun getLambda$-955116528$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$111766296$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-242051115$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1913914739$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/info/SelectedChannelMenuKt {
@@ -903,16 +903,16 @@ public final class io/getstream/chat/android/compose/ui/channels/list/ChannelsKt
 public final class io/getstream/chat/android/compose/ui/channels/list/ComposableSingletons$ChannelItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/channels/list/ComposableSingletons$ChannelItemKt;
 	public fun <init> ()V
-	public final fun getLambda$-1472148447$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-771013692$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-86407129$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-952065423$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1166029362$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1472702270$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1887486643$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-274403902$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-282474796$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1116178185$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1856191852$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$2102561016$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$501943268$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$507293945$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$657407377$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$691813735$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$415043430$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$544083894$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$713246335$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/channels/list/ComposableSingletons$ChannelListKt {
@@ -1034,7 +1034,7 @@ public final class io/getstream/chat/android/compose/ui/components/BackButtonKt 
 public final class io/getstream/chat/android/compose/ui/components/ComposableSingletons$ComposerCancelIconKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/ComposableSingletons$ComposerCancelIconKt;
 	public fun <init> ()V
-	public final fun getLambda$1634313180$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1373681311$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/ComposableSingletons$ContentBoxKt {
@@ -1049,8 +1049,8 @@ public final class io/getstream/chat/android/compose/ui/components/ComposableSin
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/ComposableSingletons$SearchInputKt;
 	public fun <init> ()V
 	public final fun getLambda$-750420177$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1565415609$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1909378300$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$233887348$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$236027516$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
@@ -1121,14 +1121,14 @@ public final class io/getstream/chat/android/compose/ui/components/TypingIndicat
 public final class io/getstream/chat/android/compose/ui/components/attachments/files/ComposableSingletons$FileTypeIconKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/attachments/files/ComposableSingletons$FileTypeIconKt;
 	public fun <init> ()V
-	public final fun getLambda$996617216$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1123694299$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/attachments/files/ComposableSingletons$FilesPickerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/attachments/files/ComposableSingletons$FilesPickerKt;
 	public fun <init> ()V
-	public final fun getLambda$-1807171839$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1876189767$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-74041324$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-814338404$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/attachments/files/FilesPickerItemImageKt {
@@ -1142,8 +1142,8 @@ public final class io/getstream/chat/android/compose/ui/components/attachments/f
 public final class io/getstream/chat/android/compose/ui/components/attachments/images/ComposableSingletons$ImagesPickerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/attachments/images/ComposableSingletons$ImagesPickerKt;
 	public fun <init> ()V
-	public final fun getLambda$1093518618$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$219419166$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-946020897$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$346496249$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPickerKt {
@@ -1182,7 +1182,7 @@ public final class io/getstream/chat/android/compose/ui/components/avatar/UserAv
 public final class io/getstream/chat/android/compose/ui/components/button/ComposableSingletons$StreamButtonKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/button/ComposableSingletons$StreamButtonKt;
 	public fun <init> ()V
-	public final fun getLambda$-1671965942$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1758989925$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/ChannelMembersKt {
@@ -1221,37 +1221,37 @@ public final class io/getstream/chat/android/compose/ui/components/channels/Chan
 public final class io/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelMembersItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelMembersItemKt;
 	public fun <init> ()V
-	public final fun getLambda$-1607936099$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1963513822$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelMembersKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelMembersKt;
 	public fun <init> ()V
-	public final fun getLambda$-737831824$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1384888714$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1022886705$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$377363061$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelOptionsKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$ChannelOptionsKt;
 	public fun <init> ()V
-	public final fun getLambda$-1559608358$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-318157067$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$MessageReadStatusIconKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$MessageReadStatusIconKt;
 	public fun <init> ()V
-	public final fun getLambda$-1898830442$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-391714226$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1790224229$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1960355408$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$291099282$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1647806185$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1791677654$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1866803557$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-532463445$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1410434217$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$UnreadCountIndicatorKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/channels/ComposableSingletons$UnreadCountIndicatorKt;
 	public fun <init> ()V
-	public final fun getLambda$-272662860$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-42321177$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-18848510$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2083398969$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIconKt {
@@ -1266,52 +1266,52 @@ public final class io/getstream/chat/android/compose/ui/components/channels/Unre
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CheckboxKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CheckboxKt;
 	public fun <init> ()V
-	public final fun getLambda$298991631$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1373305238$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CommandChipKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CommandChipKt;
 	public fun <init> ()V
-	public final fun getLambda$473282067$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1833759698$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$ContextualMenuKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$ContextualMenuKt;
 	public fun <init> ()V
-	public final fun getLambda$-1222383709$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-864803787$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1562365186$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-1654572528$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CountBadgeKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$CountBadgeKt;
 	public fun <init> ()V
-	public final fun getLambda$-719429203$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-476020088$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$MediaBadgesKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$MediaBadgesKt;
 	public fun <init> ()V
-	public final fun getLambda$-1298911357$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2087776955$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2088680098$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1298008214$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$PlayButtonKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$PlayButtonKt;
 	public fun <init> ()V
-	public final fun getLambda$-2000894519$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1757485404$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$PlaybackSpeedToggleKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$PlaybackSpeedToggleKt;
 	public fun <init> ()V
-	public final fun getLambda$698458355$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1734516466$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/ComposableSingletons$RadioControlsKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/common/ComposableSingletons$RadioControlsKt;
 	public fun <init> ()V
-	public final fun getLambda$-1046860619$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$97132495$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-766878934$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$449288698$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/common/MenuOptionItemKt {
@@ -1321,40 +1321,40 @@ public final class io/getstream/chat/android/compose/ui/components/common/MenuOp
 public final class io/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$ComposerLinkPreviewKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$ComposerLinkPreviewKt;
 	public fun <init> ()V
-	public final fun getLambda$-362064487$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1988658444$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1162160133$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$InputFieldKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$InputFieldKt;
 	public fun <init> ()V
-	public final fun getLambda$-1900866656$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-2036292143$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$87058875$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$87675692$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$MessageInputKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/composer/ComposableSingletons$MessageInputKt;
 	public fun <init> ()V
-	public final fun getLambda$-113487264$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1294719589$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1320161390$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1355851382$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1923436456$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-2062700177$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-2118032157$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-478449831$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-56438772$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-994252424$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1107182454$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1168391597$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1538434652$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1557130645$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1712133389$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1810236223$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1927791224$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2100166240$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-385204485$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-613114465$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-980303670$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$137395624$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1508406964$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1540807894$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1746250067$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$400470815$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$151741492$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1674120915$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1748505211$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1752110961$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$253863128$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$418285475$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$597539196$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$875844176$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$897469466$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$744518823$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/composer/ComposerLinkPreviewKt {
@@ -1415,28 +1415,27 @@ public final class io/getstream/chat/android/compose/ui/components/messageoption
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageAnnotationKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageAnnotationKt;
 	public fun <init> ()V
-	public final fun getLambda$-767333439$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1122911162$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageReactionsKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageReactionsKt;
 	public fun <init> ()V
-	public final fun getLambda$-1059558486$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1527197621$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1471536306$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$236674883$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1027531601$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2110365577$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-814132208$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$268701768$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageTextKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$MessageTextKt;
 	public fun <init> ()V
-	public final fun getLambda$1220446100$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$356434671$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$PollMessageContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$PollMessageContentKt;
 	public fun <init> ()V
-	public final fun getLambda$-1089255054$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1403107585$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-748128248$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$1104625805$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
@@ -1445,13 +1444,14 @@ public final class io/getstream/chat/android/compose/ui/components/messages/Comp
 	public final fun getLambda$43473281$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$491054200$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$73995334$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$772737421$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$ScrollToBottomButtonKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$ScrollToBottomButtonKt;
 	public fun <init> ()V
 	public final fun getLambda$-388063089$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-467770097$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1520155434$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/messages/ComposableSingletons$SwipeToReplyIconKt {
@@ -1519,39 +1519,39 @@ public final class io/getstream/chat/android/compose/ui/components/moderatedmess
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollAnswersKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollAnswersKt;
 	public fun <init> ()V
+	public final fun getLambda$-1299065846$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1437491986$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1980307438$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-49181804$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$87229295$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollDialogHeaderKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollDialogHeaderKt;
 	public fun <init> ()V
+	public final fun getLambda$-1287465228$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1604073059$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1766050777$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollMoreOptionsDialogKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollMoreOptionsDialogKt;
 	public fun <init> ()V
-	public final fun getLambda$1208762119$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-417831838$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollOptionInputKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollOptionInputKt;
 	public fun <init> ()V
 	public final fun getLambda$-1720332981$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$122960071$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-666808670$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollOptionVotesDialogKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollOptionVotesDialogKt;
 	public fun <init> ()V
-	public final fun getLambda$-1564698708$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1875956809$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1962869644$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-2004235384$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-760761924$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-847674759$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1237881649$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1365316907$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$715521557$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
@@ -1559,7 +1559,7 @@ public final class io/getstream/chat/android/compose/ui/components/poll/Composab
 public final class io/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollViewResultDialogKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/poll/ComposableSingletons$PollViewResultDialogKt;
 	public fun <init> ()V
-	public final fun getLambda$987675446$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1114752529$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/poll/PollAnswersKt {
@@ -1586,8 +1586,8 @@ public final class io/getstream/chat/android/compose/ui/components/poll/PollView
 public final class io/getstream/chat/android/compose/ui/components/reactionoptions/ComposableSingletons$ExtendedReactionsOptionsKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactionoptions/ComposableSingletons$ExtendedReactionsOptionsKt;
 	public fun <init> ()V
-	public final fun getLambda$-861146946$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$866156213$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$221249561$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$360082938$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPickerKt {
@@ -1598,13 +1598,13 @@ public final class io/getstream/chat/android/compose/ui/components/reactionpicke
 public final class io/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionIconKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionIconKt;
 	public fun <init> ()V
-	public final fun getLambda$1477272512$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1451796101$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionToggleKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactions/ComposableSingletons$ReactionToggleKt;
 	public fun <init> ()V
-	public final fun getLambda$1064847264$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$895131621$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/reactions/ReactionIconSize : java/lang/Enum {
@@ -1630,7 +1630,7 @@ public final class io/getstream/chat/android/compose/ui/components/reactions/Rea
 public final class io/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$MessageMenuHeaderKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$MessageMenuHeaderKt;
 	public fun <init> ()V
-	public final fun getLambda$-660138000$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1595289781$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1869643284$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
@@ -1638,25 +1638,25 @@ public final class io/getstream/chat/android/compose/ui/components/selectedmessa
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$ReactionCountRowKt;
 	public fun <init> ()V
 	public final fun getLambda$-188139460$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$44960862$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1160155747$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$ReactionsMenuKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$ReactionsMenuKt;
 	public fun <init> ()V
 	public final fun getLambda$-20300968$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
-	public final fun getLambda$-415514562$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-80286077$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1440428061$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1730935492$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$238548553$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$59986053$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$SelectedMessageMenuKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$SelectedMessageMenuKt;
 	public fun <init> ()V
-	public final fun getLambda$-191593560$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2090706559$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$225023982$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1159831283$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2118494916$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$743213741$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/selectedmessage/ComposableSingletons$UserReactionRowKt {
@@ -1681,12 +1681,12 @@ public final class io/getstream/chat/android/compose/ui/components/selectedmessa
 public final class io/getstream/chat/android/compose/ui/mentions/ComposableSingletons$MentionListKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/mentions/ComposableSingletons$MentionListKt;
 	public fun <init> ()V
-	public final fun getLambda$-1978692236$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1648615685$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-538646917$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$-795021929$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-851032954$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1350748755$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$1359378806$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$163517569$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2003796050$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1452263631$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$2116007242$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$462284$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$515697460$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
@@ -1748,13 +1748,13 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/Att
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentCameraPickerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentCameraPickerKt;
 	public fun <init> ()V
-	public final fun getLambda$-313938492$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$21289993$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentCommandPickerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentCommandPickerKt;
 	public fun <init> ()V
-	public final fun getLambda$1271230468$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1303257353$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentFilePickerKt {
@@ -1773,7 +1773,7 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/Com
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentPollPickerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentPollPickerKt;
 	public fun <init> ()V
-	public final fun getLambda$1043631876$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-995907639$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentSystemPickerKt {
@@ -1790,13 +1790,13 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/Com
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentTypePickerKt;
 	public fun <init> ()V
 	public final fun getLambda$-1321973654$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-181453354$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1539499066$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1970833877$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-28915135$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-308459981$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-765021006$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1811714596$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$996584103$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-227824919$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-276433096$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-37368329$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1797541698$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$448737969$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/media/CaptureMediaLauncherKt {
@@ -1806,51 +1806,51 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/med
 public final class io/getstream/chat/android/compose/ui/messages/attachments/permission/ComposableSingletons$RequiredPermissionKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/permission/ComposableSingletons$RequiredPermissionKt;
 	public fun <init> ()V
-	public final fun getLambda$1470298408$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1639086230$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$217660009$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1742272381$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2055624625$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$634198404$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$CreatePollScreenKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$CreatePollScreenKt;
 	public fun <init> ()V
-	public final fun getLambda$445456107$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1181137850$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollCreationDiscardDialogKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollCreationDiscardDialogKt;
 	public fun <init> ()V
 	public final fun getLambda$-2072874969$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1494974890$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$311491696$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$694017295$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollCreationHeaderKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollCreationHeaderKt;
 	public fun <init> ()V
-	public final fun getLambda$-1563672386$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1629039687$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2035736286$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-850606973$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1775632701$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollOptionListKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollOptionListKt;
 	public fun <init> ()V
-	public final fun getLambda$-1440257200$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1579021486$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1340853611$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1838918800$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-463826601$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-727191787$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollQuestionInputKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollQuestionInputKt;
 	public fun <init> ()V
-	public final fun getLambda$1373246723$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1722936098$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollSwitchListKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/attachments/poll/ComposableSingletons$PollSwitchListKt;
 	public fun <init> ()V
-	public final fun getLambda$1918515607$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2045592690$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreenKt {
@@ -1909,18 +1909,18 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/pol
 public final class io/getstream/chat/android/compose/ui/messages/composer/ComposableSingletons$MessageComposerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/ComposableSingletons$MessageComposerKt;
 	public fun <init> ()V
-	public final fun getLambda$-1104901750$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1152001217$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1267828661$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1299182102$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1344661276$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1514671585$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-442939612$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-497399815$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$118207285$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1281276965$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-182144176$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1921332230$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-403250353$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-579864284$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-80861420$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1434062186$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$327411855$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1697815360$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$419456890$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$757974155$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/MessageComposerKt {
@@ -1989,14 +1989,14 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/intern
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$MessageComposerEditIndicatorKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$MessageComposerEditIndicatorKt;
 	public fun <init> ()V
-	public final fun getLambda$-210022583$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$724784718$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$MessageComposerInputCenterBottomContentKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$MessageComposerInputCenterBottomContentKt;
 	public fun <init> ()V
-	public final fun getLambda$-1430221957$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-2059370188$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-629264362$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-976973681$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$MessageComposerInputTrailingContentKt {
@@ -2015,22 +2015,22 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/intern
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentFileItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentFileItemKt;
 	public fun <init> ()V
-	public final fun getLambda$1472501659$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1134910688$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentMediaItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentMediaItemKt;
 	public fun <init> ()V
-	public final fun getLambda$-1412908130$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-96176450$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$116152749$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1523175629$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1896414915$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$579683235$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentsKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/attachments/ComposableSingletons$MessageComposerAttachmentsKt;
 	public fun <init> ()V
-	public final fun getLambda$-141030617$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1146143444$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/suggestions/ComposableSingletons$CommandSuggestionListKt {
@@ -2053,17 +2053,17 @@ public final class io/getstream/chat/android/compose/ui/messages/header/ChannelH
 public final class io/getstream/chat/android/compose/ui/messages/header/ComposableSingletons$ChannelHeaderKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/header/ComposableSingletons$ChannelHeaderKt;
 	public fun <init> ()V
-	public final fun getLambda$-1576348248$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-211507329$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-305687282$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$156623393$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$855685815$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1746063891$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-193662957$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-665589828$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$33472594$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$69686596$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageDividerKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageDividerKt;
 	public fun <init> ()V
-	public final fun getLambda$-1392871724$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2038084143$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/list/ComposableSingletons$MessageItemKt {
@@ -2142,17 +2142,17 @@ public final class io/getstream/chat/android/compose/ui/pinned/ComposableSinglet
 public final class io/getstream/chat/android/compose/ui/pinned/ComposableSingletons$PinnedMessageListKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/pinned/ComposableSingletons$PinnedMessageListKt;
 	public fun <init> ()V
-	public final fun getLambda$-1120837415$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-1332077747$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-1435677118$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1548711106$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-1898313330$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-571196465$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-919228080$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2023693399$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-349926631$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-359893398$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-559017010$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$-985680375$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1364442154$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$182923723$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1933801843$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$102958725$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1659152085$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1679073040$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$2069332084$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$499338964$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
@@ -6247,22 +6247,22 @@ public final class io/getstream/chat/android/compose/ui/threads/ComposableSingle
 public final class io/getstream/chat/android/compose/ui/threads/ComposableSingletons$ThreadListKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/threads/ComposableSingletons$ThreadListKt;
 	public fun <init> ()V
-	public final fun getLambda$-728650777$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1513335613$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1533256568$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1602147948$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1474737923$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-2085062879$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-252283151$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-360054938$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-898366420$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1270065410$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$1876441331$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1928710492$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$285832544$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$378546529$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$432214945$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function4;
 }
 
 public final class io/getstream/chat/android/compose/ui/threads/ComposableSingletons$ThreadListLoadingItemKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/threads/ComposableSingletons$ThreadListLoadingItemKt;
 	public fun <init> ()V
-	public final fun getLambda$-1684327148$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-924643591$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-1890861228$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$957850927$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/threads/ThreadItemKt {
@@ -6317,7 +6317,7 @@ public final class io/getstream/chat/android/compose/ui/util/ChannelUtilsKt {
 public final class io/getstream/chat/android/compose/ui/util/ComposableSingletons$MessagePreviewIconFactoryKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/util/ComposableSingletons$MessagePreviewIconFactoryKt;
 	public fun <init> ()V
-	public final fun getLambda$-461649061$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$-631364704$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/util/ComposableSingletons$SnackbarPopupKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -48,6 +48,7 @@ import io.getstream.chat.android.compose.state.messages.attachments.AttachmentSt
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.components.attachments.files.FileTypeIcon
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.FileAttachmentItemParams
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
@@ -306,7 +307,7 @@ internal fun onFileAttachmentContentItemClick(
 @Preview(showBackground = true)
 @Composable
 private fun OwnFileAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         FileAttachmentContent(isMine = true)
     }
 }
@@ -314,7 +315,7 @@ private fun OwnFileAttachmentContentPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun OtherFileAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         FileAttachmentContent(isMine = false)
     }
 }
@@ -347,7 +348,7 @@ internal fun FileAttachmentContent(isMine: Boolean, isUploading: Boolean = false
 @Preview(showBackground = true)
 @Composable
 private fun UploadingFileAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         val attachments = listOf(
             Attachment(
                 mimeType = MimeType.MIME_TYPE_PDF,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -53,6 +53,7 @@ import coil3.compose.LocalAsyncImagePreviewHandler
 import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -281,7 +282,7 @@ public data class GiphyAttachmentClickData internal constructor(
 @Composable
 @Preview(showBackground = true)
 private fun GiphyAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         GiphyAttachmentContent()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -60,6 +60,7 @@ import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -316,7 +317,7 @@ internal fun onLinkAttachmentContentClick(context: Context, url: String) {
 @Preview(showBackground = true)
 @Composable
 private fun FullSizeLinkAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         LinkAttachmentContent(1)
     }
 }
@@ -324,7 +325,7 @@ private fun FullSizeLinkAttachmentContentPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun CompactLinkAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         LinkAttachmentContent(2)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -83,6 +83,7 @@ import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
 import io.getstream.chat.android.compose.ui.components.common.PlayButton
 import io.getstream.chat.android.compose.ui.components.common.PlayButtonSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -693,7 +694,7 @@ internal fun onMediaAttachmentContentItemClick(
 @Composable
 @Preview(showBackground = true)
 private fun SingleMediaAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SingleMediaAttachmentContent()
     }
 }
@@ -726,7 +727,7 @@ internal fun SingleMediaAttachmentContent() {
 @Composable
 @Preview(showBackground = true)
 private fun MultipleMediaAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MultipleMediaAttachmentContent()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/UnsupportedAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/UnsupportedAttachmentContent.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.components.attachments.files.FileTypeIcon
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -102,7 +103,7 @@ private val supportedAttachmentTypes = setOf(
 @Preview(showBackground = true)
 @Composable
 private fun OwnUnsupportedAttachmentContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         UnsupportedAttachmentContent(
             state = AttachmentState(
                 message = Message(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelFilesAttachmentsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelFilesAttachmentsScreen.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentDe
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentImage
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentStyle
 import io.getstream.chat.android.compose.ui.theme.ChannelFilesAttachmentsTopBarParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.clickable
 import io.getstream.chat.android.compose.viewmodel.channel.ChannelAttachmentsViewModel
@@ -158,7 +159,7 @@ internal fun ChannelFilesAttachmentsItem(
 @Preview
 @Composable
 private fun ChannelFilesAttachmentsLoadingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelFilesAttachmentsLoading()
     }
 }
@@ -175,7 +176,7 @@ internal fun ChannelFilesAttachmentsLoading() {
 @Preview
 @Composable
 private fun ChannelFilesAttachmentsEmptyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelFilesAttachmentsEmpty()
     }
 }
@@ -194,7 +195,7 @@ internal fun ChannelFilesAttachmentsEmpty() {
 @Preview
 @Composable
 private fun ChannelFilesAttachmentsContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelFilesAttachmentsContent()
     }
 }
@@ -218,7 +219,7 @@ internal fun ChannelFilesAttachmentsContent() {
 @Preview
 @Composable
 private fun ChannelFilesAttachmentsErrorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelFilesAttachmentsError()
     }
 }
@@ -237,7 +238,7 @@ internal fun ChannelFilesAttachmentsError() {
 @Preview
 @Composable
 private fun ChannelFilesAttachmentsLoadingMorePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelFilesAttachmentsLoadingMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsPreviewScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsPreviewScreen.kt
@@ -49,6 +49,7 @@ import io.getstream.chat.android.compose.ui.attachments.preview.internal.VideoPl
 import io.getstream.chat.android.compose.ui.attachments.preview.internal.rememberMediaGalleryPlayerState
 import io.getstream.chat.android.compose.ui.theme.ChannelMediaAttachmentsPreviewBottomBarParams
 import io.getstream.chat.android.compose.ui.theme.ChannelMediaAttachmentsPreviewTopBarParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.StreamSnackbarHost
 import io.getstream.chat.android.compose.viewmodel.channel.ChannelMediaAttachmentsPreviewViewAction
@@ -249,7 +250,7 @@ private fun ChannelMediaAttachmentsPreviewBottomBar(
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsPreviewContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsPreviewContent()
     }
 }
@@ -271,7 +272,7 @@ internal fun ChannelMediaAttachmentsPreviewContent() {
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsPreviewPreparingToShareContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsPreviewPreparingToShareContent()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsScreen.kt
@@ -40,6 +40,7 @@ import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.components.common.VideoBadge
 import io.getstream.chat.android.compose.ui.theme.ChannelMediaAttachmentsTopBarParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
@@ -185,7 +186,7 @@ internal fun ChannelMediaAttachmentsItem(
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsLoadingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsLoading()
     }
 }
@@ -201,7 +202,7 @@ internal fun ChannelMediaAttachmentsLoading() {
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsEmptyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsEmpty()
     }
 }
@@ -219,7 +220,7 @@ internal fun ChannelMediaAttachmentsEmpty() {
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsContent()
     }
 }
@@ -242,7 +243,7 @@ internal fun ChannelMediaAttachmentsContent() {
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsErrorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsError()
     }
 }
@@ -260,7 +261,7 @@ internal fun ChannelMediaAttachmentsError() {
 @Preview
 @Composable
 private fun ChannelMediaAttachmentsLoadingMorePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMediaAttachmentsLoadingMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/AddMembersScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/AddMembersScreen.kt
@@ -53,6 +53,7 @@ import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.components.button.StreamButton
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
@@ -329,7 +330,7 @@ private fun AddMembersEmptyState() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenLoadingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenLoading()
     }
 }
@@ -349,7 +350,7 @@ internal fun AddMembersScreenLoading() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenEmptyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenEmpty()
     }
 }
@@ -373,7 +374,7 @@ internal fun AddMembersScreenEmpty() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenResultsWithQueryPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenResultsWithQuery()
     }
 }
@@ -397,7 +398,7 @@ internal fun AddMembersScreenResultsWithQuery() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenResultsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenResults()
     }
 }
@@ -420,7 +421,7 @@ internal fun AddMembersScreenResults() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenResultsWithSelectionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenResultsWithSelection()
     }
 }
@@ -444,7 +445,7 @@ internal fun AddMembersScreenResultsWithSelection() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenResultsWithMemberPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenResultsWithMember()
     }
 }
@@ -468,7 +469,7 @@ internal fun AddMembersScreenResultsWithMember() {
 @Preview(showBackground = true)
 @Composable
 private fun AddMembersScreenLoadingMorePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AddMembersScreenLoadingMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoMemberInfoModalSheet.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoMemberInfoModalSheet.kt
@@ -45,6 +45,7 @@ import io.getstream.chat.android.compose.ui.components.ContentBox
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.theme.ChannelInfoMemberInfoModalSheetTopBarParams
 import io.getstream.chat.android.compose.ui.theme.ChannelInfoMemberOptionItemParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
@@ -215,7 +216,7 @@ private fun Member.getBanExpirationText(context: Context): String {
 @Preview
 @Composable
 private fun ChannelInfoMemberInfoModalSheetContentBannedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ExpandedSheet {
             ChannelInfoMemberInfoModalSheetContent(banned = true)
         }
@@ -225,7 +226,7 @@ private fun ChannelInfoMemberInfoModalSheetContentBannedPreview() {
 @Preview
 @Composable
 private fun ChannelInfoMemberInfoModalSheetContentNotBannedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ExpandedSheet {
             ChannelInfoMemberInfoModalSheetContent(banned = false)
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoOption.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoOption.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.StreamSwitch
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -170,7 +171,7 @@ internal fun ChannelInfoOptionSwitch(
 @Preview(showBackground = true)
 @Composable
 private fun ChannelInfoOptionButtonPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoOptionButton(
             icon = R.drawable.stream_design_ic_delete,
             text = "Delete",
@@ -182,7 +183,7 @@ private fun ChannelInfoOptionButtonPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelInfoOptionNavigationButtonPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoOptionNavigationButton(
             icon = R.drawable.stream_design_ic_folder,
             text = "Files",
@@ -194,7 +195,7 @@ private fun ChannelInfoOptionNavigationButtonPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelInfoOptionSwitchPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoOptionSwitch(
             icon = R.drawable.stream_design_ic_mute,
             text = "Mute",

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoOptionItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoOptionItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.ui.common.feature.channel.info.ChannelInfoViewAction
 import io.getstream.chat.android.ui.common.state.channel.info.ChannelInfoViewState
@@ -180,7 +181,7 @@ private fun ChannelInfoOptionContent(
 @Preview
 @Composable
 private fun DirectChannelInfoOptionItemsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoOptionItems()
     }
 }
@@ -188,7 +189,7 @@ private fun DirectChannelInfoOptionItemsPreview() {
 @Preview
 @Composable
 private fun GroupChannelInfoOptionItemsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoOptionItems(isGroupChannel = true)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoScreenModal.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/ChannelInfoScreenModal.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.components.SimpleDialog
 import io.getstream.chat.android.compose.ui.theme.ChannelInfoScreenModalParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.clickable
 import io.getstream.chat.android.previewdata.PreviewMembersData
@@ -200,7 +201,7 @@ private fun BanMemberModalText(
 @Preview
 @Composable
 private fun ChannelInfoScreenModalLeaveDirectChannelPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModal(
             modal = ChannelInfoViewEvent.LeaveChannelModal,
             isGroupChannel = false,
@@ -211,7 +212,7 @@ private fun ChannelInfoScreenModalLeaveDirectChannelPreview() {
 @Preview
 @Composable
 private fun ChannelInfoScreenModalLeaveGroupChannelPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModal(
             modal = ChannelInfoViewEvent.LeaveChannelModal,
             isGroupChannel = true,
@@ -222,7 +223,7 @@ private fun ChannelInfoScreenModalLeaveGroupChannelPreview() {
 @Preview
 @Composable
 private fun ChannelInfoScreenModalDeleteDirectChannelPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModal(
             modal = ChannelInfoViewEvent.DeleteChannelModal,
             isGroupChannel = false,
@@ -233,7 +234,7 @@ private fun ChannelInfoScreenModalDeleteDirectChannelPreview() {
 @Preview
 @Composable
 private fun ChannelInfoScreenModalDeleteGroupChannelPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModal(
             modal = ChannelInfoViewEvent.DeleteChannelModal,
             isGroupChannel = true,
@@ -244,7 +245,7 @@ private fun ChannelInfoScreenModalDeleteGroupChannelPreview() {
 @Preview
 @Composable
 private fun ChannelInfoScreenModalBanMemberPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModalBanMember()
     }
 }
@@ -262,7 +263,7 @@ internal fun ChannelInfoScreenModalBanMember() {
 @Preview
 @Composable
 private fun ChannelInfoScreenModalRemoveMemberPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelInfoScreenModalRemoveMember()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
@@ -50,6 +50,7 @@ import io.getstream.chat.android.compose.ui.components.ContentBox
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.theme.ChannelInfoOptionItemParams
 import io.getstream.chat.android.compose.ui.theme.ChannelInfoScreenModalParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.DirectChannelInfoAvatarContainerParams
 import io.getstream.chat.android.compose.ui.theme.DirectChannelInfoTopBarParams
@@ -315,7 +316,7 @@ internal fun List<ChannelInfoViewState.Content.Option>.filterActions() = filter 
 @Preview
 @Composable
 private fun DirectChannelInfoContentLoadingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         DirectChannelInfoLoading()
     }
 }
@@ -334,7 +335,7 @@ internal fun DirectChannelInfoLoading() {
 @Preview
 @Composable
 private fun DirectChannelInfoContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         DirectChannelInfoContent()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelEditScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelEditScreen.kt
@@ -69,6 +69,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleD
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
 import io.getstream.chat.android.compose.ui.messages.attachments.media.rememberCaptureMediaLauncher
 import io.getstream.chat.android.compose.ui.theme.ChannelAvatarParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.ViewModelStore
@@ -407,7 +408,7 @@ private fun ChannelNameField(
 @Preview
 @Composable
 private fun GroupChannelEditPlaceholderPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ViewModelStore {
             GroupChannelEditPlaceholder()
         }
@@ -424,7 +425,7 @@ internal fun GroupChannelEditPlaceholder() {
 @Preview
 @Composable
 private fun GroupChannelEditFilledPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         GroupChannelEditFilled()
     }
 }
@@ -440,7 +441,7 @@ internal fun GroupChannelEditFilled() {
 @Preview
 @Composable
 private fun GroupChannelEditBusyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         GroupChannelEditBusy()
     }
 }
@@ -457,7 +458,7 @@ internal fun GroupChannelEditBusy() {
 @Preview
 @Composable
 private fun ImagePickerOptionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ImagePickerOptionsWithRemove()
     }
 }
@@ -473,7 +474,7 @@ internal fun ImagePickerOptionsWithRemove() {
 @Preview
 @Composable
 private fun ImagePickerOptionsNoRemovePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ImagePickerOptionsNoRemove()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
@@ -581,7 +581,7 @@ internal fun GroupChannelInfoLoading() {
 @Preview(showBackground = true)
 @Composable
 private fun GroupChannelInfoCollapsedMembersPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         GroupChannelInfoCollapsedMembers()
     }
 }
@@ -625,7 +625,7 @@ internal fun GroupChannelInfoCollapsedMembers() {
 @Preview(showBackground = true)
 @Composable
 private fun GroupChannelInfoExpandedMembersPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         GroupChannelInfoExpandedMembers()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/header/ChannelListHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/header/ChannelListHeader.kt
@@ -51,6 +51,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamButton
 import io.getstream.chat.android.compose.ui.theme.ChannelListHeaderCenterContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelListHeaderLeadingContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelListHeaderTrailingContentParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
@@ -247,7 +248,7 @@ internal fun DefaultChannelListHeaderTrailingContent(
 @Preview
 @Composable
 private fun ChannelListHeaderConnectedNoUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderConnectedNoUser()
     }
 }
@@ -255,7 +256,7 @@ private fun ChannelListHeaderConnectedNoUserPreview() {
 @Preview
 @Composable
 private fun ChannelListHeaderConnectedWithUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderConnectedWithUser()
     }
 }
@@ -263,7 +264,7 @@ private fun ChannelListHeaderConnectedWithUserPreview() {
 @Preview
 @Composable
 private fun ChannelListHeaderConnectingNoUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderConnectingNoUser()
     }
 }
@@ -271,7 +272,7 @@ private fun ChannelListHeaderConnectingNoUserPreview() {
 @Preview
 @Composable
 private fun ChannelListHeaderConnectingWithUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderConnectingWithUser()
     }
 }
@@ -279,7 +280,7 @@ private fun ChannelListHeaderConnectingWithUserPreview() {
 @Preview
 @Composable
 private fun ChannelListHeaderOfflineNoUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderOfflineNoUser()
     }
 }
@@ -287,7 +288,7 @@ private fun ChannelListHeaderOfflineNoUserPreview() {
 @Preview
 @Composable
 private fun ChannelListHeaderOfflineWithUserPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelListHeaderOfflineWithUser()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/info/SelectedChannelMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/info/SelectedChannelMenu.kt
@@ -41,6 +41,7 @@ import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.theme.ChannelAvatarParams
 import io.getstream.chat.android.compose.ui.theme.ChannelMenuCenterContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelMenuHeaderContentParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.getMembersStatusText
@@ -176,7 +177,7 @@ internal fun DefaultSelectedChannelMenuHeaderContent(
 @Preview(showBackground = true, name = "SelectedChannelMenu Preview (Centered dialog)")
 @Composable
 private fun SelectedChannelMenuCenteredDialogPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Box(modifier = Modifier.fillMaxSize()) {
             val channel = PreviewChannelData.channelWithManyMembers
             SelectedChannelMenu(
@@ -206,7 +207,7 @@ private fun SelectedChannelMenuCenteredDialogPreview() {
 @Preview(showBackground = true, name = "SelectedChannelMenu Preview (Bottom sheet dialog)")
 @Composable
 private fun SelectedChannelMenuBottomSheetDialogPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Box(modifier = Modifier.fillMaxSize()) {
             val channel = PreviewChannelData.channelWithManyMembers
             SelectedChannelMenu(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -70,6 +70,7 @@ import io.getstream.chat.android.compose.ui.theme.ChannelItemReadStatusIndicator
 import io.getstream.chat.android.compose.ui.theme.ChannelItemTrailingContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelItemUnreadCountIndicatorParams
 import io.getstream.chat.android.compose.ui.theme.ChannelListConfig
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 import io.getstream.chat.android.compose.ui.theme.MuteIndicatorPosition
@@ -455,7 +456,7 @@ internal fun RowScope.DefaultChannelItemTrailingContent(
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemNoMessagesPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemNoMessages()
     }
 }
@@ -471,7 +472,7 @@ internal fun ChannelItemNoMessages() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemMutedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemMuted()
     }
 }
@@ -509,7 +510,7 @@ internal fun ChannelItemMutedTrailingBottom() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemUnreadMessagesPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemUnreadMessages()
     }
 }
@@ -527,7 +528,7 @@ internal fun ChannelItemUnreadMessages() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemLastMessagePendingStatusPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemLastMessagePendingStatus()
     }
 }
@@ -547,7 +548,7 @@ internal fun ChannelItemLastMessagePendingStatus() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemLastMessageSentStatusPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemLastMessageSentStatus()
     }
 }
@@ -567,7 +568,7 @@ internal fun ChannelItemLastMessageSentStatus() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemLastMessageDeliveredStatusPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemLastMessageDeliveredStatus()
     }
 }
@@ -593,7 +594,7 @@ internal fun ChannelItemLastMessageDeliveredStatus() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemLastMessageSeenStatusPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemLastMessageSeenStatus()
     }
 }
@@ -614,7 +615,7 @@ internal fun ChannelItemLastMessageSeenStatus() {
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemDraftMessagePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemDraftMessage()
     }
 }
@@ -652,7 +653,7 @@ private fun ChannelItem(
 @Preview(showBackground = true)
 @Composable
 private fun ChannelItemSelectedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelItemSelected()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/ComposerCancelIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/ComposerCancelIcon.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.clickable
 
@@ -61,7 +62,7 @@ public fun ComposerCancelIcon(
 @Preview
 @Composable
 private fun ComposerCancelIconPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ComposerCancelIcon {}
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/SearchInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/SearchInput.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.SearchInputClearButtonParams
 import io.getstream.chat.android.compose.ui.theme.SearchInputLabelParams
@@ -222,7 +223,7 @@ internal fun DefaultSearchClearButton(onClick: () -> Unit) {
 @Preview(name = "Search input")
 @Composable
 private fun SearchInputPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         var searchQuery by rememberSaveable { mutableStateOf("") }
 
         SearchInput(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FileTypeIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FileTypeIcon.kt
@@ -36,7 +36,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.StreamPrimitiveColors
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -70,7 +70,7 @@ private const val IconLabelFontSize = 8
 @Preview
 @Composable
 private fun FileTypeIconsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         FileTypeIcons()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
@@ -41,6 +41,7 @@ import io.getstream.chat.android.compose.state.messages.attachments.AttachmentPi
 import io.getstream.chat.android.compose.ui.components.StreamHorizontalDivider
 import io.getstream.chat.android.compose.ui.components.common.RadioButton
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -173,7 +174,7 @@ internal fun DefaultFilesPickerItem(
 @Preview(showBackground = true)
 @Composable
 private fun FilesPickerSingleSelectionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         FilesPickerSingleSelection()
     }
 }
@@ -199,7 +200,7 @@ internal fun FilesPickerSingleSelection() {
 @Preview(showBackground = true)
 @Composable
 private fun FilesPickerMultipleSelectionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         FilesPickerMultipleSelection()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -47,6 +47,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentPickerItemState
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
 import io.getstream.chat.android.compose.ui.components.common.VideoBadge
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
@@ -202,7 +203,7 @@ private const val VideoLengthInSeconds = 60L
 @Preview(showBackground = true)
 @Composable
 private fun ImagesPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ImagesPickerSelection()
     }
 }
@@ -231,7 +232,7 @@ internal fun ImagesPickerSelection() {
 @Preview(showBackground = true)
 @Composable
 private fun ImagesPickerAddMorePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ImagesPickerAddMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/AvatarStack.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/AvatarStack.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
 import io.getstream.chat.android.models.User
@@ -79,7 +80,7 @@ internal fun UserAvatarStack(
 private fun AvatarStackPreview() {
     val users = List(size = 5) { PreviewUserData.userWithoutImage.copy(name = "User $it", id = "$it") }
 
-    ChatTheme {
+    ChatPreviewTheme {
         UserAvatarStack(overlap = 16.dp, users = users, avatarSize = AvatarSize.Medium)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/ChannelAvatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/ChannelAvatar.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.common.CountBadge
 import io.getstream.chat.android.compose.ui.components.common.CountBadgeSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.applyIf
@@ -318,7 +319,7 @@ private fun directMessageRecipient(channel: Channel, currentUser: User?): User? 
 private fun ChannelAvatarPreview() {
     val sizes = AvatarSize.run { listOf(ExtraExtraLarge * 1.5f, ExtraExtraLarge, ExtraLarge, Large, Medium) }
     val variants = listOf(0, 1, 2, 3, 4, 5, 13, 1000)
-    ChatTheme {
+    ChatPreviewTheme {
         Column(
             modifier = Modifier
                 .background(ChatTheme.colors.backgroundCoreApp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/UserAvatar.kt
@@ -38,7 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
-import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.previewdata.PreviewUserData
 import io.getstream.chat.android.ui.common.utils.extensions.initials
@@ -164,7 +164,7 @@ private fun rememberPlaceholderInitials(user: User, availableWidth: Dp): String 
 private fun AvatarPreview() {
     val sizes = AvatarSize.run { listOf(ExtraLarge, Large, Medium, Small, ExtraSmall) }
 
-    ChatTheme {
+    ChatPreviewTheme {
         Column(Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(8.dp)) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/button/StreamButton.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.ifNotNull
@@ -115,7 +116,7 @@ internal fun StreamButton(
 @Preview(showBackground = true)
 @Composable
 private fun StreamButtonPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         val styles = listOf(
             StreamButtonStyleDefaults.primarySolid,
             StreamButtonStyleDefaults.primaryOutline,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelMembers.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelMembers.kt
@@ -27,7 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.Member
 import io.getstream.chat.android.models.User
@@ -71,7 +71,7 @@ public fun ChannelMembers(
 @Preview(showBackground = true, name = "ChannelMembers Preview (One member)")
 @Composable
 private fun OneMemberChannelMembersPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMembers(members = PreviewMembersData.oneMember)
     }
 }
@@ -82,7 +82,7 @@ private fun OneMemberChannelMembersPreview() {
 @Preview(showBackground = true, name = "ChannelMembers Preview (Many members)")
 @Composable
 private fun ManyMembersChannelMembersPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMembers(members = PreviewMembersData.manyMembers)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelMembersItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelMembersItem.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
 import io.getstream.chat.android.models.Member
@@ -78,7 +79,7 @@ internal fun ChannelMembersItem(
 @Preview(showBackground = true, name = "ChannelMembersItem Preview")
 @Composable
 private fun ChannelMemberItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelMembersItem(Member(user = PreviewUserData.user1))
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/ChannelOptions.kt
@@ -31,6 +31,7 @@ import io.getstream.chat.android.client.extensions.isArchive
 import io.getstream.chat.android.client.extensions.isPinned
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChannelOptionsItemParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.isDistinct
@@ -514,7 +515,7 @@ private fun buildGroupMuteAction(
 @Preview(showBackground = true, name = "ChannelOptions Preview")
 @Composable
 private fun ChannelOptionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         val channel = PreviewChannelData.channelWithMessages
         ChannelOptions(
             actions = listOf(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessageReadStatusIcon.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.extensions.deliveredReadsOf
 import io.getstream.chat.android.client.extensions.getCreatedAtOrThrow
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.getReadStatuses
@@ -200,7 +201,7 @@ private fun IsDeliveredIcon(modifier: Modifier) {
 @Preview
 @Composable
 private fun MessageReadStatusIconPendingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageReadStatusIconPending()
     }
 }
@@ -216,7 +217,7 @@ internal fun MessageReadStatusIconPending() {
 @Preview
 @Composable
 private fun MessageReadStatusIconSentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageReadStatusIconSent()
     }
 }
@@ -232,7 +233,7 @@ internal fun MessageReadStatusIconSent() {
 @Preview
 @Composable
 private fun MessageReadStatusIconDeliveredPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageReadStatusIconDelivered()
     }
 }
@@ -249,7 +250,7 @@ internal fun MessageReadStatusIconDelivered() {
 @Preview
 @Composable
 private fun MessageReadStatusIconReadPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageReadStatusIconRead()
     }
 }
@@ -266,7 +267,7 @@ internal fun MessageReadStatusIconRead() {
 @Preview
 @Composable
 private fun MessageReadStatusIconErrorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageReadStatusIconError()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/UnreadCountIndicator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/UnreadCountIndicator.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -79,7 +80,7 @@ private const val LimitTooManyUnreadCount = 99
 @Preview(showBackground = true, name = "UnreadCountIndicator Preview (Few unread messages)")
 @Composable
 private fun FewMessagesUnreadCountIndicatorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         UnreadCountIndicator(unreadCount = 5)
     }
 }
@@ -92,7 +93,7 @@ private fun FewMessagesUnreadCountIndicatorPreview() {
 @Preview(showBackground = true, name = "UnreadCountIndicator Preview (Many unread messages)")
 @Composable
 private fun ManyMessagesUnreadCountIndicatorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         UnreadCountIndicator(unreadCount = 200)
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/Checkbox.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/Checkbox.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.animation.FadingVisibility
@@ -91,7 +92,7 @@ private val CheckboxShape = RoundedCornerShape(StreamTokens.radiusSm)
 @Preview
 @Composable
 private fun CheckboxPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(
             modifier = Modifier.padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/CommandChip.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/CommandChip.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -82,7 +83,7 @@ internal fun CommandChip(
 @Preview
 @Composable
 private fun CommandChipPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         CommandChip(
             modifier = Modifier.padding(8.dp),
             command = PreviewCommandData.command1,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/ContextualMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/ContextualMenu.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -133,7 +134,7 @@ internal fun ContextualMenuDivider(modifier: Modifier = Modifier) {
 @Preview(showBackground = true)
 @Composable
 private fun ContextualMenuPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ContextualMenu(
             Modifier
                 .padding(32.dp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/CountBadge.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/CountBadge.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamDesign
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -100,7 +101,7 @@ internal data class CountBadgeSize(
 @Preview
 @Composable
 private fun CountBadgePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
             CountBadgeSize.entries.forEach { size ->
                 CountBadge(text = "+99", size = size)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/MediaBadges.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/MediaBadges.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import java.util.Locale
@@ -127,7 +128,7 @@ private fun Long.toPreciseDuration(): String = seconds.toComponents { hours, min
 @Preview
 @Composable
 private fun MediaBadgeCompactPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row {
             VideoBadge(durationInSeconds = 8, compact = true)
             AudioBadge(durationInSeconds = 8, compact = true)
@@ -138,7 +139,7 @@ private fun MediaBadgeCompactPreview() {
 @Preview
 @Composable
 private fun MediaBadgePrecisePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row {
             VideoBadge(durationInSeconds = 8)
             AudioBadge(durationInSeconds = 8)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/PlayButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/PlayButton.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.ifNotNull
 
@@ -76,7 +77,7 @@ internal enum class PlayButtonSize(val componentSize: Dp, val iconSize: Dp) {
 @Preview
 @Composable
 private fun PlayButtonPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(
             horizontalArrangement = Arrangement.spacedBy(16.dp),
             verticalAlignment = Alignment.CenterVertically,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/PlaybackSpeedToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/PlaybackSpeedToggle.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.applyIf
@@ -74,7 +75,7 @@ private val SpeedToggleShape = RoundedCornerShape(StreamTokens.radiusLg)
 @Preview
 @Composable
 private fun PlaybackSpeedTogglePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(modifier = Modifier.padding(16.dp)) {
             PlaybackSpeedToggle(
                 speed = 1.5f,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/RadioControls.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/common/RadioControls.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.animation.FadingVisibility
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -131,7 +132,7 @@ private fun RadioControlBase(
 @Preview
 @Composable
 private fun RadioButtonPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(
             modifier = Modifier.padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
@@ -147,7 +148,7 @@ private fun RadioButtonPreview() {
 @Preview
 @Composable
 private fun RadioCheckPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(
             modifier = Modifier.padding(16.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/ComposerLinkPreview.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/ComposerLinkPreview.kt
@@ -55,6 +55,7 @@ import coil3.ColorImage
 import coil3.compose.LocalAsyncImagePreviewHandler
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamDesign
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -215,7 +216,7 @@ private fun LinkPreview.resolveUrl() = attachment.run { titleLink ?: ogUrl }
 @Preview(showBackground = true)
 @Composable
 private fun ComposerLinkContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ComposerLinkPreview()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/InputField.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/InputField.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ComposerInputFieldTheme
 import io.getstream.chat.android.compose.ui.theme.StreamDesign
@@ -158,7 +159,7 @@ private class DefaultInputFieldVisualTransformation(
 @Preview
 @Composable
 private fun InputFieldPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         InputField(
             modifier = Modifier.fillMaxWidth(),
             value = "InputFieldPreview",

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.messages.composer.actions.AudioRecordingActions
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ComposerConfig
 import io.getstream.chat.android.compose.ui.theme.LocalChatUiConfig
@@ -241,7 +242,7 @@ private fun MessageInputTop(
 @Preview
 @Composable
 private fun MessageComposerInputPlaceholderPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputPlaceholder()
     }
 }
@@ -256,7 +257,7 @@ internal fun MessageComposerInputPlaceholder() {
 @Preview
 @Composable
 private fun MessageComposerInputFilledPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputFilled()
     }
 }
@@ -273,7 +274,7 @@ internal fun MessageComposerInputFilled() {
 @Preview
 @Composable
 private fun MessageComposerInputOverflowPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputOverflow()
     }
 }
@@ -296,7 +297,7 @@ internal fun MessageComposerInputOverflow() {
 @Preview
 @Composable
 private fun MessageComposerInputSlowModePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputSlowMode()
     }
 }
@@ -314,7 +315,7 @@ internal fun MessageComposerInputSlowMode() {
 @Preview
 @Composable
 private fun MessageComposerInputThreadModePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputThreadMode()
     }
 }
@@ -333,7 +334,7 @@ internal fun MessageComposerInputThreadMode() {
 @Preview
 @Composable
 private fun MessageComposerInputThreadModeAlsoSendToChannelPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputThreadModeAlsoSendToChannel()
     }
 }
@@ -353,7 +354,7 @@ internal fun MessageComposerInputThreadModeAlsoSendToChannel() {
 @Preview
 @Composable
 private fun MessageComposerInputActiveCommandPlaceholderPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputActiveCommandPlaceholder()
     }
 }
@@ -370,7 +371,7 @@ internal fun MessageComposerInputActiveCommandPlaceholder() {
 @Preview
 @Composable
 private fun MessageComposerInputActiveCommandFilledPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputActiveCommandFilled()
     }
 }
@@ -388,7 +389,7 @@ internal fun MessageComposerInputActiveCommandFilled() {
 @Preview
 @Composable
 private fun MessageComposerInputAttachmentsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputAttachments()
     }
 }
@@ -411,7 +412,7 @@ internal fun MessageComposerInputAttachments() {
 @Preview
 @Composable
 private fun MessageComposerInputLinkPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputLink()
     }
 }
@@ -433,7 +434,7 @@ internal fun MessageComposerInputLink() {
 @Preview
 @Composable
 private fun MessageComposerInputReplyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputReply()
     }
 }
@@ -450,7 +451,7 @@ internal fun MessageComposerInputReply() {
 @Preview
 @Composable
 private fun MessageComposerInputEditPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputEdit()
     }
 }
@@ -468,7 +469,7 @@ internal fun MessageComposerInputEdit() {
 @Preview
 @Composable
 private fun MessageComposerInputEditEmptyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputEditEmpty()
     }
 }
@@ -485,7 +486,7 @@ internal fun MessageComposerInputEditEmpty() {
 @Preview
 @Composable
 private fun MessageComposerInputAttachmentsAndLinkPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputAttachmentsAndLink()
     }
 }
@@ -510,7 +511,7 @@ internal fun MessageComposerInputAttachmentsAndLink() {
 @Preview
 @Composable
 private fun MessageComposerInputReplyAttachmentsAndLinkPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputReplyAttachmentsAndLink()
     }
 }
@@ -536,7 +537,7 @@ internal fun MessageComposerInputReplyAttachmentsAndLink() {
 @Preview
 @Composable
 private fun MessageComposerInputEditAttachmentsAndLinkPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputEditAttachmentsAndLink()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemState
 import io.getstream.chat.android.compose.ui.components.common.ContextualMenu
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageMenuOptionsItemParams
 import io.getstream.chat.android.compose.util.extensions.canBlockUser
@@ -291,7 +292,7 @@ private fun MessageOptionsPreview(
     currentUser: User,
     syncStatus: SyncStatus,
 ) {
-    ChatTheme {
+    ChatPreviewTheme {
         val selectedMMessage = PreviewMessageData.message1.copy(
             user = messageUser,
             syncStatus = syncStatus,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.GiphyAttachmentContentParams
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
@@ -146,7 +147,7 @@ public fun GiphyMessageContent(
 @Composable
 private fun GiphyMessageContentPreview() {
     val attachment = Attachment(type = AttachmentType.GIPHY, ogUrl = "")
-    ChatTheme {
+    ChatPreviewTheme {
         Box(Modifier.background(MessageStyling.backgroundColor(true))) {
             GiphyMessageContent(
                 message = Message(attachments = listOf(attachment)),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageAnnotation.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageAnnotation.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.ifNotNull
@@ -131,7 +132,7 @@ internal fun MessageAnnotations(modifier: Modifier) {
 @Preview
 @Composable
 internal fun MessageAnnotationsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageAnnotations(
             Modifier
                 .background(ChatTheme.colors.backgroundCoreApp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageReactions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageReactions.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.previewdata.PreviewReactionData
 import io.getstream.chat.android.compose.state.messages.MessageReactionItemState
 import io.getstream.chat.android.compose.ui.components.reactions.ReactionIconSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -192,7 +193,7 @@ private fun ReactionChip(
 @Preview
 @Composable
 private fun SingleClusteredMessageReactionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ClusteredMessageReactions(reactions = PreviewReactionData.oneReaction())
     }
 }
@@ -200,7 +201,7 @@ private fun SingleClusteredMessageReactionsPreview() {
 @Preview
 @Composable
 private fun MultipleClusteredMessageReactionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ClusteredMessageReactions(reactions = PreviewReactionData.manyReactions())
     }
 }
@@ -208,7 +209,7 @@ private fun MultipleClusteredMessageReactionsPreview() {
 @Preview
 @Composable
 private fun SingleSegmentedMessageReactionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SegmentedMessageReactions(reactions = PreviewReactionData.oneReaction())
     }
 }
@@ -216,7 +217,7 @@ private fun SingleSegmentedMessageReactionsPreview() {
 @Preview
 @Composable
 private fun MultipleSegmentedMessageReactionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SegmentedMessageReactions(reactions = PreviewReactionData.manyReactions())
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.util.fastAny
 import androidx.core.net.toUri
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.util.AnnotationTagEmail
@@ -183,7 +184,7 @@ private fun ClickableText(
 @Preview
 @Composable
 private fun MessageTextPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageText(
             message = Message(text = "Hello World!"),
             currentUser = null,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -63,6 +63,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
 import io.getstream.chat.android.compose.ui.components.composer.InputField
 import io.getstream.chat.android.compose.ui.components.poll.AddAnswerDialog
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageBubbleParams
 import io.getstream.chat.android.compose.ui.theme.MessageFailedIconParams
@@ -556,7 +557,7 @@ private fun PollOptionButton(
 @Preview
 @Composable
 private fun PollMessageContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Column(modifier = Modifier.background(ChatTheme.colors.backgroundCoreApp)) {
             PollMessageContent(
                 modifier = Modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ScrollToBottomButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/ScrollToBottomButton.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.animation.FadingVisibility
@@ -111,7 +112,7 @@ private val BadgeShape = RoundedCornerShape(StreamTokens.spacingMd)
 @Composable
 @Preview(showBackground = true)
 private fun Preview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ScrollToBottomButton(
             count = 1,
             onClick = { },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
@@ -66,6 +66,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamButtonSize
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
 import io.getstream.chat.android.compose.ui.components.composer.InputField
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
@@ -345,7 +346,7 @@ private fun AddAnswerDialogInput(newOption: MutableState<String>, modifier: Modi
 @Preview
 @Composable
 private fun PollAnswersDialogPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         val now = Date()
         val pollWithAnswers = PreviewPollData.poll1.copy(
             answers = listOf(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollDialogHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollDialogHeader.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.BackButton
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -67,7 +68,7 @@ public fun PollDialogHeader(
 @Preview
 @Composable
 private fun PollDialogHeaderPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Box(
             modifier = Modifier
                 .fillMaxWidth()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollMoreOptionsDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollMoreOptionsDialog.kt
@@ -58,6 +58,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.components.avatar.UserAvatarStack
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
@@ -339,7 +340,7 @@ private const val MaxStackedAvatars = 3
 @Preview
 @Composable
 private fun PollMoreOptionsDialogPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollMoreOptionsDialog()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionInput.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.util.buildAnnotatedInputText
 
@@ -143,7 +144,7 @@ public fun PollOptionInput(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 public fun PollOptionInputPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Column(
             modifier = Modifier
                 .background(ChatTheme.colors.backgroundCoreApp)

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
@@ -58,6 +58,7 @@ import io.getstream.chat.android.compose.R.plurals.stream_compose_poll_vote_coun
 import io.getstream.chat.android.compose.handlers.LoadMoreHandler
 import io.getstream.chat.android.compose.ui.components.ContentBox
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.ViewModelStore
@@ -230,7 +231,7 @@ private fun Content(
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionVotesLoadingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionVotesLoading()
     }
 }
@@ -252,7 +253,7 @@ internal fun PollOptionVotesLoading() {
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionVotesContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionVotesContent()
     }
 }
@@ -275,7 +276,7 @@ internal fun PollOptionVotesContent() {
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionVotesLoadingMorePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionVotesLoadingMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollViewResultDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollViewResultDialog.kt
@@ -64,6 +64,7 @@ import io.getstream.chat.android.client.extensions.internal.getVotesUnlessAnonym
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.ViewModelStore
@@ -372,7 +373,7 @@ private val NullableOptionSaver: Saver<Option?, Bundle> = Saver(
 @Preview
 @Composable
 private fun PollResultsContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Box(Modifier.background(ChatTheme.colors.backgroundCoreApp)) {
             PollResultsContent()
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionoptions/ExtendedReactionsOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionoptions/ExtendedReactionsOptions.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.state.reactionoptions.ReactionOptionItemState
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionMenuOptionItemParams
 import io.getstream.chat.android.models.Reaction
@@ -73,7 +74,7 @@ internal fun ExtendedReactionsOptions(
 @Preview(showBackground = true, name = "ExtendedReactionOptions Preview")
 @Composable
 internal fun ExtendedReactionOptionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ExtendedReactionsOptions(
             ownReactions = listOf(),
             onReactionOptionSelected = {},
@@ -87,7 +88,7 @@ internal fun ExtendedReactionOptionsPreview() {
 @Preview(showBackground = true, name = "ExtendedReactionOptions Preview (With Own Reaction)")
 @Composable
 internal fun ExtendedReactionOptionsWithOwnReactionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ExtendedReactionsOptions(
             ownReactions = listOf(
                 Reaction(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionIcon.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 
 /**
  * Component for rendering reaction emojis.
@@ -67,7 +67,7 @@ private fun ReactionIconSize.toFontSize() = when (this) {
 @Preview(showBackground = true)
 @Composable
 private fun ReactionIconPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Row(
             modifier = Modifier.padding(8.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.util.ReactionResolver
@@ -98,7 +99,7 @@ private fun ReactionToggleSize.toIconSize() = when (this) {
 @Preview(showBackground = true)
 @Composable
 private fun ReactionTogglePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Column(Modifier.padding(8.dp)) {
             Row(
                 horizontalArrangement = Arrangement.spacedBy(8.dp),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/MessageMenuHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/MessageMenuHeader.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamButton
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonSize
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.reactions.ReactionToggleSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionToggleParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -108,7 +109,7 @@ public fun MessageMenuHeader(
 @Preview(showBackground = true)
 @Composable
 private fun MessageMenuHeaderPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         val reactionType = ChatTheme.reactionResolver.supportedReactions.firstOrNull()
 
         if (reactionType != null) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/ReactionCountRow.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/ReactionCountRow.kt
@@ -40,6 +40,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.previewdata.PreviewReactionData
 import io.getstream.chat.android.compose.state.messages.MessageReactionItemState
 import io.getstream.chat.android.compose.ui.components.reactions.ReactionIconSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -139,7 +140,7 @@ private fun ReactionChip(
 @Preview(showBackground = true)
 @Composable
 private fun ReactionCountRowPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ReactionCountRow(
             reactionGroups = PreviewReactionData.manyReactions(),
             selectedReactionType = "love",

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/ReactionsMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/ReactionsMenu.kt
@@ -54,6 +54,7 @@ import io.getstream.chat.android.compose.state.userreactions.UserReactionItemSta
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionsMenuContentParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -372,7 +373,7 @@ internal fun ReactionsMenuContentManyReactions() {
 @Preview
 @Composable
 private fun OneSelectedReactionMenuPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ReactionsMenuContentOneReaction()
     }
 }
@@ -380,7 +381,7 @@ private fun OneSelectedReactionMenuPreview() {
 @Preview
 @Composable
 private fun ManySelectedReactionsMenuPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ReactionsMenuContentManyReactions()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/selectedmessage/SelectedMessageMenu.kt
@@ -63,6 +63,7 @@ import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemS
 import io.getstream.chat.android.compose.state.messages.MessageAlignment
 import io.getstream.chat.android.compose.ui.components.messageoptions.defaultMessageOptionsState
 import io.getstream.chat.android.compose.ui.messages.list.LocalSelectedMessageSnapshot
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageContainerParams
 import io.getstream.chat.android.compose.ui.theme.MessageMenuHeaderContentParams
@@ -358,7 +359,7 @@ private fun rememberMenuAnimation(
 @Preview(showBackground = true)
 @Composable
 private fun SelectedMessageMenuForIncomingMessagePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SelectedMessageMenuForIncomingMessage()
     }
 }
@@ -366,7 +367,7 @@ private fun SelectedMessageMenuForIncomingMessagePreview() {
 @Preview(showBackground = true)
 @Composable
 private fun SelectedMessageMenuForOutgoingMessagePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SelectedMessageMenuForOutgoingMessage()
     }
 }
@@ -388,7 +389,7 @@ internal fun SelectedMessageMenuForOutgoingMessage() {
 @Preview(showBackground = true)
 @Composable
 private fun SelectedMessageMenuForFailedMessagePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         SelectedMessageMenuForFailedMessage()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/mentions/MentionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/mentions/MentionList.kt
@@ -34,6 +34,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.ui.components.ContentBox
 import io.getstream.chat.android.compose.ui.components.LazyPagingColumn
 import io.getstream.chat.android.compose.ui.components.PullToRefreshBox
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MentionListEmptyContentParams
 import io.getstream.chat.android.compose.ui.theme.MentionListItemParams
@@ -250,7 +251,7 @@ internal fun MentionListLoading() {
 @Preview(showBackground = true)
 @Composable
 private fun MentionListLoadingLightPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MentionListLoading()
     }
 }
@@ -267,7 +268,7 @@ internal fun MentionListEmpty() {
 @Preview(showBackground = true)
 @Composable
 private fun MentionListEmptyLightPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MentionListEmpty()
     }
 }
@@ -300,7 +301,7 @@ internal fun MentionListLoaded() {
 @Preview(showBackground = true)
 @Composable
 private fun MentionListLoadedLightPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MentionListLoaded()
     }
 }
@@ -334,7 +335,7 @@ internal fun MentionListLoadingMore() {
 @Preview(showBackground = true)
 @Composable
 private fun MentionListLoadingMoreLightPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MentionListLoadingMore()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentCameraPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentCameraPicker.kt
@@ -52,6 +52,7 @@ import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleD
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
 import io.getstream.chat.android.compose.ui.messages.attachments.media.rememberCaptureMediaLauncher
 import io.getstream.chat.android.compose.ui.messages.attachments.permission.RequiredCameraPermission
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.ui.common.contract.internal.CaptureMediaContract
@@ -148,7 +149,7 @@ internal fun CameraPickerMode.toCaptureMediaMode(): CaptureMediaContract.Mode =
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentCameraPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentCameraPicker()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentCommandPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentCommandPicker.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.R.string.stream_compose_message_composer_instant_commands
 import io.getstream.chat.android.compose.state.messages.attachments.CommandPickerMode
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -144,7 +145,7 @@ private fun CommandItem(
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentCommandPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentCommandPicker()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentPollPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentPollPicker.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.compose.ui.components.FullscreenDialog
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
 import io.getstream.chat.android.compose.ui.messages.attachments.poll.CreatePollScreen
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.CreatePollParams
@@ -117,7 +118,7 @@ internal fun AttachmentPollPicker(
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentPollPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentPollPicker()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
@@ -44,6 +44,7 @@ import io.getstream.chat.android.compose.state.messages.attachments.CommandPicke
 import io.getstream.chat.android.compose.state.messages.attachments.FilePickerMode
 import io.getstream.chat.android.compose.state.messages.attachments.GalleryPickerMode
 import io.getstream.chat.android.compose.state.messages.attachments.PollPickerMode
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.util.extensions.isPollEnabled
@@ -225,7 +226,7 @@ private val AttachmentPickerModeInfos = mapOf(
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypePickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypePicker()
     }
 }
@@ -242,7 +243,7 @@ internal fun AttachmentTypePicker() {
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypePickerWithPollsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypePickerWithPolls()
     }
 }
@@ -262,7 +263,7 @@ internal fun AttachmentTypePickerWithPolls() {
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypePickerWithCommandsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypePickerWithCommands()
     }
 }
@@ -281,7 +282,7 @@ internal fun AttachmentTypePickerWithCommands() {
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypeSystemPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypeSystemPicker()
     }
 }
@@ -297,7 +298,7 @@ internal fun AttachmentTypeSystemPicker() {
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypeSystemPickerWithPollsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypeSystemPickerWithPolls()
     }
 }
@@ -316,7 +317,7 @@ internal fun AttachmentTypeSystemPickerWithPolls() {
 @Preview(showBackground = true)
 @Composable
 private fun AttachmentTypeSystemPickerWithCommandsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         AttachmentTypeSystemPickerWithCommands()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/permission/RequiredPermission.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/permission/RequiredPermission.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
 import io.getstream.chat.android.compose.ui.components.button.StreamTextButton
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.ui.common.utils.openSystemSettings
@@ -133,7 +134,7 @@ private fun RequiredPermission(
 @Preview(showBackground = true)
 @Composable
 private fun RequiredMediaStoragePermissionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         RequiredMediaStoragePermission()
     }
 }
@@ -146,7 +147,7 @@ internal fun RequiredMediaStoragePermission() {
 @Preview(showBackground = true)
 @Composable
 private fun RequiredFilesStoragePermissionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         RequiredFilesStoragePermission()
     }
 }
@@ -159,7 +160,7 @@ internal fun RequiredFilesStoragePermission() {
 @Preview(showBackground = true)
 @Composable
 private fun RequiredCameraPermissionPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         RequiredCameraPermission()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.CreatePollParams
@@ -148,7 +149,7 @@ public fun CreatePollScreen(
 @Preview
 @Composable
 private fun CreatePollScreenPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         CreatePollScreen()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationDiscardDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationDiscardDialog.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
 /**
@@ -123,7 +124,7 @@ public fun PollCreationDiscardDialog(
 @Preview
 @Composable
 private fun PollCreationDiscardDialogPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollCreationDiscardDialog()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationHeader.kt
@@ -43,6 +43,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.BackButton
 import io.getstream.chat.android.compose.ui.components.button.StreamButton
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
 /**
@@ -146,7 +147,7 @@ internal fun DefaultPollOptionsHeaderTrailingContent(
 @Preview
 @Composable
 private fun PollCreationHeaderEnabledPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollCreationHeaderEnabled()
     }
 }
@@ -159,7 +160,7 @@ internal fun PollCreationHeaderEnabled() {
 @Preview
 @Composable
 private fun PollCreationHeaderDisabledPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollCreationHeaderDisabled()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollOptionList.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.poll.PollOptionInput
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -244,7 +245,7 @@ private fun List<PollOptionItem>.updateOnTitleChange(
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionListEmptyPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionListEmpty()
     }
 }
@@ -261,7 +262,7 @@ internal fun PollOptionListEmpty() {
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionListBlankPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionListBlank()
     }
 }
@@ -280,7 +281,7 @@ internal fun PollOptionListBlank() {
 @Preview(showBackground = true)
 @Composable
 private fun PollOptionListDuplicatedErrorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollOptionListDuplicatedError()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollQuestionInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollQuestionInput.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.poll.PollOptionInput
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -82,7 +83,7 @@ public fun PollQuestionInput(
 @Preview(uiMode = Configuration.UI_MODE_NIGHT_YES)
 @Composable
 private fun PollOptionQuestionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollQuestionInput(
             modifier = Modifier
                 .fillMaxWidth()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.StreamSwitch
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.applyIf
@@ -336,7 +337,7 @@ private fun StepperButton(
 @Preview
 @Composable
 private fun PollSwitchListPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         PollSwitchListPreviewContent()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/MessageComposer.kt
@@ -47,6 +47,7 @@ import io.getstream.chat.android.compose.ui.messages.composer.actions.AudioRecor
 import io.getstream.chat.android.compose.ui.messages.composer.internal.suggestions.CommandSuggestionList
 import io.getstream.chat.android.compose.ui.messages.composer.internal.suggestions.SuggestionsMenu
 import io.getstream.chat.android.compose.ui.messages.composer.internal.suggestions.UserSuggestionList
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ComposerConfig
 import io.getstream.chat.android.compose.ui.theme.LocalChatUiConfig
@@ -384,7 +385,7 @@ private fun MessageInputValidationError(validationErrors: List<ValidationError>,
 @Preview
 @Composable
 private fun MessageComposerFixedStylePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFixedStyle()
     }
 }
@@ -400,7 +401,7 @@ internal fun MessageComposerFixedStyle() {
 @Preview
 @Composable
 private fun MessageComposerFixedStyleWithVisibleAttachmentPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFixedStyleWithVisibleAttachmentPicker()
     }
 }
@@ -417,7 +418,7 @@ internal fun MessageComposerFixedStyleWithVisibleAttachmentPicker() {
 @Preview
 @Composable
 private fun MessageComposerFixedStyleWithUserSuggestionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFixedStyleWithUserSuggestions()
     }
 }
@@ -441,7 +442,7 @@ internal fun MessageComposerFixedStyleWithUserSuggestions() {
 @Preview
 @Composable
 private fun MessageComposerFixedStyleWithCommandSuggestionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFixedStyleWithCommandSuggestions()
     }
 }
@@ -464,7 +465,7 @@ internal fun MessageComposerFixedStyleWithCommandSuggestions() {
 @Preview(showBackground = true)
 @Composable
 private fun MessageComposerFloatingStylePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFloatingStyle()
     }
 }
@@ -483,7 +484,7 @@ internal fun MessageComposerFloatingStyle() {
 @Preview(showBackground = true)
 @Composable
 private fun MessageComposerFloatingStyleWithVisibleAttachmentPickerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFloatingStyleWithVisibleAttachmentPicker()
     }
 }
@@ -503,7 +504,7 @@ internal fun MessageComposerFloatingStyleWithVisibleAttachmentPicker() {
 @Preview(showBackground = true)
 @Composable
 private fun MessageComposerFloatingStyleWithUserSuggestionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFloatingStyleWithUserSuggestions()
     }
 }
@@ -530,7 +531,7 @@ internal fun MessageComposerFloatingStyleWithUserSuggestions() {
 @Preview(showBackground = true)
 @Composable
 private fun MessageComposerFloatingStyleWithCommandSuggestionsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerFloatingStyleWithCommandSuggestions()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
@@ -46,6 +46,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
 import io.getstream.chat.android.compose.ui.components.messages.QuotedMessageBody
 import io.getstream.chat.android.compose.ui.components.messages.rememberBodyBuilder
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.Message
@@ -144,7 +145,7 @@ private fun EditIndicatorSubtitle(body: QuotedMessageBody) {
 @Preview
 @Composable
 private fun MessageComposerEditIndicatorPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerEditIndicator(
             message = Message(text = "I think this could work"),
         )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerInputCenterBottomContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerInputCenterBottomContent.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.common.Checkbox
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -77,7 +78,7 @@ internal fun MessageComposerInputCenterBottomContent(
 @Preview(showBackground = true)
 @Composable
 private fun SelectedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputCenterBottomContent(
             alsoSendToChannel = true,
             onAlsoSendToChannelChange = {},
@@ -88,7 +89,7 @@ private fun SelectedPreview() {
 @Preview(showBackground = true)
 @Composable
 private fun UnselectedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerInputCenterBottomContent(
             alsoSendToChannel = false,
             onAlsoSendToChannelChange = {},

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentFileItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentFileItem.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.attachments.content.FileAttachmentImage
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.Attachment
@@ -117,7 +118,7 @@ private val FileItemShape = RoundedCornerShape(StreamTokens.radiusLg)
 @Preview
 @Composable
 private fun MessageComposerAttachmentFileItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerAttachmentFileItem()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentMediaItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentMediaItem.kt
@@ -37,7 +37,7 @@ import coil3.compose.LocalAsyncImagePreviewHandler
 import io.getstream.chat.android.client.extensions.duration
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
 import io.getstream.chat.android.compose.ui.components.common.VideoBadge
-import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.AsyncImagePreviewHandler
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
@@ -95,7 +95,7 @@ private val MediaItemImageShape = RoundedCornerShape(StreamTokens.radiusLg)
 @Preview
 @Composable
 private fun MessageComposerAttachmentImageItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerAttachmentImageItem()
     }
 }
@@ -115,7 +115,7 @@ internal fun MessageComposerAttachmentImageItem() {
 @Preview
 @Composable
 private fun MessageComposerAttachmentVideoItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerAttachmentVideoItem()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachments.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachments.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.utils.attachment.isAudioRecording
 import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageComposerAttachmentAudioRecordItemParams
 import io.getstream.chat.android.compose.ui.theme.MessageComposerAttachmentFileItemParams
@@ -157,7 +158,7 @@ private fun MessageComposerAttachmentsContent(
 @Preview(widthDp = 640)
 @Composable
 private fun MessageComposerAttachmentsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessageComposerAttachments()
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
@@ -49,6 +49,7 @@ import io.getstream.chat.android.compose.ui.theme.ChannelAvatarParams
 import io.getstream.chat.android.compose.ui.theme.ChannelHeaderCenterContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelHeaderLeadingContentParams
 import io.getstream.chat.android.compose.ui.theme.ChannelHeaderTrailingContentParams
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.clickable
@@ -305,7 +306,7 @@ internal fun DefaultChannelHeaderTrailingContent(
 @Preview(name = "ChannelHeader Preview (Connected)")
 @Composable
 private fun ChannelHeaderConnectedPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelHeader(
             modifier = Modifier
                 .fillMaxWidth()
@@ -320,7 +321,7 @@ private fun ChannelHeaderConnectedPreview() {
 @Preview(name = "ChannelHeader Preview (Connecting)")
 @Composable
 private fun ChannelHeaderConnectingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelHeader(
             modifier = Modifier
                 .fillMaxWidth()
@@ -335,7 +336,7 @@ private fun ChannelHeaderConnectingPreview() {
 @Preview(name = "ChannelHeader Preview (Offline)")
 @Composable
 private fun ChannelHeaderOfflinePreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelHeader(
             modifier = Modifier
                 .fillMaxWidth()
@@ -350,7 +351,7 @@ private fun ChannelHeaderOfflinePreview() {
 @Preview(name = "ChannelHeader Preview (User Typing)")
 @Composable
 private fun ChannelHeaderUserTypingPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelHeader(
             modifier = Modifier
                 .fillMaxWidth()
@@ -366,7 +367,7 @@ private fun ChannelHeaderUserTypingPreview() {
 @Preview(name = "ChannelHeader Preview (Many Members)")
 @Composable
 private fun ChannelHeaderManyMembersPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         ChannelHeader(
             modifier = Modifier
                 .fillMaxWidth()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageDivider.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageDivider.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -49,7 +50,7 @@ internal fun MessageDivider(text: String, modifier: Modifier = Modifier) {
 @Preview
 @Composable
 private fun MessageDividerPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/pinned/PinnedMessageList.kt
@@ -43,6 +43,7 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.handlers.LoadMoreHandler
 import io.getstream.chat.android.compose.ui.components.EmptyContent
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.PinnedMessageListEmptyContentParams
 import io.getstream.chat.android.compose.ui.theme.PinnedMessageListItemDividerParams
@@ -304,7 +305,7 @@ internal fun DefaultPinnedMessageListLoadingMoreContent() {
 @Composable
 @Preview
 private fun PinnedMessageItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             PinnedMessageItem(
                 message = PreviewPinnedMessageData.pinnedMessage1,
@@ -318,7 +319,7 @@ private fun PinnedMessageItemPreview() {
 @Composable
 @Preview
 private fun DefaultPinnedMessageListEmptyContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultPinnedMessageListEmptyContent()
         }
@@ -328,7 +329,7 @@ private fun DefaultPinnedMessageListEmptyContentPreview() {
 @Composable
 @Preview
 private fun DefaultPinnedMessageListLoadingContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultPinnedMessageListLoadingContent()
         }
@@ -338,7 +339,7 @@ private fun DefaultPinnedMessageListLoadingContentPreview() {
 @Composable
 @Preview
 private fun DefaultPinnedMessageListLoadingMoreContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultPinnedMessageListLoadingMoreContent()
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadList.kt
@@ -52,6 +52,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.handlers.LoadMoreHandler
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.theme.ThreadListBannerParams
@@ -339,7 +340,7 @@ internal fun DefaultThreadListLoadingMoreContent() {
 @Preview
 @Composable
 private fun DefaultThreadListEmptyContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultThreadListEmptyContent()
         }
@@ -349,7 +350,7 @@ private fun DefaultThreadListEmptyContentPreview() {
 @Preview
 @Composable
 private fun DefaultThreadListLoadingContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultThreadListLoadingContent()
         }
@@ -359,7 +360,7 @@ private fun DefaultThreadListLoadingContentPreview() {
 @Preview
 @Composable
 private fun DefaultThreadListLoadingMoreContentPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             DefaultThreadListLoadingMoreContent()
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadListLoadingItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadListLoadingItem.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.components.ShimmerProgressIndicator
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -148,7 +149,7 @@ private val PlaceholderShape = RoundedCornerShape(StreamTokens.radiusFull)
 @Preview
 @Composable
 private fun ThreadListLoadingItemPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         Surface {
             ThreadListLoadingItem()
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewIconFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessagePreviewIconFactory.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.ui.theme.ChatPreviewTheme
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 
 /**
@@ -161,7 +162,7 @@ internal class DefaultMessagePreviewIconFactory : MessagePreviewIconFactory {
 @Preview
 @Composable
 private fun MessagePreviewIconsPreview() {
-    ChatTheme {
+    ChatPreviewTheme {
         MessagePreviewIcons()
     }
 }


### PR DESCRIPTION
### Goal

Fix Compose previews crashing because `ChatTheme` accesses `ChatClient` which is not initialized by default.

### Implementation

Replace all `ChatTheme` usages in `@Preview` functions with `ChatPreviewTheme`

### 🎨 UI Changes

None

### Testing

1. Open any file with Compose previews in Android Studio and verify they render without errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated preview theme rendering across UI components for improved design-time preview consistency.
  * Internal API surface adjustments to support ongoing maintenance and optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->