### PR TITLE
Remove customization from Compose sample

### DIFF
--- a/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
+++ b/stream-chat-android-compose-sample/src/e2e/java/io/getstream/chat/android/compose/sample/ui/StartupActivity.kt
@@ -22,12 +22,15 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.data.PredefinedUserCredentials
+import io.getstream.chat.android.compose.sample.data.customSettings
 
 class StartupActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         ChatHelper.initializeSdk(applicationContext, PredefinedUserCredentials.API_KEY, intent.getStringExtra("BASE_URL"))
+        customSettings().isComposerLinkPreviewEnabled = true
+
         val initTestActivity = intent.getSerializableExtra("InitTestActivity") as InitTestActivity
         startActivity(initTestActivity.createIntent(this@StartupActivity))
         finish()

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ChatApp.kt
@@ -75,7 +75,5 @@ class ChatApp : Application() {
 
         lateinit var sharedLocationService: SharedLocationService
             private set
-
-        public const val isComposerLinkPreviewEnabled: Boolean = true
     }
 }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/CustomSettings.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/CustomSettings.kt
@@ -33,6 +33,7 @@ class CustomSettings(private val context: Context) {
 
     var isAdaptiveLayoutEnabled: Boolean by booleanPref(AdaptiveLayout)
 
+    var isComposerLinkPreviewEnabled: Boolean by booleanPref(ComposerLinkPreview)
     var isComposerFloatingStyleEnabled: Boolean by booleanPref(ComposerFloatingStyle)
     var isSystemAttachmentPickerEnabled: Boolean by booleanPref(SystemAttachmentPicker)
 
@@ -47,6 +48,7 @@ class CustomSettings(private val context: Context) {
 }
 
 private const val AdaptiveLayout = "adaptive_layout"
+private const val ComposerLinkPreview = "composer_link_preview"
 private const val ComposerFloatingStyle = "composer_floating_style"
 private const val SystemAttachmentPicker = "system_attachment_picker"
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -24,7 +24,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
 import androidx.core.net.toUri
-import io.getstream.chat.android.compose.sample.ChatApp
 import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.isGroupChannel
 import io.getstream.chat.android.compose.sample.ui.channel.DirectChannelInfoActivity
@@ -49,7 +48,7 @@ class MessagesActivity : ComponentActivity() {
         ChannelViewModelFactory(
             context = this,
             channelId = cid,
-            isComposerLinkPreviewEnabled = ChatApp.isComposerLinkPreviewEnabled,
+            isComposerLinkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
             isComposerDraftMessageEnabled = true,
@@ -74,6 +73,7 @@ class MessagesActivity : ComponentActivity() {
         SampleChatTheme(
             config = ChatUiConfig(
                 composer = ComposerConfig(
+                    linkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
                     floatingStyleEnabled = settings.isComposerFloatingStyleEnabled,
                 ),
                 attachmentPicker = AttachmentPickerConfig(useSystemPicker = settings.isSystemAttachmentPickerEnabled),

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -29,8 +29,6 @@ import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.isGroupChannel
 import io.getstream.chat.android.compose.sample.ui.channel.DirectChannelInfoActivity
 import io.getstream.chat.android.compose.sample.ui.channel.GroupChannelInfoActivity
-import io.getstream.chat.android.compose.sample.ui.location.LocationComponentFactory
-import io.getstream.chat.android.compose.sample.vm.SharedLocationViewModelFactory
 import io.getstream.chat.android.compose.ui.messages.ChannelScreen
 import io.getstream.chat.android.compose.ui.theme.AttachmentPickerConfig
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
@@ -73,12 +71,9 @@ class MessagesActivity : ComponentActivity() {
 
     @Composable
     private fun SetupChatTheme() {
-        val locationViewModelFactory = SharedLocationViewModelFactory(cid)
         SampleChatTheme(
-            componentFactory = LocationComponentFactory(locationViewModelFactory = locationViewModelFactory),
             config = ChatUiConfig(
                 composer = ComposerConfig(
-                    linkPreviewEnabled = ChatApp.isComposerLinkPreviewEnabled,
                     floatingStyleEnabled = settings.isComposerFloatingStyleEnabled,
                 ),
                 attachmentPicker = AttachmentPickerConfig(useSystemPicker = settings.isSystemAttachmentPickerEnabled),

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/SampleChatTheme.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/SampleChatTheme.kt
@@ -24,26 +24,20 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
-import io.getstream.chat.android.compose.sample.ChatApp
-import io.getstream.chat.android.compose.ui.theme.ChatComponentFactory
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 
 /**
- * Sample app wrapper around [ChatTheme] that enables test tags as resource IDs for UIAutomator
- * E2E tests and sets [ChatApp.dateFormatter] as defaults.
+ * Sample app wrapper around [ChatTheme] that enables test tags as resource IDs for UIAutomator E2E tests.
  */
 @Composable
 internal fun SampleChatTheme(
     config: ChatUiConfig = ChatUiConfig(),
-    componentFactory: ChatComponentFactory = object : ChatComponentFactory {},
     content: @Composable () -> Unit,
 ) {
     Box(modifier = Modifier.semantics { testTagsAsResourceId = true }) {
         ChatTheme(
-            dateFormatter = ChatApp.dateFormatter,
             config = config,
-            componentFactory = componentFactory,
             content = content,
         )
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -48,7 +48,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.state.globalStateFlow
-import io.getstream.chat.android.compose.sample.ChatApp
 import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.sample.feature.channel.ChannelConstants.CHANNEL_ARG_DRAFT
@@ -609,7 +608,6 @@ class ChatsActivity : ComponentActivity() {
         channelId = channelId,
         messageId = messageId,
         parentMessageId = parentMessageId,
-        isComposerLinkPreviewEnabled = ChatApp.isComposerLinkPreviewEnabled,
     )
 
     private fun openAddChannel() {

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -50,6 +50,7 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.api.state.globalStateFlow
 import io.getstream.chat.android.compose.sample.ChatHelper
 import io.getstream.chat.android.compose.sample.R
+import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.ChannelConstants.CHANNEL_ARG_DRAFT
 import io.getstream.chat.android.compose.sample.feature.channel.add.AddChannelActivity
 import io.getstream.chat.android.compose.sample.feature.channel.isGroupChannel
@@ -606,6 +607,7 @@ class ChatsActivity : ComponentActivity() {
     ) = ChannelViewModelFactory(
         context = applicationContext,
         channelId = channelId,
+        isComposerLinkPreviewEnabled = customSettings().isComposerLinkPreviewEnabled,
         messageId = messageId,
         parentMessageId = parentMessageId,
     )

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
@@ -126,6 +126,9 @@ class CustomLoginActivity : AppCompatActivity() {
                     var userTokenText by remember { mutableStateOf("") }
                     var userNameText by remember { mutableStateOf("") }
                     var isAdaptiveLayoutEnabled by remember { mutableStateOf(settings.isAdaptiveLayoutEnabled) }
+                    var isComposerLinkPreviewEnabled by remember {
+                        mutableStateOf(settings.isComposerLinkPreviewEnabled)
+                    }
                     var isComposerFloatingStyleEnabled by remember {
                         mutableStateOf(settings.isComposerFloatingStyleEnabled)
                     }
@@ -145,6 +148,17 @@ class CustomLoginActivity : AppCompatActivity() {
                             onValueChange = {
                                 isAdaptiveLayoutEnabled = it
                                 settings.isAdaptiveLayoutEnabled = it
+                            },
+                        ),
+                        FeatureFlag(
+                            label = stringResource(R.string.custom_login_flag_composer_link_preview_label),
+                            description = stringResource(
+                                R.string.custom_login_flag_composer_link_preview_description,
+                            ),
+                            value = isComposerLinkPreviewEnabled,
+                            onValueChange = {
+                                isComposerLinkPreviewEnabled = it
+                                settings.isComposerLinkPreviewEnabled = it
                             },
                         ),
                         FeatureFlag(

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -37,6 +37,8 @@
     <string name="custom_login_flag_adaptive_layout_description">Adjust layout based on screen sizes</string>
     <string name="custom_login_flag_composer_floating_style_label">Message composer floating style</string>
     <string name="custom_login_flag_composer_floating_style_description">Message list scrolls behind some composer elements</string>
+    <string name="custom_login_flag_composer_link_preview_label">Composer link preview</string>
+    <string name="custom_login_flag_composer_link_preview_description">Show link previews in the message composer</string>
     <string name="custom_login_flag_system_attachment_picker_label">System attachment picker</string>
     <string name="custom_login_flag_system_attachment_picker_description">Use the system\'s native file/media picker</string>
 


### PR DESCRIPTION
### Goal

We're temporarily removing customizations that live in the sample, so while testing v7 we're using the SDK defaults.

### Implementation

- Do not pass custom component factory implementing location attachments
- Do not pass custom value for `linkPreviewEnabled`
- Do not pass custom date formatter (although we were passing the default one anyway)


### 🎨 UI Changes

None

### Testing

Test the sample and verify that you can't add/view location attachments and link preview in the composer is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Composer link preview is now configurable through the app settings. Users can easily toggle link preview functionality in the message composer to suit their preferences. The setting is persisted across sessions for a consistent experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->