### PR TITLE
Add configurable character limits and feature toggles for polls

### DIFF
--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -19,6 +19,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun getMessageTextTransformer ()Lio/getstream/chat/android/ui/helper/transformer/ChatMessageTextTransformer;
 	public static final fun getMimeTypeIconProvider ()Lio/getstream/chat/android/ui/helper/MimeTypeIconProvider;
 	public static final fun getNavigator ()Lio/getstream/chat/android/ui/navigation/ChatNavigator;
+	public static final fun getPollsConfig ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
 	public static final fun getQuotedAttachmentFactoryManager ()Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager;
 	public static final fun getReactionPushEmojiFactory ()Lio/getstream/chat/android/ui/common/helper/ReactionPushEmojiFactory;
 	public static final fun getShowOriginalTranslationEnabled ()Z
@@ -48,6 +49,7 @@ public final class io/getstream/chat/android/ui/ChatUI {
 	public static final fun setMessageTextTransformer (Lio/getstream/chat/android/ui/helper/transformer/ChatMessageTextTransformer;)V
 	public static final fun setMimeTypeIconProvider (Lio/getstream/chat/android/ui/helper/MimeTypeIconProvider;)V
 	public static final fun setNavigator (Lio/getstream/chat/android/ui/navigation/ChatNavigator;)V
+	public static final fun setPollsConfig (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;)V
 	public static final fun setQuotedAttachmentFactoryManager (Lio/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/attachment/QuotedAttachmentFactoryManager;)V
 	public static final fun setReactionPushEmojiFactory (Lio/getstream/chat/android/ui/common/helper/ReactionPushEmojiFactory;)V
 	public static final fun setShowOriginalTranslationEnabled (Z)V
@@ -1506,6 +1508,8 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/attach
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$Companion {
 	public final fun newInstance (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$CreatePollDialogListener;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment;
+	public final fun newInstance (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$CreatePollDialogListener;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment;
+	public static synthetic fun newInstance$default (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$Companion;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$CreatePollDialogListener;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment;
 }
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment$CreatePollDialogListener {
@@ -1524,6 +1528,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/attach
 	public final fun getPollIsReady ()Lkotlinx/coroutines/flow/StateFlow;
 	public final fun onOptionTextChanged (ILjava/lang/String;)V
 	public final fun onTitleChanged (Ljava/lang/String;)V
+	public final fun setAllowAnswers (Z)V
 	public final fun setAllowMultipleVotes (Z)V
 	public final fun setAnnonymousPoll (Z)V
 	public final fun setMaxAnswer (Ljava/lang/Integer;)V
@@ -1531,6 +1536,7 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/attach
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter : androidx/recyclerview/widget/ListAdapter {
+	public fun <init> (Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;)V
 	public fun <init> (Lkotlin/jvm/functions/Function2;)V
 	public fun getItemId (I)J
 	public synthetic fun onBindViewHolder (Landroidx/recyclerview/widget/RecyclerView$ViewHolder;I)V
@@ -1540,8 +1546,8 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/attach
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter$OptionViewHolder : androidx/recyclerview/widget/RecyclerView$ViewHolder {
-	public fun <init> (Landroid/view/ViewGroup;Lio/getstream/chat/android/ui/databinding/StreamUiPollOptionBinding;Lkotlin/jvm/functions/Function2;)V
-	public synthetic fun <init> (Landroid/view/ViewGroup;Lio/getstream/chat/android/ui/databinding/StreamUiPollOptionBinding;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Landroid/view/ViewGroup;Lio/getstream/chat/android/ui/databinding/StreamUiPollOptionBinding;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;)V
+	public synthetic fun <init> (Landroid/view/ViewGroup;Lio/getstream/chat/android/ui/databinding/StreamUiPollOptionBinding;Ljava/lang/Integer;Lkotlin/jvm/functions/Function2;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun bind (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollAnswer;)V
 }
 
@@ -1558,6 +1564,75 @@ public final class io/getstream/chat/android/ui/feature/messages/composer/attach
 	public final fun getText ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig$Companion;
+	public fun <init> (ZZ)V
+	public final fun component1 ()Z
+	public final fun component2 ()Z
+	public final fun copy (ZZ)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;ZZILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConfigurable ()Z
+	public final fun getDefaultValue ()Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig$Companion {
+	public final fun getDefault ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun getNotConfigurable ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig : android/os/Parcelable {
+	public static final field CREATOR Landroid/os/Parcelable$Creator;
+	public static final field Companion Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig$Companion;
+	public fun <init> ()V
+	public fun <init> (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Ljava/lang/Integer;Ljava/lang/Integer;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Ljava/lang/Integer;Ljava/lang/Integer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun component2 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun component3 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun component4 ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun component5 ()Ljava/lang/Integer;
+	public final fun component6 ()Ljava/lang/Integer;
+	public final fun copy (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Ljava/lang/Integer;Ljava/lang/Integer;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;Ljava/lang/Integer;Ljava/lang/Integer;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
+	public final fun describeContents ()I
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAllowComments ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun getAnonymousPoll ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun getMultipleVotes ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public final fun getOptionTextLimit ()Ljava/lang/Integer;
+	public final fun getQuestionTextLimit ()Ljava/lang/Integer;
+	public final fun getSuggestAnOption ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+	public final fun writeToParcel (Landroid/os/Parcel;I)V
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig$Companion {
+	public final fun getDefault ()Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
+}
+
+public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig$Creator : android/os/Parcelable$Creator {
+	public fun <init> ()V
+	public final fun createFromParcel (Landroid/os/Parcel;)Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
+	public synthetic fun createFromParcel (Landroid/os/Parcel;)Ljava/lang/Object;
+	public final fun newArray (I)[Lio/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig;
+	public synthetic fun newArray (I)[Ljava/lang/Object;
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/composer/attachment/preview/AttachmentPreviewFactoryManager {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/ChatUI.kt
@@ -30,6 +30,7 @@ import io.getstream.chat.android.ui.common.helper.VideoHeadersProvider
 import io.getstream.chat.android.ui.common.images.internal.StreamImageLoader
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.utils.ChannelNameFormatter
+import io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll.PollsConfig
 import io.getstream.chat.android.ui.feature.messages.composer.attachment.preview.AttachmentPreviewFactoryManager
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.AttachmentFactoryManager
 import io.getstream.chat.android.ui.feature.messages.list.adapter.viewholder.attachment.DefaultQuotedAttachmentMessageFactory
@@ -272,6 +273,15 @@ public object ChatUI {
      */
     @JvmStatic
     public var showOriginalTranslationEnabled: Boolean = false
+
+    /**
+     * Configuration for poll creation features. Controls which poll features are configurable by the user
+     * and their default values.
+     *
+     * @see PollsConfig
+     */
+    @JvmStatic
+    public var pollsConfig: PollsConfig = PollsConfig.Default
 
     /**
      * Provides a custom renderer for user avatars.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll
 
 import android.os.Bundle
+import android.text.InputFilter
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.View
@@ -30,6 +31,7 @@ import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import io.getstream.chat.android.models.PollConfig
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.utils.PollsConstants
 import io.getstream.chat.android.ui.databinding.StreamUiFragmentCreatePollBinding
@@ -40,6 +42,8 @@ import kotlinx.coroutines.launch
 
 /**
  * Represent the bottom sheet dialog that allows users to pick attachments.
+ *
+ * Use [newInstance] to create an instance with optional [PollsConfig].
  */
 public class CreatePollDialogFragment : AppCompatDialogFragment() {
 
@@ -47,8 +51,19 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
     private val binding get() = _binding!!
     private var createPollDialogListener: CreatePollDialogListener? = null
     private val createPollViewModel: CreatePollViewModel by viewModels()
+    private val pollsConfig: PollsConfig by lazy {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable(ARG_POLLS_CONFIG, PollsConfig::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            arguments?.getParcelable(ARG_POLLS_CONFIG)
+        } ?: ChatUI.pollsConfig
+    }
     private val optionsAdapter: OptionsAdapter by lazy {
-        OptionsAdapter { id, text -> createPollViewModel.onOptionTextChanged(id, text) }
+        OptionsAdapter(
+            optionTextLimit = pollsConfig.optionTextLimit,
+            onOptionChange = { id, text -> createPollViewModel.onOptionTextChanged(id, text) },
+        )
     }
     private lateinit var sendMenuItem: MenuItem
 
@@ -77,10 +92,55 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
     }
 
     /**
+     * Configures the visibility and default values of poll features based on [pollsConfig].
+     */
+    private fun configurePollFeatures() {
+        // Configure multiple votes feature
+        createPollViewModel.setAllowMultipleVotes(pollsConfig.multipleVotes.defaultValue)
+        binding.multipleAnswersLabel.isVisible = pollsConfig.multipleVotes.configurable
+        binding.multipleAnswersSwitch.isVisible = pollsConfig.multipleVotes.configurable
+        if (pollsConfig.multipleVotes.configurable) {
+            binding.multipleAnswersSwitch.isChecked = pollsConfig.multipleVotes.defaultValue
+            binding.multipleAnswersCount.isVisible = pollsConfig.multipleVotes.defaultValue
+        }
+
+        // Configure anonymous poll feature
+        createPollViewModel.setAnnonymousPoll(pollsConfig.anonymousPoll.defaultValue)
+        binding.anonymousPollLabel.isVisible = pollsConfig.anonymousPoll.configurable
+        binding.anonymousPollSwitch.isVisible = pollsConfig.anonymousPoll.configurable
+        if (pollsConfig.anonymousPoll.configurable) {
+            binding.anonymousPollSwitch.isChecked = pollsConfig.anonymousPoll.defaultValue
+        }
+
+        // Configure suggest an option feature
+        createPollViewModel.setSuggestAnOption(pollsConfig.suggestAnOption.defaultValue)
+        binding.suggestAnOptionLabel.isVisible = pollsConfig.suggestAnOption.configurable
+        binding.suggestAnOptionSwitch.isVisible = pollsConfig.suggestAnOption.configurable
+        if (pollsConfig.suggestAnOption.configurable) {
+            binding.suggestAnOptionSwitch.isChecked = pollsConfig.suggestAnOption.defaultValue
+        }
+
+        // Configure add a comment feature
+        createPollViewModel.setAllowAnswers(pollsConfig.addComments.defaultValue)
+        binding.addACommentLabel.isVisible = pollsConfig.addComments.configurable
+        binding.addACommentLabelSwitch.isVisible = pollsConfig.addComments.configurable
+        if (pollsConfig.addComments.configurable) {
+            binding.addACommentLabelSwitch.isChecked = pollsConfig.addComments.defaultValue
+        }
+    }
+
+    /**
      * Initializes the dialog.
      */
     private fun setupDialog() {
         setupToolbar(binding.toolbar)
+        pollsConfig.questionTextLimit?.takeIf { it > 0 }?.let { limit ->
+            binding.question.filters = arrayOf(InputFilter.LengthFilter(limit))
+        }
+
+        // Configure poll feature visibility and default values based on pollsConfig
+        configurePollFeatures()
+
         binding.multipleAnswersSwitch.setOnCheckedChangeListener { _, isChecked ->
             binding.multipleAnswersCount.isVisible = isChecked
             createPollViewModel.setAllowMultipleVotes(isChecked)
@@ -96,6 +156,9 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
         }
         binding.suggestAnOptionSwitch.setOnCheckedChangeListener { _, isChecked ->
             createPollViewModel.setSuggestAnOption(isChecked)
+        }
+        binding.addACommentLabelSwitch.setOnCheckedChangeListener { _, isChecked ->
+            createPollViewModel.setAllowAnswers(isChecked)
         }
         binding.addOption.setOnClickListener {
             createPollViewModel.createOption()
@@ -158,15 +221,25 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
 
     public companion object {
         public const val TAG: String = "create_poll_dialog_fragment"
+        private const val ARG_POLLS_CONFIG: String = "arg_polls_config"
 
         /**
          * Creates a new instance of [CreatePollDialogFragment].
          *
+         * @param createPollDialogListener The listener for poll creation events.
+         * @param pollsConfig Optional configuration for poll features. Defaults to [ChatUI.pollsConfig].
          * @return A new instance of [CreatePollDialogFragment].
          */
-        public fun newInstance(createPollDialogListener: CreatePollDialogListener): CreatePollDialogFragment {
-            return CreatePollDialogFragment()
-                .setCreatePollDialogListener(createPollDialogListener)
+        @JvmOverloads
+        public fun newInstance(
+            createPollDialogListener: CreatePollDialogListener,
+            pollsConfig: PollsConfig? = null,
+        ): CreatePollDialogFragment {
+            return CreatePollDialogFragment().apply {
+                arguments = Bundle().apply {
+                    pollsConfig?.let { config -> putParcelable(ARG_POLLS_CONFIG, config as android.os.Parcelable) }
+                }
+            }.setCreatePollDialogListener(createPollDialogListener)
         }
     }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollDialogFragment.kt
@@ -25,6 +25,7 @@ import android.view.ViewGroup
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.appcompat.widget.Toolbar
 import androidx.core.content.ContextCompat
+import androidx.core.os.BundleCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
 import androidx.core.widget.addTextChangedListener
@@ -39,6 +40,7 @@ import io.getstream.chat.android.ui.utils.extensions.applyEdgeToEdgePadding
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlin.jvm.java
 
 /**
  * Represent the bottom sheet dialog that allows users to pick attachments.
@@ -52,11 +54,8 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
     private var createPollDialogListener: CreatePollDialogListener? = null
     private val createPollViewModel: CreatePollViewModel by viewModels()
     private val pollsConfig: PollsConfig by lazy {
-        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-            arguments?.getParcelable(ARG_POLLS_CONFIG, PollsConfig::class.java)
-        } else {
-            @Suppress("DEPRECATION")
-            arguments?.getParcelable(ARG_POLLS_CONFIG)
+        arguments?.let {
+            BundleCompat.getParcelable(it, ARG_POLLS_CONFIG, PollsConfig::class.java)
         } ?: ChatUI.pollsConfig
     }
     private val optionsAdapter: OptionsAdapter by lazy {
@@ -89,6 +88,11 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
         super.onViewCreated(view, savedInstanceState)
         binding.root.applyEdgeToEdgePadding(typeMask = WindowInsetsCompat.Type.systemBars())
         setupDialog()
+
+        if (savedInstanceState == null) {
+            // Configure poll feature visibility and default values based on pollsConfig
+            configurePollFeatures()
+        }
     }
 
     /**
@@ -121,11 +125,11 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
         }
 
         // Configure add a comment feature
-        createPollViewModel.setAllowAnswers(pollsConfig.addComments.defaultValue)
-        binding.addACommentLabel.isVisible = pollsConfig.addComments.configurable
-        binding.addACommentLabelSwitch.isVisible = pollsConfig.addComments.configurable
-        if (pollsConfig.addComments.configurable) {
-            binding.addACommentLabelSwitch.isChecked = pollsConfig.addComments.defaultValue
+        createPollViewModel.setAllowAnswers(pollsConfig.allowComments.defaultValue)
+        binding.addACommentLabel.isVisible = pollsConfig.allowComments.configurable
+        binding.addACommentLabelSwitch.isVisible = pollsConfig.allowComments.configurable
+        if (pollsConfig.allowComments.configurable) {
+            binding.addACommentLabelSwitch.isChecked = pollsConfig.allowComments.defaultValue
         }
     }
 
@@ -137,9 +141,6 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
         pollsConfig.questionTextLimit?.takeIf { it > 0 }?.let { limit ->
             binding.question.filters = arrayOf(InputFilter.LengthFilter(limit))
         }
-
-        // Configure poll feature visibility and default values based on pollsConfig
-        configurePollFeatures()
 
         binding.multipleAnswersSwitch.setOnCheckedChangeListener { _, isChecked ->
             binding.multipleAnswersCount.isVisible = isChecked
@@ -237,7 +238,7 @@ public class CreatePollDialogFragment : AppCompatDialogFragment() {
         ): CreatePollDialogFragment {
             return CreatePollDialogFragment().apply {
                 arguments = Bundle().apply {
-                    pollsConfig?.let { config -> putParcelable(ARG_POLLS_CONFIG, config as android.os.Parcelable) }
+                    pollsConfig?.let { config -> putParcelable(ARG_POLLS_CONFIG, config) }
                 }
             }.setCreatePollDialogListener(createPollDialogListener)
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/CreatePollViewModel.kt
@@ -46,6 +46,7 @@ public class CreatePollViewModel : ViewModel() {
     private val createPoll = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
     private var suggestAnOption = false
     private var annonymousPoll = false
+    private var allowAnswers = false
     private var allowMultipleVotes = MutableStateFlow(false)
     private var maxAnswers: MutableStateFlow<Int?> = MutableStateFlow(null)
 
@@ -102,6 +103,7 @@ public class CreatePollViewModel : ViewModel() {
                     options = options.map { PollOption(text = it.text) },
                     votingVisibility = if (annonymousPoll) VotingVisibility.ANONYMOUS else VotingVisibility.PUBLIC,
                     allowUserSuggestedOptions = suggestAnOption,
+                    allowAnswers = allowAnswers,
                     maxVotesAllowed = maxAnswers.takeIf { allowMultipleVotes } ?: 1,
                     enforceUniqueVote = !allowMultipleVotes,
                 )
@@ -212,5 +214,14 @@ public class CreatePollViewModel : ViewModel() {
      */
     public fun setAnnonymousPoll(annonymousPoll: Boolean) {
         this.annonymousPoll = annonymousPoll
+    }
+
+    /**
+     * Set if the poll allows users to add answers/comments.
+     *
+     * @param allowAnswers True if the poll allows users to add answers/comments, false otherwise.
+     */
+    public fun setAllowAnswers(allowAnswers: Boolean) {
+        this.allowAnswers = allowAnswers
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/OptionsAdapter.kt
@@ -17,6 +17,7 @@
 package io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll
 
 import android.text.Editable
+import android.text.InputFilter
 import android.text.TextWatcher
 import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
@@ -27,8 +28,16 @@ import io.getstream.chat.android.ui.databinding.StreamUiPollOptionBinding
 import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
 
 public class OptionsAdapter(
+    private val optionTextLimit: Int?,
     private val onOptionChange: (id: Int, text: String) -> Unit,
 ) : ListAdapter<PollAnswer, OptionsAdapter.OptionViewHolder>(OptionDiffCallback) {
+
+    /**
+     * Builds an [OptionsAdapter] instance without providing option text limit.
+     *
+     * @param onOptionChange Callback invoked when the option text changes.
+     */
+    public constructor(onOptionChange: (id: Int, text: String) -> Unit) : this(null, onOptionChange)
 
     init {
         setHasStableIds(true)
@@ -39,6 +48,7 @@ public class OptionsAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OptionViewHolder =
         OptionViewHolder(
             parent = parent,
+            optionTextLimit = optionTextLimit,
             onOptionChange = onOptionChange,
         )
 
@@ -53,10 +63,17 @@ public class OptionsAdapter(
             parent,
             false,
         ),
+        private val optionTextLimit: Int?,
         private val onOptionChange: (id: Int, text: String) -> Unit,
     ) : RecyclerView.ViewHolder(binding.root) {
 
         private lateinit var pollAnswer: PollAnswer
+
+        init {
+            optionTextLimit?.let { limit ->
+                binding.option.filters = arrayOf(InputFilter.LengthFilter(limit))
+            }
+        }
 
         private val textWatcher = object : TextWatcher {
             override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) { /* no-op */ }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig.kt
@@ -1,0 +1,34 @@
+package io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Configuration for individual poll entry feature.
+ *
+ * @param configurable Indicates whether the poll entry is configurable. When false, the UI element is hidden.
+ * @param defaultValue Indicates the default value of the poll entry.
+ */
+@Parcelize
+public data class PollFeatureConfig(
+    val configurable: Boolean,
+    val defaultValue: Boolean,
+) : Parcelable {
+    public companion object {
+        /**
+         * The default configuration for a poll entry. It will make it configurable and disabled by default.
+         */
+        public val Default: PollFeatureConfig = PollFeatureConfig(
+            configurable = true,
+            defaultValue = false,
+        )
+
+        /**
+         * The feature should not be supported, so it is not configurable by the user and hidden from the UI.
+         */
+        public val NotConfigurable: PollFeatureConfig = PollFeatureConfig(
+            configurable = false,
+            defaultValue = false,
+        )
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollFeatureConfig.kt
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll
 
 import android.os.Parcelable

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
@@ -20,51 +20,21 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * Configuration for individual poll entry feature.
- *
- * @param configurable Indicates whether the poll entry is configurable. When false, the UI element is hidden.
- * @param defaultValue Indicates the default value of the poll entry.
- */
-@Parcelize
-public data class PollsEntryConfig(
-    val configurable: Boolean,
-    val defaultValue: Boolean,
-) : Parcelable {
-    public companion object {
-        /**
-         * The default configuration for a poll entry. It will make it configurable and disabled by default.
-         */
-        public val Default: PollsEntryConfig = PollsEntryConfig(
-            configurable = true,
-            defaultValue = false,
-        )
-
-        /**
-         * The feature should not be supported, so it is not configurable by the user and hidden from the UI.
-         */
-        public val NotConfigurable: PollsEntryConfig = PollsEntryConfig(
-            configurable = false,
-            defaultValue = false,
-        )
-    }
-}
-
-/**
  * The configuration for the various poll features. It determines if the user can or cannot enable certain poll features.
  *
  * @param multipleVotes Configuration for allowing multiple votes in a poll.
  * @param anonymousPoll Configuration for enabling anonymous polls.
  * @param suggestAnOption Configuration for allowing users to suggest options in a poll.
- * @param addComments Configuration for adding comments to a poll.
+ * @param allowComments Configuration for adding comments to a poll.
  * @param questionTextLimit Optional character limit for the poll question. Null means no limit.
  * @param optionTextLimit Optional character limit for poll answer options. Null means no limit.
  */
 @Parcelize
 public data class PollsConfig(
-    val multipleVotes: PollsEntryConfig = PollsEntryConfig.Default,
-    val anonymousPoll: PollsEntryConfig = PollsEntryConfig.Default,
-    val suggestAnOption: PollsEntryConfig = PollsEntryConfig.Default,
-    val addComments: PollsEntryConfig = PollsEntryConfig.Default,
+    val multipleVotes: PollFeatureConfig = PollFeatureConfig.Default,
+    val anonymousPoll: PollFeatureConfig = PollFeatureConfig.Default,
+    val suggestAnOption: PollFeatureConfig = PollFeatureConfig.Default,
+    val allowComments: PollFeatureConfig = PollFeatureConfig.Default,
     val questionTextLimit: Int? = null,
     val optionTextLimit: Int? = null,
 ) : Parcelable {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
@@ -39,6 +39,14 @@ public data class PollsConfig(
     val questionTextLimit: Int? = null,
     val optionTextLimit: Int? = null,
 ) : Parcelable {
+
+   init {
+        require(multipleVotes.configurable || !multipleVotes.defaultValue) {
+            "Invalid PollsConfig: multipleVotes cannot have defaultValue=true while " +
+                "configurable=false as the user would be unable to set maxVotesAllowed."
+        }
+    }
+
     public companion object {
         /**
          * The default configuration for polls. All features are configurable and disabled by default.

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
@@ -40,7 +40,7 @@ public data class PollsConfig(
     val optionTextLimit: Int? = null,
 ) : Parcelable {
 
-   init {
+    init {
         require(multipleVotes.configurable || !multipleVotes.defaultValue) {
             "Invalid PollsConfig: multipleVotes cannot have defaultValue=true while " +
                 "configurable=false as the user would be unable to set maxVotesAllowed."

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.feature.messages.composer.attachment.picker.poll
+
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+/**
+ * Configuration for individual poll entry feature.
+ *
+ * @param configurable Indicates whether the poll entry is configurable. When false, the UI element is hidden.
+ * @param defaultValue Indicates the default value of the poll entry.
+ */
+@Parcelize
+public data class PollsEntryConfig(
+    val configurable: Boolean,
+    val defaultValue: Boolean,
+) : Parcelable {
+    public companion object {
+        /**
+         * The default configuration for a poll entry. It will make it configurable and disabled by default.
+         */
+        public val Default: PollsEntryConfig = PollsEntryConfig(
+            configurable = true,
+            defaultValue = false,
+        )
+
+        /**
+         * The feature should not be supported, so it is not configurable by the user and hidden from the UI.
+         */
+        public val NotConfigurable: PollsEntryConfig = PollsEntryConfig(
+            configurable = false,
+            defaultValue = false,
+        )
+    }
+}
+
+/**
+ * The configuration for the various poll features. It determines if the user can or cannot enable certain poll features.
+ *
+ * @param multipleVotes Configuration for allowing multiple votes in a poll.
+ * @param anonymousPoll Configuration for enabling anonymous polls.
+ * @param suggestAnOption Configuration for allowing users to suggest options in a poll.
+ * @param addComments Configuration for adding comments to a poll.
+ * @param questionTextLimit Optional character limit for the poll question. Null means no limit.
+ * @param optionTextLimit Optional character limit for poll answer options. Null means no limit.
+ */
+@Parcelize
+public data class PollsConfig(
+    val multipleVotes: PollsEntryConfig = PollsEntryConfig.Default,
+    val anonymousPoll: PollsEntryConfig = PollsEntryConfig.Default,
+    val suggestAnOption: PollsEntryConfig = PollsEntryConfig.Default,
+    val addComments: PollsEntryConfig = PollsEntryConfig.Default,
+    val questionTextLimit: Int? = null,
+    val optionTextLimit: Int? = null,
+) : Parcelable {
+    public companion object {
+        /**
+         * The default configuration for polls. All features are configurable and disabled by default.
+         */
+        public val Default: PollsConfig = PollsConfig()
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/composer/attachment/picker/poll/PollsConfig.kt
@@ -20,7 +20,8 @@ import android.os.Parcelable
 import kotlinx.parcelize.Parcelize
 
 /**
- * The configuration for the various poll features. It determines if the user can or cannot enable certain poll features.
+ * The configuration for the various poll features. It determines if the user can or cannot enable
+ * certain poll features.
  *
  * @param multipleVotes Configuration for allowing multiple votes in a poll.
  * @param anonymousPoll Configuration for enabling anonymous polls.


### PR DESCRIPTION
### Goal
Introduce comprehensive configuration for poll creation features, allowing developers to control which features are available to users, set default values, and enforce character limits on questions and options. This provides flexibility for different use cases where certain poll features may need to be restricted, pre-configured, or character-limited based on UI constraints, business rules, or localization requirements. This loosely follows the [iOS implementation.](https://getstream.io/chat/docs/sdk/ios/swiftui/polls/)

### Implementation

### New Files Created
**`PollsConfig.kt`**
- New `PollsConfig` data class for configuring all poll creation features
- New `PollsEntryConfig` data class for individual feature configuration (configurable flag + default value)
- Configurable features:
  - `multipleVotes` - Allow users to select multiple options
  - `anonymousPoll` - Hide voter identities
  - `suggestAnOption` - Allow users to add their own options
  - `addComments` - Allow users to add comments to polls
- Character limits:
  - `questionTextLimit` - Optional character limit for poll questions
  - `optionTextLimit` - Optional character limit for poll options
- Both classes implement `Parcelable` for passing via Bundle arguments
- Includes `Default` and `NotConfigurable` presets

### Modified Files
**`ChatUI.kt`**
- Added `pollsConfig` property to provide global default configuration
- Defaults to `PollsConfig.Default` (all features configurable and disabled by default)

**`CreatePollDialogFragment.kt`**
- Updated `newInstance()` to accept optional `PollsConfig` parameter
- Falls back to `ChatUI.pollsConfig` when not provided
- New `configurePollFeatures()` method to show/hide UI elements based on config
- Applies character limits using `InputFilter.LengthFilter`
- Wires up "add a comment" feature that was previously in UI but not functional
- Sets initial switch states based on config default values

**`CreatePollViewModel.kt`**
- Added `allowAnswers` field and `setAllowAnswers()` method
- Passes `allowAnswers` to the poll configuration when creating polls

**`OptionsAdapter.kt`**
- Added `optionTextLimit` parameter to constructor
- Applies `InputFilter.LengthFilter` to option EditText fields when limit is specified
- Maintains backward compatibility with overloaded constructor

### Key Design Decisions
- **Backward Compatibility**: All features remain configurable by default; existing code continues to work without changes
- **Two-Level Configuration**: Features can be controlled via global `ChatUI.pollsConfig` or per-dialog via `newInstance()`
- **Visibility Control**: When a feature is not configurable, its UI elements are completely hidden
- **Default Values**: Features can be pre-configured with default on/off states
- **Optional Limits**: Character limits default to `null` (unlimited) unless explicitly specified

### Usage Examples
```kotlin
// Global configuration
ChatUI.pollsConfig = PollsConfig(
    multipleVotes = PollsEntryConfig(configurable = false, defaultValue = false),
    anonymousPoll = PollsEntryConfig(configurable = true, defaultValue = true),
    questionTextLimit = 200,
    optionTextLimit = 100
)

// Per-dialog configuration
CreatePollDialogFragment.newInstance(
    createPollDialogListener = myListener,
    pollsConfig = PollsConfig(
        suggestAnOption = PollsEntryConfig.NotConfigurable,
        addComments = PollsEntryConfig(configurable = true, defaultValue = false),
        questionTextLimit = 150,
        optionTextLimit = 75
    )
)
```

## 📱 UI Changes
- Poll features can now be hidden when not configurable
- Features can be pre-enabled with default values
- Character limits are enforced at the input level using InputFilter
- "Add a comment" switch is now functional

### Testing

### Manual Testing Steps
1. Test default behavior - all features configurable, none enabled by default
2. Hide features - set `configurable = false`, verify UI elements are hidden
3. Set default values - verify switches initialize to correct state
4. Test character limits on questions and options
5. Verify "add a comment" feature now works correctly
6. Test global `ChatUI.pollsConfig` vs per-dialog config
7. Verify backward compatibility with existing `newInstance()` calls

### Expected Behavior
- Non-configurable features are hidden from the UI
- Configurable features display with correct default switch states
- Character limits prevent input beyond specified length
- Configuration can be set globally or per-dialog
- Existing code without config works unchanged

---

### Contributor Checklist
- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required)
- [ ] I have assigned a reviewer (code owner)
- [x] This PR targets the `develop` branch
- [ ] I have added unit tests for new code
- [x] I have updated documentation (KDocs included in code)

### Reviewer Checklist
- [ ] UI Components sample app has been tested
- [ ] Compose sample app has been tested (N/A - UI Components only)
- [ ] Visuals are correct
- [ ] Feature is validated
- [ ] KDocs have been reviewed
- [ ] SDK size impact has been reviewed from CI logs

---

## 🎉 GIF
https://github.com/user-attachments/assets/f09ac394-c58c-4489-bfca-c2c2447f6690

[Screen_recording_20260511_173314.webm](https://github.com/user-attachments/assets/de6d4adc-8ca8-464b-bcb1-3d57908666ba)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced comprehensive poll configuration system enabling control over which poll creation features are available to users
  * Added configurable text limits for poll questions and options
  * Made poll settings (multiple votes, anonymous polls, suggest-an-option, add comments) individually configurable with customizable default values
  * Added option to control whether poll responses can include answers

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6435)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->