### PR TITLE
Composer attachment picker accessibility improvements

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1062,7 +1062,7 @@ public final class io/getstream/chat/android/compose/ui/components/ComposableSin
 }
 
 public final class io/getstream/chat/android/compose/ui/components/ComposerCancelIconKt {
-	public static final fun ComposerCancelIcon (Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
+	public static final fun ComposerCancelIcon (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/getstream/chat/android/compose/ui/components/EmptyContentKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/ComposerCancelIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/ComposerCancelIcon.kt
@@ -36,11 +36,13 @@ import io.getstream.chat.android.compose.ui.util.clickable
  * Represents a simple cancel icon that is used primarily for attachments.
  *
  * @param modifier Modifier for styling.
+ * @param contentDescription Text used by accessibility services to describe what this icon represents.
  * @param onClick Handler when the user clicks on the icon.
  */
 @Composable
 public fun ComposerCancelIcon(
     modifier: Modifier = Modifier,
+    contentDescription: String = stringResource(R.string.stream_compose_cancel),
     onClick: () -> Unit,
 ) {
     val colors = ChatTheme.colors
@@ -53,7 +55,7 @@ public fun ComposerCancelIcon(
             .size(20.dp)
             .clickable(bounded = false, onClick = onClick),
         painter = painterResource(R.drawable.stream_design_ic_xmark_small),
-        contentDescription = stringResource(R.string.stream_compose_cancel),
+        contentDescription = contentDescription,
         tint = colors.controlRemoveIcon,
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FileTypeIcon.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FileTypeIcon.kt
@@ -31,7 +31,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -59,7 +60,7 @@ internal fun FileTypeIcon(data: FileIconData, modifier: Modifier = Modifier) {
                 color = StreamPrimitiveColors.baseWhite,
                 modifier = Modifier
                     .padding(bottom = 4.dp)
-                    .clearAndSetSemantics {},
+                    .semantics { hideFromAccessibility() },
             )
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
@@ -34,6 +34,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
@@ -126,9 +132,18 @@ internal fun DefaultFilesPickerItem(
     onItemSelected: (AttachmentPickerItemState) -> Unit,
     allowMultipleSelection: Boolean = true,
 ) {
+    val selectActionLabel = stringResource(R.string.stream_compose_attachment_picker_select)
     Row(
         Modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                selected = fileItem.isSelected
+                onClick(label = selectActionLabel) {
+                    onItemSelected(fileItem)
+                    true
+                }
+            }
             .clickable { onItemSelected(fileItem) }
             .padding(StreamTokens.spacingSm),
         verticalAlignment = Alignment.CenterVertically,
@@ -158,11 +173,13 @@ internal fun DefaultFilesPickerItem(
 
         if (allowMultipleSelection) {
             RadioCheck(
+                modifier = Modifier.clearAndSetSemantics {},
                 checked = fileItem.isSelected,
                 onCheckedChange = null,
             )
         } else {
             RadioButton(
+                modifier = Modifier.clearAndSetSemantics {},
                 checked = fileItem.isSelected,
                 onCheckedChange = null,
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
@@ -35,7 +35,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -174,13 +174,13 @@ internal fun DefaultFilesPickerItem(
 
         if (allowMultipleSelection) {
             RadioCheck(
-                modifier = Modifier.clearAndSetSemantics {},
+                modifier = Modifier.semantics { hideFromAccessibility() },
                 checked = fileItem.isSelected,
                 onCheckedChange = null,
             )
         } else {
             RadioButton(
-                modifier = Modifier.clearAndSetSemantics {},
+                modifier = Modifier.semantics { hideFromAccessibility() },
                 checked = fileItem.isSelected,
                 onCheckedChange = null,
             )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
@@ -36,7 +36,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -145,12 +144,8 @@ internal fun DefaultFilesPickerItem(
             .semantics(mergeDescendants = true) {
                 role = Role.Button
                 selected = fileItem.isSelected
-                onClick(label = onClickLabel) {
-                    onItemSelected(fileItem)
-                    true
-                }
             }
-            .clickable { onItemSelected(fileItem) }
+            .clickable(onClickLabel = onClickLabel) { onItemSelected(fileItem) }
             .padding(StreamTokens.spacingSm),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/files/FilesPicker.kt
@@ -132,14 +132,20 @@ internal fun DefaultFilesPickerItem(
     onItemSelected: (AttachmentPickerItemState) -> Unit,
     allowMultipleSelection: Boolean = true,
 ) {
-    val selectActionLabel = stringResource(R.string.stream_compose_attachment_picker_select)
+    val onClickLabel = stringResource(
+        if (fileItem.isSelected) {
+            R.string.stream_compose_attachment_picker_remove
+        } else {
+            R.string.stream_compose_attachment_picker_select
+        },
+    )
     Row(
         Modifier
             .fillMaxWidth()
             .semantics(mergeDescendants = true) {
                 role = Role.Button
                 selected = fileItem.isSelected
-                onClick(label = selectActionLabel) {
+                onClick(label = onClickLabel) {
                     onItemSelected(fileItem)
                     true
                 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -41,7 +41,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -158,12 +157,8 @@ internal fun DefaultImagesPickerItem(
                 role = Role.Button
                 selected = imageItem.isSelected
                 testTag = "Stream_AttachmentPickerSampleImage"
-                onClick(label = onClickLabel) {
-                    onImageSelected(imageItem)
-                    true
-                }
             }
-            .clickable { onImageSelected(imageItem) },
+            .clickable(onClickLabel = onClickLabel) { onImageSelected(imageItem) },
     ) {
         StreamAsyncImage(
             imageRequest = imageRequest,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -39,8 +39,8 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -171,7 +171,7 @@ internal fun DefaultImagesPickerItem(
             modifier = Modifier
                 .align(Alignment.TopEnd)
                 .padding(StreamTokens.spacingXs)
-                .clearAndSetSemantics {},
+                .semantics { hideFromAccessibility() },
             borderColor = ChatTheme.colors.borderCoreOnAccent,
             checked = imageItem.isSelected,
             onCheckedChange = null,
@@ -182,7 +182,7 @@ internal fun DefaultImagesPickerItem(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
                     .padding(StreamTokens.spacingXs)
-                    .clearAndSetSemantics {},
+                    .semantics { hideFromAccessibility() },
                 durationInSeconds = attachmentMetaData.videoLength,
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -38,6 +38,13 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.request.ImageRequest
@@ -125,12 +132,25 @@ internal fun DefaultImagesPickerItem(
         }
         .build()
 
+    val itemContentDescription = stringResource(
+        if (isVideo) {
+            R.string.stream_compose_attachment_picker_video
+        } else {
+            R.string.stream_compose_attachment_picker_photo
+        },
+    )
+
     Box(
         modifier = Modifier
             .aspectRatio(1f)
             .clip(ItemShape)
-            .clickable { onImageSelected(imageItem) }
-            .testTag("Stream_AttachmentPickerSampleImage"),
+            .semantics(mergeDescendants = true) {
+                contentDescription = itemContentDescription
+                role = Role.Button
+                selected = imageItem.isSelected
+                testTag = "Stream_AttachmentPickerSampleImage"
+            }
+            .clickable { onImageSelected(imageItem) },
     ) {
         StreamAsyncImage(
             imageRequest = imageRequest,
@@ -142,7 +162,8 @@ internal fun DefaultImagesPickerItem(
         RadioCheck(
             modifier = Modifier
                 .align(Alignment.TopEnd)
-                .padding(StreamTokens.spacingXs),
+                .padding(StreamTokens.spacingXs)
+                .clearAndSetSemantics {},
             borderColor = ChatTheme.colors.borderCoreOnAccent,
             checked = imageItem.isSelected,
             onCheckedChange = null,
@@ -152,7 +173,8 @@ internal fun DefaultImagesPickerItem(
             VideoBadge(
                 modifier = Modifier
                     .align(Alignment.BottomStart)
-                    .padding(StreamTokens.spacingXs),
+                    .padding(StreamTokens.spacingXs)
+                    .clearAndSetSemantics {},
                 durationInSeconds = attachmentMetaData.videoLength,
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/attachments/images/ImagesPicker.kt
@@ -41,6 +41,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
@@ -114,6 +115,7 @@ public fun ImagesPicker(
  * @param imageItem The attachment item.
  * @param onImageSelected Handler when the user selects the image.
  */
+@Suppress("LongMethod")
 @Composable
 internal fun DefaultImagesPickerItem(
     imageItem: AttachmentPickerItemState,
@@ -139,6 +141,13 @@ internal fun DefaultImagesPickerItem(
             R.string.stream_compose_attachment_picker_photo
         },
     )
+    val onClickLabel = stringResource(
+        if (imageItem.isSelected) {
+            R.string.stream_compose_attachment_picker_remove
+        } else {
+            R.string.stream_compose_attachment_picker_select
+        },
+    )
 
     Box(
         modifier = Modifier
@@ -149,6 +158,10 @@ internal fun DefaultImagesPickerItem(
                 role = Role.Button
                 selected = imageItem.isSelected
                 testTag = "Stream_AttachmentPickerSampleImage"
+                onClick(label = onClickLabel) {
+                    onImageSelected(imageItem)
+                    true
+                }
             }
             .clickable { onImageSelected(imageItem) },
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerAttachmentAnnouncer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerAttachmentAnnouncer.kt
@@ -16,44 +16,41 @@
 
 package io.getstream.chat.android.compose.ui.components.composer
 
-import androidx.compose.foundation.layout.size
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.LiveRegionMode
-import androidx.compose.ui.semantics.hideFromAccessibility
-import androidx.compose.ui.semantics.liveRegion
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.utils.attachment.isAudioRecording
 import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.models.Attachment
 
+/**
+ * Announces composer attachment additions and removals to accessibility services. Must be mounted
+ * for the lifetime of the composer so size deltas are observed across attach and remove
+ * transitions.
+ *
+ * @param attachments Current composer attachments. Size deltas drive the announcement.
+ */
 @Composable
-internal fun MessageComposerLiveRegion(attachments: List<Attachment>) {
+internal fun MessageComposerAttachmentAnnouncer(attachments: List<Attachment>) {
+    val view = LocalView.current
     val photoAttached = stringResource(R.string.stream_compose_attachment_added_photo)
     val videoAttached = stringResource(R.string.stream_compose_attachment_added_video)
     val fileAttached = stringResource(R.string.stream_compose_attachment_added_file)
     val audioAttached = stringResource(R.string.stream_compose_attachment_added_audio)
     val attachmentRemoved = stringResource(R.string.stream_compose_attachment_removed)
 
-    var announcement by remember { mutableStateOf("") }
     var lastSize by remember { mutableIntStateOf(attachments.size) }
 
     LaunchedEffect(attachments.size) {
         val currentSize = attachments.size
-        announcement = when {
+        val message = when {
             currentSize > lastSize -> announceAddedAttachment(
                 added = attachments.lastOrNull(),
                 photoAttached = photoAttached,
@@ -62,22 +59,13 @@ internal fun MessageComposerLiveRegion(attachments: List<Attachment>) {
                 fileAttached = fileAttached,
             )
             currentSize < lastSize -> attachmentRemoved
-            else -> announcement
+            else -> null
+        }
+        if (message != null) {
+            view.announceForAccessibility(message)
         }
         lastSize = currentSize
     }
-
-    Text(
-        text = announcement,
-        color = Color.Transparent,
-        modifier = Modifier
-            .size(0.dp)
-            .alpha(0f)
-            .semantics {
-                liveRegion = LiveRegionMode.Polite
-                hideFromAccessibility()
-            },
-    )
 }
 
 private fun announceAddedAttachment(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerAttachmentAnnouncer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerAttachmentAnnouncer.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.compose.ui.components.composer
 
+import androidx.annotation.VisibleForTesting
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -68,7 +69,8 @@ internal fun MessageComposerAttachmentAnnouncer(attachments: List<Attachment>) {
     }
 }
 
-private fun announceAddedAttachment(
+@VisibleForTesting
+internal fun announceAddedAttachment(
     added: Attachment?,
     photoAttached: String,
     videoAttached: String,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerLiveRegion.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageComposerLiveRegion.kt
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.composer
+
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.client.utils.attachment.isAudioRecording
+import io.getstream.chat.android.client.utils.attachment.isImage
+import io.getstream.chat.android.client.utils.attachment.isVideo
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.models.Attachment
+
+@Composable
+internal fun MessageComposerLiveRegion(attachments: List<Attachment>) {
+    val photoAttached = stringResource(R.string.stream_compose_attachment_added_photo)
+    val videoAttached = stringResource(R.string.stream_compose_attachment_added_video)
+    val fileAttached = stringResource(R.string.stream_compose_attachment_added_file)
+    val audioAttached = stringResource(R.string.stream_compose_attachment_added_audio)
+    val attachmentRemoved = stringResource(R.string.stream_compose_attachment_removed)
+
+    var announcement by remember { mutableStateOf("") }
+    var lastSize by remember { mutableIntStateOf(attachments.size) }
+
+    LaunchedEffect(attachments.size) {
+        val currentSize = attachments.size
+        announcement = when {
+            currentSize > lastSize -> announceAddedAttachment(
+                added = attachments.lastOrNull(),
+                photoAttached = photoAttached,
+                videoAttached = videoAttached,
+                audioAttached = audioAttached,
+                fileAttached = fileAttached,
+            )
+            currentSize < lastSize -> attachmentRemoved
+            else -> announcement
+        }
+        lastSize = currentSize
+    }
+
+    Text(
+        text = announcement,
+        color = Color.Transparent,
+        modifier = Modifier
+            .size(0.dp)
+            .alpha(0f)
+            .semantics {
+                liveRegion = LiveRegionMode.Polite
+                hideFromAccessibility()
+            },
+    )
+}
+
+private fun announceAddedAttachment(
+    added: Attachment?,
+    photoAttached: String,
+    videoAttached: String,
+    audioAttached: String,
+    fileAttached: String,
+): String = when {
+    added == null -> ""
+    added.isImage() -> photoAttached
+    added.isVideo() -> videoAttached
+    added.isAudioRecording() -> audioAttached
+    else -> fileAttached
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -116,7 +116,7 @@ public fun MessageInput(
             .animateContentSize(alignment = Alignment.BottomStart),
         verticalArrangement = Arrangement.Bottom,
     ) {
-        MessageComposerLiveRegion(attachments = messageComposerState.attachments)
+        MessageComposerAttachmentAnnouncer(attachments = messageComposerState.attachments)
 
         MessageInputTop(
             messageComposerState = messageComposerState,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -116,6 +116,8 @@ public fun MessageInput(
             .animateContentSize(alignment = Alignment.BottomStart),
         verticalArrangement = Arrangement.Bottom,
     ) {
+        MessageComposerLiveRegion(attachments = messageComposerState.attachments)
+
         MessageInputTop(
             messageComposerState = messageComposerState,
             onAttachmentRemoved = onAttachmentRemoved,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentPicker.kt
@@ -27,6 +27,9 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.AttachmentPickerContentParams
 import io.getstream.chat.android.compose.ui.theme.AttachmentSystemPickerParams
@@ -109,8 +112,11 @@ public fun AttachmentPicker(
         actions.onAttachmentsSelected(attachmentsPickerViewModel.getAttachmentsFromMetadata(metaData))
     }
 
+    val pickerTitle = stringResource(R.string.stream_compose_attachment_picker)
     Surface(
-        modifier = modifier.testTag("Stream_AttachmentsPicker"),
+        modifier = modifier
+            .testTag("Stream_AttachmentsPicker")
+            .semantics { paneTitle = pickerTitle },
         color = ChatTheme.colors.backgroundCoreElevation1,
     ) {
         if (ChatTheme.config.attachmentPicker.useSystemPicker) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
@@ -35,6 +35,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
@@ -133,7 +137,12 @@ private fun AttachmentPickerToggleButton(
     onClick: () -> Unit,
 ) {
     FilledIconToggleButton(
-        modifier = Modifier.size(48.dp),
+        modifier = Modifier
+            .size(48.dp)
+            .semantics(mergeDescendants = true) {
+                role = Role.Tab
+                selected = isSelected
+            },
         checked = isSelected,
         onCheckedChange = { onClick() },
         colors = IconButtonDefaults.filledIconToggleButtonColors(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/AttachmentTypePicker.kt
@@ -36,9 +36,12 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.onClick
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
@@ -136,12 +139,19 @@ private fun AttachmentPickerToggleButton(
     isSelected: Boolean,
     onClick: () -> Unit,
 ) {
+    val description = stringResource(pickerTypeInfo.contentDescription)
     FilledIconToggleButton(
         modifier = Modifier
             .size(48.dp)
-            .semantics(mergeDescendants = true) {
+            .clearAndSetSemantics {
                 role = Role.Tab
                 selected = isSelected
+                contentDescription = description
+                testTag = pickerTypeInfo.testTag
+                onClick {
+                    onClick()
+                    true
+                }
             },
         checked = isSelected,
         onCheckedChange = { onClick() },
@@ -153,9 +163,8 @@ private fun AttachmentPickerToggleButton(
         ),
     ) {
         Icon(
-            modifier = Modifier.testTag(pickerTypeInfo.testTag),
             painter = painterResource(pickerTypeInfo.icon),
-            contentDescription = stringResource(pickerTypeInfo.contentDescription),
+            contentDescription = null,
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/CreatePollScreen.kt
@@ -35,9 +35,13 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.models.CreatePollParams
@@ -73,10 +77,12 @@ public fun CreatePollScreen(
             backAction()
         }
     }
+    val paneTitleText = stringResource(R.string.stream_compose_poll_title)
     Scaffold(
         modifier = Modifier
             .systemBarsPadding()
-            .imePadding(),
+            .imePadding()
+            .semantics { paneTitle = paneTitleText },
         containerColor = ChatTheme.colors.backgroundCoreApp,
         topBar = {
             PollCreationHeader(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollCreationHeader.kt
@@ -32,6 +32,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -106,6 +108,7 @@ internal fun DefaultPollOptionsHeaderCenterContent(modifier: Modifier, title: St
     ) {
         Text(
             text = title,
+            modifier = Modifier.semantics { heading() },
             style = ChatTheme.typography.headingMedium,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
@@ -94,7 +94,13 @@ internal fun MessageComposerLeadingContent(
                 Icon(
                     modifier = Modifier.graphicsLayer { rotationZ = iconRotation },
                     painter = painterResource(id = R.drawable.stream_design_ic_plus),
-                    contentDescription = stringResource(id = R.string.stream_compose_attachments),
+                    contentDescription = stringResource(
+                        id = if (isAttachmentPickerVisible) {
+                            R.string.stream_compose_message_composer_attachments_close
+                        } else {
+                            R.string.stream_compose_message_composer_attachments_open
+                        }
+                    ),
                 )
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
@@ -99,7 +99,7 @@ internal fun MessageComposerLeadingContent(
                             R.string.stream_compose_message_composer_attachments_close
                         } else {
                             R.string.stream_compose_message_composer_attachments_open
-                        }
+                        },
                     ),
                 )
             }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerLeadingContent.kt
@@ -34,6 +34,8 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -66,6 +68,13 @@ internal fun MessageComposerLeadingContent(
             val iconRotation by animateFloatAsState(
                 targetValue = if (isAttachmentPickerVisible) OpenAttachmentPickerButtonRotation else 0f,
             )
+            val pickerStateDescription = stringResource(
+                if (isAttachmentPickerVisible) {
+                    R.string.stream_compose_message_composer_attachments_expanded
+                } else {
+                    R.string.stream_compose_message_composer_attachments_collapsed
+                },
+            )
             FilledIconButton(
                 modifier = Modifier
                     .padding(end = 8.dp)
@@ -82,7 +91,8 @@ internal fun MessageComposerLeadingContent(
                         },
                     )
                     .size(48.dp)
-                    .testTag("Stream_ComposerAttachmentsButton"),
+                    .testTag("Stream_ComposerAttachmentsButton")
+                    .semantics { stateDescription = pickerStateDescription },
                 colors = IconButtonDefaults.filledIconButtonColors(
                     containerColor = ChatTheme.colors.backgroundCoreElevation1,
                     disabledContainerColor = ChatTheme.colors.backgroundCoreElevation1,
@@ -94,13 +104,7 @@ internal fun MessageComposerLeadingContent(
                 Icon(
                     modifier = Modifier.graphicsLayer { rotationZ = iconRotation },
                     painter = painterResource(id = R.drawable.stream_design_ic_plus),
-                    contentDescription = stringResource(
-                        id = if (isAttachmentPickerVisible) {
-                            R.string.stream_compose_message_composer_attachments_close
-                        } else {
-                            R.string.stream_compose_message_composer_attachments_open
-                        },
-                    ),
+                    contentDescription = stringResource(R.string.stream_compose_message_composer_attachments),
                 )
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentAudioRecordItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentAudioRecordItem.kt
@@ -29,9 +29,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.audio.audioHash
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.attachments.content.AudioRecordAttachmentContentItemBase
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
 import io.getstream.chat.android.compose.ui.components.common.PlaybackSpeedToggle
@@ -85,6 +87,7 @@ internal fun MessageComposerAttachmentAudioRecordItem(
                 .align(Alignment.TopEnd)
                 .testTag("Stream_MessageComposerAttachmentCancelIcon"),
             onClick = { onAttachmentRemoved(attachment) },
+            contentDescription = stringResource(R.string.stream_compose_remove_attachment),
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentFileItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentFileItem.kt
@@ -108,6 +108,7 @@ internal fun MessageComposerAttachmentFileItem(
                 .align(Alignment.TopEnd)
                 .testTag("Stream_MessageComposerAttachmentCancelIcon"),
             onClick = { onAttachmentRemoved(attachment) },
+            contentDescription = stringResource(R.string.stream_compose_remove_attachment),
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentMediaItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/attachments/MessageComposerAttachmentMediaItem.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil3.ColorImage
 import coil3.compose.LocalAsyncImagePreviewHandler
 import io.getstream.chat.android.client.extensions.duration
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.ComposerCancelIcon
 import io.getstream.chat.android.compose.ui.components.common.VideoBadge
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -86,6 +88,7 @@ internal fun MessageComposerAttachmentMediaItem(
                 .align(Alignment.TopEnd)
                 .testTag("Stream_MessageComposerAttachmentCancelIcon"),
             onClick = { onAttachmentRemoved(attachment) },
+            contentDescription = stringResource(R.string.stream_compose_remove_attachment),
         )
     }
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ModifierUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/ModifierUtils.kt
@@ -69,17 +69,21 @@ internal fun Modifier.dragPointerInput(
  * Unbounded ripples always animate from the target layout center, bounded ripples animate from the touch position.
  * @param enabled Controls the enabled state.
  * When `false`, [onClick], and this modifier will appear disabled for accessibility service.
+ * @param onClickLabel Semantic / accessibility label for the click action. Announced by screen readers
+ * (e.g. "double tap to <label>").
  * @param onClick The callback to be invoked when the click gesture is detected.
  */
 internal fun Modifier.clickable(
     bounded: Boolean = true,
     enabled: Boolean = true,
+    onClickLabel: String? = null,
     onClick: () -> Unit,
 ): Modifier =
     clickable(
         interactionSource = null,
         indication = ripple(bounded),
         enabled = enabled,
+        onClickLabel = onClickLabel,
         onClick = onClick,
     )
 

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -26,6 +26,8 @@
   <string name="stream_compose_attachment_commands_picker">"Comandos"</string>
   <string name="stream_compose_attachment_file_picker">"Archivos"</string>
   <string name="stream_compose_attachment_media_picker">"Multimedia"</string>
+  <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_video">"Vídeo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crear una encuesta y que todos voten"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crear encuesta"</string>
   <string name="stream_compose_attachment_polls_picker">"Encuestas"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -31,6 +31,7 @@
   <string name="stream_compose_attachment_file_picker">"Archivos"</string>
   <string name="stream_compose_attachment_media_picker">"Multimedia"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_remove">"quitar"</string>
   <string name="stream_compose_attachment_picker_select">"seleccionar"</string>
   <string name="stream_compose_attachment_picker_video">"Vídeo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crear una encuesta y que todos voten"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -29,7 +29,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"Crear una encuesta y que todos voten"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crear encuesta"</string>
   <string name="stream_compose_attachment_polls_picker">"Encuestas"</string>
-  <string name="stream_compose_attachments">"Archivos adjuntos"</string>
   <string name="stream_compose_audio_playback_pause">"Pausar"</string>
   <string name="stream_compose_audio_recording_delete">"Eliminar grabación"</string>
   <string name="stream_compose_audio_recording_hint_save">"Mantén pulsado para grabar. Suelta para guardar."</string>
@@ -107,6 +106,8 @@
   <string name="stream_compose_message_composer_send_button">"Enviar"</string>
   <string name="stream_compose_message_composer_show_in_channel">"También enviar en el canal"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Archivo adjunto no compatible"</string>
+  <string name="stream_compose_message_composer_attachments_close">"Cerrar archivos adjuntos"</string>
+  <string name="stream_compose_message_composer_attachments_open">"Abrir archivos adjuntos"</string>
   <string name="stream_compose_message_deleted">"Mensaje eliminado"</string>
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
   <string name="stream_compose_message_list_auto_translated">"Traducido"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -27,6 +27,7 @@
   <string name="stream_compose_attachment_file_picker">"Archivos"</string>
   <string name="stream_compose_attachment_media_picker">"Multimedia"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_select">"seleccionar"</string>
   <string name="stream_compose_attachment_picker_video">"Vídeo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crear una encuesta y que todos voten"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crear encuesta"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -21,6 +21,10 @@
   <string name="stream_compose_add_members_no_results">"No se encontró ningún usuario"</string>
   <string name="stream_compose_add_members_title">"Añadir miembros"</string>
   <string name="stream_compose_also_sent_to_channel">"Enviar también al canal"</string>
+  <string name="stream_compose_attachment_added_audio">"Grabación de audio adjuntada"</string>
+  <string name="stream_compose_attachment_added_file">"Archivo adjuntado"</string>
+  <string name="stream_compose_attachment_added_photo">"Foto adjuntada"</string>
+  <string name="stream_compose_attachment_added_video">"Vídeo adjuntado"</string>
   <string name="stream_compose_attachment_camera_picker">"Abrir cámara"</string>
   <string name="stream_compose_attachment_camera_picker_content">"Tomar una foto y compartir"</string>
   <string name="stream_compose_attachment_commands_picker">"Comandos"</string>
@@ -32,6 +36,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"Crear una encuesta y que todos voten"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crear encuesta"</string>
   <string name="stream_compose_attachment_polls_picker">"Encuestas"</string>
+  <string name="stream_compose_attachment_removed">"Archivo adjunto eliminado"</string>
   <string name="stream_compose_audio_playback_pause">"Pausar"</string>
   <string name="stream_compose_audio_recording_delete">"Eliminar grabación"</string>
   <string name="stream_compose_audio_recording_hint_save">"Mantén pulsado para grabar. Suelta para guardar."</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -30,6 +30,7 @@
   <string name="stream_compose_attachment_commands_picker">"Comandos"</string>
   <string name="stream_compose_attachment_file_picker">"Archivos"</string>
   <string name="stream_compose_attachment_media_picker">"Multimedia"</string>
+  <string name="stream_compose_attachment_picker">"Selector de archivos adjuntos"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
   <string name="stream_compose_attachment_picker_remove">"quitar"</string>
   <string name="stream_compose_attachment_picker_select">"seleccionar"</string>
@@ -115,8 +116,9 @@
   <string name="stream_compose_message_composer_send_button">"Enviar"</string>
   <string name="stream_compose_message_composer_show_in_channel">"También enviar en el canal"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Archivo adjunto no compatible"</string>
-  <string name="stream_compose_message_composer_attachments_close">"Cerrar archivos adjuntos"</string>
-  <string name="stream_compose_message_composer_attachments_open">"Abrir archivos adjuntos"</string>
+  <string name="stream_compose_message_composer_attachments">"Archivos adjuntos"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"contraído"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"expandido"</string>
   <string name="stream_compose_message_deleted">"Mensaje eliminado"</string>
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
   <string name="stream_compose_message_list_auto_translated">"Traducido"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -197,6 +197,7 @@
   <string name="stream_compose_reactions_you">"Tú"</string>
   <string name="stream_compose_recent_files">"Archivos recientes"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"Eliminar archivo adjunto"</string>
   <string name="stream_compose_replied_to_thread">"Respondió en un hilo"</string>
   <string name="stream_compose_reply">"Responder"</string>
   <string name="stream_compose_resend_message">"Reenviar"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -31,6 +31,7 @@
   <string name="stream_compose_attachment_file_picker">"Fichiers"</string>
   <string name="stream_compose_attachment_media_picker">"Médias"</string>
   <string name="stream_compose_attachment_picker_photo">"Photo"</string>
+  <string name="stream_compose_attachment_picker_remove">"retirer"</string>
   <string name="stream_compose_attachment_picker_select">"sélectionner"</string>
   <string name="stream_compose_attachment_picker_video">"Vidéo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Créer un sondage et laisser tout le monde voter"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -26,6 +26,8 @@
   <string name="stream_compose_attachment_commands_picker">"Commandes"</string>
   <string name="stream_compose_attachment_file_picker">"Fichiers"</string>
   <string name="stream_compose_attachment_media_picker">"Médias"</string>
+  <string name="stream_compose_attachment_picker_photo">"Photo"</string>
+  <string name="stream_compose_attachment_picker_video">"Vidéo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Créer un sondage et laisser tout le monde voter"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Créer un sondage"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondages"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -21,6 +21,10 @@
   <string name="stream_compose_add_members_no_results">"Aucun utilisateur trouvé"</string>
   <string name="stream_compose_add_members_title">"Ajouter des membres"</string>
   <string name="stream_compose_also_sent_to_channel">"Également envoyé dans le canal"</string>
+  <string name="stream_compose_attachment_added_audio">"Enregistrement audio joint"</string>
+  <string name="stream_compose_attachment_added_file">"Fichier joint"</string>
+  <string name="stream_compose_attachment_added_photo">"Photo jointe"</string>
+  <string name="stream_compose_attachment_added_video">"Vidéo jointe"</string>
   <string name="stream_compose_attachment_camera_picker">"Ouvrir la caméra"</string>
   <string name="stream_compose_attachment_camera_picker_content">"Prendre une photo et la partager"</string>
   <string name="stream_compose_attachment_commands_picker">"Commandes"</string>
@@ -32,6 +36,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"Créer un sondage et laisser tout le monde voter"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Créer un sondage"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondages"</string>
+  <string name="stream_compose_attachment_removed">"Pièce jointe supprimée"</string>
   <string name="stream_compose_audio_playback_pause">"Pause"</string>
   <string name="stream_compose_audio_recording_delete">"Supprimer l\'enregistrement"</string>
   <string name="stream_compose_audio_recording_hint_save">"Maintenez pour enregistrer. Relâchez pour sauvegarder."</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -197,6 +197,7 @@
   <string name="stream_compose_reactions_you">"Vous"</string>
   <string name="stream_compose_recent_files">"Fichiers récents"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"Supprimer la pièce jointe"</string>
   <string name="stream_compose_replied_to_thread">"A répondu dans un fil"</string>
   <string name="stream_compose_reply">"Répondre"</string>
   <string name="stream_compose_resend_message">"Renvoyer"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -27,6 +27,7 @@
   <string name="stream_compose_attachment_file_picker">"Fichiers"</string>
   <string name="stream_compose_attachment_media_picker">"Médias"</string>
   <string name="stream_compose_attachment_picker_photo">"Photo"</string>
+  <string name="stream_compose_attachment_picker_select">"sélectionner"</string>
   <string name="stream_compose_attachment_picker_video">"Vidéo"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Créer un sondage et laisser tout le monde voter"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Créer un sondage"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -30,6 +30,7 @@
   <string name="stream_compose_attachment_commands_picker">"Commandes"</string>
   <string name="stream_compose_attachment_file_picker">"Fichiers"</string>
   <string name="stream_compose_attachment_media_picker">"Médias"</string>
+  <string name="stream_compose_attachment_picker">"Sélecteur de pièces jointes"</string>
   <string name="stream_compose_attachment_picker_photo">"Photo"</string>
   <string name="stream_compose_attachment_picker_remove">"retirer"</string>
   <string name="stream_compose_attachment_picker_select">"sélectionner"</string>
@@ -115,8 +116,9 @@
   <string name="stream_compose_message_composer_send_button">"Envoyer"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Envoyer aussi dans le canal"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Pièce jointe non prise en charge"</string>
-  <string name="stream_compose_message_composer_attachments_close">"Fermer les pièces jointes"</string>
-  <string name="stream_compose_message_composer_attachments_open">"Ouvrir les pièces jointes"</string>
+  <string name="stream_compose_message_composer_attachments">"Pièces jointes"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"réduit"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"développé"</string>
   <string name="stream_compose_message_deleted">"Message supprimé"</string>
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
   <string name="stream_compose_message_list_auto_translated">"Traduit"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -29,7 +29,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"Créer un sondage et laisser tout le monde voter"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Créer un sondage"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondages"</string>
-  <string name="stream_compose_attachments">"Pièces jointes"</string>
   <string name="stream_compose_audio_playback_pause">"Pause"</string>
   <string name="stream_compose_audio_recording_delete">"Supprimer l\'enregistrement"</string>
   <string name="stream_compose_audio_recording_hint_save">"Maintenez pour enregistrer. Relâchez pour sauvegarder."</string>
@@ -107,6 +106,8 @@
   <string name="stream_compose_message_composer_send_button">"Envoyer"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Envoyer aussi dans le canal"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Pièce jointe non prise en charge"</string>
+  <string name="stream_compose_message_composer_attachments_close">"Fermer les pièces jointes"</string>
+  <string name="stream_compose_message_composer_attachments_open">"Ouvrir les pièces jointes"</string>
   <string name="stream_compose_message_deleted">"Message supprimé"</string>
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
   <string name="stream_compose_message_list_auto_translated">"Traduit"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -86,6 +86,7 @@
   <string name="stream_compose_attachment_commands_picker">"कमांड्स"</string>
   <string name="stream_compose_attachment_file_picker">"फ़ाइलें"</string>
   <string name="stream_compose_attachment_media_picker">"मीडिया"</string>
+  <string name="stream_compose_attachment_picker">"अटैचमेंट चयनकर्ता"</string>
   <string name="stream_compose_attachment_picker_photo">"फ़ोटो"</string>
   <string name="stream_compose_attachment_picker_remove">"हटाएँ"</string>
   <string name="stream_compose_attachment_picker_select">"चुनें"</string>
@@ -171,8 +172,9 @@
   <string name="stream_compose_message_composer_send_button">"भेजें"</string>
   <string name="stream_compose_message_composer_show_in_channel">"सीधे मैसेज के रूप में भी भेजें"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"असमर्थित अटैचमेंट"</string>
-  <string name="stream_compose_message_composer_attachments_close">"अटैचमेंट्स बंद करें"</string>
-  <string name="stream_compose_message_composer_attachments_open">"अटैचमेंट्स खोलें"</string>
+  <string name="stream_compose_message_composer_attachments">"अटैचमेंट्स"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"संक्षिप्त"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"विस्तृत"</string>
   <string name="stream_compose_message_deleted">"मैसेज मिटाया गया"</string>
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
   <string name="stream_compose_message_list_auto_translated">"अनुवादित"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -85,7 +85,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"पोल बनाएँ और सबको वोट करने दें"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"पोल बनाएँ"</string>
   <string name="stream_compose_attachment_polls_picker">"पोल"</string>
-  <string name="stream_compose_attachments">"अटैचमेंट्स"</string>
   <string name="stream_compose_audio_playback_pause">"रोकें"</string>
   <string name="stream_compose_audio_recording_delete">"रिकॉर्डिंग हटाएँ"</string>
   <string name="stream_compose_audio_recording_hint_save">"रिकॉर्ड करने के लिए दबाए रखें। सेव करने के लिए छोड़ें।"</string>
@@ -163,6 +162,8 @@
   <string name="stream_compose_message_composer_send_button">"भेजें"</string>
   <string name="stream_compose_message_composer_show_in_channel">"सीधे मैसेज के रूप में भी भेजें"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"असमर्थित अटैचमेंट"</string>
+  <string name="stream_compose_message_composer_attachments_close">"अटैचमेंट्स बंद करें"</string>
+  <string name="stream_compose_message_composer_attachments_open">"अटैचमेंट्स खोलें"</string>
   <string name="stream_compose_message_deleted">"मैसेज मिटाया गया"</string>
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
   <string name="stream_compose_message_list_auto_translated">"अनुवादित"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -82,6 +82,8 @@
   <string name="stream_compose_attachment_commands_picker">"कमांड्स"</string>
   <string name="stream_compose_attachment_file_picker">"फ़ाइलें"</string>
   <string name="stream_compose_attachment_media_picker">"मीडिया"</string>
+  <string name="stream_compose_attachment_picker_photo">"फ़ोटो"</string>
+  <string name="stream_compose_attachment_picker_video">"वीडियो"</string>
   <string name="stream_compose_attachment_poll_picker_content">"पोल बनाएँ और सबको वोट करने दें"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"पोल बनाएँ"</string>
   <string name="stream_compose_attachment_polls_picker">"पोल"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -87,6 +87,7 @@
   <string name="stream_compose_attachment_file_picker">"फ़ाइलें"</string>
   <string name="stream_compose_attachment_media_picker">"मीडिया"</string>
   <string name="stream_compose_attachment_picker_photo">"फ़ोटो"</string>
+  <string name="stream_compose_attachment_picker_remove">"हटाएँ"</string>
   <string name="stream_compose_attachment_picker_select">"चुनें"</string>
   <string name="stream_compose_attachment_picker_video">"वीडियो"</string>
   <string name="stream_compose_attachment_poll_picker_content">"पोल बनाएँ और सबको वोट करने दें"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -77,6 +77,10 @@
   <string name="stream_compose_add_members_no_results">"कोई उपयोगकर्ता नहीं मिला"</string>
   <string name="stream_compose_add_members_title">"सदस्य जोड़ें"</string>
   <string name="stream_compose_also_sent_to_channel">"चैनल को भी भेजा गया"</string>
+  <string name="stream_compose_attachment_added_audio">"ऑडियो रिकॉर्डिंग संलग्न की गई"</string>
+  <string name="stream_compose_attachment_added_file">"फ़ाइल संलग्न की गई"</string>
+  <string name="stream_compose_attachment_added_photo">"फ़ोटो संलग्न की गई"</string>
+  <string name="stream_compose_attachment_added_video">"वीडियो संलग्न किया गया"</string>
   <string name="stream_compose_attachment_camera_picker">"कैमरा खोलें"</string>
   <string name="stream_compose_attachment_camera_picker_content">"फ़ोटो लें और साझा करें"</string>
   <string name="stream_compose_attachment_commands_picker">"कमांड्स"</string>
@@ -88,6 +92,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"पोल बनाएँ और सबको वोट करने दें"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"पोल बनाएँ"</string>
   <string name="stream_compose_attachment_polls_picker">"पोल"</string>
+  <string name="stream_compose_attachment_removed">"अटैचमेंट हटाया गया"</string>
   <string name="stream_compose_audio_playback_pause">"रोकें"</string>
   <string name="stream_compose_audio_recording_delete">"रिकॉर्डिंग हटाएँ"</string>
   <string name="stream_compose_audio_recording_hint_save">"रिकॉर्ड करने के लिए दबाए रखें। सेव करने के लिए छोड़ें।"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -253,6 +253,7 @@
   <string name="stream_compose_reactions_you">"आप"</string>
   <string name="stream_compose_recent_files">"हाल ही की फाइलें"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"अटैचमेंट हटाएँ"</string>
   <string name="stream_compose_replied_to_thread">"एक थ्रेड को जवाब दिया"</string>
   <string name="stream_compose_reply">"जवाब दें"</string>
   <string name="stream_compose_resend_message">"पुनः भेजें"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -83,6 +83,7 @@
   <string name="stream_compose_attachment_file_picker">"फ़ाइलें"</string>
   <string name="stream_compose_attachment_media_picker">"मीडिया"</string>
   <string name="stream_compose_attachment_picker_photo">"फ़ोटो"</string>
+  <string name="stream_compose_attachment_picker_select">"चुनें"</string>
   <string name="stream_compose_attachment_picker_video">"वीडियो"</string>
   <string name="stream_compose_attachment_poll_picker_content">"पोल बनाएँ और सबको वोट करने दें"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"पोल बनाएँ"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -30,6 +30,7 @@
   <string name="stream_compose_attachment_commands_picker">"Perintah"</string>
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
+  <string name="stream_compose_attachment_picker">"Pemilih lampiran"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
   <string name="stream_compose_attachment_picker_remove">"hapus"</string>
   <string name="stream_compose_attachment_picker_select">"pilih"</string>
@@ -115,8 +116,9 @@
   <string name="stream_compose_message_composer_send_button">"Kirim"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Juga kirim di Saluran"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Lampiran tidak didukung"</string>
-  <string name="stream_compose_message_composer_attachments_close">"Tutup lampiran"</string>
-  <string name="stream_compose_message_composer_attachments_open">"Buka lampiran"</string>
+  <string name="stream_compose_message_composer_attachments">"Lampiran"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"diciutkan"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"diperluas"</string>
   <string name="stream_compose_message_deleted">"Pesan dihapus"</string>
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
   <string name="stream_compose_message_list_auto_translated">"Diterjemahkan"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -26,6 +26,8 @@
   <string name="stream_compose_attachment_commands_picker">"Perintah"</string>
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
+  <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Buat polling dan biarkan semua orang memilih"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Buat Polling"</string>
   <string name="stream_compose_attachment_polls_picker">"Polling"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -197,6 +197,7 @@
   <string name="stream_compose_reactions_you">"Anda"</string>
   <string name="stream_compose_recent_files">"File Terbaru"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"Hapus lampiran"</string>
   <string name="stream_compose_replied_to_thread">"Membalas di utas"</string>
   <string name="stream_compose_reply">"Balas"</string>
   <string name="stream_compose_resend_message">"Kirim ulang"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -31,6 +31,7 @@
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_remove">"hapus"</string>
   <string name="stream_compose_attachment_picker_select">"pilih"</string>
   <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Buat polling dan biarkan semua orang memilih"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -21,6 +21,10 @@
   <string name="stream_compose_add_members_no_results">"Pengguna tidak ditemukan"</string>
   <string name="stream_compose_add_members_title">"Tambahkan Anggota"</string>
   <string name="stream_compose_also_sent_to_channel">"Juga dikirim ke saluran"</string>
+  <string name="stream_compose_attachment_added_audio">"Rekaman audio dilampirkan"</string>
+  <string name="stream_compose_attachment_added_file">"File dilampirkan"</string>
+  <string name="stream_compose_attachment_added_photo">"Foto dilampirkan"</string>
+  <string name="stream_compose_attachment_added_video">"Video dilampirkan"</string>
   <string name="stream_compose_attachment_camera_picker">"Buka Kamera"</string>
   <string name="stream_compose_attachment_camera_picker_content">"Ambil foto dan bagikan"</string>
   <string name="stream_compose_attachment_commands_picker">"Perintah"</string>
@@ -32,6 +36,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"Buat polling dan biarkan semua orang memilih"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Buat Polling"</string>
   <string name="stream_compose_attachment_polls_picker">"Polling"</string>
+  <string name="stream_compose_attachment_removed">"Lampiran dihapus"</string>
   <string name="stream_compose_audio_playback_pause">"Jeda"</string>
   <string name="stream_compose_audio_recording_delete">"Hapus rekaman"</string>
   <string name="stream_compose_audio_recording_hint_save">"Tahan untuk merekam. Lepas untuk menyimpan."</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -29,7 +29,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"Buat polling dan biarkan semua orang memilih"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Buat Polling"</string>
   <string name="stream_compose_attachment_polls_picker">"Polling"</string>
-  <string name="stream_compose_attachments">"Lampiran"</string>
   <string name="stream_compose_audio_playback_pause">"Jeda"</string>
   <string name="stream_compose_audio_recording_delete">"Hapus rekaman"</string>
   <string name="stream_compose_audio_recording_hint_save">"Tahan untuk merekam. Lepas untuk menyimpan."</string>
@@ -107,6 +106,8 @@
   <string name="stream_compose_message_composer_send_button">"Kirim"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Juga kirim di Saluran"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Lampiran tidak didukung"</string>
+  <string name="stream_compose_message_composer_attachments_close">"Tutup lampiran"</string>
+  <string name="stream_compose_message_composer_attachments_open">"Buka lampiran"</string>
   <string name="stream_compose_message_deleted">"Pesan dihapus"</string>
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
   <string name="stream_compose_message_list_auto_translated">"Diterjemahkan"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -27,6 +27,7 @@
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_select">"pilih"</string>
   <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Buat polling dan biarkan semua orang memilih"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Buat Polling"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -86,6 +86,7 @@
   <string name="stream_compose_attachment_commands_picker">"Comandi"</string>
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
+  <string name="stream_compose_attachment_picker">"Selettore allegati"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
   <string name="stream_compose_attachment_picker_remove">"rimuovi"</string>
   <string name="stream_compose_attachment_picker_select">"seleziona"</string>
@@ -171,8 +172,9 @@
   <string name="stream_compose_message_composer_send_button">"Invia"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Invia anche nel canale"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Allegato non supportato"</string>
-  <string name="stream_compose_message_composer_attachments_close">"Chiudi allegati"</string>
-  <string name="stream_compose_message_composer_attachments_open">"Apri allegati"</string>
+  <string name="stream_compose_message_composer_attachments">"Allegati"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"compresso"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"espanso"</string>
   <string name="stream_compose_message_deleted">"Messaggio cancellato"</string>
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
   <string name="stream_compose_message_list_auto_translated">"Tradotto"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -83,6 +83,7 @@
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_select">"seleziona"</string>
   <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crea un sondaggio e lascia votare tutti"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crea sondaggio"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -85,7 +85,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"Crea un sondaggio e lascia votare tutti"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crea sondaggio"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondaggi"</string>
-  <string name="stream_compose_attachments">"Allegati"</string>
   <string name="stream_compose_audio_playback_pause">"Pausa"</string>
   <string name="stream_compose_audio_recording_delete">"Elimina registrazione"</string>
   <string name="stream_compose_audio_recording_hint_save">"Tieni premuto per registrare. Rilascia per salvare."</string>
@@ -163,6 +162,8 @@
   <string name="stream_compose_message_composer_send_button">"Invia"</string>
   <string name="stream_compose_message_composer_show_in_channel">"Invia anche nel canale"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"Allegato non supportato"</string>
+  <string name="stream_compose_message_composer_attachments_close">"Chiudi allegati"</string>
+  <string name="stream_compose_message_composer_attachments_open">"Apri allegati"</string>
   <string name="stream_compose_message_deleted">"Messaggio cancellato"</string>
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
   <string name="stream_compose_message_list_auto_translated">"Tradotto"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -82,6 +82,8 @@
   <string name="stream_compose_attachment_commands_picker">"Comandi"</string>
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
+  <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crea un sondaggio e lascia votare tutti"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crea sondaggio"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondaggi"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -87,6 +87,7 @@
   <string name="stream_compose_attachment_file_picker">"File"</string>
   <string name="stream_compose_attachment_media_picker">"Media"</string>
   <string name="stream_compose_attachment_picker_photo">"Foto"</string>
+  <string name="stream_compose_attachment_picker_remove">"rimuovi"</string>
   <string name="stream_compose_attachment_picker_select">"seleziona"</string>
   <string name="stream_compose_attachment_picker_video">"Video"</string>
   <string name="stream_compose_attachment_poll_picker_content">"Crea un sondaggio e lascia votare tutti"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -253,6 +253,7 @@
   <string name="stream_compose_reactions_you">"Tu"</string>
   <string name="stream_compose_recent_files">"File recenti"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"Rimuovi allegato"</string>
   <string name="stream_compose_replied_to_thread">"Ha risposto in un thread"</string>
   <string name="stream_compose_reply">"Rispondi"</string>
   <string name="stream_compose_resend_message">"Reinvia"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -77,6 +77,10 @@
   <string name="stream_compose_add_members_no_results">"Nessun utente trovato"</string>
   <string name="stream_compose_add_members_title">"Aggiungi membri"</string>
   <string name="stream_compose_also_sent_to_channel">"Inviato anche al canale"</string>
+  <string name="stream_compose_attachment_added_audio">"Registrazione audio allegata"</string>
+  <string name="stream_compose_attachment_added_file">"File allegato"</string>
+  <string name="stream_compose_attachment_added_photo">"Foto allegata"</string>
+  <string name="stream_compose_attachment_added_video">"Video allegato"</string>
   <string name="stream_compose_attachment_camera_picker">"Apri fotocamera"</string>
   <string name="stream_compose_attachment_camera_picker_content">"Scatta una foto e condividila"</string>
   <string name="stream_compose_attachment_commands_picker">"Comandi"</string>
@@ -88,6 +92,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"Crea un sondaggio e lascia votare tutti"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"Crea sondaggio"</string>
   <string name="stream_compose_attachment_polls_picker">"Sondaggi"</string>
+  <string name="stream_compose_attachment_removed">"Allegato rimosso"</string>
   <string name="stream_compose_audio_playback_pause">"Pausa"</string>
   <string name="stream_compose_audio_recording_delete">"Elimina registrazione"</string>
   <string name="stream_compose_audio_recording_hint_save">"Tieni premuto per registrare. Rilascia per salvare."</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -30,6 +30,7 @@
   <string name="stream_compose_attachment_commands_picker">"コマンド"</string>
   <string name="stream_compose_attachment_file_picker">"ファイル"</string>
   <string name="stream_compose_attachment_media_picker">"メディア"</string>
+  <string name="stream_compose_attachment_picker">"添付ファイル選択"</string>
   <string name="stream_compose_attachment_picker_photo">"写真"</string>
   <string name="stream_compose_attachment_picker_remove">"削除"</string>
   <string name="stream_compose_attachment_picker_select">"選択"</string>
@@ -123,8 +124,9 @@
   <string name="stream_compose_message_composer_send_button">"送信"</string>
   <string name="stream_compose_message_composer_show_in_channel">"チャンネルにも送信"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"サポートされていない添付ファイル"</string>
-  <string name="stream_compose_message_composer_attachments_close">"添付ファイルを閉じる"</string>
-  <string name="stream_compose_message_composer_attachments_open">"添付ファイルを開く"</string>
+  <string name="stream_compose_message_composer_attachments">"添付ファイル"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"折りたたみ"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"展開"</string>
   <string name="stream_compose_message_deleted">"メッセージは削除されました"</string>
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
   <string name="stream_compose_message_list_auto_translated">"翻訳済み"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -229,6 +229,7 @@
   <string name="stream_compose_reactions_you">"あなた"</string>
   <string name="stream_compose_recent_files">"最近のファイル"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"添付ファイルを削除"</string>
   <string name="stream_compose_replied_to_thread">"スレッドに返信しました"</string>
   <string name="stream_compose_reply">"返信"</string>
   <string name="stream_compose_resend_message">"再送信"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -26,6 +26,8 @@
   <string name="stream_compose_attachment_commands_picker">"コマンド"</string>
   <string name="stream_compose_attachment_file_picker">"ファイル"</string>
   <string name="stream_compose_attachment_media_picker">"メディア"</string>
+  <string name="stream_compose_attachment_picker_photo">"写真"</string>
+  <string name="stream_compose_attachment_picker_video">"動画"</string>
   <string name="stream_compose_attachment_poll_picker_content">"投票を作成してみんなに投票してもらう"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"投票を作成"</string>
   <string name="stream_compose_attachment_polls_picker">"投票"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -29,7 +29,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"投票を作成してみんなに投票してもらう"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"投票を作成"</string>
   <string name="stream_compose_attachment_polls_picker">"投票"</string>
-  <string name="stream_compose_attachments">"添付ファイル"</string>
   <string name="stream_compose_audio_playback_pause">"一時停止"</string>
   <string name="stream_compose_audio_recording_delete">"録音を削除"</string>
   <string name="stream_compose_audio_recording_hint_save">"長押しで録音。離すと保存。"</string>
@@ -115,6 +114,8 @@
   <string name="stream_compose_message_composer_send_button">"送信"</string>
   <string name="stream_compose_message_composer_show_in_channel">"チャンネルにも送信"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"サポートされていない添付ファイル"</string>
+  <string name="stream_compose_message_composer_attachments_close">"添付ファイルを閉じる"</string>
+  <string name="stream_compose_message_composer_attachments_open">"添付ファイルを開く"</string>
   <string name="stream_compose_message_deleted">"メッセージは削除されました"</string>
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
   <string name="stream_compose_message_list_auto_translated">"翻訳済み"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -21,6 +21,10 @@
   <string name="stream_compose_add_members_no_results">"ユーザーが見つかりません"</string>
   <string name="stream_compose_add_members_title">"メンバーを追加"</string>
   <string name="stream_compose_also_sent_to_channel">"チャンネルにも送信済み"</string>
+  <string name="stream_compose_attachment_added_audio">"音声録音を添付しました"</string>
+  <string name="stream_compose_attachment_added_file">"ファイルを添付しました"</string>
+  <string name="stream_compose_attachment_added_photo">"写真を添付しました"</string>
+  <string name="stream_compose_attachment_added_video">"動画を添付しました"</string>
   <string name="stream_compose_attachment_camera_picker">"カメラを開く"</string>
   <string name="stream_compose_attachment_camera_picker_content">"写真を撮って共有"</string>
   <string name="stream_compose_attachment_commands_picker">"コマンド"</string>
@@ -32,6 +36,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"投票を作成してみんなに投票してもらう"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"投票を作成"</string>
   <string name="stream_compose_attachment_polls_picker">"投票"</string>
+  <string name="stream_compose_attachment_removed">"添付ファイルを削除しました"</string>
   <string name="stream_compose_audio_playback_pause">"一時停止"</string>
   <string name="stream_compose_audio_recording_delete">"録音を削除"</string>
   <string name="stream_compose_audio_recording_hint_save">"長押しで録音。離すと保存。"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -31,6 +31,7 @@
   <string name="stream_compose_attachment_file_picker">"ファイル"</string>
   <string name="stream_compose_attachment_media_picker">"メディア"</string>
   <string name="stream_compose_attachment_picker_photo">"写真"</string>
+  <string name="stream_compose_attachment_picker_remove">"削除"</string>
   <string name="stream_compose_attachment_picker_select">"選択"</string>
   <string name="stream_compose_attachment_picker_video">"動画"</string>
   <string name="stream_compose_attachment_poll_picker_content">"投票を作成してみんなに投票してもらう"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -27,6 +27,7 @@
   <string name="stream_compose_attachment_file_picker">"ファイル"</string>
   <string name="stream_compose_attachment_media_picker">"メディア"</string>
   <string name="stream_compose_attachment_picker_photo">"写真"</string>
+  <string name="stream_compose_attachment_picker_select">"選択"</string>
   <string name="stream_compose_attachment_picker_video">"動画"</string>
   <string name="stream_compose_attachment_poll_picker_content">"投票を作成してみんなに投票してもらう"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"投票を作成"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -29,7 +29,6 @@
   <string name="stream_compose_attachment_poll_picker_content">"투표를 만들어 모두가 참여하게 하세요"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"투표 만들기"</string>
   <string name="stream_compose_attachment_polls_picker">"투표"</string>
-  <string name="stream_compose_attachments">"첨부파일"</string>
   <string name="stream_compose_audio_playback_pause">"일시정지"</string>
   <string name="stream_compose_audio_recording_delete">"녹음 삭제"</string>
   <string name="stream_compose_audio_recording_hint_save">"길게 눌러 녹음. 놓으면 저장."</string>
@@ -115,6 +114,8 @@
   <string name="stream_compose_message_composer_send_button">"보내기"</string>
   <string name="stream_compose_message_composer_show_in_channel">"채널에도 전송"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"지원되지 않는 첨부파일"</string>
+  <string name="stream_compose_message_composer_attachments_close">"첨부파일 닫기"</string>
+  <string name="stream_compose_message_composer_attachments_open">"첨부파일 열기"</string>
   <string name="stream_compose_message_deleted">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_list_auto_translated">"번역됨"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -31,6 +31,7 @@
   <string name="stream_compose_attachment_file_picker">"파일"</string>
   <string name="stream_compose_attachment_media_picker">"미디어"</string>
   <string name="stream_compose_attachment_picker_photo">"사진"</string>
+  <string name="stream_compose_attachment_picker_remove">"삭제"</string>
   <string name="stream_compose_attachment_picker_select">"선택"</string>
   <string name="stream_compose_attachment_picker_video">"동영상"</string>
   <string name="stream_compose_attachment_poll_picker_content">"투표를 만들어 모두가 참여하게 하세요"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -27,6 +27,7 @@
   <string name="stream_compose_attachment_file_picker">"파일"</string>
   <string name="stream_compose_attachment_media_picker">"미디어"</string>
   <string name="stream_compose_attachment_picker_photo">"사진"</string>
+  <string name="stream_compose_attachment_picker_select">"선택"</string>
   <string name="stream_compose_attachment_picker_video">"동영상"</string>
   <string name="stream_compose_attachment_poll_picker_content">"투표를 만들어 모두가 참여하게 하세요"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"투표 만들기"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -30,6 +30,7 @@
   <string name="stream_compose_attachment_commands_picker">"명령어"</string>
   <string name="stream_compose_attachment_file_picker">"파일"</string>
   <string name="stream_compose_attachment_media_picker">"미디어"</string>
+  <string name="stream_compose_attachment_picker">"첨부파일 선택기"</string>
   <string name="stream_compose_attachment_picker_photo">"사진"</string>
   <string name="stream_compose_attachment_picker_remove">"삭제"</string>
   <string name="stream_compose_attachment_picker_select">"선택"</string>
@@ -123,8 +124,9 @@
   <string name="stream_compose_message_composer_send_button">"보내기"</string>
   <string name="stream_compose_message_composer_show_in_channel">"채널에도 전송"</string>
   <string name="stream_compose_message_composer_unsupported_attachment">"지원되지 않는 첨부파일"</string>
-  <string name="stream_compose_message_composer_attachments_close">"첨부파일 닫기"</string>
-  <string name="stream_compose_message_composer_attachments_open">"첨부파일 열기"</string>
+  <string name="stream_compose_message_composer_attachments">"첨부파일"</string>
+  <string name="stream_compose_message_composer_attachments_collapsed">"축소됨"</string>
+  <string name="stream_compose_message_composer_attachments_expanded">"확장됨"</string>
   <string name="stream_compose_message_deleted">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_list_auto_translated">"번역됨"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -229,6 +229,7 @@
   <string name="stream_compose_reactions_you">"나"</string>
   <string name="stream_compose_recent_files">"최근 파일"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>
+  <string name="stream_compose_remove_attachment">"첨부파일 삭제"</string>
   <string name="stream_compose_replied_to_thread">"스레드에 답장했습니다"</string>
   <string name="stream_compose_reply">"답장"</string>
   <string name="stream_compose_resend_message">"재전송"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -26,6 +26,8 @@
   <string name="stream_compose_attachment_commands_picker">"명령어"</string>
   <string name="stream_compose_attachment_file_picker">"파일"</string>
   <string name="stream_compose_attachment_media_picker">"미디어"</string>
+  <string name="stream_compose_attachment_picker_photo">"사진"</string>
+  <string name="stream_compose_attachment_picker_video">"동영상"</string>
   <string name="stream_compose_attachment_poll_picker_content">"투표를 만들어 모두가 참여하게 하세요"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"투표 만들기"</string>
   <string name="stream_compose_attachment_polls_picker">"투표"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -21,6 +21,10 @@
   <string name="stream_compose_add_members_no_results">"사용자를 찾을 수 없습니다"</string>
   <string name="stream_compose_add_members_title">"멤버 추가"</string>
   <string name="stream_compose_also_sent_to_channel">"채널에도 전송됨"</string>
+  <string name="stream_compose_attachment_added_audio">"음성 녹음 첨부됨"</string>
+  <string name="stream_compose_attachment_added_file">"파일 첨부됨"</string>
+  <string name="stream_compose_attachment_added_photo">"사진 첨부됨"</string>
+  <string name="stream_compose_attachment_added_video">"동영상 첨부됨"</string>
   <string name="stream_compose_attachment_camera_picker">"카메라 열기"</string>
   <string name="stream_compose_attachment_camera_picker_content">"사진을 찍어 공유하세요"</string>
   <string name="stream_compose_attachment_commands_picker">"명령어"</string>
@@ -32,6 +36,7 @@
   <string name="stream_compose_attachment_poll_picker_content">"투표를 만들어 모두가 참여하게 하세요"</string>
   <string name="stream_compose_attachment_poll_picker_cta">"투표 만들기"</string>
   <string name="stream_compose_attachment_polls_picker">"투표"</string>
+  <string name="stream_compose_attachment_removed">"첨부파일 삭제됨"</string>
   <string name="stream_compose_audio_playback_pause">"일시정지"</string>
   <string name="stream_compose_audio_recording_delete">"녹음 삭제"</string>
   <string name="stream_compose_audio_recording_hint_save">"길게 눌러 녹음. 놓으면 저장."</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -224,6 +224,11 @@
     <string name="stream_compose_attachment_polls_picker">Polls</string>
     <string name="stream_compose_attachment_poll_picker_content">Create a poll and let everyone vote</string>
     <string name="stream_compose_attachment_poll_picker_cta">Create Poll</string>
+    <string name="stream_compose_attachment_added_audio">Audio recording attached</string>
+    <string name="stream_compose_attachment_added_file">File attached</string>
+    <string name="stream_compose_attachment_added_photo">Photo attached</string>
+    <string name="stream_compose_attachment_added_video">Video attached</string>
+    <string name="stream_compose_attachment_removed">Attachment removed</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
     <string name="stream_compose_attachment_picker_photo">Photo</string>
     <string name="stream_compose_attachment_picker_select">select</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -238,6 +238,7 @@
     <string name="stream_compose_image_order">%1$d of %2$d</string>
     <string name="stream_compose_scroll_to_bottom">Scroll to bottom</string>
     <string name="stream_compose_remaining_media_attachments_count">+%1$d</string>
+    <string name="stream_compose_remove_attachment">Remove attachment</string>
     <string name="stream_compose_giphy_label">GIPHY</string>
     <string name="stream_compose_pinned_to_channel">Pinned</string>
     <string name="stream_compose_pinned_to_channel_by">Pinned by %1$s</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -231,6 +231,7 @@
     <string name="stream_compose_attachment_removed">Attachment removed</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
     <string name="stream_compose_attachment_picker_photo">Photo</string>
+    <string name="stream_compose_attachment_picker_remove">remove</string>
     <string name="stream_compose_attachment_picker_select">select</string>
     <string name="stream_compose_attachment_picker_video">Video</string>
 

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -174,8 +174,9 @@
     <string name="stream_compose_message_composer_unsupported_attachment">Unsupported attachment</string>
     <string name="stream_compose_message_composer_send_button">Send</string>
     <string name="stream_compose_message_composer_save_button">Save</string>
-    <string name="stream_compose_message_composer_attachments_close">Close attachments</string>
-    <string name="stream_compose_message_composer_attachments_open">Open attachments</string>
+    <string name="stream_compose_message_composer_attachments">Attachments</string>
+    <string name="stream_compose_message_composer_attachments_collapsed">collapsed</string>
+    <string name="stream_compose_message_composer_attachments_expanded">expanded</string>
 
     <!-- Message Preview -->
     <string name="stream_compose_audio_recording_preview">Voice message</string>
@@ -230,6 +231,7 @@
     <string name="stream_compose_attachment_added_video">Video attached</string>
     <string name="stream_compose_attachment_removed">Attachment removed</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
+    <string name="stream_compose_attachment_picker">Attachment picker</string>
     <string name="stream_compose_attachment_picker_photo">Photo</string>
     <string name="stream_compose_attachment_picker_remove">remove</string>
     <string name="stream_compose_attachment_picker_select">select</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -225,6 +225,8 @@
     <string name="stream_compose_attachment_poll_picker_content">Create a poll and let everyone vote</string>
     <string name="stream_compose_attachment_poll_picker_cta">Create Poll</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
+    <string name="stream_compose_attachment_picker_photo">Photo</string>
+    <string name="stream_compose_attachment_picker_video">Video</string>
 
     <string name="stream_compose_recent_files">Recent Files</string>
     <string name="stream_compose_thread_title">Thread Reply</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -226,6 +226,7 @@
     <string name="stream_compose_attachment_poll_picker_cta">Create Poll</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
     <string name="stream_compose_attachment_picker_photo">Photo</string>
+    <string name="stream_compose_attachment_picker_select">select</string>
     <string name="stream_compose_attachment_picker_video">Video</string>
 
     <string name="stream_compose_recent_files">Recent Files</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -174,6 +174,8 @@
     <string name="stream_compose_message_composer_unsupported_attachment">Unsupported attachment</string>
     <string name="stream_compose_message_composer_send_button">Send</string>
     <string name="stream_compose_message_composer_save_button">Save</string>
+    <string name="stream_compose_message_composer_attachments_close">Close attachments</string>
+    <string name="stream_compose_message_composer_attachments_open">Open attachments</string>
 
     <!-- Message Preview -->
     <string name="stream_compose_audio_recording_preview">Voice message</string>
@@ -224,7 +226,6 @@
     <string name="stream_compose_attachment_poll_picker_cta">Create Poll</string>
     <string name="stream_compose_attachment_commands_picker">Commands</string>
 
-    <string name="stream_compose_attachments">Attachments</string>
     <string name="stream_compose_recent_files">Recent Files</string>
     <string name="stream_compose_thread_title">Thread Reply</string>
     <string name="stream_compose_thread_subtitle">with %1$s</string>

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/components/composer/AnnounceAddedAttachmentTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/components/composer/AnnounceAddedAttachmentTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.components.composer
+
+import io.getstream.chat.android.models.AttachmentType
+import io.getstream.chat.android.randomAttachment
+import io.getstream.chat.android.randomString
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+internal class AnnounceAddedAttachmentTest {
+
+    private val photoAttached = randomString()
+    private val videoAttached = randomString()
+    private val audioAttached = randomString()
+    private val fileAttached = randomString()
+
+    @Test
+    fun `returns empty string when attachment is null`() {
+        val result = announceAddedAttachment(
+            added = null,
+            photoAttached = photoAttached,
+            videoAttached = videoAttached,
+            audioAttached = audioAttached,
+            fileAttached = fileAttached,
+        )
+
+        assertEquals("", result)
+    }
+
+    @Test
+    fun `returns photoAttached label for an image attachment`() {
+        val result = announceAddedAttachment(
+            added = randomAttachment(type = AttachmentType.IMAGE),
+            photoAttached = photoAttached,
+            videoAttached = videoAttached,
+            audioAttached = audioAttached,
+            fileAttached = fileAttached,
+        )
+
+        assertEquals(photoAttached, result)
+    }
+
+    @Test
+    fun `returns videoAttached label for a video attachment`() {
+        val result = announceAddedAttachment(
+            added = randomAttachment(type = AttachmentType.VIDEO),
+            photoAttached = photoAttached,
+            videoAttached = videoAttached,
+            audioAttached = audioAttached,
+            fileAttached = fileAttached,
+        )
+
+        assertEquals(videoAttached, result)
+    }
+
+    @Test
+    fun `returns audioAttached label for an audio recording attachment`() {
+        val result = announceAddedAttachment(
+            added = randomAttachment(type = AttachmentType.AUDIO_RECORDING),
+            photoAttached = photoAttached,
+            videoAttached = videoAttached,
+            audioAttached = audioAttached,
+            fileAttached = fileAttached,
+        )
+
+        assertEquals(audioAttached, result)
+    }
+
+    @Test
+    fun `returns fileAttached label for any other attachment type`() {
+        val result = announceAddedAttachment(
+            added = randomAttachment(type = AttachmentType.FILE),
+            photoAttached = photoAttached,
+            videoAttached = videoAttached,
+            audioAttached = audioAttached,
+            fileAttached = fileAttached,
+        )
+
+        assertEquals(fileAttached, result)
+    }
+}


### PR DESCRIPTION
### Goal

Address the accessibility audit ([Notion DB](https://www.notion.so/stream-wiki/c2599560f8774c95b7d904b5ad49d6fd?v=6a01d11916874a85908ab37c2b40afb2)). All findings concentrate on the **attachment picker**.

### Implementation

| Audit | Fix | Files |
|---|---|---|
| A1 (Critical) | Media grid items announce label / role / selected state | `ImagesPicker.kt` |
| A2 | Picker tabs use `Role.Tab` via `clearAndSetSemantics` (suppresses `ToggleableState`) | `AttachmentTypePicker.kt` |
| A3, A4(1) | Composer button uses `contentDescription = "Attachments"` + `stateDescription = "collapsed" / "expanded"`. `paneTitle` on the picker root announces the new pane on entry | `MessageComposerLeadingContent.kt`, `AttachmentPicker.kt` |
| A5(1), A8(1) | Accessibility announcements ("Photo / Video / File / Audio recording attached" / "Attachment removed") via `View.announceForAccessibility()` | `MessageComposerAttachmentAnnouncer.kt`, `MessageInput.kt` |
| A5(2), A10 | Action hint flips between "select" / "remove" based on `isSelected` | `ImagesPicker.kt`, `FilesPicker.kt` |
| A6 | Composer chip × labelled "Remove attachment" via additive `contentDescription` parameter on `ComposerCancelIcon` | `ComposerCancelIcon.kt` + 3 chip call sites |
| A9 | CreatePoll sheet announces the screen title before the auto-focused field via `paneTitle` + `heading()` | `CreatePollScreen.kt`, `PollCreationHeader.kt` |

#### Designer-aligned scope

Audit **A7** (focus → text input on chip remove) is resolved by the new "Attachment removed" announcement: the literal fix pops the keyboard mid-picker, and TalkBack's natural left-to-right / top-to-bottom progression after removal lands on the mic — the announcement provides the audible confirmation. Designer accepted; A7 is closed in Notion. The **focus halves** of A4 and A8 share the same root cause (Compose programmatic focus moves don't reliably propagate to TalkBack across our merged-semantics tab nodes) and ship in the same state pending designer alignment.

#### API surface

- `ComposerCancelIcon` gains a defaulted `contentDescription: String` parameter — additive, non-breaking per project convention. `apiDump` reflects the addition.
- One unused public string ID removed (`stream_compose_attachments`). Theoretical soft binary break for any consumer that referenced it; in practice unused.
- All other changes are internal.

#### Strings & translations

New string IDs added in the `_message_composer_*`, `_attachment_picker_*`, and `_attachment_added_*` / `_attachment_removed` namespaces. Translations added for the seven supported locales (it / in / ja / fr / hi / ko / es).

### Testing

All scenarios assume the Compose sample app, a channel with media/files/audio attachments, and TalkBack enabled on a real device with a working TTS engine. Single-tap focuses; double-tap activates.

1. **Composer button.** Tap the `+`. *"Collapsed, attachments, button, double tap to activate."* Activate it. *"Expanded, attachments, button"* + *"Attachment picker"* (paneTitle).
2. **Tab bar.** Tap each tab. Active: *"Selected, media, tab"*. Inactive: *"Files, tab, double tap to activate"*. No "checkbox" / "checked" wording.
3. **Media grid.** Tap a thumbnail: *"Non-selected, photo, button, double tap to select"*. Activate: *"Photo attached"* + *"Selected"*. Re-focus the same item: hint flips to *"double tap to remove"*.
4. **File row.** Switch to Files tab. Tap a row: *"Non-selected, &lt;filename&gt;, &lt;size&gt;, button, double tap to select"*.
5. **Camera capture.** Switch to Camera tab, take a photo: *"Photo attached"* fires automatically.
6. **Composer chip.** Tap chip's `×`: *"Remove attachment, button"*. Activate: *"Attachment removed"*.
7. **CreatePoll sheet.** Switch to Polls tab, activate: *"Create Poll"* announced before the IME / field announcements.
8. **Visual regression.** Scroll through the composer, picker, CreatePoll sheet. No visible changes vs `develop`. Paparazzi snapshots unchanged.

API impact: one additive defaulted parameter on `ComposerCancelIcon`. Everything else internal.

No visible UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced accessibility across attachment UI with improved screen reader support and semantic descriptions.
  * Added attachment announcements for audio, file, photo, and video uploads.
  * Improved attachment picker and message composer with better semantic labeling.

* **API Changes**
  * `ComposerCancelIcon` now accepts a customizable content description parameter.

* **Localization**
  * Added localized attachment-related strings for Spanish, French, Hindi, Indonesian, Italian, Japanese, and Korean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->