### PR TITLE
Drop dead databinding ignore and add benchmark to apiValidation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -114,10 +114,10 @@ tasks.withType<Delete> {
 }
 
 apiValidation {
-    ignoredPackages.add("com/getstream/sdk/chat/databinding")
     ignoredPackages.add("io/getstream/chat/android/ui/databinding")
 
     ignoredProjects += listOf(
+        "stream-chat-android-benchmark",
         "stream-chat-android-client-test",
         "stream-chat-android-compose-sample",
         "stream-chat-android-docs",


### PR DESCRIPTION
### Goal

Bring the root `apiValidation` block in line with the current module layout: drop a dead entry and close one gap so the list is the single source of truth for "what we don't validate."

### Implementation

- Remove `com/getstream/sdk/chat/databinding` from `ignoredPackages` — the `com.getstream.sdk` namespace no longer exists anywhere in the repo.
- Add `stream-chat-android-benchmark` to `ignoredProjects` — it was the only non-validated module missing from the list.

No public API surface changes; `./gradlew apiCheck` passes with no `.api` regeneration needed.

### Testing

1. Run `./gradlew apiCheck` — should succeed.
2. Run `./gradlew apiCheck --dry-run` — `apiCheck` tasks should run for the 6 published library modules (`client`, `compose`, `core`, `markdown-transformer`, `ui-common`, `ui-components`) and no others.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration for API validation and benchmark module exclusions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6432)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->