### PR TITLE
Sort instant commands universal-first preserving backend order

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -1125,8 +1125,8 @@ public class MessageComposerController(
     }
 
     /**
-     * Sorts by availability when [Config.activeCommandEnabled] is `true`; returns the list
-     * unchanged in legacy mode.
+     * Applies [sortedByAvailability] when [Config.activeCommandEnabled] is `true`; returns the
+     * list unchanged in legacy mode.
      */
     private fun List<Command>.orderedForComposer(): List<Command> =
         if (config.activeCommandEnabled) sortedByAvailability(activeAction) else this

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/CommandAvailability.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/state/messages/composer/CommandAvailability.kt
@@ -42,14 +42,20 @@ public fun Command.isAvailableFor(action: MessageAction?): Boolean = when (actio
 }
 
 /**
- * Returns a new list with commands available for [action] first, followed by unavailable ones.
- * The sort is stable, so the original order is preserved within each availability group.
+ * Returns a new list sorted by, in order:
+ * 1. Availability for [action] (available first).
+ * 2. Universal commands (`set != "moderation_set"`) before contextual ones.
+ *
+ * The sort is stable, so within each group the input order is preserved.
  *
  * @param action The composer action currently active, or `null` when the composer is in its
  * default state.
  */
 @InternalStreamChatApi
 public fun List<Command>.sortedByAvailability(action: MessageAction?): List<Command> =
-    sortedByDescending { it.isAvailableFor(action) }
+    sortedWith(
+        compareByDescending<Command> { it.isAvailableFor(action) }
+            .thenByDescending { it.set != MODERATION_COMMAND_SET },
+    )
 
 private const val MODERATION_COMMAND_SET: String = "moderation_set"

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -1081,10 +1081,15 @@ internal class MessageComposerControllerTest {
     }
 
     @Test
-    fun `Given slash typed When action becomes Reply Then suggestions re-sort by availability`() = runTest {
-        // Given
-        val muteCommand = randomCommand(set = MODERATION_SET)
-        val funCommand = randomCommand()
+    fun `Given slash typed Then suggestions are universal-first preserving backend order regardless of action`() = runTest {
+        // Given the backend hands out commands in an order where a moderation command precedes a
+        // universal one — the SDK's sort must move universal commands to the front while
+        // preserving the backend's relative order within each tier.
+        val banCommand = randomCommand(name = "ban", set = MODERATION_SET)
+        val giphyCommand = randomCommand(name = "giphy", set = "")
+        val muteCommand = randomCommand(name = "mute", set = MODERATION_SET)
+        val unbanCommand = randomCommand(name = "unban", set = MODERATION_SET)
+        val unmuteCommand = randomCommand(name = "unmute", set = MODERATION_SET)
         val repliedMessage = randomMessage(cid = CID)
         val controller = Fixture()
             .givenConfig(MessageComposerController.Config(activeCommandEnabled = true))
@@ -1093,19 +1098,26 @@ internal class MessageComposerControllerTest {
             .givenClientState(randomUser())
             .givenGlobalState()
             .givenChannelState(
-                configState = MutableStateFlow(Config(commands = listOf(muteCommand, funCommand))),
+                configState = MutableStateFlow(
+                    Config(
+                        commands = listOf(banCommand, giphyCommand, muteCommand, unbanCommand, unmuteCommand),
+                    ),
+                ),
             )
             .get()
+        val expectedOrder = listOf(giphyCommand, banCommand, muteCommand, unbanCommand, unmuteCommand)
+
+        // When typing slash with the composer in its default state
         controller.setMessageInput("/")
         advanceUntilIdle()
-        assertEquals(listOf(muteCommand, funCommand), controller.state.value.commandSuggestions)
 
-        // When
+        // Then suggestions surface universal commands first, with backend order preserved within each tier.
+        assertEquals(expectedOrder, controller.state.value.commandSuggestions)
+
+        // And switching to Reply mode preserves the same order — no re-shuffle.
         controller.performMessageAction(Reply(repliedMessage))
         advanceUntilIdle()
-
-        // Then
-        assertEquals(listOf(funCommand, muteCommand), controller.state.value.commandSuggestions)
+        assertEquals(expectedOrder, controller.state.value.commandSuggestions)
     }
 
     @Test


### PR DESCRIPTION
### Goal

Address [Issue #8 — Instant commands sort order](https://www.notion.so/3516a5d7f9f680cba85ee7ec0b3d10cb) from the SDK Testing Feedback Notion board. Today, the suggestion list shows backend commands in raw order, which mixes universal commands (`giphy`) with moderation-set ones (`ban`, `unban`, `mute`, `unmute`) — moderation commands appear right after `giphy` even when the user is composing a normal message, which is noisy and not what most users expect to see.

### Implementation

- **`sortedByAvailability` gains a tier tie-breaker.** The sort is now keyed first by availability for the current `MessageAction`, then by *universal-first* (`set != "moderation_set"` before moderation-set commands).
- **Sort stays stable.** Within each tier the input order from the backend's `Channel.config.commands` is preserved — no client-side opinion on the relative order between commands of the same tier. Backends that already prefer a specific order (e.g. `giphy, ban, unban, mute, unmute` in the Stream chat backend) keep their intended order.
- **Single sort site, two consumers.** `sortedByAvailability` is the only place that orders the suggestion list — both the Compose composer suggestion list (via `MessageComposerController.orderedForComposer`) and the Compose attachment command picker (`AttachmentCommandPicker`) inherit the new ordering.
- **No new constants leak out.** `MODERATION_COMMAND_SET` stays `private` to `CommandAvailability.kt`. `@InternalStreamChatApi` boundary unchanged.
- **Tests.** `MessageComposerControllerTest` extended to assert the universal-first ordering on top of the existing availability tier.

> [!IMPORTANT]
> **Decision — sort by tier, not by hardcoded command list**
>
> Considered hardcoding a preference list (e.g. `[giphy, ban, unban, mute, unmute]`) but rejected: the SDK shouldn't carry an opinion about specific command names. Sorting by `set` (a backend-declared property) keeps the SDK generic and lets the backend evolve commands without a client release. Stable sort preserves whatever order the backend provides within each tier.

### Testing

1. Run the Compose sample app on this branch and open any channel.
2. Tap the slash icon (commands picker) or type `/` in the composer.
   - Expected: universal commands (e.g. `giphy`) appear first; moderation commands (`ban`, `unban`, `mute`, `unmute`) follow. Within each group, the order matches the backend's `Channel.config.commands` declaration order.
3. Compose a reply (long-press a message → "Reply") and reopen the commands picker.
   - Expected: same ordering as step 2.
4. Repeat for any composer action that affects command availability (edit, thread reply).
   - Expected: commands unavailable for that action are pushed to the bottom; within the available group, universal-first ordering still applies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command suggestion ordering in the message composer—standard commands now appear before moderation-specific commands when typing a slash.

* **Tests**
  * Added test coverage for command suggestion ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->