### PR TITLE
Cap channel CIDs at 100 when calling `getSyncHistory`

### DIFF
--- a/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
+++ b/stream-chat-android-state/src/main/java/io/getstream/chat/android/state/sync/internal/SyncManager.kt
@@ -78,6 +78,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 
 private const val QUERIES_TO_RETRY = 3
+private const val SYNC_MAX_CIDS = 100
 
 /**
  * This class is responsible to sync messages, reactions and channel data. It tries to sync then, if necessary,
@@ -303,10 +304,11 @@ internal class SyncManager(
         val lastSyncAt = syncState?.lastSyncedAt ?: Date(now())
         val rawLastSyncAt = syncState?.rawLastSyncedAt
         logger.v { "[performSync] lastSyncAt: $lastSyncAt, rawLastSyncAt: $rawLastSyncAt" }
+        val cappedCids = cids.take(SYNC_MAX_CIDS)
         val result = if (rawLastSyncAt != null) {
-            chatClient.getSyncHistory(cids, rawLastSyncAt).await()
+            chatClient.getSyncHistory(cappedCids, rawLastSyncAt).await()
         } else {
-            chatClient.getSyncHistory(cids, lastSyncAt).await()
+            chatClient.getSyncHistory(cappedCids, lastSyncAt).await()
         }
         if (result.isTooManyEventsToSyncError()) {
             logger.e { "[performSync] failed (too many events to sync): $result" }

--- a/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/SyncManagerTest.kt
+++ b/stream-chat-android-state/src/test/java/io/getstream/chat/android/state/internal/SyncManagerTest.kt
@@ -70,6 +70,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -221,6 +222,27 @@ internal class SyncManagerTest {
             /* Then */
             assertEquals(listOf(mockedChatEvent), awaitItem())
         }
+    }
+
+    @Test
+    fun `performSync caps channel_cids at 100`() = runTest(testDispatcher) {
+        /* Given */
+        _syncState.value = null
+        whenever(repositoryFacade.selectSyncState(any())) doReturn null
+        val cids = (1..150).map { "messaging:channel-$it" }
+        val expectedCids = cids.take(100)
+
+        whenever(chatClient.getSyncHistory(any(), any<Date>())) doReturn TestCall(
+            Result.Success(emptyList()),
+        )
+
+        val syncManager = buildSyncManager()
+
+        /* When */
+        syncManager.performSync(cids = cids)
+
+        /* Then */
+        verify(chatClient).getSyncHistory(eq(expectedCids), any<Date>())
     }
 
     @Test


### PR DESCRIPTION
### Goal

The `getSyncHistory` endpoint enforces a server-side limit on the number of `channel_cids` it accepts. When users have a large number of active channels, the SDK was forwarding the full list, which could lead to failed sync requests.

Note: Aligns with the iOS limit set in: https://github.com/GetStream/stream-chat-swift/pull/3863

### Implementation

In `SyncManager.performSync`, cap the `cids` list at 100 (`SYNC_MAX_CIDS`) before passing it to `chatClient.getSyncHistory`. Both code paths (with and without `rawLastSyncAt`) use the capped list.

### UI Changes

No UI changes.

### Testing

- New unit test `performSync caps channel_cids at 100` in `SyncManagerTest` verifies that when 150 cids are passed in, only the first 100 reach `getSyncHistory`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved channel synchronization reliability by implementing a batch processing limit, preventing potential stability issues when syncing large numbers of channels in a single operation.

* **Tests**
  * Added test coverage to validate the new channel synchronization batch limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->