### PR TITLE
Fix default Giphy framerate by using `ORIGINAL` info type

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -90,7 +90,7 @@ import io.getstream.chat.android.ui.common.utils.giphyInfo
 public fun GiphyAttachmentContent(
     state: AttachmentState,
     modifier: Modifier = Modifier,
-    giphyInfoType: GiphyInfoType = GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED,
+    giphyInfoType: GiphyInfoType = GiphyInfoType.ORIGINAL,
     giphySizingMode: GiphySizingMode = GiphySizingMode.ADAPTIVE,
     contentScale: ContentScale = ContentScale.Crop,
     onItemClick: (GiphyAttachmentClickData) -> Unit = {},


### PR DESCRIPTION
### Goal

The `FIXED_HEIGHT_DOWNSAMPLED` Giphy info type reduces the framerate of GIF animations, causing them to appear choppy. Switch the default to `ORIGINAL` so Giphys play at their intended framerate.

### Implementation

Changed the default value of `giphyInfoType` in `GiphyAttachmentContent` from `GiphyInfoType.FIXED_HEIGHT_DOWNSAMPLED` to `GiphyInfoType.ORIGINAL`.

### UI Changes

<table>
<thead>
<tr>
<th>Before / After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/ad4df662-abbe-40b7-ae2d-6ffee0f0a9f3" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Testing

- Open a channel with Giphy messages and verify animations play smoothly at full framerate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced Giphy attachment display quality—attachments now render in original resolution instead of a lower resolution variant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->