### PR TITLE
Register the OkHttp network fetcher explicitly in the default image loader

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactory.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactory.kt
@@ -25,6 +25,7 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.intercept.Interceptor
 import coil3.memory.MemoryCache
+import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.request.allowHardware
 import coil3.request.crossfade
 import coil3.video.VideoFrameDecoder
@@ -82,6 +83,7 @@ public class StreamImageLoaderFactory(
             }
             .components {
                 interceptors.forEach { add(it) }
+                add(OkHttpNetworkFetcherFactory())
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     add(AnimatedImageDecoder.Factory(enforceMinimumFrameDelay = true))
                 } else {

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactoryTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactoryTest.kt
@@ -24,6 +24,7 @@ import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.memory.MemoryCache
 import coil3.network.NetworkFetcher
+import coil3.serviceLoaderEnabled
 import coil3.video.VideoFrameDecoder
 import okio.Path.Companion.toOkioPath
 import org.amshove.kluent.internal.assertEquals
@@ -105,8 +106,8 @@ internal class StreamImageLoaderFactoryTest {
     }
 
     @Test
-    fun `newImageLoader registers network fetcher for HTTP URLs`() {
-        val sut = StreamImageLoaderFactory()
+    fun `newImageLoader registers network fetcher explicitly without relying on ServiceLoader`() {
+        val sut = StreamImageLoaderFactory(builder = { serviceLoaderEnabled(false) })
 
         val imageLoader = sut.newImageLoader(context)
 

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactoryTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactoryTest.kt
@@ -23,6 +23,7 @@ import coil3.disk.DiskCache
 import coil3.gif.AnimatedImageDecoder
 import coil3.gif.GifDecoder
 import coil3.memory.MemoryCache
+import coil3.network.NetworkFetcher
 import coil3.video.VideoFrameDecoder
 import okio.Path.Companion.toOkioPath
 import org.amshove.kluent.internal.assertEquals
@@ -101,6 +102,17 @@ internal class StreamImageLoaderFactoryTest {
         assertTrue(hasAnimatedDecoder)
         assertFalse(hasGifDecoder)
         assertTrue(hasVideoDecoder)
+    }
+
+    @Test
+    fun `newImageLoader registers network fetcher for HTTP URLs`() {
+        val sut = StreamImageLoaderFactory()
+
+        val imageLoader = sut.newImageLoader(context)
+
+        val hasNetworkFetcher = imageLoader.components.fetcherFactories
+            .any { (factory, _) -> factory is NetworkFetcher.Factory }
+        assertTrue(hasNetworkFetcher)
     }
 
     @Test


### PR DESCRIPTION
### Goal

Since the Coil 2 → Coil 3 migration in 6.13.0, customers have reported blank/placeholder images in release builds ([support ticket](https://getstream.slack.com/archives/C02D4SFMPQ9/p1776113279587439)). Coil 3 registers `OkHttpNetworkFetcherFactory` via `ServiceLoader`, which R8 full-mode can strip, leaving the `ImageLoader` without a fetcher for HTTP URLs. Registering it explicitly removes the `ServiceLoader` dependency.

### Implementation

**`StreamImageLoaderFactory`** — add `OkHttpNetworkFetcherFactory()` to the components block. Integrators delegating to `StreamImageLoaderFactory` (Compose `StreamCoilImageLoaderFactory.defaultFactory()` and the XML `StreamCoil` singleton) pick up the fix for free. No public API changes.

**Not included** — consumer R8 keep rules for Coil 3 `ServiceLoader` descriptors. With the fetcher registered in code, those only matter for integrators building a fully custom `ImageLoader`, which is already covered by the docs.

### Testing

1. `./gradlew :stream-chat-android-ui-common:testDebugUnitTest --tests "StreamImageLoaderFactoryTest"` — includes a new assertion that `fetcherFactories` contains a `NetworkFetcher.Factory`.
2. Build a minified release of `stream-chat-android-compose-sample` on a device that previously reproduced the blank-image symptom, open a channel with image attachments, confirm images load without any integrator-side fetcher registration.
3. Run the Compose sample in debug — images, GIFs, and video thumbnails render as before.

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify proper registration of image loading components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->