### PR TITLE
Expand message long-press hit area to entire cell

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -175,12 +175,15 @@ public fun MessageContainer(
     val focusState = messageItem.focusState
     val haptic = LocalHapticFeedback.current
 
+    val canOpenThread = message.isThreadStart() && !messageItem.isInThread
+    val canOpenActions = !message.isDeleted() && !message.isUploading()
+
     val clickModifier = Modifier.combinedClickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = ripple(),
-        onClick = { if (message.isThreadStart() && !messageItem.isInThread) onThreadClick(message) },
+        onClick = { if (canOpenThread) onThreadClick(message) },
         onLongClick = {
-            if (!message.isDeleted() && !message.isUploading()) {
+            if (canOpenActions) {
                 haptic.performHapticFeedback(HapticFeedbackType.LongPress)
                 onLongItemClick(message)
             }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -181,6 +181,7 @@ public fun MessageContainer(
     val clickModifier = Modifier.combinedClickable(
         interactionSource = remember { MutableInteractionSource() },
         indication = ripple(),
+        enabled = canOpenThread || canOpenActions,
         onClick = { if (canOpenThread) onThreadClick(message) },
         onLongClick = {
             if (canOpenActions) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -24,6 +24,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -38,7 +39,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -222,89 +222,87 @@ public fun MessageContainer(
         onReply = { onReply(replyMessage) },
         isSwipeable = isSwipeable,
     ) {
-        Box(
+        Row(
             modifier = Modifier
-                .testTag("Stream_MessageItem")
+                .testTag("Stream_MessageCell")
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .background(color = color)
                 .then(clickModifier)
                 .semantics { contentDescription = description },
-            contentAlignment = messageAlignment.itemAlignment,
+            horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
+                Arrangement.Start
+            } else {
+                Arrangement.End
+            },
         ) {
-            Row(
-                Modifier
-                    .wrapContentWidth()
-                    .testTag("Stream_MessageCell"),
-            ) {
-                with(ChatTheme.componentFactory) {
-                    when (messageAlignment) {
-                        MessageAlignment.Start -> MessageAuthor(
-                            params = MessageAuthorParams(
-                                messageItem = messageItem,
-                                onUserAvatarClick = onUserAvatarClick,
-                            ),
-                        )
+            with(ChatTheme.componentFactory) {
+                when (messageAlignment) {
+                    MessageAlignment.Start -> MessageAuthor(
+                        params = MessageAuthorParams(
+                            messageItem = messageItem,
+                            onUserAvatarClick = onUserAvatarClick,
+                        ),
+                    )
 
-                        MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                    }
+                    MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                }
 
-                    Column(
-                        modifier = Modifier.weight(1f, fill = false),
-                        horizontalAlignment = messageAlignment.contentAlignment,
-                    ) {
-                        MessageTop(
-                            params = MessageTopParams(
-                                messageItem = messageItem,
-                                onThreadClick = onThreadClick,
-                            ),
-                        )
-                        MessageContentWithReactions(
-                            messageAlignment = messageAlignment,
-                            reactions = rememberMessageReactions(message)?.let { reactions ->
-                                {
-                                    MessageReactions(
-                                        params = MessageReactionsParams(
-                                            message = message,
-                                            reactions = reactions,
-                                            onClick = onReactionsClick,
-                                        ),
-                                    )
-                                }
-                            },
-                            content = {
-                                MessageContent(
-                                    params = MessageContentParams(
-                                        messageItem = messageItem,
-                                        onLongItemClick = onLongItemClick,
-                                        onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
-                                        onGiphyActionClick = onGiphyActionClick,
-                                        onQuotedMessageClick = onQuotedMessageClick,
-                                        onLinkClick = onLinkClick,
-                                        onUserMentionClick = onUserMentionClick,
-                                        onPollUpdated = onPollUpdated,
-                                        onCastVote = onCastVote,
-                                        onRemoveVote = onRemoveVote,
-                                        selectPoll = selectPoll,
-                                        onAddAnswer = onAddAnswer,
-                                        onClosePoll = onClosePoll,
-                                        onAddPollOption = onAddPollOption,
+                Column(
+                    modifier = Modifier.weight(1f, fill = false),
+                    horizontalAlignment = messageAlignment.contentAlignment,
+                ) {
+                    MessageTop(
+                        params = MessageTopParams(
+                            messageItem = messageItem,
+                            onThreadClick = onThreadClick,
+                        ),
+                    )
+                    MessageContentWithReactions(
+                        messageAlignment = messageAlignment,
+                        reactions = rememberMessageReactions(message)?.let { reactions ->
+                            {
+                                MessageReactions(
+                                    params = MessageReactionsParams(
+                                        message = message,
+                                        reactions = reactions,
+                                        onClick = onReactionsClick,
                                     ),
                                 )
-                            },
-                        )
-                        MessageBottom(params = MessageBottomParams(messageItem = messageItem))
-                    }
+                            }
+                        },
+                        content = {
+                            MessageContent(
+                                params = MessageContentParams(
+                                    messageItem = messageItem,
+                                    onLongItemClick = onLongItemClick,
+                                    onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
+                                    onGiphyActionClick = onGiphyActionClick,
+                                    onQuotedMessageClick = onQuotedMessageClick,
+                                    onLinkClick = onLinkClick,
+                                    onUserMentionClick = onUserMentionClick,
+                                    onPollUpdated = onPollUpdated,
+                                    onCastVote = onCastVote,
+                                    onRemoveVote = onRemoveVote,
+                                    selectPoll = selectPoll,
+                                    onAddAnswer = onAddAnswer,
+                                    onClosePoll = onClosePoll,
+                                    onAddPollOption = onAddPollOption,
+                                ),
+                            )
+                        },
+                    )
+                    MessageBottom(params = MessageBottomParams(messageItem = messageItem))
+                }
 
-                    when (messageAlignment) {
-                        MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                        MessageAlignment.End -> MessageAuthor(
-                            params = MessageAuthorParams(
-                                messageItem = messageItem,
-                                onUserAvatarClick = onUserAvatarClick,
-                            ),
-                        )
-                    }
+                when (messageAlignment) {
+                    MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                    MessageAlignment.End -> MessageAuthor(
+                        params = MessageAuthorParams(
+                            messageItem = messageItem,
+                            onUserAvatarClick = onUserAvatarClick,
+                        ),
+                    )
                 }
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -39,6 +39,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.material3.ripple
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -176,7 +177,7 @@ public fun MessageContainer(
 
     val clickModifier = Modifier.combinedClickable(
         interactionSource = remember { MutableInteractionSource() },
-        indication = null,
+        indication = ripple(),
         onClick = { if (message.isThreadStart() && !messageItem.isInThread) onThreadClick(message) },
         onLongClick = {
             if (!message.isDeleted() && !message.isUploading()) {
@@ -224,13 +225,13 @@ public fun MessageContainer(
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .background(color = color)
+                .then(clickModifier)
                 .semantics { contentDescription = description },
             contentAlignment = messageAlignment.itemAlignment,
         ) {
             Row(
                 Modifier
                     .wrapContentWidth()
-                    .then(clickModifier)
                     .testTag("Stream_MessageCell"),
             ) {
                 with(ChatTheme.componentFactory) {


### PR DESCRIPTION
### Goal

Long-press to open the message actions menu now targets the entire message cell, not the bubble alone. Aligns the long-press surface with the existing swipe-to-reply surface (already cell-wide), gives short one or two character messages an adequate gesture target, and matches the dominant convention on WhatsApp / iMessage.

### Implementation

Three commits, intentionally separate so the structural change is reviewable in isolation:

1. **`Expand message long-press hit area to entire cell`** — moves the `Modifier.combinedClickable` from the inner content row (`wrapContentWidth`) to the outer container (`fillMaxWidth`), so the click and long-click handlers fire anywhere across the row. Switches `indication = null` to `indication = ripple()` so the gesture target is visible to the user. Reaction bar and actions menu remain anchored to the bubble; only the gesture surface widens.
2. **`Extract message click predicates into named locals`** — replaces the inline boolean expressions inside the click and long-click lambdas with `canOpenThread` and `canOpenActions`, so the gesture handlers read as intent.
3. **`Collapse message item Box+Row wrapper into a single Row`** — the outer `Box(fillMaxWidth, contentAlignment)` was only providing edge alignment, which a Row achieves directly via `horizontalArrangement`. Drops the redundant `Stream_MessageItem` test tag (zero references outside this file) and keeps `Stream_MessageCell` on the merged Row, where it accurately labels the cell that the gesture surface lives on.

#### API surface

No public API changes. `apiDump` produces no diff.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/9834757a-2f37-4648-a62a-5f6c8ecbabcd" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/9d139527-92dd-4667-8bae-be194940a94c" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Testing

Run the Compose sample app on a device and open any channel.

1. **Hit-area expansion.** Long-press in the empty space to the side of a short message bubble (e.g. a one-character "k"). Expected: the message actions menu opens — previously only long-pressing on the bubble itself worked.
2. **Ripple feedback.** Tap any message anywhere on the row. Expected: a ripple emanates from the touch point across the full row width.
3. **Bubble-anchored UI unchanged.** Open the message actions menu and the reactions picker. Expected: both remain visually anchored to the bubble, not the cell — the gesture target widened, not the visual anchor.
4. **Swipe-to-reply.** Horizontal swipe on the row. Expected: works as before — `SwipeToReply` is still the parent of the merged Row.
5. **Thread-start tap.** Tap on a message that started a thread, from outside that thread. Expected: opens the thread, exactly as before.
6. **Deleted / uploading messages.** Long-press a deleted message or one that is mid-upload. Expected: no actions menu appears (gated by `canOpenActions`).
7. **Outgoing vs incoming alignment.** Scroll through a mix of own and other-user messages. Expected: outgoing messages remain right-aligned, incoming left-aligned, with the avatar on the correct side.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced message interactions with ripple effect feedback, improving visual response when tapping messages.
  * Improved message layout structure for better rendering consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->