### PR TITLE
Group ChannelViewModelFactory params into classes

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -48,8 +48,8 @@ class MessagesActivity : ComponentActivity() {
             context = this,
             channelId = cid,
             composerOptions = ComposerOptions(
-                isLinkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
-                isDraftMessageEnabled = true,
+                linkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
+                draftMessagesEnabled = true,
             ),
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/MessagesActivity.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.compose.ui.theme.AttachmentPickerConfig
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 import io.getstream.chat.android.compose.ui.theme.ComposerConfig
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.ComposerOptions
 import io.getstream.chat.android.models.Channel
 
 class MessagesActivity : ComponentActivity() {
@@ -46,10 +47,12 @@ class MessagesActivity : ComponentActivity() {
         ChannelViewModelFactory(
             context = this,
             channelId = cid,
-            isComposerLinkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
+            composerOptions = ComposerOptions(
+                isLinkPreviewEnabled = settings.isComposerLinkPreviewEnabled,
+                isDraftMessageEnabled = true,
+            ),
             messageId = intent.getStringExtra(KEY_MESSAGE_ID),
             parentMessageId = intent.getStringExtra(KEY_PARENT_MESSAGE_ID),
-            isComposerDraftMessageEnabled = true,
         )
     }
 

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -87,6 +87,7 @@ import io.getstream.chat.android.compose.viewmodel.channel.ChannelInfoViewModel
 import io.getstream.chat.android.compose.viewmodel.channel.ChannelInfoViewModelFactory
 import io.getstream.chat.android.compose.viewmodel.channels.ChannelListViewModelFactory
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.ComposerOptions
 import io.getstream.chat.android.compose.viewmodel.pinned.PinnedMessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.pinned.PinnedMessageListViewModelFactory
 import io.getstream.chat.android.models.AttachmentType
@@ -607,7 +608,7 @@ class ChatsActivity : ComponentActivity() {
     ) = ChannelViewModelFactory(
         context = applicationContext,
         channelId = channelId,
-        isComposerLinkPreviewEnabled = customSettings().isComposerLinkPreviewEnabled,
+        composerOptions = ComposerOptions(isLinkPreviewEnabled = customSettings().isComposerLinkPreviewEnabled),
         messageId = messageId,
         parentMessageId = parentMessageId,
     )

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/chats/ChatsActivity.kt
@@ -608,7 +608,7 @@ class ChatsActivity : ComponentActivity() {
     ) = ChannelViewModelFactory(
         context = applicationContext,
         channelId = channelId,
-        composerOptions = ComposerOptions(isLinkPreviewEnabled = customSettings().isComposerLinkPreviewEnabled),
+        composerOptions = ComposerOptions(linkPreviewEnabled = customSettings().isComposerLinkPreviewEnabled),
         messageId = messageId,
         parentMessageId = parentMessageId,
     )

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -6622,10 +6622,10 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/Composer
 	public final fun copy (IZZ)Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;
 	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;IZZILjava/lang/Object;)Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDraftMessagesEnabled ()Z
+	public final fun getLinkPreviewEnabled ()Z
 	public final fun getMaxAttachmentCount ()I
 	public fun hashCode ()I
-	public final fun isDraftMessageEnabled ()Z
-	public final fun isLinkPreviewEnabled ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -6604,11 +6604,29 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/AudioPla
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory : androidx/lifecycle/ViewModelProvider$Factory {
 	public static final field $stable I
-	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZZ)V
-	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;ILio/getstream/chat/android/ui/common/helper/ClipboardHandler;ZIZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/ui/common/helper/ClipboardHandler;Lio/getstream/chat/android/compose/viewmodel/messages/MessageListOptions;Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;)V
+	public synthetic fun <init> (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZLio/getstream/chat/android/client/ChatClient;Lio/getstream/chat/android/client/setup/state/ClientState;Lio/getstream/sdk/chat/audio/recording/StreamMediaRecorder;Lio/getstream/chat/android/ui/common/feature/messages/composer/mention/UserLookupHandler;Lkotlin/jvm/functions/Function1;Lio/getstream/chat/android/ui/common/helper/ClipboardHandler;Lio/getstream/chat/android/compose/viewmodel/messages/MessageListOptions;Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun create (Ljava/lang/Class;)Landroidx/lifecycle/ViewModel;
 	public fun create (Ljava/lang/Class;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
 	public fun create (Lkotlin/reflect/KClass;Landroidx/lifecycle/viewmodel/CreationExtras;)Landroidx/lifecycle/ViewModel;
+}
+
+public final class io/getstream/chat/android/compose/viewmodel/messages/ComposerOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (IZZ)V
+	public synthetic fun <init> (IZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Z
+	public final fun component3 ()Z
+	public final fun copy (IZZ)Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;IZZILjava/lang/Object;)Lio/getstream/chat/android/compose/viewmodel/messages/ComposerOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMaxAttachmentCount ()I
+	public fun hashCode ()I
+	public final fun isDraftMessageEnabled ()Z
+	public final fun isLinkPreviewEnabled ()Z
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/MessageComposerViewModel : androidx/lifecycle/ViewModel {
@@ -6650,6 +6668,38 @@ public final class io/getstream/chat/android/compose/viewmodel/messages/MessageC
 	public final fun stopRecording ()V
 	public final fun toggleCommandsVisibility ()V
 	public final fun toggleRecordingPlayback ()V
+}
+
+public final class io/getstream/chat/android/compose/viewmodel/messages/MessageListOptions {
+	public static final field $stable I
+	public fun <init> ()V
+	public fun <init> (IZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;ZLio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZ)V
+	public synthetic fun <init> (IZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;ZLio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component10 ()Z
+	public final fun component2 ()Z
+	public final fun component3 ()Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;
+	public final fun component4 ()Z
+	public final fun component5 ()Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;
+	public final fun component6 ()Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;
+	public final fun component7 ()Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;
+	public final fun component8 ()Z
+	public final fun component9 ()Z
+	public final fun copy (IZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;ZLio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZ)Lio/getstream/chat/android/compose/viewmodel/messages/MessageListOptions;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/viewmodel/messages/MessageListOptions;IZLio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;ZLio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;ZZZILjava/lang/Object;)Lio/getstream/chat/android/compose/viewmodel/messages/MessageListOptions;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDateSeparatorHandler ()Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;
+	public final fun getEnforceUniqueReactions ()Z
+	public final fun getMessageFooterVisibility ()Lio/getstream/chat/android/ui/common/state/messages/list/MessageFooterVisibility;
+	public final fun getMessageLimit ()I
+	public final fun getMessagePositionHandler ()Lio/getstream/chat/android/ui/common/feature/messages/list/MessagePositionHandler;
+	public final fun getShowDateSeparatorInEmptyThread ()Z
+	public final fun getShowSystemMessages ()Z
+	public final fun getShowThreadSeparatorInEmptyThread ()Z
+	public final fun getThreadDateSeparatorHandler ()Lio/getstream/chat/android/ui/common/feature/messages/list/DateSeparatorHandler;
+	public final fun getThreadLoadOlderToNewer ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public final class io/getstream/chat/android/compose/viewmodel/messages/MessageListViewModel : androidx/lifecycle/ViewModel {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModel.kt
@@ -88,7 +88,7 @@ import kotlin.coroutines.cancellation.CancellationException
  * When `null`, the server-side default is used.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
  * @param searchDebounceMs The debounce time for search queries.
- * @param isDraftMessageEnabled If the draft message feature is enabled.
+ * @param draftMessagesEnabled If the draft message feature is enabled.
  * @param messageSearchSort Sorting for message search results. When `null`, the server-side default is used.
  * @param globalState A flow emitting the current [GlobalState].
  */
@@ -103,7 +103,7 @@ public class ChannelListViewModel(
     private val messageLimit: Int? = null,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
     searchDebounceMs: Long = SEARCH_DEBOUNCE_MS,
-    private val isDraftMessageEnabled: Boolean = true,
+    private val draftMessagesEnabled: Boolean = true,
     private val messageSearchSort: QuerySorter<Message>? = null,
     private val globalState: Flow<GlobalState> = chatClient.globalStateFlow,
 ) : ViewModel() {
@@ -459,7 +459,7 @@ public class ChannelListViewModel(
                                     channels = state.channels,
                                     channelMutes = channelMutes,
                                     typingEvents = typingChannels,
-                                    draftMessages = channelDraftMessages.takeIf { isDraftMessageEnabled } ?: emptyMap(),
+                                    draftMessages = channelDraftMessages.takeIf { draftMessagesEnabled } ?: emptyMap(),
                                 ),
                                 isLoadingMore = false,
                                 endOfChannels = queryChannelsState.endOfChannels.value,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelFactory.kt
@@ -40,7 +40,7 @@ import io.getstream.chat.android.models.querysort.QuerySorter
  * @param messageLimit How many messages are fetched for each channel item when loading channels.
  * When `null`, the server-side default is used.
  * @param chatEventHandlerFactory The instance of [ChatEventHandlerFactory] used to create [ChatEventHandler].
- * @param isDraftMessageEnabled If the draft message feature is enabled.
+ * @param draftMessagesEnabled If the draft message feature is enabled.
  * @param messageSearchSort Optional sorting for message search results. When `null`, the server-side default is used.
  */
 public class ChannelListViewModelFactory(
@@ -51,7 +51,7 @@ public class ChannelListViewModelFactory(
     private val memberLimit: Int? = null,
     private val messageLimit: Int? = null,
     private val chatEventHandlerFactory: ChatEventHandlerFactory = ChatEventHandlerFactory(chatClient.clientState),
-    private val isDraftMessageEnabled: Boolean = true,
+    private val draftMessagesEnabled: Boolean = true,
     private val messageSearchSort: QuerySorter<Message>? = null,
 ) : ViewModelProvider.Factory {
 
@@ -71,7 +71,7 @@ public class ChannelListViewModelFactory(
             messageLimit = messageLimit,
             memberLimit = memberLimit,
             chatEventHandlerFactory = chatEventHandlerFactory,
-            isDraftMessageEnabled = isDraftMessageEnabled,
+            draftMessagesEnabled = draftMessagesEnabled,
             messageSearchSort = messageSearchSort,
         ) as T
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
@@ -78,13 +78,13 @@ public data class MessageListOptions(
  * Configuration for the message composer behavior.
  *
  * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
- * @param isLinkPreviewEnabled If the link preview is enabled in the composer.
- * @param isDraftMessageEnabled If the draft message is enabled in the composer.
+ * @param linkPreviewEnabled If the link preview is enabled in the composer.
+ * @param draftMessagesEnabled If draft messages are enabled in the composer.
  */
 public data class ComposerOptions(
     val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
-    val isLinkPreviewEnabled: Boolean = false,
-    val isDraftMessageEnabled: Boolean = true,
+    val linkPreviewEnabled: Boolean = false,
+    val draftMessagesEnabled: Boolean = true,
 )
 
 /**
@@ -179,8 +179,8 @@ public class ChannelViewModelFactory(
                     channelCid = channelId,
                     config = MessageComposerController.Config(
                         maxAttachmentCount = composerOptions.maxAttachmentCount,
-                        isLinkPreviewEnabled = composerOptions.isLinkPreviewEnabled,
-                        isDraftMessageEnabled = composerOptions.isDraftMessageEnabled,
+                        isLinkPreviewEnabled = composerOptions.linkPreviewEnabled,
+                        isDraftMessageEnabled = composerOptions.draftMessagesEnabled,
                         isActiveCommandEnabled = true,
                     ),
                     savedStateHandle = savedStateHandle ?: SavedStateHandle(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
@@ -179,9 +179,9 @@ public class ChannelViewModelFactory(
                     channelCid = channelId,
                     config = MessageComposerController.Config(
                         maxAttachmentCount = composerOptions.maxAttachmentCount,
-                        isLinkPreviewEnabled = composerOptions.linkPreviewEnabled,
-                        isDraftMessageEnabled = composerOptions.draftMessagesEnabled,
-                        isActiveCommandEnabled = true,
+                        linkPreviewEnabled = composerOptions.linkPreviewEnabled,
+                        draftMessageEnabled = composerOptions.draftMessagesEnabled,
+                        activeCommandEnabled = true,
                     ),
                     savedStateHandle = savedStateHandle ?: SavedStateHandle(),
                 ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/viewmodel/messages/ChannelViewModelFactory.kt
@@ -48,6 +48,46 @@ import kotlinx.coroutines.flow.StateFlow
 import java.io.File
 
 /**
+ * Configuration for the message list behavior.
+ *
+ * @param messageLimit The number of messages to load in a single page.
+ * @param showSystemMessages If we should show system message items in the list.
+ * @param messageFooterVisibility The behavior of message footers in the list and their visibility.
+ * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
+ * @param dateSeparatorHandler Handler that determines when the date separators should be visible.
+ * @param threadDateSeparatorHandler Handler that determines when the thread date separators should be visible.
+ * @param messagePositionHandler Determines the position of the message inside a group.
+ * @param showDateSeparatorInEmptyThread Configures if we show a date separator when threads are empty.
+ * @param showThreadSeparatorInEmptyThread Configures if we show a thread separator when threads are empty.
+ * @param threadLoadOlderToNewer Configures if the thread should load older messages to newer messages.
+ */
+public data class MessageListOptions(
+    val messageLimit: Int = MessageListController.DEFAULT_MESSAGES_LIMIT,
+    val showSystemMessages: Boolean = true,
+    val messageFooterVisibility: MessageFooterVisibility = MessageFooterVisibility.LastInGroup,
+    val enforceUniqueReactions: Boolean = false,
+    val dateSeparatorHandler: DateSeparatorHandler = DateSeparatorHandler.getDefaultDateSeparatorHandler(),
+    val threadDateSeparatorHandler: DateSeparatorHandler = DateSeparatorHandler.getDefaultThreadDateSeparatorHandler(),
+    val messagePositionHandler: MessagePositionHandler = MessagePositionHandler.defaultHandler(),
+    val showDateSeparatorInEmptyThread: Boolean = false,
+    val showThreadSeparatorInEmptyThread: Boolean = false,
+    val threadLoadOlderToNewer: Boolean = false,
+)
+
+/**
+ * Configuration for the message composer behavior.
+ *
+ * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
+ * @param isLinkPreviewEnabled If the link preview is enabled in the composer.
+ * @param isDraftMessageEnabled If the draft message is enabled in the composer.
+ */
+public data class ComposerOptions(
+    val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
+    val isLinkPreviewEnabled: Boolean = false,
+    val isDraftMessageEnabled: Boolean = true,
+)
+
+/**
  * Holds all the dependencies needed to build the ViewModels for the Messages Screen.
  * Currently, builds the [MessageComposerViewModel], [MessageListViewModel] and [AttachmentsPickerViewModel].
  *
@@ -62,22 +102,9 @@ import java.io.File
  * @param mediaRecorder The media recorder for async voice messages.
  * @param userLookupHandler Handler used to look up users for mention autocomplete.
  * @param fileToUriConverter Converts a local [File] to a URI string used as an attachment source.
- * @param messageLimit The number of messages to load in a single page.
  * @param clipboardHandler [ClipboardHandler] used to copy messages.
- * @param enforceUniqueReactions Flag to enforce unique reactions or enable multiple from the same user.
- * @param maxAttachmentCount The maximum number of attachments that can be sent in a single message.
- * @param showSystemMessages If we should show system message items in the list.
- * @param messageFooterVisibility The behavior of message footers in the list and their visibility.
- * @param dateSeparatorHandler Handler that determines when the date separators should be visible.
- * @param threadDateSeparatorHandler Handler that determines when the thread date separators should be visible.
- * @param messagePositionHandler Determines the position of the message inside a group.
- * @param showDateSeparatorInEmptyThread Configures if we show a date separator when threads are empty.
- * Adds the separator item when the value is `true`.
- * @param showThreadSeparatorInEmptyThread Configures if we show a thread separator when threads are empty.
- * Adds the separator item when the value is `true`.
- * @param threadLoadOlderToNewer Configures if the thread should load older messages to newer messages.
- * @param isComposerLinkPreviewEnabled If the link preview is enabled in the composer.
- * @param isComposerDraftMessageEnabled If the draft message is enabled in the composer.
+ * @param messageListOptions Configuration for the message list behavior.
+ * @param composerOptions Configuration for the message composer behavior.
  */
 public class ChannelViewModelFactory(
     private val context: Context,
@@ -90,34 +117,23 @@ public class ChannelViewModelFactory(
     private val mediaRecorder: StreamMediaRecorder = DefaultStreamMediaRecorder(context.applicationContext),
     private val userLookupHandler: UserLookupHandler = DefaultUserLookupHandler(chatClient, channelId),
     private val fileToUriConverter: (File) -> String = { file -> file.toUri().toString() },
-    private val messageLimit: Int = MessageListController.DEFAULT_MESSAGES_LIMIT,
     private val clipboardHandler: ClipboardHandler = ClipboardHandlerImpl(
         clipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager,
         autoTranslationEnabled = autoTranslationEnabled,
         getCurrentUser = chatClient::getCurrentUser,
     ),
-    private val enforceUniqueReactions: Boolean = false,
-    private val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
-    private val showSystemMessages: Boolean = true,
-    private val messageFooterVisibility: MessageFooterVisibility = MessageFooterVisibility.LastInGroup,
-    private val dateSeparatorHandler: DateSeparatorHandler = DateSeparatorHandler.getDefaultDateSeparatorHandler(),
-    private val threadDateSeparatorHandler: DateSeparatorHandler =
-        DateSeparatorHandler.getDefaultThreadDateSeparatorHandler(),
-    private val messagePositionHandler: MessagePositionHandler = MessagePositionHandler.defaultHandler(),
-    private val showDateSeparatorInEmptyThread: Boolean = false,
-    private val showThreadSeparatorInEmptyThread: Boolean = false,
-    private val threadLoadOlderToNewer: Boolean = false,
-    private val isComposerLinkPreviewEnabled: Boolean = false,
-    private val isComposerDraftMessageEnabled: Boolean = true,
+    private val messageListOptions: MessageListOptions = MessageListOptions(),
+    private val composerOptions: ComposerOptions = ComposerOptions(),
 ) : ViewModelProvider.Factory {
 
     private val channelStateFlow: StateFlow<ChannelState?> by lazy {
         val scope = chatClient.inheritScope { SupervisorJob(it) + DispatcherProvider.Immediate }
         when {
             messageId != null && parentMessageId == null ->
-                chatClient.watchChannelAsState(channelId, messageLimit, messageId, scope)
+                chatClient.watchChannelAsState(channelId, messageListOptions.messageLimit, messageId, scope)
+
             else ->
-                chatClient.watchChannelAsState(channelId, messageLimit, scope)
+                chatClient.watchChannelAsState(channelId, messageListOptions.messageLimit, scope)
         }
     }
 
@@ -162,41 +178,44 @@ public class ChannelViewModelFactory(
                     fileToUri = fileToUriConverter,
                     channelCid = channelId,
                     config = MessageComposerController.Config(
-                        maxAttachmentCount = maxAttachmentCount,
-                        isLinkPreviewEnabled = isComposerLinkPreviewEnabled,
-                        isDraftMessageEnabled = isComposerDraftMessageEnabled,
+                        maxAttachmentCount = composerOptions.maxAttachmentCount,
+                        isLinkPreviewEnabled = composerOptions.isLinkPreviewEnabled,
+                        isDraftMessageEnabled = composerOptions.isDraftMessageEnabled,
                         isActiveCommandEnabled = true,
                     ),
                     savedStateHandle = savedStateHandle ?: SavedStateHandle(),
                 ),
                 storageHelper = storageHelper,
             )
+
             MessageListViewModel::class.java -> MessageListViewModel(
                 MessageListController(
                     cid = channelId,
                     clipboardHandler = clipboardHandler,
-                    threadLoadOrderOlderToNewer = threadLoadOlderToNewer,
+                    threadLoadOrderOlderToNewer = messageListOptions.threadLoadOlderToNewer,
                     messageId = messageId,
                     parentMessageId = parentMessageId,
-                    messageLimit = messageLimit,
+                    messageLimit = messageListOptions.messageLimit,
                     chatClient = chatClient,
                     clientState = clientState,
                     channelState = channelStateFlow,
-                    enforceUniqueReactions = enforceUniqueReactions,
-                    showSystemMessages = showSystemMessages,
-                    messageFooterVisibility = messageFooterVisibility,
-                    dateSeparatorHandler = dateSeparatorHandler,
-                    threadDateSeparatorHandler = threadDateSeparatorHandler,
-                    messagePositionHandler = messagePositionHandler,
-                    showDateSeparatorInEmptyThread = showDateSeparatorInEmptyThread,
-                    showThreadSeparatorInEmptyThread = showThreadSeparatorInEmptyThread,
+                    enforceUniqueReactions = messageListOptions.enforceUniqueReactions,
+                    showSystemMessages = messageListOptions.showSystemMessages,
+                    messageFooterVisibility = messageListOptions.messageFooterVisibility,
+                    dateSeparatorHandler = messageListOptions.dateSeparatorHandler,
+                    threadDateSeparatorHandler = messageListOptions.threadDateSeparatorHandler,
+                    messagePositionHandler = messageListOptions.messagePositionHandler,
+                    showDateSeparatorInEmptyThread = messageListOptions.showDateSeparatorInEmptyThread,
+                    showThreadSeparatorInEmptyThread = messageListOptions.showThreadSeparatorInEmptyThread,
                 ),
             )
+
             AttachmentsPickerViewModel::class.java -> AttachmentsPickerViewModel(
                 storageHelper = storageHelper,
                 channelState = channelStateFlow,
                 savedStateHandle = savedStateHandle ?: SavedStateHandle(),
             )
+
             else -> throw IllegalArgumentException(
                 "ChannelViewModelFactory can only create instances of " +
                     "${MessageComposerViewModel::class.java.simpleName}, " +

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/viewmodel/channels/ChannelListViewModelTest.kt
@@ -631,7 +631,7 @@ internal class ChannelListViewModelTest {
                 chatClient = chatClient,
                 initialSort = initialSort,
                 initialFilters = initialFilters,
-                isDraftMessageEnabled = false,
+                draftMessagesEnabled = false,
                 chatEventHandlerFactory = ChatEventHandlerFactory(clientState),
                 messageSearchSort = messageSearchSort,
                 globalState = MutableStateFlow(globalState),

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/Overview.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/Overview.kt
@@ -13,8 +13,9 @@ import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.ChatClient
 import io.getstream.chat.android.compose.ui.messages.list.MessageList
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
-import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 
 /**
  * [ViewModels](https://getstream.io/chat/docs/sdk/android/compose/overview/#viewmodels)
@@ -28,9 +29,11 @@ private object OverviewViewModelsSnippet {
                 context = this,
                 chatClient = ChatClient.instance(),
                 channelId = "messaging:123",
-                enforceUniqueReactions = true,
-                messageLimit = 30,
-                threadLoadOlderToNewer = false,
+                messageListOptions = MessageListOptions(
+                    enforceUniqueReactions = true,
+                    messageLimit = 30,
+                    threadLoadOlderToNewer = false,
+                ),
             )
         }
 

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/general/ChatTheme.kt
@@ -18,6 +18,7 @@ import io.getstream.chat.android.compose.ui.theme.StreamDesign
 import io.getstream.chat.android.compose.ui.util.MessagePreviewFormatter
 import io.getstream.chat.android.compose.ui.util.MessageTextFormatter
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.helper.DateFormatter
@@ -56,7 +57,7 @@ private object ChatThemeUsageSnippet {
                         viewModelFactory = ChannelViewModelFactory(
                             context = this,
                             channelId = "messaging:123",
-                            messageLimit = 30
+                            messageListOptions = MessageListOptions(messageLimit = 30),
                         ),
                         onBackPressed = { finish() },
                         onHeaderTitleClick = {},

--- a/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/ChannelScreen.kt
+++ b/stream-chat-android-docs/src/main/kotlin/io/getstream/chat/docs/kotlin/compose/messages/ChannelScreen.kt
@@ -12,6 +12,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.messages.AttachmentsPickerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 
 /**
@@ -88,9 +89,11 @@ private object ChannelScreenCustomizationSnippet {
                         viewModelFactory = ChannelViewModelFactory(
                             context = this,
                             channelId = channelId,
-                            messageLimit = 30,
-                            enforceUniqueReactions = true,
-                            showSystemMessages = true
+                            messageListOptions = MessageListOptions(
+                                messageLimit = 30,
+                                enforceUniqueReactions = true,
+                                showSystemMessages = true,
+                            ),
                         ),
                     )
                 }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -431,7 +431,7 @@ public class MessageComposerController(
             syncAttachments()
         }.launchIn(scope)
 
-        if (config.isDraftMessageEnabled) {
+        if (config.draftMessageEnabled) {
             channelDraftMessages.onEach {
                 if (it[channelCid] == null &&
                     !currentDraftId.isNullOrEmpty() &&
@@ -506,7 +506,7 @@ public class MessageComposerController(
     }
 
     private suspend fun saveDraftMessage(messageMode: MessageMode) {
-        if (!config.isDraftMessageEnabled) return
+        if (!config.draftMessageEnabled) return
         currentDraftId = null
         when (val messageText = _messageInput.value.text) {
             "" -> clearDraftMessage(messageMode)
@@ -527,7 +527,7 @@ public class MessageComposerController(
     }
 
     private fun fetchDraftMessage(messageMode: MessageMode) {
-        if (!config.isDraftMessageEnabled) return
+        if (!config.draftMessageEnabled) return
         getDraftMessageOrEmpty(messageMode).let { draftMessage ->
             currentDraftId = draftMessage.id
             setMessageInputInternal(draftMessage.text, MessageInput.Source.DraftMessage)
@@ -715,7 +715,7 @@ public class MessageComposerController(
     }
 
     private suspend fun clearDraftMessage(messageMode: MessageMode) {
-        if (!config.isDraftMessageEnabled) return
+        if (!config.draftMessageEnabled) return
         getDraftMessage(messageMode)?.let { draftMessage ->
             chatClient.deleteDraftMessages(
                 channelType = channelType,
@@ -829,7 +829,7 @@ public class MessageComposerController(
         val activeAction = activeAction
 
         val currentUserId = chatClient.getCurrentUser()?.id
-        val fullText = if (config.isActiveCommandEnabled) {
+        val fullText = if (config.activeCommandEnabled) {
             _state.value.activeCommand?.let { "/${it.name} $message" } ?: message
         } else {
             message
@@ -960,7 +960,7 @@ public class MessageComposerController(
     public fun selectCommand(command: Command) {
         _state.update { it.copy(activeCommand = command) }
         setMessageInputInternal(
-            value = if (config.isActiveCommandEnabled) "" else "/${command.name} ",
+            value = if (config.activeCommandEnabled) "" else "/${command.name} ",
             source = MessageInput.Source.CommandSelected,
         )
         _inputFocusEvents.tryEmit(Unit)
@@ -1164,7 +1164,7 @@ public class MessageComposerController(
         val url = LinkPattern.find(messageText)?.value
         logger.v { "[handleLinkPreview] url: $url" }
         val preview = url
-            ?.takeIf { config.isLinkPreviewEnabled && !it.equals(dismissedLinkPreviewUrl, ignoreCase = true) }
+            ?.takeIf { config.linkPreviewEnabled && !it.equals(dismissedLinkPreviewUrl, ignoreCase = true) }
             ?.let { chatClient.enrichPreview(it).await().getOrNull() }
         logger.v { "[handleLinkPreview] preview: ${preview?.originUrl}" }
         _state.update { it.copy(linkPreview = preview) }
@@ -1223,16 +1223,16 @@ public class MessageComposerController(
      * Configuration for the message composer controller.
      *
      * @param maxAttachmentCount The maximum number of attachments allowed in a message.
-     * @param isLinkPreviewEnabled If link previews are enabled.
-     * @param isDraftMessageEnabled If draft messages are enabled.
-     * @param isActiveCommandEnabled If active commands are enabled.
+     * @param linkPreviewEnabled If link previews are enabled.
+     * @param draftMessageEnabled If draft messages are enabled.
+     * @param activeCommandEnabled If active commands are enabled.
      */
     @InternalStreamChatApi
     public data class Config(
         val maxAttachmentCount: Int = AttachmentConstants.MAX_ATTACHMENTS_COUNT,
-        val isLinkPreviewEnabled: Boolean = false,
-        val isDraftMessageEnabled: Boolean = true,
-        val isActiveCommandEnabled: Boolean = false,
+        val linkPreviewEnabled: Boolean = false,
+        val draftMessageEnabled: Boolean = true,
+        val activeCommandEnabled: Boolean = false,
     )
 
     private fun getDraftMessageOrEmpty(messageMode: MessageMode): DraftMessage =

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -581,7 +581,7 @@ internal class MessageComposerControllerTest {
         // Given
         val command = Command("giphy", "Search GIFs", "[text]", "fun_set")
         val controller = Fixture()
-            .givenConfig(MessageComposerController.Config(isActiveCommandEnabled = false))
+            .givenConfig(MessageComposerController.Config(activeCommandEnabled = false))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -605,7 +605,7 @@ internal class MessageComposerControllerTest {
         // Given
         val command = Command("giphy", "Search GIFs", "[text]", "fun_set")
         val controller = Fixture()
-            .givenConfig(MessageComposerController.Config(isActiveCommandEnabled = true))
+            .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -655,7 +655,7 @@ internal class MessageComposerControllerTest {
         // Given
         val command = Command("giphy", "Search GIFs", "[text]", "fun_set")
         val controller = Fixture()
-            .givenConfig(MessageComposerController.Config(isActiveCommandEnabled = true))
+            .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -679,7 +679,7 @@ internal class MessageComposerControllerTest {
         // Given
         val command = Command("giphy", "Search GIFs", "[text]", "fun_set")
         val controller = Fixture()
-            .givenConfig(MessageComposerController.Config(isActiveCommandEnabled = true))
+            .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -1283,7 +1283,7 @@ internal class MessageComposerControllerTest {
             doWork = { resolveSignal.await() },
         )
         val fixture = Fixture()
-            .givenConfig(MessageComposerController.Config(isLinkPreviewEnabled = true))
+            .givenConfig(MessageComposerController.Config(linkPreviewEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -1348,7 +1348,7 @@ internal class MessageComposerControllerTest {
         val url = "https://example.com"
         val sentMessage = randomMessage(cid = CID, text = url)
         val fixture = Fixture()
-            .givenConfig(MessageComposerController.Config(isLinkPreviewEnabled = true))
+            .givenConfig(MessageComposerController.Config(linkPreviewEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -1385,7 +1385,7 @@ internal class MessageComposerControllerTest {
         val newUrl = "https://getstream.io"
         val sentMessage = randomMessage(cid = CID, text = newUrl)
         val fixture = Fixture()
-            .givenConfig(MessageComposerController.Config(isLinkPreviewEnabled = true))
+            .givenConfig(MessageComposerController.Config(linkPreviewEnabled = true))
             .givenAppSettings()
             .givenAudioPlayer(mock())
             .givenClientState(randomUser())
@@ -1422,7 +1422,7 @@ internal class MessageComposerControllerTest {
             val url = "https://example.com"
             val sentMessage = randomMessage(cid = CID, text = "$url hello")
             val fixture = Fixture()
-                .givenConfig(MessageComposerController.Config(isLinkPreviewEnabled = true))
+                .givenConfig(MessageComposerController.Config(linkPreviewEnabled = true))
                 .givenAppSettings()
                 .givenAudioPlayer(mock())
                 .givenClientState(randomUser())

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/ChannelViewModelFactory.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/ChannelViewModelFactory.kt
@@ -150,7 +150,7 @@ public class ChannelViewModelFactory @JvmOverloads constructor(
                     channelState = channelStateFlow,
                     config = MessageComposerController.Config(
                         maxAttachmentCount = maxAttachmentCount,
-                        isDraftMessageEnabled = isComposerDraftMessagesEnabled,
+                        draftMessageEnabled = isComposerDraftMessagesEnabled,
                     ),
                     savedStateHandle = savedStateHandle,
                 ),

--- a/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customattachments/MessagesActivity.kt
+++ b/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customattachments/MessagesActivity.kt
@@ -45,6 +45,7 @@ import io.getstream.chat.android.compose.ui.messages.list.MessageList
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
 import io.getstream.chat.android.compose.viewmodel.messages.MessageComposerViewModel
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
 import io.getstream.chat.android.compose.viewmodel.messages.MessageListViewModel
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.state.messages.MessageMode
@@ -88,7 +89,7 @@ class MessagesActivity : AppCompatActivity() {
         val factory = ChannelViewModelFactory(
             context = LocalContext.current,
             channelId = channelId,
-            threadLoadOlderToNewer = threadLoadOlderToNewer,
+            messageListOptions = MessageListOptions(threadLoadOlderToNewer = threadLoadOlderToNewer),
         )
 
         val messageListViewModel = viewModel(MessageListViewModel::class.java, factory = factory)

--- a/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customizingimageandvideoattachments/MessagesActivity.kt
+++ b/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customizingimageandvideoattachments/MessagesActivity.kt
@@ -37,6 +37,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatComponentFactory
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageComposerAttachmentMediaItemParams
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
 import io.getstream.chat.android.guides.catalog.compose.customizingimageandvideoattachments.ui.CustomPlayButton
 import io.getstream.chat.android.models.AttachmentType
 
@@ -52,8 +53,8 @@ class MessagesActivity : ComponentActivity() {
     private val channelViewModelFactory by lazy {
         ChannelViewModelFactory(
             context = this,
-            requireNotNull(intent.getStringExtra(KEY_CHANNEL_ID)),
-            threadLoadOlderToNewer = true,
+            channelId = requireNotNull(intent.getStringExtra(KEY_CHANNEL_ID)),
+            messageListOptions = MessageListOptions(threadLoadOlderToNewer = true),
         )
     }
 

--- a/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customreactions/MessagesActivity.kt
+++ b/stream-chat-android-ui-guides/src/main/java/io/getstream/chat/android/guides/catalog/compose/customreactions/MessagesActivity.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.util.ReactionResolver
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
+import io.getstream.chat.android.compose.viewmodel.messages.MessageListOptions
 import io.getstream.chat.android.guides.R
 
 /**
@@ -51,7 +52,7 @@ class MessagesActivity : AppCompatActivity() {
                     viewModelFactory = ChannelViewModelFactory(
                         context = this,
                         channelId = channelId,
-                        threadLoadOlderToNewer = true,
+                        messageListOptions = MessageListOptions(threadLoadOlderToNewer = true),
                     ),
                     onBackPressed = { finish() },
                     onHeaderTitleClick = {},


### PR DESCRIPTION
### Goal

Reduce the parameter count of `ChannelViewModelFactory` by grouping related parameters into dedicated configuration classes.

### Implementation

- Introduce `MessageListOptions` and `ComposerOptions` grouping message list and composer parameters
- Update all usages

### Testing

Everything should be working as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized message and composer configuration settings into structured options objects. MessageListOptions consolidates message display, threading, separator, and loading behavior settings, while ComposerOptions groups attachment limits and feature enablement settings. This change provides a cleaner, more organized approach to managing messaging customizations while maintaining full compatibility with existing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->