### PR TITLE
Split hold-to-record hint based on audioRecordingSendOnComplete

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
@@ -449,7 +449,14 @@ private class RecordingHintState(
 private fun rememberRecordingHint(): RecordingHintState {
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
-    val message = stringResource(R.string.stream_compose_audio_recording_hint)
+    val sendOnComplete = ChatTheme.config.composer.audioRecordingSendOnComplete
+    val message = stringResource(
+        if (sendOnComplete) {
+            R.string.stream_compose_audio_recording_hint_send
+        } else {
+            R.string.stream_compose_audio_recording_hint_save
+        },
+    )
     return remember(snackbarHostState, scope, message) {
         RecordingHintState(snackbarHostState, scope, message)
     }

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -200,7 +200,8 @@
 
     <!-- Audio Recording -->
     <string name="stream_compose_audio_recording_start">Record audio message</string>
-    <string name="stream_compose_audio_recording_hint">Hold to record. Release to send.</string>
+    <string name="stream_compose_audio_recording_hint_send">Hold to record. Release to send.</string>
+    <string name="stream_compose_audio_recording_hint_save">Hold to record. Release to save.</string>
     <string name="stream_compose_audio_recording_slide_to_cancel">Slide to cancel</string>
     <string name="stream_compose_audio_recording_delete">Delete recording</string>
     <string name="stream_compose_audio_recording_stop">Stop recording</string>

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/guides/AddingRecordingSupport.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/ui/guides/AddingRecordingSupport.kt
@@ -19,7 +19,7 @@ class AddingRecordingSupport {
     fun customizeUiInMessageComposer(context: Context) {
         TransformStyle.messageComposerStyleTransformer = StyleTransformer { defaultStyle ->
             defaultStyle.copy(
-                audioRecordingHoldToRecordText = context.getString(R.string.stream_ui_message_composer_hold_to_record),
+                audioRecordingHoldToRecordText = context.getString(R.string.stream_ui_message_composer_hold_to_record_save),
                 audioRecordingHoldToRecordTextStyle = TextStyle(
                     size = context.getDimension(R.dimen.stream_ui_text_medium),
                     color = context.getColorCompat(R.color.stream_ui_text_color_secondary),

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/MessageComposerViewStyle.kt
@@ -107,7 +107,8 @@ import io.getstream.chat.android.ui.common.R as UiCommonR
  * @param audioRecordingButtonWidth The width of the button to record audio.
  * @param audioRecordingButtonHeight The height of the button to record audio.
  * @param audioRecordingButtonPadding The padding of the button to record audio.
- * @param audioRecordingHoldToRecordText The info text that will be shown if touch event on audio button was too short.
+ * @param audioRecordingHoldToRecordText Optional override for the info text shown on a short touch of the audio button.
+ * When `null`, the text is resolved from string resources based on [audioRecordingSendOnComplete].
  * @param audioRecordingHoldToRecordTextStyle The text style that will be used for the "hold to record" text.
  * @param audioRecordingHoldToRecordBackgroundDrawable The drawable will be used as a background for the "hold to
  * record" text.
@@ -215,7 +216,7 @@ public data class MessageComposerViewStyle(
     public val messageInputVideoAttachmentIconDrawablePaddingStart: Int,
     public val messageInputVideoAttachmentIconDrawablePaddingEnd: Int,
     // Center overlap content
-    public val audioRecordingHoldToRecordText: String,
+    public val audioRecordingHoldToRecordText: String?,
     public val audioRecordingHoldToRecordTextStyle: TextStyle,
     public val audioRecordingHoldToRecordBackgroundDrawable: Drawable,
     @ColorInt public val audioRecordingHoldToRecordBackgroundDrawableTint: Int?,
@@ -534,7 +535,7 @@ public data class MessageComposerViewStyle(
                  */
                 val audioRecordingHoldToRecordText = a.getString(
                     R.styleable.MessageComposerView_streamUiMessageComposerAudioRecordingHoldToRecordText,
-                ) ?: context.getString(R.string.stream_ui_message_composer_hold_to_record)
+                )
                 val audioRecordingHoldToRecordTextStyle = TextStyle.Builder(a)
                     .size(
                         R.styleable.MessageComposerView_streamUiMessageComposerAudioRecordingHoldToRecordTextSize,

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerOverlappingContent.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/content/DefaultMessageComposerOverlappingContent.kt
@@ -717,7 +717,13 @@ public open class DefaultMessageComposerOverlappingContent : ConstraintLayout, M
             false,
         ).also {
             it.findViewById<TextView>(R.id.holdToRecordText).apply {
-                text = style.audioRecordingHoldToRecordText
+                text = style.audioRecordingHoldToRecordText ?: context.getString(
+                    if (style.audioRecordingSendOnComplete) {
+                        R.string.stream_ui_message_composer_hold_to_record_send
+                    } else {
+                        R.string.stream_ui_message_composer_hold_to_record_save
+                    },
+                )
                 setTextStyle(style.audioRecordingHoldToRecordTextStyle)
                 background = style.audioRecordingHoldToRecordBackgroundDrawable.applyTint(
                     style.audioRecordingHoldToRecordBackgroundDrawableTint,

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_center_overlap_floating_hold.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_message_composer_default_center_overlap_floating_hold.xml
@@ -28,7 +28,7 @@
         android:background="@drawable/stream_ui_message_composer_audio_record_hold_background"
         android:paddingHorizontal="16dp"
         android:gravity="center_vertical"
-        android:text="@string/stream_ui_message_composer_hold_to_record"
+        android:text="@string/stream_ui_message_composer_hold_to_record_save"
         android:textColor="@color/stream_ui_white_snow"
         android:textStyle="bold"
         />

--- a/stream-chat-android-ui-components/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values-es/strings.xml
@@ -62,7 +62,8 @@
   <string name="stream_ui_message_composer_gallery_access">"Permitir acceso a tu galería"</string>
   <string name="stream_ui_message_composer_hint_cannot_send_message">"No puedes enviar mensajes en este canal"</string>
   <string name="stream_ui_message_composer_hint_normal">"Escribe algo aquí"</string>
-  <string name="stream_ui_message_composer_hold_to_record">"Mantén pulsado para empezar, suelta para enviar."</string>
+  <string name="stream_ui_message_composer_hold_to_record_send">"Mantén pulsado para empezar, suelta para enviar."</string>
+  <string name="stream_ui_message_composer_hold_to_record_save">"Mantén pulsado para empezar, suelta para guardar."</string>
   <string name="stream_ui_message_composer_instant_commands">"Comandos instantáneos"</string>
   <string name="stream_ui_message_composer_mode_edit">"Editar Mensaje"</string>
   <string name="stream_ui_message_composer_mode_reply">"Contestar al mensaje"</string>

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -108,7 +108,8 @@
 
     <!-- Audio Recording -->
     <string name="stream_ui_message_composer_slide_to_cancel">Slide to cancel</string>
-    <string name="stream_ui_message_composer_hold_to_record">Hold to record. Release to send.</string>
+    <string name="stream_ui_message_composer_hold_to_record_send">Hold to record. Release to send.</string>
+    <string name="stream_ui_message_composer_hold_to_record_save">Hold to record. Release to save.</string>
 
     <string name="stream_ui_message_list_empty">No messages</string>
     <string name="stream_ui_message_list_download_started">Download started</string>

--- a/stream-chat-android-ui-components/src/main/res/values/styles.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/styles.xml
@@ -1369,9 +1369,6 @@
         </item>
 
         <!-- Center overlap content -->
-        <item name="streamUiMessageComposerAudioRecordingHoldToRecordText">
-            @string/stream_ui_message_composer_hold_to_record
-        </item>
         <item name="streamUiMessageComposerAudioRecordingHoldToRecordTextSize">
             @dimen/stream_ui_text_medium
         </item>


### PR DESCRIPTION
### Goal

Distinguish between two recording modes in the hold-to-record hint text. When `audioRecordingSendOnComplete` is `true`, the hint says "Hold to record. Release to send." When `false` (default), it says "Hold to record. Release to save."

### Implementation

- **Compose module:** Split `stream_compose_audio_recording_hint` into `_hint_send` and `_hint_save`. `rememberRecordingHint()` picks the correct one based on `ChatTheme.config.composer.audioRecordingSendOnComplete`.
- **UI Components module:** Split `stream_ui_message_composer_hold_to_record` into `_hold_to_record_send` and `_hold_to_record_save`. `MessageComposerViewStyle.audioRecordingHoldToRecordText` changed from `String` to `String?` — `null` (default) resolves the text from string resources based on `audioRecordingSendOnComplete`; non-null acts as a customer override.
- Updated Spanish translations, layout XML fallback, styles.xml default, and docs sample.

### Testing

- Set `audioRecordingSendOnComplete = true` → tap (don't hold) mic button → hint says "Hold to record. Release to send."
- Set `audioRecordingSendOnComplete = false` (default) → tap mic button → hint says "Hold to record. Release to save."
- Set custom `audioRecordingHoldToRecordText` via `StyleTransformer` → verify custom text is shown regardless of the flag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Audio recording prompts now provide context-specific guidance with different text displayed based on whether audio will be sent or saved upon release
  * Localization support updated across multiple languages to reflect recording action context

<!-- end of auto-generated comment: release notes by coderabbit.ai -->