### PR TITLE
Align message actions options visibility params with class name

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -4173,7 +4173,7 @@ public final class io/getstream/chat/android/compose/ui/theme/MessageActionsConf
 	public final fun copy (Lio/getstream/chat/android/compose/ui/components/messageoptions/MessageActionsOptionsVisibility;Z)Lio/getstream/chat/android/compose/ui/theme/MessageActionsConfig;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/ui/theme/MessageActionsConfig;Lio/getstream/chat/android/compose/ui/components/messageoptions/MessageActionsOptionsVisibility;ZILjava/lang/Object;)Lio/getstream/chat/android/compose/ui/theme/MessageActionsConfig;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getOptionVisibility ()Lio/getstream/chat/android/compose/ui/components/messageoptions/MessageActionsOptionsVisibility;
+	public final fun getOptionsVisibility ()Lio/getstream/chat/android/compose/ui/components/messageoptions/MessageActionsOptionsVisibility;
 	public final fun getReactionsEnabled ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageoptions/MessageOptions.kt
@@ -105,7 +105,7 @@ public fun defaultMessageOptionsState(
     }
     val selectedMessageUserId = selectedMessage.user.id
     val ownCapabilities = channel.ownCapabilities
-    val visibility = ChatTheme.config.messageActions.optionVisibility
+    val visibility = ChatTheme.config.messageActions.optionsVisibility
 
     return listOfNotNull(
         if (visibility.canRetryMessage(currentUser, selectedMessage)) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -203,9 +203,9 @@ public fun MessageContainer(
 
     val messageAlignment = ChatTheme.messageAlignmentProvider.provideMessageAlignment(messageItem)
     val description = stringResource(id = R.string.stream_compose_cd_message_item)
-    val optionVisibility = ChatTheme.config.messageActions.optionVisibility
-    val isSwipeable = remember(message, messageItem.ownCapabilities, optionVisibility) {
-        optionVisibility.canReplyToMessage(message, messageItem.ownCapabilities)
+    val optionsVisibility = ChatTheme.config.messageActions.optionsVisibility
+    val isSwipeable = remember(message, messageItem.ownCapabilities, optionsVisibility) {
+        optionsVisibility.canReplyToMessage(message, messageItem.ownCapabilities)
     }
 
     // Remember the message to ensure updated values are captured in the onReply lambda

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatUiConfig.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatUiConfig.kt
@@ -214,10 +214,10 @@ private val DefaultAttachmentPickerModes = listOf(
 /**
  * Configuration for the message actions overlay.
  *
- * @param optionVisibility Controls which message action options are shown.
+ * @param optionsVisibility Controls which message action options are shown.
  * @param reactionsEnabled Whether the reaction option row is visible in the overlay.
  */
 public data class MessageActionsConfig(
-    val optionVisibility: MessageActionsOptionsVisibility = MessageActionsOptionsVisibility(),
+    val optionsVisibility: MessageActionsOptionsVisibility = MessageActionsOptionsVisibility(),
     val reactionsEnabled: Boolean = true,
 )


### PR DESCRIPTION
### Goal

Align `MessageActionsConfig.optionVisibility` naming with the class name
`MessageActionsOptionsVisibility` by renaming it to `optionsVisibility`.

### Implementation

- Rename `optionVisibility` to `optionsVisibility` in `MessageActionsConfig`
- Update all usages

### Testing

Nothing should change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated message actions configuration property naming from singular to plural form for consistency across the API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->