### PR TITLE
Round-trip active command through draft messages

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -269,6 +269,8 @@ internal class DomainMapping(
             mentionedUsersIds = message.mentioned_users?.map { it.id } ?: emptyList(),
             silent = message.silent,
             text = message.text,
+            command = message.command,
+            args = message.args,
             extraData = message.extraData ?: emptyMap(),
         )
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DtoMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DtoMapping.kt
@@ -125,6 +125,7 @@ internal class DtoMapping(
                     attachments = attachments.map { it.toDto() },
                     cid = cid,
                     command = command,
+                    args = null,
                     html = html,
                     id = id,
                     type = type,
@@ -156,7 +157,8 @@ internal class DtoMapping(
     internal fun DraftMessage.toDto(): UpstreamMessageDto = UpstreamMessageDto(
         attachments = attachments.map { it.toDto() },
         cid = cid,
-        command = null,
+        command = command,
+        args = args,
         id = id,
         html = "",
         mentioned_users = mentionedUsersIds,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/MessageDtos.kt
@@ -33,6 +33,7 @@ internal data class UpstreamMessageDto(
     val attachments: List<AttachmentDto>,
     val cid: String,
     val command: String?,
+    val args: String?,
     val html: String,
     val id: String,
     val type: String,
@@ -119,6 +120,8 @@ internal data class DownstreamDraftDto(
 internal data class DownstreamDraftMessageDto(
     val id: String,
     val text: String,
+    val command: String? = null,
+    val args: String? = null,
     val attachments: List<AttachmentDto>? = null,
     val mentioned_users: List<DownstreamUserDto>? = null,
     val silent: Boolean = false,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/database/internal/ChatDatabase.kt
@@ -88,7 +88,7 @@ import io.getstream.chat.android.client.internal.offline.repository.domain.user.
         ThreadOrderEntity::class,
         DraftMessageEntity::class,
     ],
-    version = 102,
+    version = 103,
     exportSchema = false,
 )
 @TypeConverters(

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DraftMessageEntity.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/DraftMessageEntity.kt
@@ -32,6 +32,8 @@ internal data class DraftMessageEntity(
     val silent: Boolean,
     val showInChannel: Boolean,
     val replyMessageId: String? = null,
+    val command: String? = null,
+    val args: String? = null,
     val extraData: Map<String, Any> = mapOf(),
 )
 

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapper.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/offline/repository/domain/message/internal/MessageMapper.kt
@@ -237,6 +237,8 @@ internal fun DraftMessage.toEntity(): DraftMessageEntity = DraftMessageEntity(
     showInChannel = showInChannel,
     replyMessageId = replyMessage?.id,
     text = text,
+    command = command,
+    args = args,
     extraData = extraData,
 )
 
@@ -251,6 +253,8 @@ internal suspend fun DraftMessageEntity.toModel(
     showInChannel = showInChannel,
     replyMessage = replyMessageId?.let { getMessage(it) },
     text = text,
+    command = command,
+    args = args,
     extraData = extraData,
 )
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -261,6 +261,8 @@ internal object Mother {
     fun randomDownstreamDraftMessageDto(
         id: String = randomString(),
         text: String = randomString(),
+        command: String? = null,
+        args: String? = null,
         attachments: List<AttachmentDto>? = emptyList(),
         mentionedUsers: List<DownstreamUserDto>? = emptyList(),
         silent: Boolean = randomBoolean(),
@@ -268,6 +270,8 @@ internal object Mother {
     ): DownstreamDraftMessageDto = DownstreamDraftMessageDto(
         id = id,
         text = text,
+        command = command,
+        args = args,
         attachments = attachments,
         mentioned_users = mentionedUsers,
         silent = silent,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -166,7 +166,12 @@ internal class DomainMappingTest {
 
     @Test
     fun `DownstreamDraftDto is correctly mapped to DraftMessage`() {
-        val draftMessageResponse = randomDownstreamDraftDto()
+        val draftMessageResponse = randomDownstreamDraftDto(
+            message = randomDownstreamDraftMessageDto(
+                command = "giphy",
+                args = "cat",
+            ),
+        )
         val sut = Fixture()
             .get()
         val expectedMappedDraftMessage = with(sut) {
@@ -183,6 +188,8 @@ internal class DomainMappingTest {
                 extraData = draftMessageResponse.message.extraData ?: emptyMap(),
                 silent = draftMessageResponse.message.silent,
                 showInChannel = draftMessageResponse.message.show_in_channel,
+                command = draftMessageResponse.message.command,
+                args = draftMessageResponse.message.args,
             )
         }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DtoMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DtoMappingTest.kt
@@ -141,7 +141,8 @@ internal class DtoMappingTest {
         val expected = UpstreamMessageDto(
             attachments = message.attachments.map { with(mapping) { it.toDto() } },
             cid = message.cid,
-            command = null,
+            command = message.command,
+            args = message.args,
             html = "",
             id = message.id,
             type = "regular",
@@ -176,6 +177,7 @@ internal class DtoMappingTest {
             attachments = message.attachments.map { with(mapping) { it.toDto() } },
             cid = message.cid,
             command = message.command,
+            args = null,
             html = message.html,
             id = message.id,
             type = message.type,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/MessageDtoTestData.kt
@@ -415,6 +415,7 @@ internal object MessageDtoTestData {
         html = "html",
         parent_id = null,
         command = null,
+        args = null,
         silent = false,
         shadowed = false,
         extraData = mapOf(
@@ -471,6 +472,7 @@ internal object MessageDtoTestData {
         html = "",
         parent_id = null,
         command = null,
+        args = null,
         silent = false,
         shadowed = false,
         extraData = emptyMap(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessagePreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessagePreviewContent.kt
@@ -96,7 +96,8 @@ internal fun DraftPreviewContent(
     modifier: Modifier = Modifier,
 ) {
     val draftLabel = stringResource(R.string.stream_compose_channel_list_draft)
-    val fullPreview = "$draftLabel ${draftMessage.text}"
+    val draftBody = draftMessage.previewBody()
+    val fullPreview = "$draftLabel $draftBody"
     Row(
         modifier = modifier
             .testTag("Stream_MessagePreview")
@@ -110,11 +111,22 @@ internal fun DraftPreviewContent(
             maxLines = 1,
         )
         Text(
-            text = draftMessage.text,
+            text = draftBody,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             style = ChatTheme.typography.captionDefault,
             color = ChatTheme.colors.textSecondary,
         )
     }
+}
+
+/**
+ * Renders the body of the draft preview. Active commands are surfaced with their `/name` prefix
+ * so the channel list reflects what the user actually composed (matches legacy mode, where the
+ * prefix was carried inside `text`).
+ */
+private fun DraftMessage.previewBody(): String {
+    val name = command ?: return text
+    val typed = args ?: text
+    return if (typed.isEmpty()) "/$name" else "/$name $typed"
 }

--- a/stream-chat-android-core/api/stream-chat-android-core.api
+++ b/stream-chat-android-core/api/stream-chat-android-core.api
@@ -848,10 +848,12 @@ public final class io/getstream/chat/android/models/DistinctFilterObject : io/ge
 
 public final class io/getstream/chat/android/models/DraftMessage : io/getstream/chat/android/models/CustomObject, io/getstream/chat/android/models/querysort/ComparableFieldProvider {
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component10 ()Lio/getstream/chat/android/models/Message;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
@@ -860,11 +862,13 @@ public final class io/getstream/chat/android/models/DraftMessage : io/getstream/
 	public final fun component7 ()Ljava/util/Map;
 	public final fun component8 ()Z
 	public final fun component9 ()Z
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;)Lio/getstream/chat/android/models/DraftMessage;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/models/DraftMessage;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/models/DraftMessage;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/models/DraftMessage;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZLio/getstream/chat/android/models/Message;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/models/DraftMessage;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getArgs ()Ljava/lang/String;
 	public final fun getAttachments ()Ljava/util/List;
 	public final fun getCid ()Ljava/lang/String;
+	public final fun getCommand ()Ljava/lang/String;
 	public fun getComparableField (Ljava/lang/String;)Ljava/lang/Comparable;
 	public fun getExtraData ()Ljava/util/Map;
 	public fun getExtraValue (Ljava/lang/String;Ljava/lang/Object;)Ljava/lang/Object;
@@ -885,8 +889,10 @@ public final class io/getstream/chat/android/models/DraftMessage$Builder {
 	public fun <init> ()V
 	public fun <init> (Lio/getstream/chat/android/models/DraftMessage;)V
 	public final fun build ()Lio/getstream/chat/android/models/DraftMessage;
+	public final fun withArgs (Ljava/lang/String;)Lio/getstream/chat/android/models/DraftMessage$Builder;
 	public final fun withAttachments (Ljava/util/List;)Lio/getstream/chat/android/models/DraftMessage$Builder;
 	public final fun withCid (Ljava/lang/String;)Lio/getstream/chat/android/models/DraftMessage$Builder;
+	public final fun withCommand (Ljava/lang/String;)Lio/getstream/chat/android/models/DraftMessage$Builder;
 	public final fun withExtraData (Ljava/util/Map;)Lio/getstream/chat/android/models/DraftMessage$Builder;
 	public final fun withId (Ljava/lang/String;)Lio/getstream/chat/android/models/DraftMessage$Builder;
 	public final fun withMentionedUsersIds (Ljava/util/List;)Lio/getstream/chat/android/models/DraftMessage$Builder;

--- a/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/DraftMessage.kt
+++ b/stream-chat-android-core/src/main/java/io/getstream/chat/android/models/DraftMessage.kt
@@ -75,6 +75,18 @@ public data class DraftMessage(
      */
     val replyMessage: Message? = null,
 
+    /**
+     * The name of the slash command active on this draft (e.g. `"giphy"`), or `null` when the
+     * draft is plain text.
+     */
+    val command: String? = null,
+
+    /**
+     * The arguments typed for the active slash command (the text that follows the `/name `
+     * prefix), or `null` when [command] is `null`.
+     */
+    val args: String? = null,
+
 ) : CustomObject, ComparableFieldProvider {
 
     @Suppress("ComplexMethod")
@@ -116,6 +128,8 @@ public data class DraftMessage(
         append(", silent=").append(silent)
         append(", showInChannel=").append(showInChannel)
         if (replyMessage != null) append(", replyMessage=").append(replyMessage)
+        if (command != null) append(", command=\"").append(command).append("\"")
+        if (args != null) append(", args=\"").append(args).append("\"")
         if (extraData.isNotEmpty()) append(", extraData=").append(extraData)
         append(")")
     }.toString()
@@ -136,6 +150,8 @@ public data class DraftMessage(
         private var silent: Boolean = false
         private var showInChannel: Boolean = false
         private var replyMessage: Message? = null
+        private var command: String? = null
+        private var args: String? = null
 
         public constructor(message: DraftMessage) : this() {
             id = message.id
@@ -148,6 +164,8 @@ public data class DraftMessage(
             silent = message.silent
             showInChannel = message.showInChannel
             replyMessage = message.replyMessage
+            command = message.command
+            args = message.args
         }
 
         public fun withId(id: String): Builder = apply { this.id = id }
@@ -162,6 +180,8 @@ public data class DraftMessage(
         public fun withSilent(silent: Boolean): Builder = apply { this.silent = silent }
         public fun withShowInChannel(showInChannel: Boolean): Builder = apply { this.showInChannel = showInChannel }
         public fun withReplyMessage(replyMessage: Message?): Builder = apply { this.replyMessage = replyMessage }
+        public fun withCommand(command: String?): Builder = apply { this.command = command }
+        public fun withArgs(args: String?): Builder = apply { this.args = args }
 
         public fun build(): DraftMessage {
             return DraftMessage(
@@ -175,6 +195,8 @@ public data class DraftMessage(
                 silent = silent,
                 showInChannel = showInChannel,
                 replyMessage = replyMessage,
+                command = command,
+                args = args,
             )
         }
     }

--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -278,6 +278,8 @@ public fun randomDraftMessage(
     silent: Boolean = randomBoolean(),
     showInChannel: Boolean = randomBoolean(),
     replyMessage: Message? = randomMessage(),
+    command: String? = null,
+    args: String? = null,
 ): DraftMessage = DraftMessage(
     id = id,
     cid = cid,
@@ -290,6 +292,8 @@ public fun randomDraftMessage(
     silent = silent,
     showInChannel = showInChannel,
     replyMessage = replyMessage,
+    command = command,
+    args = args,
 )
 
 public fun randomQueryDraftsResult(

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -529,36 +529,66 @@ public class MessageComposerController(
     private suspend fun saveDraftMessage(messageMode: MessageMode) {
         if (!config.draftMessageEnabled) return
         currentDraftId = null
-        when (val messageText = _messageInput.value.text) {
-            "" -> clearDraftMessage(messageMode)
-            else -> {
-                getDraftMessageOrEmpty(messageMode).let {
-                    chatClient.createDraftMessage(
-                        channelType = channelType,
-                        channelId = channelId,
-                        message = it.copy(
-                            text = messageText,
-                            showInChannel = _state.value.alsoSendToChannel,
-                            replyMessage = (_messageActions.value.firstOrNull { it is Reply } as? Reply)?.message,
-                        ),
-                    ).await()
-                }
-            }
+        val inputText = _messageInput.value.text
+        // In legacy mode the slash + name + args is encoded inside `text`, so command/args fields
+        // would duplicate what's already there and confuse cross-SDK readers.
+        val activeCommand = _state.value.activeCommand.takeIf { config.activeCommandEnabled }
+        if (inputText.isEmpty() && activeCommand == null) {
+            clearDraftMessage(messageMode)
+            return
+        }
+        getDraftMessageOrEmpty(messageMode).let {
+            chatClient.createDraftMessage(
+                channelType = channelType,
+                channelId = channelId,
+                message = it.copy(
+                    text = inputText,
+                    command = activeCommand?.name,
+                    args = if (activeCommand != null) inputText else null,
+                    showInChannel = _state.value.alsoSendToChannel,
+                    replyMessage = (_messageActions.value.firstOrNull { it is Reply } as? Reply)?.message,
+                ),
+            ).await()
         }
     }
 
     private fun fetchDraftMessage(messageMode: MessageMode) {
         if (!config.draftMessageEnabled) return
+        // Drop any active command + stash carried over from the previous mode so leftover state
+        // doesn't block the new mode's reply-action restore or leak into a later cancel-restore.
+        _state.update { it.copy(activeCommand = null) }
+        discardCommandStash()
         getDraftMessageOrEmpty(messageMode).let { draftMessage ->
             currentDraftId = draftMessage.id
-            setMessageInputInternal(draftMessage.text, MessageInput.Source.DraftMessage)
-            setAlsoSendToChannel(draftMessage.showInChannel)
+            // Restore the reply action first so command-availability checks see the right action.
             draftMessage.replyMessage
                 ?.let { performMessageAction(Reply(it)) }
                 ?: run {
                     _messageActions.value = _messageActions.value.filterNot { it is Reply }.toSet()
                 }
+            val command = restoreDraftCommandIfAvailable(draftMessage.command)
+            val inputText = if (command != null) draftMessage.args ?: draftMessage.text else draftMessage.text
+            setMessageInputInternal(inputText, MessageInput.Source.DraftMessage)
+            setAlsoSendToChannel(draftMessage.showInChannel)
         }
+    }
+
+    /**
+     * Activates the command from a fetched draft when [Config.activeCommandEnabled] is `true`,
+     * the command is known to the channel, and it is available for the current composer action.
+     * Updates state directly rather than via [selectCommand] — draft restore must not emit
+     * [MessageComposerViewEvent.CommandUnavailable] or trigger the pre-command stash.
+     *
+     * @param commandName The command name from the draft, or `null` for plain-text drafts.
+     * @return The restored [Command], or `null` when no command was applied.
+     */
+    private fun restoreDraftCommandIfAvailable(commandName: String?): Command? {
+        if (!config.activeCommandEnabled) return null
+        val name = commandName ?: return null
+        val command = commands.firstOrNull { it.name == name } ?: return null
+        if (!command.isAvailableFor(activeAction)) return null
+        _state.update { it.copy(activeCommand = command) }
+        return command
     }
 
     /**

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -75,6 +75,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -1384,31 +1385,36 @@ internal class MessageComposerControllerTest {
         }
 
     @Test
-    fun `Given active command When performMessageAction with ThreadReply Then no block and thread mode applies`() = runTest {
-        // Given
-        val muteCommand = randomCommand(set = MODERATION_SET)
-        val parentMessage = randomMessage(cid = CID)
-        val controller = Fixture()
-            .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
-            .givenAppSettings()
-            .givenAudioPlayer(mock())
-            .givenClientState(randomUser())
-            .givenGlobalState()
-            .givenChannelState(
-                configState = MutableStateFlow(Config(commands = listOf(muteCommand))),
-            )
-            .get()
-        controller.selectCommand(muteCommand)
-        advanceUntilIdle()
+    fun `Given active command When performMessageAction with ThreadReply Then no event is emitted and thread mode applies`() =
+        runTest {
+            // Given
+            val muteCommand = randomCommand(set = MODERATION_SET)
+            val parentMessage = randomMessage(cid = CID)
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState()
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(muteCommand))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+            controller.selectCommand(muteCommand)
+            advanceUntilIdle()
 
-        // When
-        controller.performMessageAction(ThreadReply(parentMessage))
-        advanceUntilIdle()
+            // When / Then — ThreadReply is compatible with the active command, so the conflict
+            // guard must not emit CancelCommandRequired and the thread mode must apply.
+            controller.events.test {
+                controller.performMessageAction(ThreadReply(parentMessage))
+                advanceUntilIdle()
 
-        // Then
-        assertEquals(muteCommand, controller.state.value.activeCommand)
-        assertEquals(MessageMode.MessageThread(parentMessage), controller.state.value.messageMode)
-    }
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertEquals(MessageMode.MessageThread(parentMessage), controller.state.value.messageMode)
+        }
 
     @Test
     fun `Given reply mode When selectCommand called with fun_set command Then activeCommand is set`() = runTest {
@@ -1589,6 +1595,264 @@ internal class MessageComposerControllerTest {
         // Then
         assertNull(controller.state.value.activeCommand)
     }
+
+    @Test
+    fun `Given draft with command and args When controller initializes Then activeCommand is restored and args populate the input`() =
+        runTest {
+            // Given
+            val giphyCommand = randomCommand(name = "giphy")
+            val draft = DraftMessage(
+                cid = CID,
+                text = "",
+                command = "giphy",
+                args = "cat",
+            )
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState(channelDrafts = mapOf(CID to draft))
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(giphyCommand))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+            advanceUntilIdle()
+
+            // Then
+            assertEquals(giphyCommand, controller.state.value.activeCommand)
+            assertEquals("cat", controller.state.value.inputValue)
+        }
+
+    @Test
+    fun `Given draft with unknown command When controller initializes Then command is not restored and text is preserved`() =
+        runTest {
+            // Given
+            val draft = DraftMessage(
+                cid = CID,
+                text = "fallback",
+                command = "ban",
+                args = null,
+            )
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState(channelDrafts = mapOf(CID to draft))
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(randomCommand(name = "giphy")))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+            advanceUntilIdle()
+
+            // Then
+            assertNull(controller.state.value.activeCommand)
+            assertEquals("fallback", controller.state.value.inputValue)
+        }
+
+    @Test
+    fun `Given draft with moderation command and reply When controller initializes Then command is silently skipped`() =
+        runTest {
+            // Given
+            val muteCommand = randomCommand(name = "mute", set = MODERATION_SET)
+            val repliedMessage = randomMessage(cid = CID)
+            val draft = DraftMessage(
+                cid = CID,
+                text = "",
+                command = "mute",
+                args = "@alice",
+                replyMessage = repliedMessage,
+            )
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState(channelDrafts = mapOf(CID to draft))
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(muteCommand))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+
+            // When / Then — collect events, expect none for the draft restore
+            controller.events.test {
+                advanceUntilIdle()
+                expectNoEvents()
+                cancelAndIgnoreRemainingEvents()
+            }
+            assertNull(controller.state.value.activeCommand)
+            assertEquals(Reply(repliedMessage), controller.state.value.action)
+        }
+
+    @Test
+    fun `Given activeCommandEnabled false When controller initializes with command draft Then command is ignored`() =
+        runTest {
+            // Given
+            val draft = DraftMessage(
+                cid = CID,
+                text = "fallback text",
+                command = "giphy",
+                args = "cat",
+            )
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = false))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState(channelDrafts = mapOf(CID to draft))
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(randomCommand(name = "giphy")))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+            advanceUntilIdle()
+
+            // Then — legacy mode reads `text`, ignores command/args
+            assertNull(controller.state.value.activeCommand)
+            assertEquals("fallback text", controller.state.value.inputValue)
+        }
+
+    @Test
+    fun `Given activeCommand and empty input When mode changes Then draft is saved with command and empty text`() =
+        runTest {
+            // Given
+            val giphyCommand = randomCommand(name = "giphy")
+            val parentMessage = randomMessage(cid = CID)
+            val fixture = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState()
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(giphyCommand))),
+                )
+                .givenDraftMessageStubs()
+            val controller = fixture.get()
+            controller.selectCommand(giphyCommand)
+            advanceUntilIdle()
+
+            // When — mode change triggers saveDraftMessage on the previous (Normal) mode
+            controller.setMessageMode(MessageMode.MessageThread(parentMessage))
+            advanceUntilIdle()
+
+            // Then — chatClient.createDraftMessage was called with command set and text empty
+            val captor = argumentCaptor<DraftMessage>()
+            verify(fixture.chatClient).createDraftMessage(eq(CHANNEL_TYPE), eq(CHANNEL_ID), captor.capture())
+            val saved = captor.firstValue
+            assertEquals("giphy", saved.command)
+            assertEquals("", saved.text)
+            assertEquals("", saved.args)
+        }
+
+    @Test
+    fun `Given active command in normal mode When switching to thread Then leftover command does not block reply restore`() =
+        runTest {
+            // Given — Normal mode has a moderation command active. Thread draft has a reply pending.
+            val muteCommand = randomCommand(name = "mute", set = MODERATION_SET)
+            val parentMessage = randomMessage(cid = CID)
+            val repliedInThread = randomMessage(cid = CID)
+            val threadDraft = DraftMessage(
+                cid = CID,
+                parentId = parentMessage.id,
+                text = "thread draft",
+                replyMessage = repliedInThread,
+            )
+            val controller = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState(threadDrafts = mapOf(parentMessage.id to threadDraft))
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(muteCommand))),
+                )
+                .givenDraftMessageStubs()
+                .get()
+            controller.selectCommand(muteCommand)
+            advanceUntilIdle()
+            assertEquals(muteCommand, controller.state.value.activeCommand)
+
+            // When
+            controller.setMessageMode(MessageMode.MessageThread(parentMessage))
+            advanceUntilIdle()
+
+            // Then — the new mode's reply action applies; the leftover mute command is gone.
+            assertNull(controller.state.value.activeCommand)
+            assertEquals(Reply(repliedInThread), controller.state.value.action)
+        }
+
+    @Test
+    fun `Given activeCommandEnabled false When draft is saved Then command and args are not persisted`() = runTest {
+        // Given — legacy mode with a command active in state (legacy keeps slash inside text).
+        val giphyCommand = randomCommand(name = "giphy")
+        val parentMessage = randomMessage(cid = CID)
+        val fixture = Fixture()
+            .givenConfig(MessageComposerController.Config(activeCommandEnabled = false))
+            .givenAppSettings()
+            .givenAudioPlayer(mock())
+            .givenClientState(randomUser())
+            .givenGlobalState()
+            .givenChannelState(
+                configState = MutableStateFlow(Config(commands = listOf(giphyCommand))),
+            )
+            .givenDraftMessageStubs()
+        val controller = fixture.get()
+        controller.selectCommand(giphyCommand)
+        controller.setMessageInput("/giphy cat")
+        advanceUntilIdle()
+
+        // When
+        controller.setMessageMode(MessageMode.MessageThread(parentMessage))
+        advanceUntilIdle()
+
+        // Then — wire format stays clean: text holds the legacy form, command/args stay null.
+        val captor = argumentCaptor<DraftMessage>()
+        verify(fixture.chatClient).createDraftMessage(eq(CHANNEL_TYPE), eq(CHANNEL_ID), captor.capture())
+        val saved = captor.firstValue
+        assertEquals("/giphy cat", saved.text)
+        assertNull(saved.command)
+        assertNull(saved.args)
+    }
+
+    @Test
+    fun `Given activeCommand and typed args When mode changes Then draft is saved with text and args populated`() =
+        runTest {
+            // Given
+            val giphyCommand = randomCommand(name = "giphy")
+            val parentMessage = randomMessage(cid = CID)
+            val fixture = Fixture()
+                .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
+                .givenAppSettings()
+                .givenAudioPlayer(mock())
+                .givenClientState(randomUser())
+                .givenGlobalState()
+                .givenChannelState(
+                    configState = MutableStateFlow(Config(commands = listOf(giphyCommand))),
+                )
+                .givenDraftMessageStubs()
+            val controller = fixture.get()
+            controller.selectCommand(giphyCommand)
+            controller.setMessageInput("Test")
+            advanceUntilIdle()
+
+            // When
+            controller.setMessageMode(MessageMode.MessageThread(parentMessage))
+            advanceUntilIdle()
+
+            // Then — text is populated (so channel-list previews render the user's input) and args
+            // mirrors it for cross-SDK readers that distinguish them.
+            val captor = argumentCaptor<DraftMessage>()
+            verify(fixture.chatClient).createDraftMessage(eq(CHANNEL_TYPE), eq(CHANNEL_ID), captor.capture())
+            val saved = captor.firstValue
+            assertEquals("giphy", saved.command)
+            assertEquals("Test", saved.text)
+            assertEquals("Test", saved.args)
+        }
 
     @Test
     fun `Given normal mode When sendMessage called Then chatClient sendMessage is invoked with correct message`() = runTest {
@@ -2425,6 +2689,13 @@ internal class MessageComposerControllerTest {
 
         fun givenDeleteMessage(message: Message) = apply {
             whenever(chatClient.deleteMessage(any(), any())) doReturn message.asCall()
+        }
+
+        fun givenDraftMessageStubs(): Fixture = apply {
+            whenever(chatClient.createDraftMessage(any(), any(), any())) doAnswer { invocation ->
+                (invocation.arguments[2] as DraftMessage).asCall()
+            }
+            whenever(chatClient.deleteDraftMessages(any(), any(), any())) doReturn Unit.asCall()
         }
 
         fun givenGlobalState(


### PR DESCRIPTION
### Goal

Under DS-030's `activeCommandEnabled = true` mode, the active slash command lives as state separate from the input text. Draft save/fetch previously persisted text only — typing `/giphy funny cat`, switching threads, and coming back left only `funny cat` as plain text without the `/giphy` chip. This PR persists and restores the command on drafts so a `/command args` round-trips intact.

Mirrors the iOS SDK wire format (`command` and `args` as top-level JSON fields on the draft payload) so a draft saved on one platform restores correctly on another.

### Implementation

**`stream-chat-android-core` — domain model**
- `DraftMessage` gains `command: String? = null` and `args: String? = null` (additive trailing-defaulted public fields). `Builder` and `toString` updated.

**`stream-chat-android-client` — wire + offline cache**
- `UpstreamMessageDto` adds `args: String?` (existing `command: String?` reused). `DownstreamDraftMessageDto` adds both `command` and `args`. The `@StreamHandsOff` constraint forbids renames; additions are safe.
- `DraftMessage.toDto()` and `DownstreamDraftDto.toDomain()` thread the fields through.
- `DraftMessageEntity` adds `command` and `args` columns. `ChatDatabase` schema bumps `102 → 103`. The existing `fallbackToDestructiveMigration()` strategy recreates the offline cache on upgrade, matching how every other field has been added to this database. Entity ↔ model mappers updated.

**`stream-chat-android-ui-common` — controller**
- `MessageComposerController.saveDraftMessage` now persists when *either* text or active command is non-null. With command active: `text = ""`, `command = activeCommand.name`, `args = inputText`. Without: legacy shape (`text = inputText`, command/args null).
- `fetchDraftMessage` restores the reply action *before* the command-availability check, then activates the command via a new private `restoreDraftCommandIfAvailable` helper. The helper updates state directly rather than via `selectCommand` so draft restore can't emit `CommandUnavailable` events or trigger the pre-command stash. Skips silently if the command is no longer in the channel or isn't available for the current action.
- Input text on restore: `args ?: text` when a command was restored; `text` otherwise.
- All new behavior gated on `Config.activeCommandEnabled` — XML legacy SDK unchanged.

### Testing

Compose sample app, channel with `/giphy` (fun_set) and `/mute` (moderation_set). All scenarios assume `activeCommandEnabled = true` (Compose default).

1. **Round-trip happy path.** Pick `/giphy`, type "funny cat". Switch into a thread → switch back to the parent. Expect: `/giphy` chip restored, input field shows "funny cat".
2. **Empty-args draft.** Pick `/giphy`, leave args empty. Switch threads → back. Expect: `/giphy` chip restored, input empty (draft was not cleared).
3. **Stale command.** Save a draft with `/giphy`, then on a build without `/giphy` configured (or after the command is removed channel-side), reopen. Expect: input shows the args text, no chip, no snackbar.
4. **Action mismatch.** Save a draft with `/mute @alice` in normal mode. Open the channel via deep-link into reply mode. Expect: reply action applies; `/mute` is not restored; no `Command unavailable` snackbar.
5. **Legacy XML SDK.** In the XML sample (`activeCommandEnabled = false`), legacy text-based draft round-trip continues to work; `command`/`args` fields ignored.
6. **Cross-SDK.** Save a draft on iOS with `/giphy cat` → open the same channel on Android. Expect: chip restored, input shows "cat". Reverse direction also works.
7. **DB upgrade path.** Install the previous build, save a draft, upgrade to this build. Expect: offline cache recreated cleanly (no crash on launch); fresh drafts round-trip the new fields.

API impact: additive on `stream-chat-android-core` (two trailing-defaulted fields on the public `DraftMessage` data class). All other touched modules are internal-only.

No UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Draft messages now support slash commands and their arguments, enabling users to save and restore command selections within draft messages.
  * Enhanced draft restoration to properly restore active commands and their associated arguments when reopening previously saved drafts.
  * Improved behavior when switching between different message composition modes, with better handling of draft state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->