### PR TITLE
Set required permissions for the SDK size and DB entities checks

### DIFF
--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -2,6 +2,11 @@ name: Check DB Entities
 
 on: [pull_request]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/check-entities.yml
+++ b/.github/workflows/check-entities.yml
@@ -5,7 +5,6 @@ on: [pull_request]
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -3,6 +3,11 @@ name: SDK size checks
 on:
   pull_request:
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/sdk-size-checks.yml
+++ b/.github/workflows/sdk-size-checks.yml
@@ -6,7 +6,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  issues: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
### Goal

SDK size & DB entities checks need write permissions for writing comments, so we're adding the relevant permission block. Up until now, this didn't cause problems because the token we're using has those permissions, but that doesn't work for Dependabot PRs. [They receive a read-only token](https://docs.github.com/en/code-security/reference/supply-chain-security/troubleshoot-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows) unless we declare permissions, which is why the corresponding failures in https://github.com/GetStream/stream-chat-android/pull/6394.

### Implementation

Add the permissions block

### Testing

After merging this PR, we should update dependabot's PR and verify that the SDK size check succeeds

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to explicitly define authorization scopes for continuous integration checks and SDK size verification tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->