### PR TITLE
Add sort order support for channel attachments

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -4833,8 +4833,8 @@ public final class io/getstream/chat/android/compose/util/KeyValuePair {
 
 public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel : androidx/lifecycle/ViewModel {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEvents ()Lkotlinx/coroutines/flow/SharedFlow;
 	public final fun getState ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun onViewAction (Lio/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewAction;)V
@@ -4842,8 +4842,8 @@ public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAt
 
 public final class io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModel.kt
@@ -19,6 +19,8 @@ package io.getstream.chat.android.compose.viewmodel.channel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewController
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewEvent
@@ -32,17 +34,20 @@ import kotlinx.coroutines.flow.StateFlow
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
  * @param localFilter A function to filter attachments locally after fetching.
+ * @param sort The sort order for the search results. If `null`, the server default order is used.
  * @param controllerProvider The provider for [ChannelAttachmentsViewController].
  */
 public class ChannelAttachmentsViewModel(
     private val cid: String,
     private val attachmentTypes: List<String>,
     private val localFilter: (attachment: Attachment) -> Boolean = { true },
+    private val sort: QuerySorter<Message>? = null,
     private val controllerProvider: ViewModel.() -> ChannelAttachmentsViewController = {
         ChannelAttachmentsViewController(
             cid = cid,
             attachmentTypes = attachmentTypes,
             localFilter = localFilter,
+            sort = sort,
             scope = viewModelScope,
         )
     },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
@@ -19,6 +19,8 @@ package io.getstream.chat.android.compose.viewmodel.channel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.querysort.QuerySorter
 
 /**
  * Factory for creating instances of [ChannelAttachmentsViewModel].
@@ -26,11 +28,13 @@ import io.getstream.chat.android.models.Attachment
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
  * @param localFilter A function to filter attachments locally after fetching.
+ * @param sort The sort order for the search results. If `null`, the server default order is used.
  */
 public class ChannelAttachmentsViewModelFactory(
     private val cid: String,
     private val attachmentTypes: List<String>,
     private val localFilter: (attachment: Attachment) -> Boolean = { true },
+    private val sort: QuerySorter<Message>? = null,
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -38,6 +42,6 @@ public class ChannelAttachmentsViewModelFactory(
             "ChannelAttachmentsViewModelFactory can only create instances of ChannelAttachmentsViewModel"
         }
         @Suppress("UNCHECKED_CAST")
-        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter) as T
+        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter, sort) as T
     }
 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewController.kt
@@ -21,7 +21,9 @@ import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SearchMessagesResult
+import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.ui.common.state.channel.attachments.ChannelAttachmentsViewState
 import io.getstream.log.taggedLogger
 import io.getstream.result.Error
@@ -49,6 +51,7 @@ import kotlinx.coroutines.flow.update
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types to filter by.
  * @param localFilter A function to filter attachments locally after fetching.
+ * @param sort The sort order for the search results. If `null`, the server default order is used.
  * @param chatClient The [ChatClient] instance used for interacting with the chat API.
  * @param scope The [CoroutineScope] used for launching coroutines.
  */
@@ -57,6 +60,7 @@ public class ChannelAttachmentsViewController(
     private val cid: String,
     private val attachmentTypes: List<String>,
     private val localFilter: (attachment: Attachment) -> Boolean = { true },
+    private val sort: QuerySorter<Message>? = null,
     private val chatClient: ChatClient = ChatClient.instance(),
     scope: CoroutineScope,
 ) {
@@ -116,6 +120,7 @@ public class ChannelAttachmentsViewController(
             messageFilter = messageFilter,
             limit = QUERY_LIMIT,
             next = nextPage,
+            sort = sort,
         ).await()
     }
 

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewControllerTest.kt
@@ -21,7 +21,10 @@ import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.client.extensions.cidToTypeAndId
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Filters
+import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.SearchMessagesResult
+import io.getstream.chat.android.models.querysort.QuerySortByField
+import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.randomAttachment
 import io.getstream.chat.android.randomCID
 import io.getstream.chat.android.randomMessage
@@ -246,6 +249,32 @@ internal class ChannelAttachmentsViewControllerTest {
             expectNoEvents()
         }
     }
+
+    @Test
+    fun `when sort is provided, should forward it to search and return sorted results`() = runTest {
+        val sort = QuerySortByField.ascByName<Message>("created_at")
+        val attachment = randomAttachment()
+        val message = randomMessage(cid = CID, attachments = listOf(attachment))
+        val searchMessagesResult = SearchMessagesResult(
+            messages = listOf(message),
+            next = null,
+        )
+        val sut = Fixture()
+            .givenSearchMessagesResult(sort = sort, result = searchMessagesResult)
+            .get(backgroundScope, sort = sort)
+
+        sut.state.test {
+            skipItems(1) // Skip initial state
+            val viewState = awaitItem()
+
+            assertTrue(viewState is ChannelAttachmentsViewState.Content)
+            viewState as ChannelAttachmentsViewState.Content
+            val expectedItems = listOf(
+                ChannelAttachmentsViewState.Content.Item(message, attachment),
+            )
+            assertEquals(expectedItems, viewState.items)
+        }
+    }
 }
 
 private val CID = randomCID()
@@ -257,6 +286,7 @@ private class Fixture {
 
     fun givenSearchMessagesResult(
         next: String? = null,
+        sort: QuerySorter<Message>? = null,
         result: SearchMessagesResult? = null,
         error: Error? = null,
     ) = apply {
@@ -268,15 +298,20 @@ private class Fixture {
                 offset = null,
                 limit = 30,
                 next = next,
-                sort = null,
+                sort = sort,
             ),
         ) doAnswer { result?.asCall() ?: error?.asCall() }
     }
 
-    fun get(scope: CoroutineScope, localFilter: (Attachment) -> Boolean = { true }) = ChannelAttachmentsViewController(
+    fun get(
+        scope: CoroutineScope,
+        localFilter: (Attachment) -> Boolean = { true },
+        sort: QuerySorter<Message>? = null,
+    ) = ChannelAttachmentsViewController(
         cid = CID,
         attachmentTypes = listOf(ATTACHMENT_TYPE),
         localFilter = localFilter,
+        sort = sort,
         chatClient = chatClient,
         scope = scope,
     )

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -4312,16 +4312,16 @@ public final class io/getstream/chat/android/ui/utils/extensions/UserKt {
 }
 
 public final class io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel : androidx/lifecycle/ViewModel {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/jvm/functions/Function1;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEvents ()Landroidx/lifecycle/LiveData;
 	public final fun getState ()Landroidx/lifecycle/LiveData;
 	public final fun onViewAction (Lio/getstream/chat/android/ui/common/feature/channel/attachments/ChannelAttachmentsViewAction;)V
 }
 
 public final class io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
-	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/List;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/models/querysort/QuerySorter;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModel.kt
@@ -21,6 +21,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
 import androidx.lifecycle.viewModelScope
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.querysort.QuerySorter
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewController
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewEvent
@@ -33,17 +35,20 @@ import io.getstream.chat.android.ui.utils.asSingleLiveEvent
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
  * @param localFilter A function to filter attachments locally after fetching.
+ * @param sort The sort order for the search results. If `null`, the server default order is used.
  * @param controllerProvider The provider for [ChannelAttachmentsViewController].
  */
 public class ChannelAttachmentsViewModel(
     private val cid: String,
     private val attachmentTypes: List<String>,
     private val localFilter: (attachment: Attachment) -> Boolean = { true },
+    private val sort: QuerySorter<Message>? = null,
     controllerProvider: ViewModel.() -> ChannelAttachmentsViewController = {
         ChannelAttachmentsViewController(
             cid = cid,
             attachmentTypes = attachmentTypes,
             localFilter = localFilter,
+            sort = sort,
             scope = viewModelScope,
         )
     },

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/channel/ChannelAttachmentsViewModelFactory.kt
@@ -19,6 +19,8 @@ package io.getstream.chat.android.ui.viewmodel.channel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.querysort.QuerySorter
 
 /**
  * Factory for creating instances of [ChannelAttachmentsViewModel].
@@ -26,11 +28,13 @@ import io.getstream.chat.android.models.Attachment
  * @param cid The full channel identifier (e.g., "messaging:123").
  * @param attachmentTypes The list of attachment types (e.g., "image", "file").
  * @param localFilter A function to filter attachments locally after fetching.
+ * @param sort The sort order for the search results. If `null`, the server default order is used.
  */
 public class ChannelAttachmentsViewModelFactory(
     private val cid: String,
     private val attachmentTypes: List<String>,
     private val localFilter: (attachment: Attachment) -> Boolean = { true },
+    private val sort: QuerySorter<Message>? = null,
 ) : ViewModelProvider.Factory {
 
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -38,6 +42,6 @@ public class ChannelAttachmentsViewModelFactory(
             "ChannelAttachmentsViewModelFactory can only create instances of ChannelAttachmentsViewModel"
         }
         @Suppress("UNCHECKED_CAST")
-        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter) as T
+        return ChannelAttachmentsViewModel(cid, attachmentTypes, localFilter, sort) as T
     }
 }


### PR DESCRIPTION
### Goal

Allow developers to control the sort order of media and file attachments in the channel info screens (`ChannelMediaAttachmentsScreen` / `ChannelFilesAttachmentsScreen`).

Resolves #6359

### Implementation

The `ChatClient.searchMessages()` API already supports a `sort: QuerySorter<Message>?` parameter, but `ChannelAttachmentsViewController` was not passing it through. This change threads an optional `sort` parameter through the full stack:

- **`ChannelAttachmentsViewController`** (ui-common) — accepts `sort` and forwards it to `searchMessages()`
- **`ChannelAttachmentsViewModel`** (compose + ui-components) — accepts `sort` and passes it to the controller
- **`ChannelAttachmentsViewModelFactory`** (compose + ui-components) — accepts `sort` and passes it to the ViewModel

All new parameters default to `null`, preserving existing behavior. Integrators configure sort when constructing the factory:

```kotlin
ChannelAttachmentsViewModelFactory(
    cid = cid,
    attachmentTypes = listOf("image", "video"),
    sort = QuerySortByField.descByName("created_at"),
)
```

No UI changes.

### Testing

- New unit test verifying the sort parameter is forwarded to `searchMessages()` and results are returned correctly
- Existing tests remain green — the `Fixture` helper was updated to support the new `sort` parameter with a `null` default, so all pre-existing test scenarios are unaffected


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable sorting for attachment search functionality in channel views. Search results can now be sorted according to user-defined criteria, with server defaults applied when no custom sort order is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->