### PR TITLE
Improve channel list TalkBack accessibility

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/list/ChannelItem.kt
@@ -47,8 +47,6 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -142,7 +140,8 @@ public fun ChannelItem(
     },
 ) {
     val channel = channelItem.channel
-    val description = stringResource(id = R.string.stream_compose_cd_channel_item)
+    val openLabel = stringResource(R.string.stream_compose_channel_item_open)
+    val optionsLabel = stringResource(R.string.stream_compose_channel_item_options)
 
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
@@ -154,13 +153,14 @@ public fun ChannelItem(
             .testTag("Stream_ChannelItem")
             .fillMaxWidth()
             .wrapContentHeight()
-            .semantics { contentDescription = description }
             .applyIf(isFocused) { border(2.dp, ChatTheme.colors.borderUtilityFocused, shape) }
             .clip(shape)
             .applyIf(channelItem.isSelected) { background(ChatTheme.colors.backgroundUtilitySelected, shape) }
             .combinedClickable(
                 onClick = { onChannelClick(channel) },
+                onClickLabel = openLabel,
                 onLongClick = { onChannelLongClick(channel) },
+                onLongClickLabel = optionsLabel,
                 indication = ripple(),
                 interactionSource = interactionSource,
             ),
@@ -283,7 +283,7 @@ private fun TitleRow(
                         .testTag("Stream_ChannelMutedIcon")
                         .size(16.dp),
                     painter = painterResource(id = R.drawable.stream_design_ic_mute),
-                    contentDescription = null,
+                    contentDescription = stringResource(R.string.stream_compose_channel_item_muted),
                     tint = ChatTheme.colors.textTertiary,
                 )
             }
@@ -350,7 +350,7 @@ private fun MessageRow(
                     .testTag("Stream_ChannelMutedIcon")
                     .size(16.dp),
                 painter = painterResource(id = R.drawable.stream_design_ic_mute),
-                contentDescription = null,
+                contentDescription = stringResource(R.string.stream_compose_channel_item_muted),
                 tint = ChatTheme.colors.textTertiary,
             )
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/HeaderScaffold.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/HeaderScaffold.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
@@ -140,7 +142,8 @@ internal fun RowScope.DefaultListHeaderCenterContent(
                 modifier = Modifier
                     .weight(1f)
                     .wrapContentWidth()
-                    .padding(horizontal = StreamTokens.spacingMd),
+                    .padding(horizontal = StreamTokens.spacingMd)
+                    .semantics { heading() },
                 text = title,
                 style = ChatTheme.typography.headingSmall,
                 maxLines = 1,
@@ -154,7 +157,8 @@ internal fun RowScope.DefaultListHeaderCenterContent(
                 modifier = Modifier
                     .weight(1f)
                     .wrapContentWidth()
-                    .padding(horizontal = StreamTokens.spacingMd),
+                    .padding(horizontal = StreamTokens.spacingMd)
+                    .semantics { heading() },
                 text = stringResource(R.string.stream_compose_disconnected),
                 style = ChatTheme.typography.headingSmall,
                 maxLines = 1,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessagePreviewContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/MessagePreviewContent.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.text
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
@@ -64,7 +64,7 @@ internal fun MessagePreviewContent(
     Row(
         modifier = modifier
             .testTag("Stream_MessagePreview")
-            .semantics { text = AnnotatedString(fullPreview) },
+            .clearAndSetSemantics { text = AnnotatedString(fullPreview) },
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing3xs),
     ) {
         if (senderName != null) {
@@ -101,7 +101,7 @@ internal fun DraftPreviewContent(
     Row(
         modifier = modifier
             .testTag("Stream_MessagePreview")
-            .semantics { text = AnnotatedString(fullPreview) },
+            .clearAndSetSemantics { text = AnnotatedString(fullPreview) },
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing3xs),
     ) {
         Text(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/UnreadCountIndicator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/channels/UnreadCountIndicator.kt
@@ -27,9 +27,13 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 
@@ -47,12 +51,18 @@ public fun UnreadCountIndicator(
     color: Color = ChatTheme.colors.accentPrimary,
 ) {
     val displayText = if (unreadCount > LimitTooManyUnreadCount) UnreadCountMany else unreadCount.toString()
+    val description = pluralStringResource(
+        R.plurals.stream_compose_channel_item_unread,
+        unreadCount,
+        unreadCount,
+    )
 
     Box(
         modifier = modifier
             .defaultMinSize(minWidth = 20.dp, minHeight = 20.dp)
             .background(shape = CircleShape, color = color)
-            .padding(horizontal = StreamTokens.spacing2xs), // 4dp horizontal content padding
+            .padding(horizontal = StreamTokens.spacing2xs)
+            .clearAndSetSemantics { contentDescription = description },
         contentAlignment = Alignment.Center,
     ) {
         Text(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/TextUtils.kt
@@ -226,16 +226,21 @@ private fun AnnotatedString.Builder.tagUser(
 
         if (start < 0) return@forEach
 
+        // Backtrack one position to include the leading `@`. Clamp to 0 when the mention is at the
+        // start of the text and no `@` precedes it — otherwise the resulting -1 span start crashes
+        // TalkBack's spannable conversion with `setSpan (-1 ...) starts before 0`.
+        val styledStart = (start - 1).coerceAtLeast(0)
+
         addStyle(
             style = SpanStyle(color = mentionsColor),
-            start = start - 1, // -1 to include the @ symbol
+            start = styledStart,
             end = end,
         )
 
         addStringAnnotation(
             tag = AnnotationTagMention,
             annotation = userName,
-            start = start - 1, // -1 to include the @ symbol
+            start = styledStart,
             end = end,
         )
     }

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -56,7 +56,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"Bloquear usuario"</string>
   <string name="stream_compose_cancel">"Cancelar"</string>
-  <string name="stream_compose_cd_channel_item">"Elemento de canal"</string>
+  <string name="stream_compose_channel_item_muted">"silenciado"</string>
+  <string name="stream_compose_channel_item_open">"Abrir conversación"</string>
+  <string name="stream_compose_channel_item_options">"Opciones de conversación"</string>
   <string name="stream_compose_cd_message_item">"Elemento de mensaje"</string>
   <string name="stream_compose_cd_play_button">"Botón de reproducción"</string>
   <string name="stream_compose_channel_list_draft">"Borrador: "</string>
@@ -259,6 +261,10 @@
   <string name="stream_compose_user_status_online">"Conectado"</string>
   <string name="stream_compose_video_preview">"Vídeo"</string>
   <string name="stream_compose_waiting_for_network">"Esperando conexión de red"</string>
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d mensaje sin leer"</item>
+    <item quantity="other">"%d mensajes sin leer"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="one">"%d persona está escribiendo"</item>
     <item quantity="other">"%d personas están escribiendo"</item>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -58,7 +58,7 @@
   <string name="stream_compose_cancel">"Cancelar"</string>
   <string name="stream_compose_channel_item_muted">"silenciado"</string>
   <string name="stream_compose_channel_item_open">"Abrir conversación"</string>
-  <string name="stream_compose_channel_item_options">"Opciones de conversación"</string>
+  <string name="stream_compose_channel_item_options">"Abrir opciones de conversación"</string>
   <string name="stream_compose_cd_message_item">"Elemento de mensaje"</string>
   <string name="stream_compose_cd_play_button">"Botón de reproducción"</string>
   <string name="stream_compose_channel_list_draft">"Borrador: "</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -58,7 +58,7 @@
   <string name="stream_compose_cancel">"Annuler"</string>
   <string name="stream_compose_channel_item_muted">"en sourdine"</string>
   <string name="stream_compose_channel_item_open">"Ouvrir la conversation"</string>
-  <string name="stream_compose_channel_item_options">"Options de la conversation"</string>
+  <string name="stream_compose_channel_item_options">"Ouvrir les options de conversation"</string>
   <string name="stream_compose_cd_message_item">"Élément de message"</string>
   <string name="stream_compose_cd_play_button">"Bouton de lecture"</string>
   <string name="stream_compose_channel_list_draft">"Brouillon : "</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -56,7 +56,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"Bloquer l\'utilisateur"</string>
   <string name="stream_compose_cancel">"Annuler"</string>
-  <string name="stream_compose_cd_channel_item">"Élément de canal"</string>
+  <string name="stream_compose_channel_item_muted">"en sourdine"</string>
+  <string name="stream_compose_channel_item_open">"Ouvrir la conversation"</string>
+  <string name="stream_compose_channel_item_options">"Options de la conversation"</string>
   <string name="stream_compose_cd_message_item">"Élément de message"</string>
   <string name="stream_compose_cd_play_button">"Bouton de lecture"</string>
   <string name="stream_compose_channel_list_draft">"Brouillon : "</string>
@@ -259,6 +261,10 @@
   <string name="stream_compose_user_status_online">"En ligne"</string>
   <string name="stream_compose_video_preview">"Vidéo"</string>
   <string name="stream_compose_waiting_for_network">"En attente de réseau"</string>
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d message non lu"</item>
+    <item quantity="other">"%d messages non lus"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="one">"%d personne écrit"</item>
     <item quantity="other">"%d personnes écrivent"</item>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -15,6 +15,10 @@
     limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d अपठित संदेश"</item>
+    <item quantity="other">"%d अपठित संदेश"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="one">"%d व्यक्ति टाइप कर रहा है"</item>
     <item quantity="other">"%d लोग टाइप कर रहे हैं"</item>
@@ -112,7 +116,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"उपयोगकर्ता को ब्लॉक करें"</string>
   <string name="stream_compose_cancel">"रद्द करें"</string>
-  <string name="stream_compose_cd_channel_item">"चैनल आइटम"</string>
+  <string name="stream_compose_channel_item_muted">"म्यूट किया गया"</string>
+  <string name="stream_compose_channel_item_open">"बातचीत खोलें"</string>
+  <string name="stream_compose_channel_item_options">"बातचीत के विकल्प"</string>
   <string name="stream_compose_cd_message_item">"मैसेज आइटम"</string>
   <string name="stream_compose_cd_play_button">"चलाएँ बटन"</string>
   <string name="stream_compose_channel_list_draft">"ड्राफ़्ट: "</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -118,7 +118,7 @@
   <string name="stream_compose_cancel">"रद्द करें"</string>
   <string name="stream_compose_channel_item_muted">"म्यूट किया गया"</string>
   <string name="stream_compose_channel_item_open">"बातचीत खोलें"</string>
-  <string name="stream_compose_channel_item_options">"बातचीत के विकल्प"</string>
+  <string name="stream_compose_channel_item_options">"बातचीत के विकल्प खोलें"</string>
   <string name="stream_compose_cd_message_item">"मैसेज आइटम"</string>
   <string name="stream_compose_cd_play_button">"चलाएँ बटन"</string>
   <string name="stream_compose_channel_list_draft">"ड्राफ़्ट: "</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -56,7 +56,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"Blokir pengguna"</string>
   <string name="stream_compose_cancel">"Batal"</string>
-  <string name="stream_compose_cd_channel_item">"Item saluran"</string>
+  <string name="stream_compose_channel_item_muted">"dibisukan"</string>
+  <string name="stream_compose_channel_item_open">"Buka percakapan"</string>
+  <string name="stream_compose_channel_item_options">"Opsi percakapan"</string>
   <string name="stream_compose_cd_message_item">"Item pesan"</string>
   <string name="stream_compose_cd_play_button">"Tombol putar"</string>
   <string name="stream_compose_channel_list_draft">"Draf: "</string>
@@ -259,6 +261,10 @@
   <string name="stream_compose_user_status_online">"Online"</string>
   <string name="stream_compose_video_preview">"Video"</string>
   <string name="stream_compose_waiting_for_network">"Menunggu jaringan"</string>
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d pesan belum dibaca"</item>
+    <item quantity="other">"%d pesan belum dibaca"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="other">"%d orang sedang mengetik"</item>
   </plurals>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -58,7 +58,7 @@
   <string name="stream_compose_cancel">"Batal"</string>
   <string name="stream_compose_channel_item_muted">"dibisukan"</string>
   <string name="stream_compose_channel_item_open">"Buka percakapan"</string>
-  <string name="stream_compose_channel_item_options">"Opsi percakapan"</string>
+  <string name="stream_compose_channel_item_options">"Buka opsi percakapan"</string>
   <string name="stream_compose_cd_message_item">"Item pesan"</string>
   <string name="stream_compose_cd_play_button">"Tombol putar"</string>
   <string name="stream_compose_channel_list_draft">"Draf: "</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -15,6 +15,10 @@
     limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d messaggio non letto"</item>
+    <item quantity="other">"%d messaggi non letti"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="one">"%d persona sta scrivendo"</item>
     <item quantity="other">"%d persone stanno scrivendo"</item>
@@ -112,7 +116,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"Blocca utente"</string>
   <string name="stream_compose_cancel">"Annulla"</string>
-  <string name="stream_compose_cd_channel_item">"Elemento canale"</string>
+  <string name="stream_compose_channel_item_muted">"silenziato"</string>
+  <string name="stream_compose_channel_item_open">"Apri conversazione"</string>
+  <string name="stream_compose_channel_item_options">"Opzioni conversazione"</string>
   <string name="stream_compose_cd_message_item">"Elemento messaggio"</string>
   <string name="stream_compose_cd_play_button">"Pulsante riproduci"</string>
   <string name="stream_compose_channel_list_draft">"Bozza: "</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -118,7 +118,7 @@
   <string name="stream_compose_cancel">"Annulla"</string>
   <string name="stream_compose_channel_item_muted">"silenziato"</string>
   <string name="stream_compose_channel_item_open">"Apri conversazione"</string>
-  <string name="stream_compose_channel_item_options">"Opzioni conversazione"</string>
+  <string name="stream_compose_channel_item_options">"Apri opzioni conversazione"</string>
   <string name="stream_compose_cd_message_item">"Elemento messaggio"</string>
   <string name="stream_compose_cd_play_button">"Pulsante riproduci"</string>
   <string name="stream_compose_channel_list_draft">"Bozza: "</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -58,7 +58,7 @@
   <string name="stream_compose_cancel">"キャンセル"</string>
   <string name="stream_compose_channel_item_muted">"ミュート中"</string>
   <string name="stream_compose_channel_item_open">"会話を開く"</string>
-  <string name="stream_compose_channel_item_options">"会話のオプション"</string>
+  <string name="stream_compose_channel_item_options">"会話のオプションを開く"</string>
   <string name="stream_compose_cd_message_item">"メッセージ項目"</string>
   <string name="stream_compose_cd_play_button">"再生ボタン"</string>
   <string name="stream_compose_channel_list_draft">"下書き: "</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -56,7 +56,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"ユーザーをブロック"</string>
   <string name="stream_compose_cancel">"キャンセル"</string>
-  <string name="stream_compose_cd_channel_item">"チャンネル項目"</string>
+  <string name="stream_compose_channel_item_muted">"ミュート中"</string>
+  <string name="stream_compose_channel_item_open">"会話を開く"</string>
+  <string name="stream_compose_channel_item_options">"会話のオプション"</string>
   <string name="stream_compose_cd_message_item">"メッセージ項目"</string>
   <string name="stream_compose_cd_play_button">"再生ボタン"</string>
   <string name="stream_compose_channel_list_draft">"下書き: "</string>
@@ -64,6 +66,10 @@
   <string name="stream_compose_channel_list_empty_search_results">"\"%1$s\"の検索結果はありません"</string>
   <string name="stream_compose_channel_list_header_new_chat">"新しいチャット"</string>
   <string name="stream_compose_channel_list_start_chat">"チャットを始める"</string>
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d件の未読メッセージ"</item>
+    <item quantity="other">"%d件の未読メッセージ"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="other">"%d人が入力中"</item>
   </plurals>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -58,7 +58,7 @@
   <string name="stream_compose_cancel">"취소"</string>
   <string name="stream_compose_channel_item_muted">"음소거됨"</string>
   <string name="stream_compose_channel_item_open">"대화 열기"</string>
-  <string name="stream_compose_channel_item_options">"대화 옵션"</string>
+  <string name="stream_compose_channel_item_options">"대화 옵션 열기"</string>
   <string name="stream_compose_cd_message_item">"메시지 항목"</string>
   <string name="stream_compose_cd_play_button">"재생 버튼"</string>
   <string name="stream_compose_channel_list_draft">"임시 저장: "</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -56,7 +56,9 @@
   <string name="stream_compose_avatar_overflow_count">"+%1$d"</string>
   <string name="stream_compose_block_user">"사용자 차단"</string>
   <string name="stream_compose_cancel">"취소"</string>
-  <string name="stream_compose_cd_channel_item">"채널 항목"</string>
+  <string name="stream_compose_channel_item_muted">"음소거됨"</string>
+  <string name="stream_compose_channel_item_open">"대화 열기"</string>
+  <string name="stream_compose_channel_item_options">"대화 옵션"</string>
   <string name="stream_compose_cd_message_item">"메시지 항목"</string>
   <string name="stream_compose_cd_play_button">"재생 버튼"</string>
   <string name="stream_compose_channel_list_draft">"임시 저장: "</string>
@@ -64,6 +66,10 @@
   <string name="stream_compose_channel_list_empty_search_results">"\"%1$s\"에 대한 검색결과가 없습니다"</string>
   <string name="stream_compose_channel_list_header_new_chat">"새 채팅"</string>
   <string name="stream_compose_channel_list_start_chat">"채팅 시작하기"</string>
+  <plurals name="stream_compose_channel_item_unread">
+    <item quantity="one">"%d개의 안 읽은 메시지"</item>
+    <item quantity="other">"%d개의 안 읽은 메시지"</item>
+  </plurals>
   <plurals name="stream_compose_channel_list_typing_many">
     <item quantity="other">"%d명이 입력 중"</item>
   </plurals>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -288,7 +288,13 @@
     <string name="stream_compose_media_gallery_share_large_file_prompt_message">%.2f MB needs to be downloaded before sharing.</string>
 
     <!-- Content Description -->
-    <string name="stream_compose_cd_channel_item">Channel item</string>
+    <string name="stream_compose_channel_item_open">Open conversation</string>
+    <string name="stream_compose_channel_item_options">Open conversation options</string>
+    <string name="stream_compose_channel_item_muted">muted</string>
+    <plurals name="stream_compose_channel_item_unread">
+        <item quantity="one">%d unread message</item>
+        <item quantity="other">%d unread messages</item>
+    </plurals>
     <string name="stream_compose_cd_message_item">Message item</string>
     <string name="stream_compose_cd_play_button">Play button</string>
 


### PR DESCRIPTION
### Goal

Resolve TalkBack accessibility gaps on the Compose channel list:

1. Each channel row announced as a generic *"Channel item, …"* with the unread badge speaking just a digit and the mute icon silent.
2. Long-press / activation hints were generic (*"double-tap to activate"*) with no verb.
3. The screen header title (*"Chats"*) was not reachable via TalkBack's swipe-by-heading gesture.
4. Two latent TalkBack bugs: `MessagePreviewContent` announced previews twice, and a span computation in `tagUser` crashed the platform whenever an accessibility service tried to read a message whose text started with a mention.

### Implementation

Four self-contained commits, each scoped to one concern:

1. **`Fix duplicated TalkBack readout in channel preview`** — switch `MessagePreviewContent` / `DraftPreviewContent` from `semantics { text = … }` to `clearAndSetSemantics`, so child `Text`s are no longer also merged into the surrounding clickable.
2. **`Fix TalkBack crash on mentions at the start of a message`** — clamp the `start - 1` backtrack in `TextUtils.tagUser` to 0. Without an accessibility service the bad span renders harmlessly; with TalkBack on, `Spannable.setSpan(-1, …)` throws and crashes the message list.
3. **`Make channel list rows accessible to TalkBack`** — leaf-first a11y. Mute `Icon` carries a localized *"muted"* `contentDescription`; `UnreadCountIndicator` overrides its bare numeric `Text` with a plural label (*"N unread messages"*) via `clearAndSetSemantics` on the badge (also benefits `ThreadItem`); outer `Column` drops the static *"Channel item"* placeholder and declares `onClickLabel` / `onLongClickLabel` on `combinedClickable`. Compose's natural merge composes name, timestamp, read-status, and preview in visual reading order. Adds four new strings + translations for all 7 supported locales; drops the obsolete `stream_compose_cd_channel_item`.
4. **`Mark list-header title as a TalkBack heading`** — adds `Modifier.semantics { heading() }` to the title `Text` (and the offline *"Disconnected"* `Text`) in `DefaultListHeaderCenterContent`. Shared by `ChannelListHeader` and `ThreadListHeader`, so both screens gain heading navigation.

No public API surface changes (apiDump clean).

### Testing

Manual steps on the Compose sample with **TalkBack ON** and **Settings → Accessibility → TalkBack → Verbosity → Speak usage hints** enabled:

1. **Header heading** — set the TalkBack reading control to *"Headings"* (swipe up + right repeatedly). On the channels screen, swipe down — TalkBack should land on the title (*"Chats"*) and announce it as a heading. Switch the reading control back to *"Default"* for the rest of the steps.
2. **Row announcement** — focus a channel row. TalkBack should announce, in visual reading order: channel name, *"muted"* (if applicable), timestamp, *"N unread messages"* (if applicable), read-status (if applicable), message preview, *"button"*, *"double-tap to Open conversation, double-tap and hold to Open conversation options"*.
3. **Draft preview** — focus a row whose last message is a saved draft. The *"Draft: <text>"* portion must be announced **once**, not twice. Repeat for a non-draft row: sender prefix + message text must also be announced once.
4. **Mention crash** — find or send a message whose text **starts with a mention** (e.g. `"@Chewbacca hello"`). With TalkBack on, opening the channel previously crashed with `IndexOutOfBoundsException: setSpan (-1 …)`. It must now open normally.
5. **TalkBack navigation** — with TalkBack on, focus a channel row and double-tap to confirm the conversation opens; long-press to confirm the channel options sheet appears.
6. **Localization** — repeat step 2 with the device language set to one of: Spanish, French, Hindi, Indonesian, Italian, Japanese, or Korean. The new labels should be translated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility throughout the channel list and messaging interface with improved action labels, semantic descriptions for unread counts, and heading navigation support.

* **Bug Fixes**
  * Fixed potential crash when handling mention text at the beginning of messages.

* **Localization**
  * Updated translations across Spanish, French, Hindi, Indonesian, Italian, Japanese, and Korean for channel item actions and unread message counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6436)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->