### PR TITLE
Harden E2E UiAutomator text-wait helpers against recomposition

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotChannelListAsserts.kt
@@ -37,7 +37,10 @@ fun UserRobot.assertMessageInChannelPreview(text: String, fromCurrentUser: Boole
         false -> "${ParticipantRobot.name}: $text"
         null -> text
     }
-    assertEquals(expectedPreview, Channel.messagePreview.waitToAppear().waitForText(expectedPreview).text.trimEnd())
+    assertEquals(
+        expectedPreview,
+        Channel.messagePreview.waitForText(expectedPreview, mustBeEqual = false).trimEnd(),
+    )
     return this
 }
 

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -119,10 +119,8 @@ fun UserRobot.assertMessageFailedIcon(isDisplayed: Boolean): UserRobot {
 
 fun UserRobot.assertEditedMessage(text: String): UserRobot {
     assertMessage(text)
-    assertEquals(
-        appContext.getString(R.string.stream_compose_message_list_footnote_edited),
-        Message.editedLabel.waitToAppear().text,
-    )
+    val expectedLabel = appContext.getString(R.string.stream_compose_message_list_footnote_edited)
+    assertEquals(expectedLabel, Message.editedLabel.waitForText(expectedLabel))
     return this
 }
 
@@ -237,8 +235,7 @@ fun UserRobot.assertMentionWasApplied(): UserRobot {
 }
 
 fun UserRobot.assertComposerText(expectedText: String): UserRobot {
-    val actualText = Composer.inputField.waitToAppear().text
-    assertEquals(expectedText, actualText)
+    assertEquals(expectedText, Composer.inputField.waitForText(expectedText))
     return this
 }
 
@@ -268,27 +265,20 @@ fun UserRobot.assertThreadReplyLabelOnParentMessage(): UserRobot {
         1,
         1,
     )
-    assertEquals(
-        expectedResult,
-        Message.threadRepliesLabel.waitToAppear().text,
-    )
+    assertEquals(expectedResult, Message.threadRepliesLabel.waitForText(expectedResult))
     assertTrue(Message.threadParticipantAvatar.isDisplayed())
     return this
 }
 
 fun UserRobot.assertAlsoInTheChannelLabelInChannel(): UserRobot {
-    assertEquals(
-        appContext.getString(R.string.stream_compose_replied_to_thread),
-        Message.messageHeaderLabel.waitToAppear().text,
-    )
+    val expectedLabel = appContext.getString(R.string.stream_compose_replied_to_thread)
+    assertEquals(expectedLabel, Message.messageHeaderLabel.waitForText(expectedLabel))
     return this
 }
 
 fun UserRobot.assertAlsoInTheChannelLabelInThread(): UserRobot {
-    assertEquals(
-        appContext.getString(R.string.stream_compose_also_sent_to_channel),
-        Message.messageHeaderLabel.waitToAppear().text,
-    )
+    val expectedLabel = appContext.getString(R.string.stream_compose_also_sent_to_channel)
+    assertEquals(expectedLabel, Message.messageHeaderLabel.waitForText(expectedLabel))
     return this
 }
 
@@ -360,7 +350,7 @@ fun UserRobot.assertThreadReplyLabel(replies: Int, inThread: Boolean = false): U
             replies,
             replies,
         )
-        assertEquals(expectedResult, Message.threadRepliesLabel.waitToAppear().text)
+        assertEquals(expectedResult, Message.threadRepliesLabel.waitForText(expectedResult))
     }
     return this
 }

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -143,7 +143,7 @@ fun UserRobot.assertDeletedMessage(text: String? = null, hard: Boolean = false):
 fun UserRobot.assertQuotedMessage(text: String, quote: String = "", isDisplayed: Boolean = true): UserRobot {
     val quotedMessageInList = Message.quotedMessage.hasAncestor(MessageListPage.MessageList.messages)
     if (isDisplayed) {
-        assertEquals(quote, quotedMessageInList.waitToAppear().waitForText(quote).text)
+        assertEquals(quote, quotedMessageInList.waitForText(quote))
     } else {
         assertFalse(quotedMessageInList.waitToDisappear().isDisplayed())
     }
@@ -231,7 +231,7 @@ fun UserRobot.assertMentionWasApplied(): UserRobot {
     val additionalSpace = " "
     val userName = ParticipantRobot.name
     val expectedText = "@${userName}$additionalSpace"
-    val actualText = Composer.inputField.findObject().waitForText(expectedText).text
+    val actualText = Composer.inputField.waitForText(expectedText)
     assertEquals(expectedText, actualText)
     return this
 }
@@ -352,7 +352,7 @@ fun UserRobot.assertThreadReplyLabel(replies: Int, inThread: Boolean = false): U
         )
         assertEquals(
             expectedResult,
-            ThreadPage.ThreadList.repliesCountLabel.waitToAppear().waitForText(expectedResult).text,
+            ThreadPage.ThreadList.repliesCountLabel.waitForText(expectedResult),
         )
     } else {
         val expectedResult = appContext.resources.getQuantityString(

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/tests/QuotedReplyTests.kt
@@ -560,7 +560,6 @@ class QuotedReplyTests : StreamTestCase() {
     }
 
     @AllureId("5898")
-    @Ignore("https://linear.app/stream/issue/AND-1136")
     @Test
     fun test_quotedReplyInThreadAndAlsoInChannel() {
         val quotedText = messagesCount.toString()

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
@@ -25,14 +25,33 @@ public fun sleep(timeOutMillis: Long = defaultTimeout) {
     Thread.sleep(timeOutMillis)
 }
 
+/**
+ * Waits up to [timeOutMillis] for an object matching this selector and returns it.
+ *
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without a matching object.
+ */
 public fun BySelector.waitToAppear(timeOutMillis: Long = defaultTimeout): UiObject2 {
     wait(timeOutMillis)
-    return findObject()
+    return device.findObject(this)
+        ?: error("waitToAppear timed out after ${timeOutMillis}ms; no object matched selector: $this")
 }
 
+/**
+ * Waits up to [timeOutMillis] for objects matching this selector and returns the one at [withIndex].
+ *
+ * @param withIndex The zero-based index of the object to return.
+ * @param timeOutMillis Maximum time to wait before failing.
+ * @throws IllegalStateException when the timeout elapses without enough matching objects.
+ */
 public fun BySelector.waitToAppear(withIndex: Int, timeOutMillis: Long = defaultTimeout): UiObject2 {
     wait(timeOutMillis)
-    return findObjects()[withIndex]
+    val objects = device.findObjects(this)
+    return objects.getOrNull(withIndex)
+        ?: error(
+            "waitToAppear(withIndex=$withIndex) timed out after ${timeOutMillis}ms; " +
+                "only ${objects.size} objects matched selector: $this",
+        )
 }
 
 public fun BySelector.wait(timeOutMillis: Long = defaultTimeout): BySelector {
@@ -46,9 +65,9 @@ public fun BySelector.waitToDisappear(timeOutMillis: Long = defaultTimeout): ByS
 }
 
 /**
- * Polls by re-finding the object on each iteration so a mid-poll recomposition does not produce
- * a [StaleObjectException]. Returns the text that was observed when the match succeeded, or the
- * last observed text on timeout — never throws. Callers typically wrap the result in an
+ * Waits for an object matching this selector whose text matches [expectedText]. Returns the
+ * matched text, or the last observed text on timeout. Never throws — recompositions and
+ * mid-poll node recycling are absorbed internally, so callers should wrap the result in an
  * assertion to surface mismatch/timeout.
  *
  * @param expectedText The text to match.

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.compose.uiautomator
 
 import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.StaleObjectException
 import androidx.test.uiautomator.UiObject2
 import androidx.test.uiautomator.Until
 
@@ -44,17 +45,40 @@ public fun BySelector.waitToDisappear(timeOutMillis: Long = defaultTimeout): ByS
     return this
 }
 
-public fun UiObject2.waitForText(
+/**
+ * Polls by re-finding the object on each iteration so a mid-poll recomposition does not produce
+ * a [StaleObjectException]. Returns the text that was observed when the match succeeded, or the
+ * last observed text on timeout — never throws. Callers typically wrap the result in an
+ * assertion to surface mismatch/timeout.
+ *
+ * @param expectedText The text to match.
+ * @param mustBeEqual When `true`, requires exact match; otherwise a substring match.
+ * @param timeOutMillis Maximum time to keep polling before returning the last observed text.
+ */
+public fun BySelector.waitForText(
     expectedText: String,
     mustBeEqual: Boolean = true,
     timeOutMillis: Long = defaultTimeout,
-): UiObject2 {
+): String {
     val endTime = System.currentTimeMillis() + timeOutMillis
-    var textPresent = false
-    while (!textPresent && System.currentTimeMillis() < endTime) {
-        textPresent = if (mustBeEqual) text == expectedText else text.contains(expectedText)
+    var lastText = ""
+    while (System.currentTimeMillis() < endTime) {
+        val actual = currentTextOrNull()
+        if (actual != null) {
+            lastText = actual
+            val matches = if (mustBeEqual) actual == expectedText else actual.contains(expectedText)
+            if (matches) return actual
+        }
     }
-    return this
+    return lastText
+}
+
+// Call [device] directly — [findObject] lies about nullability and NPEs when the selector hasn't
+// matched yet, which is the normal case during polling.
+private fun BySelector.currentTextOrNull(): String? = try {
+    device.findObject(this)?.text
+} catch (_: StaleObjectException) {
+    null
 }
 
 public fun BySelector.waitForCount(count: Int, timeOutMillis: Long = defaultTimeout): List<UiObject2> {

--- a/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
+++ b/stream-chat-android-e2e-test/src/main/kotlin/io/getstream/chat/android/e2e/test/uiautomator/Wait.kt
@@ -88,9 +88,12 @@ public fun BySelector.waitForText(
             val matches = if (mustBeEqual) actual == expectedText else actual.contains(expectedText)
             if (matches) return actual
         }
+        Thread.sleep(POLL_INTERVAL_MILLIS)
     }
     return lastText
 }
+
+private const val POLL_INTERVAL_MILLIS = 50L
 
 // Call [device] directly — [findObject] lies about nullability and NPEs when the selector hasn't
 // matched yet, which is the normal case during polling.


### PR DESCRIPTION
### Goal

Compose-driven nodes get recycled mid-poll, causing `waitForText` to hit `StaleObjectException` or NPE and fail tests deterministically on slow emulators. Tighten the helpers so assertions survive recomposition and surface timeouts with a clear error.

### Implementation

**`stream-chat-android-e2e-test / Wait.kt`**
- `waitForText` moved from `UiObject2` receiver to `BySelector`. Re-resolves the node on every iteration via `device.findObject(this)`, swallows `StaleObjectException` as "no match yet", sleeps 50 ms per poll, and returns the matched `String` (or last observed text on timeout).
- `waitToAppear` (both overloads) now throws a descriptive `IllegalStateException` on timeout instead of leaking a null NPE or `ArrayIndexOutOfBoundsException`.
- KDoc added describing throw/stale semantics.

**`stream-chat-android-compose-sample / robots`**
- Call sites in `UserRobotChannelListAsserts` and `UserRobotMessageListAsserts` migrated to the new `BySelector.waitForText(…)` signature, dropping the prior `waitToAppear().text` pattern that was susceptible to the same recomposition races.

**API** — `waitForText` receiver and return type changed (`UiObject2 → BySelector`, `UiObject2 → String`). Internal to the test-infra module; all in-repo consumers migrated.

### Testing

E2E run required (device/emulator). On `stream-chat-android-compose-sample` with the mock server:

1. **Recomposition resilience** — run the message-list asserts (`assertEditedMessage`, `assertQuotedMessage`, `assertMentionWasApplied`, `assertThreadReplyLabel`) and `ChannelListTests.test_channelPreviewShowsPreviousMessage_whenLastMessageIsDeleted`. Expect: no intermittent `StaleObjectException` in logcat; previously flaky suites pass consistently.
2. **Timeout surfaces cleanly** — temporarily break a selector (e.g. wrong resource id) at any `waitToAppear` call site and re-run. Expect: `IllegalStateException: waitToAppear timed out after 10000ms; no object matched selector: …` instead of an NPE.

### Follow-up tasks (out of scope here)

Separate PRs planned under `refactor/e2e-uiautomator-helpers` and `perf/e2e-test-runtime`:

- `BySelector.wait()` discards its boolean — either return it or throw on timeout; migrate call sites that currently do `.wait().isDisplayed()`.
- Apply the same stale-guard + poll sleep to sister helpers in `Wait.kt` (`waitForCount`, `waitForTextToChange`) and to `UiObject2.isDisplayed()` in `Element.kt`.
- `assertSystemMessage` currently discards `isDisplayed()` — add the missing `assertTrue`/`assertFalse`.
- `openChannel` hits `ArrayIndexOutOfBoundsException` when the channel list hasn't loaded; switch to `waitToAppear(withIndex = …)`.
- Scroll helpers (`scrollUp/DownUntilDisplayed`) NPE on miss — replace with descriptive error.
- Replace fixed `sleep(500/1000/5000)` with predicate waits where possible; reduce `defaultTimeout` from 10 s and add an explicit long timeout for known-slow ops.
- Route typing through `UiObject2.typeText` (direct `.text =`) instead of `adb shell input text` where the field is addressable — the shell path types character-by-character and dominates runtime for long strings.
- `RetryRule` attachment recording fires per failed attempt — record only the final attempt.

No UI changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved assertion reliability for channel message previews with enhanced text matching logic.
  * Added test coverage for deleted message placeholders displayed in channel preview lists.
  * Refined UI automation wait mechanisms with more accurate text polling and explicit timeout error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->