### PR TITLE
Fix offline persisted drafts not cleared on logout

### DIFF
--- a/stream-chat-android-offline/api/stream-chat-android-offline.api
+++ b/stream-chat-android-offline/api/stream-chat-android-offline.api
@@ -107,6 +107,7 @@ public final class io/getstream/chat/android/offline/repository/domain/message/i
 public final class io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao_Impl : io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao {
 	public fun <init> (Landroidx/room/RoomDatabase;)V
 	public fun deleteAll (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun deleteAllDrafts (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun deleteAttachments (Ljava/util/List;)V
 	public fun deleteAttachmentsChunked (Ljava/util/List;)V
 	public fun deleteChannelMessagesBefore (Ljava/lang/String;Ljava/util/Date;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/DatabaseMessageRepository.kt
@@ -258,6 +258,7 @@ internal class DatabaseMessageRepository(
         replyMessageCache.evictAll()
         dbMutex.withLock {
             messageDao.deleteAll()
+            messageDao.deleteAllDrafts()
             replyMessageDao.deleteAll()
         }
     }

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/message/internal/MessageDao.kt
@@ -253,6 +253,9 @@ internal interface MessageDao {
     @Query("DELETE FROM $MESSAGE_ENTITY_TABLE_NAME")
     suspend fun deleteAll()
 
+    @Query("DELETE FROM $DRAFT_MESSAGE_ENTITY_TABLE_NAME")
+    suspend fun deleteAllDrafts()
+
     private companion object {
         private const val SQLITE_MAX_VARIABLE_NUMBER: Int = 999
         private const val NO_LIMIT: Int = -1

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/MessageRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/MessageRepositoryTests.kt
@@ -219,4 +219,26 @@ internal class MessageRepositoryTests {
         // then
         verify(messageDao).deleteMessages(messageIds)
     }
+
+    @Test
+    fun `when calling clear, then all related tables are cleared`() = runTest(testDispatcher) {
+        // given
+        val repository = DatabaseMessageRepository(
+            this,
+            messageDao,
+            replyMessageDao,
+            pollDao,
+            ::randomUser,
+            randomUser(id = "currentUserId"),
+            emptySet(),
+        )
+
+        // when
+        repository.clear()
+
+        // then
+        verify(messageDao).deleteAll()
+        verify(messageDao).deleteAllDrafts()
+        verify(replyMessageDao).deleteAll()
+    }
 }


### PR DESCRIPTION
### Goal
We were not clearing the drafts offline storage on user logout. This resulted in a stuck draft message between sessions. 

### Implementation
Clear the drafts table on logout (same as all other tables)

### Testing
1. Create a draft (enter channel, write a message (don't send), exit channel)
2. Re-enter same channel and send the message
3. Logout
4. Login
5. The Draft should NOT be present in the channel 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added draft message cleanup to the repository clearing operation, ensuring draft messages are properly removed along with other cached data.

* **Tests**
  * Added unit test to verify draft message deletion during repository clearing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->