### PR TITLE
Improve message list TalkBack accessibility

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -37,6 +37,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -45,6 +46,7 @@ import io.getstream.chat.android.client.utils.attachment.isAudio
 import io.getstream.chat.android.client.utils.attachment.isFile
 import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.attachments.preview.handler.AttachmentPreviewHandler
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
@@ -100,6 +102,7 @@ public fun FileAttachmentContent(
             )
             .testTag("Stream_MultipleFileAttachmentsColumn"),
     ) {
+        val openAttachmentLabel = stringResource(R.string.stream_compose_message_attachment_open)
         for (attachment in message.attachments) {
             if (attachment.isFile() || attachment.isAudio()) {
                 ChatTheme.componentFactory.FileAttachmentItem(
@@ -114,6 +117,7 @@ public fun FileAttachmentContent(
                             .combinedClickable(
                                 indication = ripple(),
                                 interactionSource = remember { MutableInteractionSource() },
+                                onClickLabel = openAttachmentLabel,
                                 onClick = { onItemClick(previewHandlers, attachment) },
                                 onLongClick = { attachmentState.onLongItemClick(message) },
                             ),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/LinkAttachmentContent.kt
@@ -50,6 +50,7 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -105,6 +106,7 @@ public fun LinkAttachmentContent(
     }
 
     val context = LocalContext.current
+    val openAttachmentLabel = stringResource(R.string.stream_compose_message_attachment_open)
     val textColor = MessageStyling.textColor(outgoing = state.isMine)
     val baseModifier = modifier
         .padding(MessageStyling.messageSectionPadding)
@@ -114,6 +116,7 @@ public fun LinkAttachmentContent(
         .combinedClickable(
             indication = ripple(),
             interactionSource = remember { MutableInteractionSource() },
+            onClickLabel = openAttachmentLabel,
             onClick = {
                 onItemClick(
                     LinkAttachmentClickData(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -452,6 +452,7 @@ internal fun MediaAttachmentContentItem(
         attachment.uploadState is Attachment.UploadState.InProgress ||
         attachment.uploadState is Attachment.UploadState.Idle
 
+    val openAttachmentLabel = stringResource(R.string.stream_compose_message_attachment_open)
     Box(
         modifier = modifier
             .semantics {
@@ -465,6 +466,7 @@ internal fun MediaAttachmentContentItem(
             .combinedClickable(
                 interactionSource = remember { MutableInteractionSource() },
                 indication = ripple(),
+                onClickLabel = openAttachmentLabel,
                 onClick = {
                     if (message.syncStatus == SyncStatus.COMPLETED) {
                         onItemClick(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageFooter.kt
@@ -27,8 +27,6 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextOverflow
 import io.getstream.chat.android.client.extensions.getCreatedAtOrNull
 import io.getstream.chat.android.client.utils.message.isDeleted
@@ -91,9 +89,7 @@ public fun MessageFooter(
                 if (!messageItem.isMine) {
                     Text(
                         modifier = Modifier
-                            .clearAndSetSemantics {
-                                testTag = "Stream_MessageAuthorName"
-                            }
+                            .testTag("Stream_MessageAuthorName")
                             .padding(end = StreamTokens.spacingXs)
                             .weight(1f, fill = false),
                         text = message.user.name,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageReactions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageReactions.kt
@@ -34,11 +34,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.previewdata.PreviewReactionData
 import io.getstream.chat.android.compose.state.messages.MessageReactionItemState
 import io.getstream.chat.android.compose.ui.components.reactions.ReactionIconSize
@@ -67,6 +69,7 @@ public fun ClusteredMessageReactions(
         reactions.size,
         reactions.size,
     )
+    val openLabel = stringResource(R.string.stream_compose_message_reactions_show)
     val colors = ChatTheme.colors
     val count = reactions.sumOf(MessageReactionItemState::count)
 
@@ -78,7 +81,7 @@ public fun ClusteredMessageReactions(
             }
             .background(colors.backgroundCoreElevation1, CircleShape)
             .border(1.dp, color = colors.borderCoreSubtle, shape = CircleShape)
-            .ifNotNull(onClick) { clip(CircleShape).clickable(onClick = it) }
+            .ifNotNull(onClick) { clip(CircleShape).clickable(onClickLabel = openLabel, onClick = it) }
             .padding(horizontal = StreamTokens.spacingXs, vertical = StreamTokens.spacing2xs),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing2xs),
@@ -175,13 +178,14 @@ private fun ReactionChip(
     onClick: (() -> Unit)?,
     content: @Composable RowScope.() -> Unit,
 ) {
+    val openLabel = stringResource(R.string.stream_compose_message_reactions_show)
     val colors = ChatTheme.colors
     Row(
         modifier = Modifier
             .fillMaxHeight()
             .background(colors.backgroundCoreElevation1, CircleShape)
             .border(1.dp, color = colors.borderCoreSubtle, shape = CircleShape)
-            .ifNotNull(onClick) { clip(CircleShape).clickable(onClick = it) }
+            .ifNotNull(onClick) { clip(CircleShape).clickable(onClickLabel = openLabel, onClick = it) }
             .padding(horizontal = StreamTokens.spacingXs, vertical = StreamTokens.spacing2xs),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing2xs),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -72,7 +72,7 @@ internal fun ReactionToggle(
                     .ifNotNull(onCheckedChange) { onChange ->
                         clip(CircleShape).toggleable(
                             value = checked,
-                            role = Role.Switch,
+                            role = Role.Checkbox,
                             onValueChange = onChange,
                         )
                     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -23,11 +23,13 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -35,7 +37,6 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.util.ReactionResolver
 import io.getstream.chat.android.compose.ui.util.applyIf
-import io.getstream.chat.android.compose.ui.util.clickable
 import io.getstream.chat.android.compose.ui.util.ifNotNull
 
 /**
@@ -69,7 +70,11 @@ internal fun ReactionToggle(
                         background(ChatTheme.colors.backgroundUtilitySelected, CircleShape)
                     }
                     .ifNotNull(onCheckedChange) { onChange ->
-                        clip(CircleShape).clickable { onChange(!checked) }
+                        clip(CircleShape).toggleable(
+                            value = checked,
+                            role = Role.Switch,
+                            onValueChange = onChange,
+                        )
                     }
                     .defaultMinSize(minWidth = containerSize, minHeight = containerSize)
                     .wrapContentSize(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -62,8 +62,6 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -177,12 +175,16 @@ public fun MessageContainer(
     val canOpenActions = !message.isDeleted() && !message.isUploading()
     val onLongItemClick = rememberHapticLongClick(onLongItemClick)
 
+    val openThreadLabel = stringResource(R.string.stream_compose_message_item_open_thread)
+    val messageOptionsLabel = stringResource(R.string.stream_compose_message_item_options)
     val clickModifier = Modifier.combinedClickable(
         interactionSource = remember(::MutableInteractionSource),
         indication = null,
         enabled = canOpenThread || canOpenActions,
         onClick = { if (canOpenThread) onThreadClick(message) },
         onLongClick = { if (canOpenActions) onLongItemClick(message) },
+        onClickLabel = openThreadLabel.takeIf { canOpenThread },
+        onLongClickLabel = messageOptionsLabel.takeIf { canOpenActions },
     )
 
     val highlightColor = ChatTheme.colors.backgroundCoreHighlight
@@ -198,7 +200,6 @@ public fun MessageContainer(
     )
 
     val messageAlignment = ChatTheme.messageAlignmentProvider.provideMessageAlignment(messageItem)
-    val description = stringResource(id = R.string.stream_compose_cd_message_item)
     val optionsVisibility = ChatTheme.config.messageActions.optionsVisibility
     val isSwipeable = remember(message, messageItem.ownCapabilities, optionsVisibility) {
         optionsVisibility.canReplyToMessage(message, messageItem.ownCapabilities)
@@ -223,8 +224,7 @@ public fun MessageContainer(
                 .fillMaxWidth()
                 .wrapContentHeight()
                 .background(color = color)
-                .then(clickModifier)
-                .semantics { contentDescription = description },
+                .then(clickModifier),
             horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
                 Arrangement.Start
             } else {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -39,10 +39,14 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
+import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -331,10 +335,15 @@ internal fun DefaultMessageModeratedContent(moderatedMessageItemState: Moderated
  */
 @Composable
 internal fun DefaultMessageTypingIndicatorContent(state: TypingItemState) {
+    val typingDescription = typingUsersDescription(state.typingUsers)
     Row(
         modifier = Modifier
             .padding(StreamTokens.spacingXs)
-            .testTag("Stream_MessageListTypingIndicator"),
+            .testTag("Stream_MessageListTypingIndicator")
+            .semantics(mergeDescendants = true) {
+                contentDescription = typingDescription
+                liveRegion = LiveRegionMode.Polite
+            },
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
         verticalAlignment = Alignment.Bottom,
     ) {
@@ -366,6 +375,27 @@ internal fun DefaultMessageTypingIndicatorContent(state: TypingItemState) {
                 TypingIndicator()
             }
         }
+    }
+}
+
+@Composable
+private fun typingUsersDescription(typingUsers: List<User>): String {
+    val resources = LocalResources.current
+    return when (typingUsers.size) {
+        1 -> stringResource(
+            R.string.stream_compose_channel_list_typing_one,
+            typingUsers.first().name,
+        )
+        2 -> stringResource(
+            R.string.stream_compose_channel_list_typing_two,
+            typingUsers[0].name,
+            typingUsers[1].name,
+        )
+        else -> resources.getQuantityString(
+            R.plurals.stream_compose_channel_list_typing_many,
+            typingUsers.size,
+            typingUsers.size,
+        )
     }
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -220,6 +221,7 @@ internal fun DefaultMessageDateSeparatorContent(dateSeparator: DateSeparatorItem
         modifier = Modifier
             .semantics(mergeDescendants = true) {
                 testTag = "Stream_MessageDateSeparator"
+                heading()
             }
             .padding(vertical = StreamTokens.spacingXs)
             .fillMaxWidth(),
@@ -233,13 +235,16 @@ internal fun DefaultMessageDateSeparatorContent(dateSeparator: DateSeparatorItem
  */
 @Composable
 internal fun DefaultMessageUnreadSeparatorContent(unreadSeparatorItemState: UnreadSeparatorItemState) {
+    val unreadCount = unreadSeparatorItemState.unreadCount
     MessagesStripDivider(
         modifier = Modifier.semantics(mergeDescendants = true) {
             testTag = "Stream_UnreadMessagesBadge"
+            heading()
         },
-        text = stringResource(
-            R.string.stream_compose_message_list_unread_separator,
-            unreadSeparatorItemState.unreadCount,
+        text = pluralStringResource(
+            R.plurals.stream_compose_message_list_unread_separator,
+            unreadCount,
+            unreadCount,
         ),
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageItem.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.layout.LayoutCoordinates
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
-import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
@@ -379,9 +378,8 @@ internal fun DefaultMessageTypingIndicatorContent(state: TypingItemState) {
 }
 
 @Composable
-private fun typingUsersDescription(typingUsers: List<User>): String {
-    val resources = LocalResources.current
-    return when (typingUsers.size) {
+private fun typingUsersDescription(typingUsers: List<User>): String =
+    when (typingUsers.size) {
         1 -> stringResource(
             R.string.stream_compose_channel_list_typing_one,
             typingUsers.first().name,
@@ -391,13 +389,12 @@ private fun typingUsersDescription(typingUsers: List<User>): String {
             typingUsers[0].name,
             typingUsers[1].name,
         )
-        else -> resources.getQuantityString(
+        else -> pluralStringResource(
             R.plurals.stream_compose_channel_list_typing_many,
             typingUsers.size,
             typingUsers.size,
         )
     }
-}
 
 private const val MaxTypingUsersAvatars = 3
 

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
   <string name="stream_compose_message_item_open_thread">"Abrir hilo"</string>
   <string name="stream_compose_message_item_options">"Mostrar opciones del mensaje"</string>
+  <string name="stream_compose_message_attachment_open">"Abrir archivo adjunto"</string>
   <string name="stream_compose_message_reactions_show">"Mostrar reacciones"</string>
   <string name="stream_compose_message_list_auto_translated">"Traducido"</string>
   <string name="stream_compose_message_list_empty_messages">"Sin mensajes"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -59,7 +59,6 @@
   <string name="stream_compose_channel_item_muted">"silenciado"</string>
   <string name="stream_compose_channel_item_open">"Abrir conversación"</string>
   <string name="stream_compose_channel_item_options">"Abrir opciones de conversación"</string>
-  <string name="stream_compose_cd_message_item">"Elemento de mensaje"</string>
   <string name="stream_compose_cd_play_button">"Botón de reproducción"</string>
   <string name="stream_compose_channel_list_draft">"Borrador: "</string>
   <string name="stream_compose_channel_list_empty_channels">"No hay conversaciones aún"</string>
@@ -123,6 +122,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"expandido"</string>
   <string name="stream_compose_message_deleted">"Mensaje eliminado"</string>
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
+  <string name="stream_compose_message_item_open_thread">"Abrir hilo"</string>
+  <string name="stream_compose_message_item_options">"Mostrar opciones del mensaje"</string>
   <string name="stream_compose_message_list_auto_translated">"Traducido"</string>
   <string name="stream_compose_message_list_empty_messages">"Sin mensajes"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"No hay ninguna aplicación para ver esta URL:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
   <string name="stream_compose_message_item_open_thread">"Abrir hilo"</string>
   <string name="stream_compose_message_item_options">"Mostrar opciones del mensaje"</string>
+  <string name="stream_compose_message_reactions_show">"Mostrar reacciones"</string>
   <string name="stream_compose_message_list_auto_translated">"Traducido"</string>
   <string name="stream_compose_message_list_empty_messages">"Sin mensajes"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"No hay ninguna aplicación para ver esta URL:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -136,7 +136,10 @@
   <string name="stream_compose_message_list_show_translation">"Mostrar traducción"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_replies">"%d respuestas"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_reply">"%d respuesta"</string>
-  <string name="stream_compose_message_list_unread_separator">"%d mensajes no leídos"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d mensaje no leído"</item>
+    <item quantity="other">"%d mensajes no leídos"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"Archivo adjunto no compatible"</string>
   <string name="stream_compose_message_list_view">"Ver"</string>
   <string name="stream_compose_message_list_view_original">"Ver original"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -136,7 +136,10 @@
   <string name="stream_compose_message_list_show_translation">"Afficher la traduction"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_replies">"%d réponses"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_reply">"%d réponse"</string>
-  <string name="stream_compose_message_list_unread_separator">"%d messages non lus"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d message non lu"</item>
+    <item quantity="other">"%d messages non lus"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"Pièce jointe non prise en charge"</string>
   <string name="stream_compose_message_list_view">"Voir"</string>
   <string name="stream_compose_message_list_view_original">"Voir l\'original"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
   <string name="stream_compose_message_item_open_thread">"Ouvrir le fil"</string>
   <string name="stream_compose_message_item_options">"Afficher les options du message"</string>
+  <string name="stream_compose_message_reactions_show">"Afficher les réactions"</string>
   <string name="stream_compose_message_list_auto_translated">"Traduit"</string>
   <string name="stream_compose_message_list_empty_messages">"Aucun message"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Aucune application pour ouvrir cette URL :\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -59,7 +59,6 @@
   <string name="stream_compose_channel_item_muted">"en sourdine"</string>
   <string name="stream_compose_channel_item_open">"Ouvrir la conversation"</string>
   <string name="stream_compose_channel_item_options">"Ouvrir les options de conversation"</string>
-  <string name="stream_compose_cd_message_item">"Élément de message"</string>
   <string name="stream_compose_cd_play_button">"Bouton de lecture"</string>
   <string name="stream_compose_channel_list_draft">"Brouillon : "</string>
   <string name="stream_compose_channel_list_empty_channels">"Aucune conversation pour le moment"</string>
@@ -123,6 +122,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"développé"</string>
   <string name="stream_compose_message_deleted">"Message supprimé"</string>
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
+  <string name="stream_compose_message_item_open_thread">"Ouvrir le fil"</string>
+  <string name="stream_compose_message_item_options">"Afficher les options du message"</string>
   <string name="stream_compose_message_list_auto_translated">"Traduit"</string>
   <string name="stream_compose_message_list_empty_messages">"Aucun message"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Aucune application pour ouvrir cette URL :\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
   <string name="stream_compose_message_item_open_thread">"Ouvrir le fil"</string>
   <string name="stream_compose_message_item_options">"Afficher les options du message"</string>
+  <string name="stream_compose_message_attachment_open">"Ouvrir la pièce jointe"</string>
   <string name="stream_compose_message_reactions_show">"Afficher les réactions"</string>
   <string name="stream_compose_message_list_auto_translated">"Traduit"</string>
   <string name="stream_compose_message_list_empty_messages">"Aucun message"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -119,7 +119,6 @@
   <string name="stream_compose_channel_item_muted">"म्यूट किया गया"</string>
   <string name="stream_compose_channel_item_open">"बातचीत खोलें"</string>
   <string name="stream_compose_channel_item_options">"बातचीत के विकल्प खोलें"</string>
-  <string name="stream_compose_cd_message_item">"मैसेज आइटम"</string>
   <string name="stream_compose_cd_play_button">"चलाएँ बटन"</string>
   <string name="stream_compose_channel_list_draft">"ड्राफ़्ट: "</string>
   <string name="stream_compose_channel_list_empty_channels">"कोई चैनल उपलब्ध नहीं है"</string>
@@ -183,6 +182,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"विस्तृत"</string>
   <string name="stream_compose_message_deleted">"मैसेज मिटाया गया"</string>
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
+  <string name="stream_compose_message_item_open_thread">"थ्रेड खोलें"</string>
+  <string name="stream_compose_message_item_options">"संदेश के विकल्प दिखाएँ"</string>
   <string name="stream_compose_message_list_auto_translated">"अनुवादित"</string>
   <string name="stream_compose_message_list_empty_messages">"कोई मैसेज नहीं"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"इस url को देखने के लिए कोई ऐप नहीं है:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -196,7 +196,10 @@
   <string name="stream_compose_message_list_show_translation">"अनुवाद दिखाएँ"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_replies">"%d जवाब"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_reply">"%d जवाब"</string>
-  <string name="stream_compose_message_list_unread_separator">"%d अपठित मैसेज"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d अपठित मैसेज"</item>
+    <item quantity="other">"%d अपठित मैसेज"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"असमर्थित अटैचमेंट"</string>
   <string name="stream_compose_message_list_view">"देखें"</string>
   <string name="stream_compose_message_list_view_original">"मूल देखें"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -184,6 +184,7 @@
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
   <string name="stream_compose_message_item_open_thread">"थ्रेड खोलें"</string>
   <string name="stream_compose_message_item_options">"संदेश के विकल्प दिखाएँ"</string>
+  <string name="stream_compose_message_attachment_open">"अटैचमेंट खोलें"</string>
   <string name="stream_compose_message_reactions_show">"प्रतिक्रियाएँ दिखाएँ"</string>
   <string name="stream_compose_message_list_auto_translated">"अनुवादित"</string>
   <string name="stream_compose_message_list_empty_messages">"कोई मैसेज नहीं"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -184,6 +184,7 @@
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
   <string name="stream_compose_message_item_open_thread">"थ्रेड खोलें"</string>
   <string name="stream_compose_message_item_options">"संदेश के विकल्प दिखाएँ"</string>
+  <string name="stream_compose_message_reactions_show">"प्रतिक्रियाएँ दिखाएँ"</string>
   <string name="stream_compose_message_list_auto_translated">"अनुवादित"</string>
   <string name="stream_compose_message_list_empty_messages">"कोई मैसेज नहीं"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"इस url को देखने के लिए कोई ऐप नहीं है:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
   <string name="stream_compose_message_item_open_thread">"Buka utas"</string>
   <string name="stream_compose_message_item_options">"Tampilkan opsi pesan"</string>
+  <string name="stream_compose_message_attachment_open">"Buka lampiran"</string>
   <string name="stream_compose_message_reactions_show">"Tampilkan reaksi"</string>
   <string name="stream_compose_message_list_auto_translated">"Diterjemahkan"</string>
   <string name="stream_compose_message_list_empty_messages">"Tidak ada pesan"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -124,6 +124,7 @@
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
   <string name="stream_compose_message_item_open_thread">"Buka utas"</string>
   <string name="stream_compose_message_item_options">"Tampilkan opsi pesan"</string>
+  <string name="stream_compose_message_reactions_show">"Tampilkan reaksi"</string>
   <string name="stream_compose_message_list_auto_translated">"Diterjemahkan"</string>
   <string name="stream_compose_message_list_empty_messages">"Tidak ada pesan"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Tidak ada aplikasi untuk membuka URL ini:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -59,7 +59,6 @@
   <string name="stream_compose_channel_item_muted">"dibisukan"</string>
   <string name="stream_compose_channel_item_open">"Buka percakapan"</string>
   <string name="stream_compose_channel_item_options">"Buka opsi percakapan"</string>
-  <string name="stream_compose_cd_message_item">"Item pesan"</string>
   <string name="stream_compose_cd_play_button">"Tombol putar"</string>
   <string name="stream_compose_channel_list_draft">"Draf: "</string>
   <string name="stream_compose_channel_list_empty_channels">"Belum ada percakapan"</string>
@@ -123,6 +122,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"diperluas"</string>
   <string name="stream_compose_message_deleted">"Pesan dihapus"</string>
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
+  <string name="stream_compose_message_item_open_thread">"Buka utas"</string>
+  <string name="stream_compose_message_item_options">"Tampilkan opsi pesan"</string>
   <string name="stream_compose_message_list_auto_translated">"Diterjemahkan"</string>
   <string name="stream_compose_message_list_empty_messages">"Tidak ada pesan"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Tidak ada aplikasi untuk membuka URL ini:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -136,7 +136,10 @@
   <string name="stream_compose_message_list_show_translation">"Tampilkan terjemahan"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_replies">"%d balasan"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_reply">"%d balasan"</string>
-  <string name="stream_compose_message_list_unread_separator">"%d pesan belum dibaca"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d pesan belum dibaca"</item>
+    <item quantity="other">"%d pesan belum dibaca"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"Lampiran tidak didukung"</string>
   <string name="stream_compose_message_list_view">"Lihat"</string>
   <string name="stream_compose_message_list_view_original">"Lihat aslinya"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -184,6 +184,7 @@
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
   <string name="stream_compose_message_item_open_thread">"Apri thread"</string>
   <string name="stream_compose_message_item_options">"Mostra opzioni messaggio"</string>
+  <string name="stream_compose_message_attachment_open">"Apri allegato"</string>
   <string name="stream_compose_message_reactions_show">"Mostra reazioni"</string>
   <string name="stream_compose_message_list_auto_translated">"Tradotto"</string>
   <string name="stream_compose_message_list_empty_messages">"Nessun messaggio"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -184,6 +184,7 @@
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
   <string name="stream_compose_message_item_open_thread">"Apri thread"</string>
   <string name="stream_compose_message_item_options">"Mostra opzioni messaggio"</string>
+  <string name="stream_compose_message_reactions_show">"Mostra reazioni"</string>
   <string name="stream_compose_message_list_auto_translated">"Tradotto"</string>
   <string name="stream_compose_message_list_empty_messages">"Nessun messaggio"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Nessuna app per aprire questo url:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -196,7 +196,10 @@
   <string name="stream_compose_message_list_show_translation">"Mostra traduzione"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_replies">"%d risposte"</string>
   <string name="stream_compose_message_list_thread_footnote_thread_reply">"%d risposta"</string>
-  <string name="stream_compose_message_list_unread_separator">"%d messaggi non letti"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d messaggio non letto"</item>
+    <item quantity="other">"%d messaggi non letti"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"Allegato non supportato"</string>
   <string name="stream_compose_message_list_view">"Visualizza"</string>
   <string name="stream_compose_message_list_view_original">"Vedi originale"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -119,7 +119,6 @@
   <string name="stream_compose_channel_item_muted">"silenziato"</string>
   <string name="stream_compose_channel_item_open">"Apri conversazione"</string>
   <string name="stream_compose_channel_item_options">"Apri opzioni conversazione"</string>
-  <string name="stream_compose_cd_message_item">"Elemento messaggio"</string>
   <string name="stream_compose_cd_play_button">"Pulsante riproduci"</string>
   <string name="stream_compose_channel_list_draft">"Bozza: "</string>
   <string name="stream_compose_channel_list_empty_channels">"Nessuna conversazione"</string>
@@ -183,6 +182,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"espanso"</string>
   <string name="stream_compose_message_deleted">"Messaggio cancellato"</string>
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
+  <string name="stream_compose_message_item_open_thread">"Apri thread"</string>
+  <string name="stream_compose_message_item_options">"Mostra opzioni messaggio"</string>
   <string name="stream_compose_message_list_auto_translated">"Tradotto"</string>
   <string name="stream_compose_message_list_empty_messages">"Nessun messaggio"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"Nessuna app per aprire questo url:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -136,6 +136,7 @@
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
   <string name="stream_compose_message_item_open_thread">"スレッドを開く"</string>
   <string name="stream_compose_message_item_options">"メッセージのオプションを表示"</string>
+  <string name="stream_compose_message_reactions_show">"リアクションを表示"</string>
   <string name="stream_compose_message_list_auto_translated">"翻訳済み"</string>
   <string name="stream_compose_message_list_empty_messages">"メッセージはありません"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"このURLを開くアプリがありません:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -136,6 +136,7 @@
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
   <string name="stream_compose_message_item_open_thread">"スレッドを開く"</string>
   <string name="stream_compose_message_item_options">"メッセージのオプションを表示"</string>
+  <string name="stream_compose_message_attachment_open">"添付ファイルを開く"</string>
   <string name="stream_compose_message_reactions_show">"リアクションを表示"</string>
   <string name="stream_compose_message_list_auto_translated">"翻訳済み"</string>
   <string name="stream_compose_message_list_empty_messages">"メッセージはありません"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -59,7 +59,6 @@
   <string name="stream_compose_channel_item_muted">"ミュート中"</string>
   <string name="stream_compose_channel_item_open">"会話を開く"</string>
   <string name="stream_compose_channel_item_options">"会話のオプションを開く"</string>
-  <string name="stream_compose_cd_message_item">"メッセージ項目"</string>
   <string name="stream_compose_cd_play_button">"再生ボタン"</string>
   <string name="stream_compose_channel_list_draft">"下書き: "</string>
   <string name="stream_compose_channel_list_empty_channels">"会話はまだありません"</string>
@@ -135,6 +134,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"展開"</string>
   <string name="stream_compose_message_deleted">"メッセージは削除されました"</string>
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
+  <string name="stream_compose_message_item_open_thread">"スレッドを開く"</string>
+  <string name="stream_compose_message_item_options">"メッセージのオプションを表示"</string>
   <string name="stream_compose_message_list_auto_translated">"翻訳済み"</string>
   <string name="stream_compose_message_list_empty_messages">"メッセージはありません"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"このURLを開くアプリがありません:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -151,7 +151,10 @@
   <plurals name="stream_compose_message_list_thread_separator">
     <item quantity="other">"%d件の返信"</item>
   </plurals>
-  <string name="stream_compose_message_list_unread_separator">"%d件の未読メッセージ"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d件の未読メッセージ"</item>
+    <item quantity="other">"%d件の未読メッセージ"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"サポートされていない添付ファイル"</string>
   <string name="stream_compose_message_list_view">"表示"</string>
   <string name="stream_compose_message_list_view_original">"原文を表示"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -136,6 +136,7 @@
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_item_open_thread">"스레드 열기"</string>
   <string name="stream_compose_message_item_options">"메시지 옵션 표시"</string>
+  <string name="stream_compose_message_reactions_show">"반응 보기"</string>
   <string name="stream_compose_message_list_auto_translated">"번역됨"</string>
   <string name="stream_compose_message_list_empty_messages">"메시지 없음"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"이 URL을 열 수 있는 앱이 없습니다:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -151,7 +151,10 @@
   <plurals name="stream_compose_message_list_thread_separator">
     <item quantity="other">"%d개의 답장"</item>
   </plurals>
-  <string name="stream_compose_message_list_unread_separator">"%d개의 읽지 않은 메시지"</string>
+  <plurals name="stream_compose_message_list_unread_separator">
+    <item quantity="one">"%d개의 읽지 않은 메시지"</item>
+    <item quantity="other">"%d개의 읽지 않은 메시지"</item>
+  </plurals>
   <string name="stream_compose_message_list_unsupported_attachment">"지원되지 않는 첨부파일"</string>
   <string name="stream_compose_message_list_view">"보기"</string>
   <string name="stream_compose_message_list_view_original">"원문 보기"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -59,7 +59,6 @@
   <string name="stream_compose_channel_item_muted">"음소거됨"</string>
   <string name="stream_compose_channel_item_open">"대화 열기"</string>
   <string name="stream_compose_channel_item_options">"대화 옵션 열기"</string>
-  <string name="stream_compose_cd_message_item">"메시지 항목"</string>
   <string name="stream_compose_cd_play_button">"재생 버튼"</string>
   <string name="stream_compose_channel_list_draft">"임시 저장: "</string>
   <string name="stream_compose_channel_list_empty_channels">"아직 대화가 없습니다"</string>
@@ -135,6 +134,8 @@
   <string name="stream_compose_message_composer_attachments_expanded">"확장됨"</string>
   <string name="stream_compose_message_deleted">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
+  <string name="stream_compose_message_item_open_thread">"스레드 열기"</string>
+  <string name="stream_compose_message_item_options">"메시지 옵션 표시"</string>
   <string name="stream_compose_message_list_auto_translated">"번역됨"</string>
   <string name="stream_compose_message_list_empty_messages">"메시지 없음"</string>
   <string name="stream_compose_message_list_error_cannot_open_link">"이 URL을 열 수 있는 앱이 없습니다:\n%s"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -136,6 +136,7 @@
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_item_open_thread">"스레드 열기"</string>
   <string name="stream_compose_message_item_options">"메시지 옵션 표시"</string>
+  <string name="stream_compose_message_attachment_open">"첨부파일 열기"</string>
   <string name="stream_compose_message_reactions_show">"반응 보기"</string>
   <string name="stream_compose_message_list_auto_translated">"번역됨"</string>
   <string name="stream_compose_message_list_empty_messages">"메시지 없음"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -104,6 +104,8 @@
     <string name="stream_compose_message_list_error_cannot_open_link">There is no app to view this url:\n%s</string>
     <string name="stream_compose_message_list_unsupported_attachment">Unsupported attachment</string>
     <string name="stream_compose_message_list_show_translation">Show translation</string>
+    <string name="stream_compose_message_item_open_thread">Open thread</string>
+    <string name="stream_compose_message_item_options">Show message options</string>
 
     <!--  Quoted Message  -->
     <string name="stream_compose_quoted_message_audio_recording">Voice message (%s)</string>
@@ -295,7 +297,6 @@
         <item quantity="one">%d unread message</item>
         <item quantity="other">%d unread messages</item>
     </plurals>
-    <string name="stream_compose_cd_message_item">Message item</string>
     <string name="stream_compose_cd_play_button">Play button</string>
 
     <!--  Poll  -->

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -109,6 +109,7 @@
     <string name="stream_compose_message_list_show_translation">Show translation</string>
     <string name="stream_compose_message_item_open_thread">Open thread</string>
     <string name="stream_compose_message_item_options">Show message options</string>
+    <string name="stream_compose_message_reactions_show">Show reactions</string>
 
     <!--  Quoted Message  -->
     <string name="stream_compose_quoted_message_audio_recording">Voice message (%s)</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -99,7 +99,10 @@
         <item quantity="one">%d Reply</item>
         <item quantity="other">%d Replies</item>
     </plurals>
-    <string name="stream_compose_message_list_unread_separator">%d unread messages</string>
+    <plurals name="stream_compose_message_list_unread_separator">
+        <item quantity="one">%d unread message</item>
+        <item quantity="other">%d unread messages</item>
+    </plurals>
     <string name="stream_compose_message_list_empty_messages">No messages</string>
     <string name="stream_compose_message_list_error_cannot_open_link">There is no app to view this url:\n%s</string>
     <string name="stream_compose_message_list_unsupported_attachment">Unsupported attachment</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -110,6 +110,7 @@
     <string name="stream_compose_message_item_open_thread">Open thread</string>
     <string name="stream_compose_message_item_options">Show message options</string>
     <string name="stream_compose_message_reactions_show">Show reactions</string>
+    <string name="stream_compose_message_attachment_open">Open attachment</string>
 
     <!--  Quoted Message  -->
     <string name="stream_compose_quoted_message_audio_recording">Voice message (%s)</string>


### PR DESCRIPTION
### Goal

Resolve TalkBack accessibility gaps on the Compose message list (channel screen, threads screen). Issues a screen-reader user hits today:

1. Every message row announces as a generic *"Message item, …"*, **the sender name is silently hidden** (a `clearAndSetSemantics` wrapper kept only the testTag), and tap/long-press hints have no verb.
2. Date separators (*"Today"*, *"Yesterday"*) and the unread divider are plain text — TalkBack's swipe-by-heading gesture skips them. The unread divider also renders *"1 unread messages"* for `n = 1` (no `<plurals>`).
3. The typing indicator is visual-only (avatars + animated dots). TalkBack picks nothing up — no focus, no announcement when someone starts typing.
4. Reactions: the long-press reaction picker shows a checked background for the user's own reactions but exposes no role or selected state, so a TalkBack user can't tell which reactions they already chose. In-bubble reaction chips have no action verb.
5. Image / video / file / link attachments announce *"double-tap to activate"* — no concrete verb for the action.

### Implementation

Five self-contained commits, each scoped to one concern:

1. **`Make message rows accessible to TalkBack`** — drop the static *"Message item"* placeholder on the outer `Row`; `combinedClickable` gains `onClickLabel = "Open thread"` (when `canOpenThread`) and `onLongClickLabel = "Show message options"` (when `canOpenActions`). `MessageFooter` sender-name `Text` drops its destructive `clearAndSetSemantics { testTag = … }` for `Modifier.testTag(…)` so the user name is spoken again. Drops the orphaned `stream_compose_cd_message_item` placeholder across all 8 locales.
2. **`Make message list separators accessible as headings`** — add `Modifier.semantics { heading() }` to both the date and unread separators in `DefaultMessageDateSeparatorContent` / `DefaultMessageUnreadSeparatorContent`. Convert `stream_compose_message_list_unread_separator` from `<string>` to `<plurals>` across all 8 locales so n=1 reads as a singular.
3. **`Announce typing indicator to TalkBack`** — wrap the indicator row in a polite live region with a localized description (*"X is typing"* / *"X and Y are typing"* / *"N people are typing"*, reusing the existing `stream_compose_channel_list_typing_*` strings). The description is built by a small private helper to keep the composable under the method-length cap.
4. **`Announce reaction state to TalkBack`** — `ReactionToggle` (the picker tile) swaps `Modifier.clickable { onChange(!checked) }` for `Modifier.toggleable(value = checked, role = Role.Switch, onValueChange = onChange)` so TalkBack announces the emoji plus *"switch, on / off, double-tap to toggle"*. In-bubble reactions get `onClickLabel = "Show reactions"` on both `ClusteredMessageReactions` and per-chip `ReactionChip` clickables.
5. **`Label message attachment tap action for TalkBack`** — add `onClickLabel = "Open attachment"` to the `combinedClickable` on `MediaAttachmentContent`, `FileAttachmentContent`, and `LinkAttachmentContent`.

All four new strings (`stream_compose_message_item_open_thread`, `stream_compose_message_item_options`, `stream_compose_message_reactions_show`, `stream_compose_message_attachment_open`) ship with translations for the 7 supported locales (es, fr, hi, in, it, ja, ko). No public API surface changes (apiDump clean).

### Testing

Manual steps on the Compose sample with **TalkBack ON** and **Settings → Accessibility → TalkBack → Verbosity → Speak usage hints** enabled. Open any group channel with a mix of messages.

1. **Row announcement** — focus an incoming text message in a group channel. TalkBack should announce *"<sender>, <message text>, <timestamp>, <reactions if any>, button, double-tap to Open thread (or activate), double-tap and hold to Show message options"*. Confirm the **sender name is read** for both regular and threaded messages. The previous *"Message item, …"* prefix should be gone.
2. **Read receipt** — focus your own outgoing message. TalkBack should announce the read-receipt status (*"Read"* / *"Delivered"* / *"Sent"*) instead of just timestamp.
3. **Deleted message** — focus a deleted message. TalkBack should announce *"<sender>, message deleted, …, disabled"* — no spurious thread/options hints.
4. **Date separator** — focus a date separator (*"Today"*, *"Yesterday"*). TalkBack should append *"heading"* to the announcement. With reading control set to "Headings", swipe down/up should jump between date separators (skipping messages).
5. **Unread separator** — scroll to a position with exactly **one** unread message below it. The separator should announce *"1 unread message, heading"* (singular). Repeat with multiple unread to confirm the plural form.
6. **Typing indicator** — have someone start typing from another device (or another sample-app session). With TalkBack on, the bubble should announce *"<name> is typing"* automatically when it appears, without you needing to focus it. Repeat with 2 and 3+ typing users.
7. **Reactions — in bubble** — focus a message that has reactions. The reactions row reads *"N reactions"*. Focus an individual reaction pill: TalkBack should say *"<emoji>, double-tap to Show reactions"*.
8. **Reactions — long-press picker** — long-press a message, focus a reaction tile in the picker. TalkBack should announce *"<emoji>, switch, off, double-tap to toggle"*. Toggle the reaction on and refocus: the state should now be *"on"*.
9. **Attachments** — focus an image, video, file, and link preview in turn. Each should announce its existing type/filename followed by *"double-tap to Open attachment"* (previously *"double-tap to activate"*).
10. **Localization** — repeat steps 1, 7, 8, and 9 with the device language set to one of: Spanish, French, Hindi, Indonesian, Italian, Japanese, or Korean. The new labels should be translated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility with descriptive action labels for opening attachments, message reactions, and thread interactions.
  * Improved pluralization support for unread message counts across multiple languages.

* **Localization**
  * Updated string resources and translations in Spanish, French, Hindi, Indonesian, Italian, Japanese, and Korean.

* **Improvements**
  * Refined message list item semantics and typing indicator descriptions for better screen reader support.
  * Simplified message author name test tag implementation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6440)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->