### PR TITLE
Fix MessageListView rotation crash and custom messagesStart not being applied

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -662,9 +662,9 @@ public class MessageListView : ConstraintLayout {
         binding = StreamUiMessageListViewBinding.inflate(streamThemeInflater, this)
 
         messageListViewStyle = MessageListViewStyle(context, attr)
-        messageListViewStyle?.messagesStart?.let(::chatMessageStart)
 
         initRecyclerView()
+        messageListViewStyle?.messagesStart?.let(::chatMessageStart)
         initScrollHelper()
         initSwipeToReply()
         initLoadingView()
@@ -710,9 +710,7 @@ public class MessageListView : ConstraintLayout {
 
     private fun initRecyclerView() {
         binding.chatMessagesRV.apply {
-            layoutManager = LinearLayoutManager(context).apply {
-                stackFromEnd = true
-            }
+            layoutManager = LinearLayoutManager(context)
             setHasFixedSize(false)
             setItemViewCacheSize(20)
         }
@@ -1332,15 +1330,16 @@ public class MessageListView : ConstraintLayout {
 
     private fun changeLayoutForMessageStart(messagesStart: MessagesStart) {
         val messagesRV = binding.chatMessagesRV
+        val layoutManager = messagesRV.layoutManager as? LinearLayoutManager ?: return
 
         when (messagesStart) {
             MessagesStart.BOTTOM -> {
-                messagesRV.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT)
+                layoutManager.stackFromEnd = true
                 messagesRV.overScrollMode = View.OVER_SCROLL_NEVER
             }
 
             MessagesStart.TOP -> {
-                messagesRV.layoutParams = LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT)
+                layoutManager.stackFromEnd = false
                 messagesRV.overScrollMode = View.OVER_SCROLL_ALWAYS
             }
         }


### PR DESCRIPTION
### Goal

Fix a `MessageListView` crash on configuration change (e.g. rotation) when the activity restores its state into a list that gets submitted before the layout pipeline has settled:

```
IllegalArgumentException: Tmp detached view should be removed from RecyclerView before it can be recycled
```

The race was reliably reproducible in the sample app with `app:streamUiMessagesStart="top"`: open a channel, open the create-poll dialog, fill title/options, then rotate.

While debugging, also fixed a second bug: setting `messagesStart` via `TransformStyle.messageListStyleTransformer` (the customer-facing API) didn't actually apply.

### Implementation

- Stop swapping `chatMessagesRV`'s height between `MATCH_PARENT` and `WRAP_CONTENT` based on `MessagesStart`. Both modes now use the inflated `MATCH_PARENT × MATCH_PARENT`. The TOP vs BOTTOM anchoring is expressed via `LinearLayoutManager.stackFromEnd` instead, which gives the same visual result without re-measuring the RV on every `onBindViewHolder`. The repeated re-measure cascade was what produced the animator/recycler race.
- Call `chatMessageStart` after `initRecyclerView` in `init`, so the layout manager exists when the style is applied. Previously the layout manager was null at that point, the new `stackFromEnd`-based path returned early, and the configured `messagesStart` was effectively ignored on first render.

### Testing

Verified all four `messagesStart` / `threadMessagesStart` combinations via `TransformStyle.messageListStyleTransformer` in the sample app:

- `BOTTOM` / `BOTTOM`: main and threads anchored to bottom.
- `TOP` / `TOP`: main and threads anchored to top.
- `TOP` / `BOTTOM` and `BOTTOM` / `TOP`: mixed anchors render correctly per surface.

For each combination:

- Open a channel with many messages: items pack as expected, scrolling unaffected.
- Open a channel with few messages: empty space lands on the expected side.
- Repeat in a thread.
- Repro the original flow (poll as last message → open create-poll dialog → fill title and options → rotate): no crash in any combination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved message list initialization order to ensure proper layout configuration when messages start at the top or bottom.

* **Refactor**
  * Optimized message list layout handling logic for better consistency and performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6438)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->