### PR TITLE
Fix `ChannelAvatar` not using `UserAvatar` from `ComponentFactory`

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/ChannelAvatar.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/avatar/ChannelAvatar.kt
@@ -46,6 +46,7 @@ import io.getstream.chat.android.compose.ui.components.common.CountBadge
 import io.getstream.chat.android.compose.ui.components.common.CountBadgeSize
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
+import io.getstream.chat.android.compose.ui.theme.UserAvatarParams
 import io.getstream.chat.android.compose.ui.util.applyIf
 import io.getstream.chat.android.models.Channel
 import io.getstream.chat.android.models.User
@@ -85,11 +86,13 @@ public fun ChannelAvatar(
         val directMessageRecipient = directMessageRecipient(channel, currentUser)
 
         if (directMessageRecipient != null) {
-            UserAvatar(
-                modifier = testTagModifier,
-                user = directMessageRecipient,
-                showIndicator = showIndicator,
-                showBorder = showBorder,
+            ChatTheme.componentFactory.UserAvatar(
+                params = UserAvatarParams(
+                    modifier = testTagModifier,
+                    user = directMessageRecipient,
+                    showIndicator = showIndicator,
+                    showBorder = showBorder,
+                ),
             )
         } else {
             StackedGroupAvatar(
@@ -209,10 +212,12 @@ private fun StackedGroupAvatar(
             1 -> {
                 val colors = ChatTheme.colors
 
-                UserAvatar(
-                    user = channel.members.first().user,
-                    showBorder = showBorder,
-                    modifier = baseModifier.align(alignments[0]),
+                ChatTheme.componentFactory.UserAvatar(
+                    params = UserAvatarParams(
+                        user = channel.members.first().user,
+                        showBorder = showBorder,
+                        modifier = baseModifier.align(alignments[0]),
+                    ),
                 )
 
                 UserAvatarIconPlaceholder(
@@ -234,10 +239,12 @@ private fun StackedGroupAvatar(
                     }
                 }
                 for (i in alignments.indices) {
-                    UserAvatar(
-                        user = displayMembers[i].user,
-                        showBorder = showBorder,
-                        modifier = baseModifier.align(alignments[i]),
+                    ChatTheme.componentFactory.UserAvatar(
+                        params = UserAvatarParams(
+                            user = displayMembers[i].user,
+                            showBorder = showBorder,
+                            modifier = baseModifier.align(alignments[i]),
+                        ),
                     )
                 }
                 if (membersCount > 4) {


### PR DESCRIPTION
### Goal

`ChannelAvatar` was rendering its inner user avatars by calling `UserAvatar` directly instead of going through `ChatTheme.componentFactory.UserAvatar`. This meant integrators who customised `UserAvatar` via the component factory saw their override ignored when the avatar was shown inside a channel avatar (DM and stacked group variants).

Closes AND-1167.

### Implementation

Replaced direct `UserAvatar(...)` calls in `ChannelAvatar.kt` with `ChatTheme.componentFactory.UserAvatar(params = UserAvatarParams(...))` in all three sites:

- DM recipient avatar
- Single-member stacked group avatar
- Multi-member stacked group avatars

This routes the rendering through the configured component factory so factory overrides are respected.

### UI Changes

No UI changes by default. Integrators who provide a custom `UserAvatar` via `ChatTheme.componentFactory` will now see their override applied inside `ChannelAvatar`.

### Testing

- Build & run the Compose sample app and verify channel avatars (DM and group) still render correctly.
- Provide a custom `ComponentFactory` that overrides `UserAvatar` and confirm the override is now used by channel avatars.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved avatar rendering architecture in the channel avatar component for enhanced theme consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->