### PR TITLE
Allow voters to add poll comments in UI Components

### DIFF
--- a/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
+++ b/stream-chat-android-core/src/testFixtures/kotlin/io/getstream/chat/android/Mother.kt
@@ -917,6 +917,22 @@ public fun randomOption(
     text = text,
 )
 
+public fun randomVote(
+    id: String = randomString(),
+    pollId: String = randomString(),
+    optionId: String = randomString(),
+    createdAt: Date = randomDate(),
+    updatedAt: Date = randomDate(),
+    user: User? = randomUser(),
+): Vote = Vote(
+    id = id,
+    pollId = pollId,
+    optionId = optionId,
+    createdAt = createdAt,
+    updatedAt = updatedAt,
+    user = user,
+)
+
 public fun randomPollOption(
     id: String? = randomString(),
     text: String = randomString(),

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -3252,6 +3252,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/vi
 
 public final class io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
 	public fun <init> (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;)V
+	public synthetic fun <init> (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component11 ()Lio/getstream/chat/android/ui/font/TextStyle;

--- a/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
+++ b/stream-chat-android-ui-components/api/stream-chat-android-ui-components.api
@@ -2338,6 +2338,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun setModeratedMessageHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ModeratedMessageOptionHandler;)V
 	public final fun setModeratedMessageLongClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$ModeratedMessageLongClickListener;)V
 	public final fun setNewMessagesBehaviour (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;)V
+	public final fun setOnAddPollCommentClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAddPollCommentClickListener;)V
 	public final fun setOnAttachmentClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAttachmentClickListener;)V
 	public final fun setOnAttachmentDownloadClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAttachmentDownloadClickListener;)V
 	public final fun setOnEnterThreadListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnEnterThreadListener;)V
@@ -2359,6 +2360,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public final fun setOnUnreadLabelReachedListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUnreadLabelReachedListener;)V
 	public final fun setOnUserClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUserClickListener;)V
 	public final fun setOnUserReactionClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUserReactionClickListener;)V
+	public final fun setOnViewPollCommentsClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollCommentsClickListener;)V
 	public final fun setOnViewPollResultClickListener (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollResultClickListener;)V
 	public final fun setOpenThreadHandler (Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OpenThreadHandler;)V
 	public final fun setOwnCapabilities (Ljava/util/Set;)V
@@ -2533,6 +2535,10 @@ public final class io/getstream/chat/android/ui/feature/messages/list/MessageLis
 	public static fun values ()[Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$NewMessagesBehaviour;
 }
 
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAddPollCommentClickListener {
+	public abstract fun onAddPollCommentClick (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Poll;)Z
+}
+
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAttachmentClickListener {
 	public abstract fun onAttachmentClick (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Attachment;)Z
 }
@@ -2627,6 +2633,10 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnUserReactionClickListener {
 	public abstract fun onUserReactionClick (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/User;Lio/getstream/chat/android/models/Reaction;)Z
+}
+
+public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollCommentsClickListener {
+	public abstract fun onViewPollCommentsClick (Lio/getstream/chat/android/models/Message;Lio/getstream/chat/android/models/Poll;)Z
 }
 
 public abstract interface class io/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollResultClickListener {
@@ -3155,10 +3165,12 @@ public abstract interface class io/getstream/chat/android/ui/feature/messages/li
 	public abstract fun getMessageClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnMessageClickListener;
 	public abstract fun getMessageLongClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnMessageLongClickListener;
 	public abstract fun getMessageRetryListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnMessageRetryListener;
+	public abstract fun getOnAddPollCommentClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnAddPollCommentClickListener;
 	public abstract fun getOnPollCloseClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnPollCloseClickListener;
 	public abstract fun getOnPollOptionClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnPollOptionClickListener;
 	public abstract fun getOnShowAllPollOptionClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnShowAllPollOptionClickListener;
 	public abstract fun getOnSuggestPollOptionClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnSuggestPollOptionClickListener;
+	public abstract fun getOnViewPollCommentsClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollCommentsClickListener;
 	public abstract fun getOnViewPollResultClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnViewPollResultClickListener;
 	public abstract fun getReactionViewClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnReactionViewClickListener;
 	public abstract fun getThreadClickListener ()Lio/getstream/chat/android/ui/feature/messages/list/MessageListView$OnThreadClickListener;
@@ -3239,8 +3251,10 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/vi
 }
 
 public final class io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle : io/getstream/chat/android/ui/helper/ViewStyle {
-	public fun <init> (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;)V
+	public fun <init> (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;)V
 	public final fun component1 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component10 ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun component11 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component2 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component3 ()Landroid/graphics/drawable/Drawable;
 	public final fun component4 ()Lio/getstream/chat/android/ui/font/TextStyle;
@@ -3249,9 +3263,10 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/vi
 	public final fun component7 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component8 ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun component9 ()Lio/getstream/chat/android/ui/font/TextStyle;
-	public final fun copy (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;
+	public final fun copy (Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Landroid/graphics/drawable/Drawable;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;Lio/getstream/chat/android/ui/font/TextStyle;ILjava/lang/Object;)Lio/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPollAddCommentTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getPollCloseTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getPollOptionCheckDrawable ()Landroid/graphics/drawable/Drawable;
 	public final fun getPollOptionTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
@@ -3261,6 +3276,7 @@ public final class io/getstream/chat/android/ui/feature/messages/list/adapter/vi
 	public final fun getPollSubtitleTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getPollSuggestOptionTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public final fun getPollTitleTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
+	public final fun getPollViewCommentsTextStyle ()Lio/getstream/chat/android/ui/font/TextStyle;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -4986,6 +5002,21 @@ public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListVi
 	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PinMessage;Lio/getstream/chat/android/models/Message;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PinMessage;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PollAnswerCast : io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PollAnswerCast;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PollAnswerCast;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel$Event$PollAnswerCast;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnswer ()Ljava/lang/String;
+	public final fun getMessageId ()Ljava/lang/String;
+	public final fun getPollId ()Ljava/lang/String;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -2381,14 +2381,23 @@ public class MessageListView : ConstraintLayout {
         public fun onViewPollResultClick(poll: Poll): Boolean
     }
 
+    /**
+     * Listener for clicks on the "Suggest an option" button of a poll that allows user-suggested options.
+     */
     public fun interface OnSuggestPollOptionClickListener {
         public fun onSuggestPollOptionClick(poll: Poll): Boolean
     }
 
+    /**
+     * Listener for clicks on the "Add a comment" button of a poll that allows answers.
+     */
     public fun interface OnAddPollCommentClickListener {
         public fun onAddPollCommentClick(message: Message, poll: Poll): Boolean
     }
 
+    /**
+     * Listener for clicks on the "View comments" button of a poll that has answers.
+     */
     public fun interface OnViewPollCommentsClickListener {
         public fun onViewPollCommentsClick(message: Message, poll: Poll): Boolean
     }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/MessageListView.kt
@@ -91,7 +91,9 @@ import io.getstream.chat.android.ui.feature.messages.list.internal.HiddenMessage
 import io.getstream.chat.android.ui.feature.messages.list.internal.MessageListScrollHelper
 import io.getstream.chat.android.ui.feature.messages.list.internal.SwipeReplyCallback
 import io.getstream.chat.android.ui.feature.messages.list.internal.canReplyToMessage
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment
 import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AllPollOptionsDialogFragment
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.PollCommentsDialogFragment
 import io.getstream.chat.android.ui.feature.messages.list.internal.poll.PollResultsDialogFragment
 import io.getstream.chat.android.ui.feature.messages.list.internal.poll.SuggestPollOptionDialogFragment
 import io.getstream.chat.android.ui.feature.messages.list.options.message.MessageOptionItem
@@ -623,6 +625,21 @@ public class MessageListView : ConstraintLayout {
             true
         } ?: false
     }
+    private val defaultOnAddPollCommentClickListener = OnAddPollCommentClickListener { message, poll ->
+        context.getFragmentManager()?.let { fragmentManager ->
+            AddPollCommentDialogFragment.newInstance(messageId = message.id, pollId = poll.id)
+                .show(fragmentManager, AddPollCommentDialogFragment.TAG)
+            true
+        } ?: false
+    }
+    private val defaultOnViewPollCommentsClickListener = OnViewPollCommentsClickListener { message, _ ->
+        context.getFragmentManager()?.let { fragmentManager ->
+            PollCommentsDialogFragment
+                .newInstance(cid = message.cid, messageId = message.id)
+                .show(fragmentManager, PollCommentsDialogFragment.TAG)
+            true
+        } ?: false
+    }
 
     private val listenerContainer = MessageListListenerContainerImpl(
         messageClickListener = defaultMessageClickListener,
@@ -641,6 +658,8 @@ public class MessageListView : ConstraintLayout {
         onPollCloseClickListener = defaultOnPollCloseClickListener,
         onViewPollResultClickListener = defaultOnViewPollResultClickListener,
         onSuggestPollOptionClickListener = defaultOnSuggestPollOptionClickListener,
+        onAddPollCommentClickListener = defaultOnAddPollCommentClickListener,
+        onViewPollCommentsClickListener = defaultOnViewPollCommentsClickListener,
     )
     private var enterThreadListener = defaultEnterThreadListener
     private var userReactionClickListener = defaultUserReactionClickListener
@@ -1453,6 +1472,34 @@ public class MessageListView : ConstraintLayout {
                 defaultOnSuggestPollOptionClickListener
             } else {
                 OnSuggestPollOptionClickListener(listener::onSuggestPollOptionClick)
+            }
+    }
+
+    /**
+     * Set the Add Poll Comment click listener to be used by MessageListView.
+     *
+     * @param listener The listener to use. If null, the default will be used instead.
+     */
+    public fun setOnAddPollCommentClickListener(listener: OnAddPollCommentClickListener?) {
+        listenerContainer.onAddPollCommentClickListener =
+            if (listener == null) {
+                defaultOnAddPollCommentClickListener
+            } else {
+                OnAddPollCommentClickListener(listener::onAddPollCommentClick)
+            }
+    }
+
+    /**
+     * Set the View Poll Comments click listener to be used by MessageListView.
+     *
+     * @param listener The listener to use. If null, the default will be used instead.
+     */
+    public fun setOnViewPollCommentsClickListener(listener: OnViewPollCommentsClickListener?) {
+        listenerContainer.onViewPollCommentsClickListener =
+            if (listener == null) {
+                defaultOnViewPollCommentsClickListener
+            } else {
+                OnViewPollCommentsClickListener(listener::onViewPollCommentsClick)
             }
     }
 
@@ -2336,6 +2383,14 @@ public class MessageListView : ConstraintLayout {
 
     public fun interface OnSuggestPollOptionClickListener {
         public fun onSuggestPollOptionClick(poll: Poll): Boolean
+    }
+
+    public fun interface OnAddPollCommentClickListener {
+        public fun onAddPollCommentClick(message: Message, poll: Poll): Boolean
+    }
+
+    public fun interface OnViewPollCommentsClickListener {
+        public fun onViewPollCommentsClick(message: Message, poll: Poll): Boolean
     }
 
     @Deprecated(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainer.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainer.kt
@@ -23,6 +23,7 @@ import io.getstream.chat.android.ui.feature.messages.list.MessageListView.LinkCl
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.MessageClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.MessageLongClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.MessageRetryListener
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAddPollCommentClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAttachmentClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAttachmentDownloadClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnGiphySendListener
@@ -40,6 +41,7 @@ import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnThre
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnTranslatedLabelClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUnreadLabelReachedListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUserClickListener
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollCommentsClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollResultClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.ReactionViewClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.ThreadClickListener
@@ -82,6 +84,8 @@ public sealed interface MessageListListeners {
     public val onPollCloseClickListener: OnPollCloseClickListener
     public val onViewPollResultClickListener: OnViewPollResultClickListener
     public val onSuggestPollOptionClickListener: OnSuggestPollOptionClickListener
+    public val onAddPollCommentClickListener: OnAddPollCommentClickListener
+    public val onViewPollCommentsClickListener: OnViewPollCommentsClickListener
 }
 
 @Deprecated(

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainerImpl.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/MessageListListenerContainerImpl.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.chat.android.ui.feature.messages.list.adapter
 
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAddPollCommentClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAttachmentClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnAttachmentDownloadClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnGiphySendListener
@@ -33,9 +34,11 @@ import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnThre
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnTranslatedLabelClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUnreadLabelReachedListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnUserClickListener
+import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollCommentsClickListener
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView.OnViewPollResultClickListener
 import io.getstream.chat.android.ui.utils.ListenerDelegate
 
+@Suppress("LongParameterList")
 internal class MessageListListenerContainerImpl(
     messageClickListener: OnMessageClickListener = OnMessageClickListener(EmptyFunctions.ONE_PARAM),
     messageLongClickListener: OnMessageLongClickListener = OnMessageLongClickListener(EmptyFunctions.ONE_PARAM),
@@ -59,6 +62,8 @@ internal class MessageListListenerContainerImpl(
     onPollCloseClickListener: OnPollCloseClickListener,
     onViewPollResultClickListener: OnViewPollResultClickListener,
     onSuggestPollOptionClickListener: OnSuggestPollOptionClickListener,
+    onAddPollCommentClickListener: OnAddPollCommentClickListener,
+    onViewPollCommentsClickListener: OnViewPollCommentsClickListener,
 ) : MessageListListeners {
     private object EmptyFunctions {
         val ONE_PARAM: (Any) -> Boolean = { _ -> false }
@@ -206,6 +211,22 @@ internal class MessageListListenerContainerImpl(
     ) { realListener ->
         OnSuggestPollOptionClickListener { poll ->
             realListener().onSuggestPollOptionClick(poll)
+        }
+    }
+
+    override var onAddPollCommentClickListener: OnAddPollCommentClickListener by ListenerDelegate(
+        onAddPollCommentClickListener,
+    ) { realListener ->
+        OnAddPollCommentClickListener { message, poll ->
+            realListener().onAddPollCommentClick(message, poll)
+        }
+    }
+
+    override var onViewPollCommentsClickListener: OnViewPollCommentsClickListener by ListenerDelegate(
+        onViewPollCommentsClickListener,
+    ) { realListener ->
+        OnViewPollCommentsClickListener { message, poll ->
+            realListener().onViewPollCommentsClick(message, poll)
         }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle.kt
@@ -39,6 +39,8 @@ public data class PollViewStyle(
     public val pollResultsTextStyle: TextStyle,
     public val pollShowAllOptionsTextStyle: TextStyle,
     public val pollSuggestOptionTextStyle: TextStyle,
+    public val pollAddCommentTextStyle: TextStyle,
+    public val pollViewCommentsTextStyle: TextStyle,
 ) : ViewStyle {
 
     internal companion object {
@@ -204,6 +206,44 @@ public data class PollViewStyle(
                         Typeface.NORMAL,
                     )
                     .build()
+
+                val pollAddCommentTextStyle = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.PollView_streamUiPollAddCommentTextSize,
+                        context.getDimension(R.dimen.stream_ui_text_large),
+                    )
+                    .color(
+                        R.styleable.PollView_streamUiPollAddCommentTextColor,
+                        context.getColorCompat(R.color.stream_ui_accent_blue),
+                    )
+                    .font(
+                        R.styleable.PollView_streamUiPollAddCommentFontAssets,
+                        R.styleable.PollView_streamUiPollAddCommentTextFont,
+                    )
+                    .style(
+                        R.styleable.PollView_streamUiPollAddCommentTextStyle,
+                        Typeface.NORMAL,
+                    )
+                    .build()
+
+                val pollViewCommentsTextStyle = TextStyle.Builder(a)
+                    .size(
+                        R.styleable.PollView_streamUiPollViewCommentsTextSize,
+                        context.getDimension(R.dimen.stream_ui_text_large),
+                    )
+                    .color(
+                        R.styleable.PollView_streamUiPollViewCommentsTextColor,
+                        context.getColorCompat(R.color.stream_ui_accent_blue),
+                    )
+                    .font(
+                        R.styleable.PollView_streamUiPollViewCommentsFontAssets,
+                        R.styleable.PollView_streamUiPollViewCommentsTextFont,
+                    )
+                    .style(
+                        R.styleable.PollView_streamUiPollViewCommentsTextStyle,
+                        Typeface.NORMAL,
+                    )
+                    .build()
                 return PollViewStyle(
                     pollTitleTextStyle = pollTitleTextStyle,
                     pollSubtitleTextStyle = pollSubtitleTextStyle,
@@ -214,6 +254,8 @@ public data class PollViewStyle(
                     pollResultsTextStyle = pollResultsTextStyle,
                     pollShowAllOptionsTextStyle = pollShowAllOptionsTextStyle,
                     pollSuggestOptionTextStyle = pollSuggestOptionTextStyle,
+                    pollAddCommentTextStyle = pollAddCommentTextStyle,
+                    pollViewCommentsTextStyle = pollViewCommentsTextStyle,
                 ).let(TransformStyle.pollViewStyleTransformer::transform)
             }
         }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/PollViewStyle.kt
@@ -39,8 +39,8 @@ public data class PollViewStyle(
     public val pollResultsTextStyle: TextStyle,
     public val pollShowAllOptionsTextStyle: TextStyle,
     public val pollSuggestOptionTextStyle: TextStyle,
-    public val pollAddCommentTextStyle: TextStyle,
-    public val pollViewCommentsTextStyle: TextStyle,
+    public val pollAddCommentTextStyle: TextStyle = TextStyle(),
+    public val pollViewCommentsTextStyle: TextStyle = TextStyle(),
 ) : ViewStyle {
 
     internal companion object {

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/PollView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/PollView.kt
@@ -34,12 +34,14 @@ import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.utils.PollsConstants
 import io.getstream.chat.android.ui.common.utils.extensions.getSubtitle
+import io.getstream.chat.android.ui.databinding.StreamUiItemPollAddCommentBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollAnswerBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollCloseBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollHeaderBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollResultsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollShowAllOptionsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollSuggestOptionBinding
+import io.getstream.chat.android.ui.databinding.StreamUiItemPollViewCommentsBinding
 import io.getstream.chat.android.ui.feature.messages.list.adapter.view.PollViewStyle
 import io.getstream.chat.android.ui.font.setTextStyle
 import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
@@ -58,6 +60,8 @@ internal class PollView : RecyclerView {
     var onViewPollResultsClick: ((Poll) -> Unit) = { _ -> }
     var onShowAllPollOptionClick: (() -> Unit) = { }
     var onSuggestOptionClick: ((Poll) -> Unit) = { _ -> }
+    var onAddCommentClick: ((Poll) -> Unit) = { _ -> }
+    var onViewCommentsClick: ((Poll) -> Unit) = { _ -> }
 
     constructor(context: Context) : this(context, null, 0)
 
@@ -90,6 +94,8 @@ internal class PollView : RecyclerView {
                 onViewPollResultsClick = { onViewPollResultsClick(poll) },
                 onShowAllOptionsClick = { onShowAllPollOptionClick() },
                 onSuggestOptionClick = { onSuggestOptionClick(poll) },
+                onAddCommentClick = { onAddCommentClick(poll) },
+                onViewCommentsClick = { onViewCommentsClick(poll) },
             )
             adapter = pollAdapter
         }
@@ -127,6 +133,13 @@ internal class PollView : RecyclerView {
         PollItem.SuggestOption.takeIf { poll.allowUserSuggestedOptions && !poll.closed }
             ?.let(pollItems::add)
 
+        PollItem.AddComment.takeIf { poll.allowAnswers && poll.answers.isEmpty() && !poll.closed }
+            ?.let(pollItems::add)
+
+        PollItem.ViewComments(count = poll.answers.size)
+            .takeIf { poll.allowAnswers && poll.answers.isNotEmpty() }
+            ?.let(pollItems::add)
+
         pollItems.add(PollItem.ViewResults)
 
         PollItem.Close.takeIf { isMine && !poll.closed }
@@ -136,6 +149,7 @@ internal class PollView : RecyclerView {
     }
 }
 
+@Suppress("LongParameterList")
 private class PollAdapter(
     private val pollViewStyle: PollViewStyle,
     private val onOptionClick: (Option) -> Unit,
@@ -143,6 +157,8 @@ private class PollAdapter(
     private val onViewPollResultsClick: () -> Unit,
     private val onShowAllOptionsClick: () -> Unit,
     private val onSuggestOptionClick: () -> Unit,
+    private val onAddCommentClick: () -> Unit,
+    private val onViewCommentsClick: () -> Unit,
 ) : ListAdapter<PollItem, PollItemViewHolder<out PollItem>>(PollItemDiffCallback) {
 
     companion object {
@@ -152,6 +168,8 @@ private class PollAdapter(
         private const val VIEW_TYPE_RESULTS = 4
         private const val VIEW_TYPE_SHOW_ALL_OPTIONS = 5
         private const val VIEW_TYPE_SUGGEST_OPTION = 6
+        private const val VIEW_TYPE_ADD_COMMENT = 7
+        private const val VIEW_TYPE_VIEW_COMMENTS = 8
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): PollItemViewHolder<out PollItem> {
@@ -191,6 +209,18 @@ private class PollAdapter(
                 onSuggestOptionClick,
             )
 
+            VIEW_TYPE_ADD_COMMENT -> AddCommentViewHolder(
+                StreamUiItemPollAddCommentBinding.inflate(parent.streamThemeInflater, parent, false)
+                    .applyStyle(pollViewStyle),
+                onAddCommentClick,
+            )
+
+            VIEW_TYPE_VIEW_COMMENTS -> ViewCommentsViewHolder(
+                StreamUiItemPollViewCommentsBinding.inflate(parent.streamThemeInflater, parent, false)
+                    .applyStyle(pollViewStyle),
+                onViewCommentsClick,
+            )
+
             else -> throw IllegalArgumentException("Unknown view type: $viewType")
         }
     }
@@ -202,6 +232,8 @@ private class PollAdapter(
         PollItem.ViewResults -> VIEW_TYPE_RESULTS
         is PollItem.ShowAllOptions -> VIEW_TYPE_SHOW_ALL_OPTIONS
         PollItem.SuggestOption -> VIEW_TYPE_SUGGEST_OPTION
+        PollItem.AddComment -> VIEW_TYPE_ADD_COMMENT
+        is PollItem.ViewComments -> VIEW_TYPE_VIEW_COMMENTS
     }
 
     override fun onBindViewHolder(holder: PollItemViewHolder<out PollItem>, position: Int) {
@@ -240,6 +272,8 @@ private sealed class PollItem {
     data class ShowAllOptions(val count: Int) : PollItem()
     data object ViewResults : PollItem()
     data object SuggestOption : PollItem()
+    data object AddComment : PollItem()
+    data class ViewComments(val count: Int) : PollItem()
 }
 
 private sealed class PollItemViewHolder<T : PollItem>(binding: ViewBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -359,6 +393,29 @@ private class SuggestOptionViewHolder(
     }
 }
 
+private class AddCommentViewHolder(
+    private val binding: StreamUiItemPollAddCommentBinding,
+    private val onAddCommentClick: () -> Unit,
+) : PollItemViewHolder<PollItem.AddComment>(binding) {
+    override fun bind(pollItem: PollItem.AddComment) {
+        binding.root.setOnClickListener { onAddCommentClick() }
+    }
+}
+
+private class ViewCommentsViewHolder(
+    private val binding: StreamUiItemPollViewCommentsBinding,
+    private val onViewCommentsClick: () -> Unit,
+) : PollItemViewHolder<PollItem.ViewComments>(binding) {
+    override fun bind(pollItem: PollItem.ViewComments) {
+        binding.pollViewComments.text = binding.root.resources.getQuantityString(
+            R.plurals.stream_ui_poll_action_view_comments,
+            pollItem.count,
+            pollItem.count,
+        )
+        binding.root.setOnClickListener { onViewCommentsClick() }
+    }
+}
+
 private fun StreamUiItemPollHeaderBinding.applyStyle(style: PollViewStyle) = this.apply {
     title.setTextStyle(style.pollTitleTextStyle)
     subtitle.setTextStyle(style.pollSubtitleTextStyle)
@@ -384,4 +441,12 @@ private fun StreamUiItemPollShowAllOptionsBinding.applyStyle(style: PollViewStyl
 
 private fun StreamUiItemPollSuggestOptionBinding.applyStyle(style: PollViewStyle) = this.apply {
     pollSuggestOption.setTextStyle(style.pollSuggestOptionTextStyle)
+}
+
+private fun StreamUiItemPollAddCommentBinding.applyStyle(style: PollViewStyle) = this.apply {
+    pollAddComment.setTextStyle(style.pollAddCommentTextStyle)
+}
+
+private fun StreamUiItemPollViewCommentsBinding.applyStyle(style: PollViewStyle) = this.apply {
+    pollViewComments.setTextStyle(style.pollViewCommentsTextStyle)
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/PollViewHolder.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/viewholder/impl/PollViewHolder.kt
@@ -59,6 +59,12 @@ public class PollViewHolder(
                 binding.pollView.onSuggestOptionClick = {
                     messageListListeners?.onSuggestPollOptionClickListener?.onSuggestPollOptionClick(poll)
                 }
+                binding.pollView.onAddCommentClick = {
+                    messageListListeners?.onAddPollCommentClickListener?.onAddPollCommentClick(data.message, poll)
+                }
+                binding.pollView.onViewCommentsClick = {
+                    messageListListeners?.onViewPollCommentsClickListener?.onViewPollCommentsClick(data.message, poll)
+                }
             }
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AddPollCommentDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AddPollCommentDialogFragment.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.feature.messages.list.internal.poll
+
+import android.app.Dialog
+import android.os.Bundle
+import android.view.WindowManager
+import androidx.appcompat.app.AlertDialog
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.os.bundleOf
+import androidx.core.widget.doAfterTextChanged
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.databinding.StreamUiDialogAddPollCommentBinding
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment.Companion.BUNDLE_KEY_ANSWER
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment.Companion.BUNDLE_KEY_MESSAGE_ID
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment.Companion.BUNDLE_KEY_POLL_ID
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment.Companion.REQUEST_KEY
+import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
+import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
+
+/**
+ * Dialog that lets a voter add (or edit) a free-text comment / answer on a poll.
+ *
+ * Delivers the entered comment via the fragment-result API under [REQUEST_KEY], with
+ * the message id in [BUNDLE_KEY_MESSAGE_ID], the poll id in [BUNDLE_KEY_POLL_ID],
+ * and the trimmed answer in [BUNDLE_KEY_ANSWER].
+ */
+internal class AddPollCommentDialogFragment : AppCompatDialogFragment() {
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val args = requireArguments()
+        val messageId = args.getString(ARG_MESSAGE_ID) ?: error("Message ID not found in arguments")
+        val pollId = args.getString(ARG_POLL_ID) ?: error("Poll ID not found in arguments")
+        val initialText = args.getString(ARG_INITIAL_TEXT)
+
+        val binding = StreamUiDialogAddPollCommentBinding.inflate(requireContext().streamThemeInflater)
+        if (savedInstanceState == null && !initialText.isNullOrEmpty()) {
+            binding.answerInput.setText(initialText)
+            binding.answerInput.setSelection(initialText.length)
+        }
+
+        val titleRes = if (initialText.isNullOrEmpty()) {
+            R.string.stream_ui_poll_add_a_comment_label
+        } else {
+            R.string.stream_ui_poll_update_comment_label
+        }
+
+        val dialog = AlertDialog.Builder(requireContext().createStreamThemeWrapper())
+            .setTitle(titleRes)
+            .setView(binding.root)
+            .setPositiveButton(R.string.stream_ui_poll_add_comment_dialog_submit) { _, _ ->
+                val text = binding.answerInput.text?.toString()?.trim().orEmpty()
+                if (text.isNotEmpty()) {
+                    parentFragmentManager.setFragmentResult(
+                        REQUEST_KEY,
+                        bundleOf(
+                            BUNDLE_KEY_MESSAGE_ID to messageId,
+                            BUNDLE_KEY_POLL_ID to pollId,
+                            BUNDLE_KEY_ANSWER to text,
+                        ),
+                    )
+                }
+            }
+            .setNegativeButton(R.string.stream_ui_poll_add_comment_dialog_cancel, null)
+            .create()
+
+        dialog.setOnShowListener {
+            val confirm = dialog.getButton(AlertDialog.BUTTON_POSITIVE)
+            confirm.isEnabled = binding.answerInput.text?.toString()?.trim()?.isNotEmpty() == true
+            binding.answerInput.doAfterTextChanged { editable ->
+                confirm.isEnabled = editable?.toString()?.trim()?.isNotEmpty() == true
+            }
+            binding.answerInput.requestFocus()
+            dialog.window?.setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE)
+        }
+
+        return dialog
+    }
+
+    companion object {
+        const val TAG: String = "AddPollCommentDialogFragment"
+        const val REQUEST_KEY: String = "stream_ui_add_poll_comment_request"
+        const val BUNDLE_KEY_MESSAGE_ID: String = "stream_ui_add_poll_comment_message_id"
+        const val BUNDLE_KEY_POLL_ID: String = "stream_ui_add_poll_comment_poll_id"
+        const val BUNDLE_KEY_ANSWER: String = "stream_ui_add_poll_comment_answer"
+
+        private const val ARG_MESSAGE_ID: String = "arg_message_id"
+        private const val ARG_POLL_ID: String = "arg_poll_id"
+        private const val ARG_INITIAL_TEXT: String = "arg_initial_text"
+
+        fun newInstance(
+            messageId: String,
+            pollId: String,
+            initialText: String? = null,
+        ): AddPollCommentDialogFragment =
+            AddPollCommentDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_MESSAGE_ID to messageId,
+                    ARG_POLL_ID to pollId,
+                    ARG_INITIAL_TEXT to initialText,
+                )
+            }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/PollCommentsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/PollCommentsDialogFragment.kt
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.feature.messages.list.internal.poll
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.appcompat.app.AppCompatDialogFragment
+import androidx.core.os.bundleOf
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import io.getstream.chat.android.models.Answer
+import io.getstream.chat.android.models.Poll
+import io.getstream.chat.android.models.VotingVisibility
+import io.getstream.chat.android.ui.ChatUI
+import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.databinding.StreamUiFragmentPollCommentsBinding
+import io.getstream.chat.android.ui.databinding.StreamUiItemPollCommentBinding
+import io.getstream.chat.android.ui.utils.extensions.applyEdgeToEdgePadding
+import io.getstream.chat.android.ui.utils.extensions.streamThemeInflater
+import io.getstream.chat.android.ui.viewmodel.messages.PollCommentsViewModel
+
+internal class PollCommentsDialogFragment : AppCompatDialogFragment() {
+
+    private var _binding: StreamUiFragmentPollCommentsBinding? = null
+    private val binding get() = _binding!!
+
+    private val cid: String
+        get() = requireArguments().getString(ARG_CID) ?: error("Channel cid not found in arguments")
+
+    private val messageId: String
+        get() = requireArguments().getString(ARG_MESSAGE_ID) ?: error("Message ID not found in arguments")
+
+    private val viewModel: PollCommentsViewModel by viewModels {
+        PollCommentsViewModel.Factory(cid = cid, messageId = messageId)
+    }
+
+    private val commentsAdapter = CommentsAdapter()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = StreamUiFragmentPollCommentsBinding.inflate(requireContext().streamThemeInflater, container, false)
+        return binding.root
+    }
+
+    override fun getTheme(): Int = R.style.StreamUiBottomSheetDialogTheme
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.root.applyEdgeToEdgePadding(typeMask = WindowInsetsCompat.Type.systemBars())
+        binding.toolbar.setNavigationOnClickListener { dismiss() }
+        binding.commentList.adapter = commentsAdapter
+        viewModel.poll.observe(viewLifecycleOwner, ::render)
+    }
+
+    private fun render(poll: Poll) {
+        val showUser = poll.votingVisibility == VotingVisibility.PUBLIC
+        commentsAdapter.submitList(poll.answers.map { CommentItem(it, showUser) })
+        binding.ctaContainer.isVisible = !poll.closed
+        if (poll.closed) return
+        val ownAnswer = ChatUI.currentUserProvider.getCurrentUser()?.id
+            ?.let { id -> poll.answers.firstOrNull { it.user?.id == id } }
+        binding.ctaButton.setText(
+            if (ownAnswer == null) {
+                R.string.stream_ui_poll_add_a_comment_label
+            } else {
+                R.string.stream_ui_poll_update_comment_label
+            },
+        )
+        binding.ctaButton.setOnClickListener {
+            AddPollCommentDialogFragment
+                .newInstance(messageId = messageId, pollId = poll.id, initialText = ownAnswer?.text)
+                .show(parentFragmentManager, AddPollCommentDialogFragment.TAG)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    companion object {
+        const val TAG: String = "PollCommentsDialogFragment"
+        private const val ARG_CID: String = "arg_cid"
+        private const val ARG_MESSAGE_ID: String = "arg_message_id"
+
+        fun newInstance(cid: String, messageId: String): PollCommentsDialogFragment =
+            PollCommentsDialogFragment().apply {
+                arguments = bundleOf(
+                    ARG_CID to cid,
+                    ARG_MESSAGE_ID to messageId,
+                )
+            }
+    }
+
+    private data class CommentItem(val answer: Answer, val showUser: Boolean)
+
+    private class CommentsAdapter :
+        ListAdapter<CommentItem, CommentsAdapter.CommentViewHolder>(CommentDiffCallback) {
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): CommentViewHolder =
+            CommentViewHolder(
+                StreamUiItemPollCommentBinding.inflate(LayoutInflater.from(parent.context), parent, false),
+            )
+
+        override fun onBindViewHolder(holder: CommentViewHolder, position: Int) {
+            holder.bind(getItem(position))
+        }
+
+        private object CommentDiffCallback : DiffUtil.ItemCallback<CommentItem>() {
+            override fun areItemsTheSame(oldItem: CommentItem, newItem: CommentItem): Boolean =
+                oldItem.answer.id == newItem.answer.id
+
+            override fun areContentsTheSame(oldItem: CommentItem, newItem: CommentItem): Boolean =
+                oldItem == newItem
+        }
+
+        private class CommentViewHolder(
+            private val binding: StreamUiItemPollCommentBinding,
+        ) : RecyclerView.ViewHolder(binding.root) {
+
+            fun bind(item: CommentItem) {
+                val answer = item.answer
+                binding.answerText.text = answer.text
+                val user = answer.user?.takeIf { item.showUser }
+                if (user != null) {
+                    binding.name.text = user.name
+                    binding.userAvatarView.setUser(user)
+                    binding.userAvatarView.isVisible = true
+                } else {
+                    binding.name.text = ""
+                    binding.userAvatarView.isInvisible = true
+                }
+                binding.date.text = ChatUI.dateFormatter.formatRelativeDate(answer.createdAt)
+                binding.time.text = ChatUI.dateFormatter.formatTime(answer.createdAt)
+            }
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModel.kt
@@ -310,6 +310,11 @@ public class MessageListViewModel(
                 pollId = event.pollId,
                 option = event.option,
             )
+            is Event.PollAnswerCast -> messageListController.castAnswer(
+                messageId = event.messageId,
+                pollId = event.pollId,
+                answer = event.answer,
+            )
         }
     }
 
@@ -843,5 +848,18 @@ public class MessageListViewModel(
          * @param option The text of the option suggested by the user.
          */
         public data class PollOptionSuggested(val pollId: String, val option: String) : Event()
+
+        /**
+         * When the user casts a free-text answer / comment on a poll.
+         *
+         * @param messageId The id of the message that hosts the poll.
+         * @param pollId The id of the poll to cast the answer on.
+         * @param answer The text of the answer / comment.
+         */
+        public data class PollAnswerCast(
+            val messageId: String,
+            val pollId: String,
+            val answer: String,
+        ) : Event()
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/MessageListViewModelBinding.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.state.utils.EventObserver
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.feature.gallery.toAttachment
 import io.getstream.chat.android.ui.feature.messages.list.MessageListView
+import io.getstream.chat.android.ui.feature.messages.list.internal.poll.AddPollCommentDialogFragment
 import io.getstream.chat.android.ui.feature.messages.list.internal.poll.SuggestPollOptionDialogFragment
 import io.getstream.chat.android.ui.utils.PermissionChecker
 import io.getstream.chat.android.ui.utils.extensions.getFragmentManager
@@ -199,5 +200,16 @@ public fun MessageListViewModel.bindView(
                 ?.takeIf(String::isNotEmpty)
                 ?: return@setFragmentResultListener
             onEvent(MessageListViewModel.Event.PollOptionSuggested(pollId, optionText))
+        }
+    view.context.getFragmentManager()
+        ?.setFragmentResultListener(AddPollCommentDialogFragment.REQUEST_KEY, lifecycleOwner) { _, bundle ->
+            val messageId = bundle.getString(AddPollCommentDialogFragment.BUNDLE_KEY_MESSAGE_ID)
+                ?: return@setFragmentResultListener
+            val pollId = bundle.getString(AddPollCommentDialogFragment.BUNDLE_KEY_POLL_ID)
+                ?: return@setFragmentResultListener
+            val answer = bundle.getString(AddPollCommentDialogFragment.BUNDLE_KEY_ANSWER)?.trim()
+                ?.takeIf(String::isNotEmpty)
+                ?: return@setFragmentResultListener
+            onEvent(MessageListViewModel.Event.PollAnswerCast(messageId = messageId, pollId = pollId, answer = answer))
         }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/PollCommentsViewModel.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/viewmodel/messages/PollCommentsViewModel.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.viewmodel.messages
+
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.asLiveData
+import io.getstream.chat.android.client.ChatClient
+import io.getstream.chat.android.client.extensions.cidToTypeAndId
+import io.getstream.chat.android.models.Poll
+import io.getstream.chat.android.state.extensions.state
+import io.getstream.chat.android.state.plugin.state.StateRegistry
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.map
+
+/**
+ * Observes the live [Poll] hosted by the message identified by [messageId] inside the channel
+ * identified by [cid].
+ */
+internal class PollCommentsViewModel(
+    cid: String,
+    messageId: String,
+    state: StateRegistry = ChatClient.instance().state,
+) : ViewModel() {
+
+    val poll: LiveData<Poll> = run {
+        val (channelType, channelId) = cid.cidToTypeAndId()
+        state.channel(channelType, channelId).messages
+            .map { messages -> messages.find { it.id == messageId }?.poll }
+            .filterNotNull()
+            .distinctUntilChanged()
+            .asLiveData()
+    }
+
+    class Factory(
+        private val cid: String,
+        private val messageId: String,
+    ) : ViewModelProvider.Factory {
+        @Suppress("UNCHECKED_CAST")
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            require(modelClass == PollCommentsViewModel::class.java) {
+                "Factory can only create instances of PollCommentsViewModel"
+            }
+            return PollCommentsViewModel(cid = cid, messageId = messageId) as T
+        }
+    }
+}

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_add_poll_comment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_dialog_add_poll_comment.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/stream_ui_spacing_medium"
+    >
+
+    <androidx.appcompat.widget.AppCompatEditText
+        android:id="@+id/answerInput"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center_vertical"
+        android:imeOptions="actionDone"
+        android:inputType="text"
+        android:textAppearance="@style/StreamUiTextAppearance.Headline"
+        />
+</FrameLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_poll_comments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_fragment_poll_comments.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/stream_ui_white"
+    >
+
+    <androidx.appcompat.widget.Toolbar
+        android:id="@+id/toolbar"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:background="@color/stream_ui_white"
+        android:elevation="0dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/stream_ui_arrow_left"
+        app:title="@string/stream_ui_poll_comments_title"
+        />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/commentList"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingHorizontal="@dimen/stream_ui_spacing_medium"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@+id/ctaContainer"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/toolbar"
+        />
+
+    <FrameLayout
+        android:id="@+id/ctaContainer"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/stream_ui_spacing_medium"
+        android:paddingVertical="@dimen/stream_ui_spacing_medium"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        >
+
+        <androidx.appcompat.widget.AppCompatTextView
+            android:id="@+id/ctaButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="?android:attr/selectableItemBackground"
+            android:gravity="center"
+            android:paddingVertical="@dimen/stream_ui_spacing_medium"
+            android:textAppearance="@style/StreamUiTextAppearance.Headline"
+            android:textColor="@color/stream_ui_accent_blue"
+            android:textDirection="locale"
+            />
+    </FrameLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_add_comment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_add_comment.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="@dimen/stream_ui_spacing_small"
+    android:paddingVertical="@dimen/stream_ui_spacing_small"
+    android:layout_gravity="center"
+    android:background="?android:attr/selectableItemBackground"
+    >
+
+    <TextView
+        android:id="@+id/pollAddComment"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/StreamUiTextAppearance.Headline"
+        android:textColor="@color/stream_ui_accent_blue"
+        android:gravity="center"
+        android:textDirection="locale"
+        android:text="@string/stream_ui_poll_add_a_comment_label"
+        />
+</FrameLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_comment.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_comment.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginVertical="@dimen/stream_ui_spacing_small"
+    android:background="@drawable/stream_ui_poll_input_bg"
+    android:padding="@dimen/stream_ui_spacing_medium"
+    >
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/answerText"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/StreamUiTextAppearance.HeadlineBold"
+        android:textColor="@color/stream_ui_text_color_primary"
+        android:textDirection="locale"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="My comment goes here"
+        />
+
+    <io.getstream.chat.android.ui.widgets.avatar.UserAvatarView
+        android:id="@+id/userAvatarView"
+        android:layout_width="25dp"
+        android:layout_height="25dp"
+        android:layout_marginTop="@dimen/stream_ui_spacing_small"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/answerText"
+        app:streamUiAvatarBorderWidth="0dp"
+        />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/name"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:lines="1"
+        android:paddingHorizontal="@dimen/stream_ui_spacing_tiny"
+        android:textAppearance="@style/StreamUiTextAppearance.Headline"
+        android:textColor="@color/stream_ui_text_color_primary"
+        android:textDirection="locale"
+        app:layout_constraintBottom_toBottomOf="@+id/userAvatarView"
+        app:layout_constraintEnd_toStartOf="@+id/date"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@+id/userAvatarView"
+        app:layout_constraintTop_toTopOf="@+id/userAvatarView"
+        tools:text="@tools:sample/full_names"
+        />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/date"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="@dimen/stream_ui_spacing_tiny"
+        android:textAppearance="@style/StreamUiTextAppearance.Body"
+        android:textColor="@color/stream_ui_text_color_secondary"
+        android:textDirection="locale"
+        app:layout_constraintBottom_toBottomOf="@+id/userAvatarView"
+        app:layout_constraintEnd_toStartOf="@+id/time"
+        app:layout_constraintTop_toTopOf="@+id/userAvatarView"
+        tools:text="@tools:sample/date/mmddyy"
+        />
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/time"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/StreamUiTextAppearance.Body"
+        android:textColor="@color/stream_ui_text_color_secondary"
+        android:textDirection="locale"
+        app:layout_constraintBottom_toBottomOf="@+id/userAvatarView"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="@+id/userAvatarView"
+        tools:text="@tools:sample/date/hhmm"
+        />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_view_comments.xml
+++ b/stream-chat-android-ui-components/src/main/res/layout/stream_ui_item_poll_view_comments.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+
+    Licensed under the Stream License;
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+      https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<FrameLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingHorizontal="@dimen/stream_ui_spacing_small"
+    android:paddingVertical="@dimen/stream_ui_spacing_small"
+    android:layout_gravity="center"
+    android:background="?android:attr/selectableItemBackground"
+    >
+
+    <TextView
+        android:id="@+id/pollViewComments"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textAppearance="@style/StreamUiTextAppearance.Headline"
+        android:textColor="@color/stream_ui_accent_blue"
+        android:gravity="center"
+        android:textDirection="locale"
+        />
+</FrameLayout>

--- a/stream-chat-android-ui-components/src/main/res/values/attrs_poll_view.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/attrs_poll_view.xml
@@ -135,5 +135,25 @@
             <flag name="bold" value="1" />
             <flag name="italic" value="2" />
         </attr>
+
+        <attr name="streamUiPollAddCommentTextSize" format="dimension|reference" />
+        <attr name="streamUiPollAddCommentTextColor" format="color|reference" />
+        <attr name="streamUiPollAddCommentFontAssets" format="string" />
+        <attr name="streamUiPollAddCommentTextFont" format="reference" />
+        <attr name="streamUiPollAddCommentTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
+
+        <attr name="streamUiPollViewCommentsTextSize" format="dimension|reference" />
+        <attr name="streamUiPollViewCommentsTextColor" format="color|reference" />
+        <attr name="streamUiPollViewCommentsFontAssets" format="string" />
+        <attr name="streamUiPollViewCommentsTextFont" format="reference" />
+        <attr name="streamUiPollViewCommentsTextStyle">
+            <flag name="normal" value="0" />
+            <flag name="bold" value="1" />
+            <flag name="italic" value="2" />
+        </attr>
     </declare-styleable>
 </resources>

--- a/stream-chat-android-ui-components/src/main/res/values/strings.xml
+++ b/stream-chat-android-ui-components/src/main/res/values/strings.xml
@@ -206,6 +206,10 @@
     <string name="stream_ui_poll_suggest_option_dialog_title">Suggest an option</string>
     <string name="stream_ui_poll_suggest_option_dialog_submit">Confirm</string>
     <string name="stream_ui_poll_suggest_option_dialog_cancel">Dismiss</string>
+    <string name="stream_ui_poll_add_comment_dialog_submit">Confirm</string>
+    <string name="stream_ui_poll_add_comment_dialog_cancel">Dismiss</string>
+    <string name="stream_ui_poll_comments_title">Poll Comments</string>
+    <string name="stream_ui_poll_update_comment_label">Update comment</string>
     <!-- Header Title -->
     <string name="stream_ui_message_list_header_thread_title">Thread Reply</string>
     <string name="stream_ui_message_list_header_untitled_channel">Channel without name</string>

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/MessageListViewModelTest.kt
@@ -32,6 +32,7 @@ import io.getstream.chat.android.models.User
 import io.getstream.chat.android.randomChannelUserRead
 import io.getstream.chat.android.randomInt
 import io.getstream.chat.android.randomString
+import io.getstream.chat.android.randomVote
 import io.getstream.chat.android.state.plugin.config.StatePluginConfig
 import io.getstream.chat.android.state.plugin.factory.StreamStatePluginFactory
 import io.getstream.chat.android.state.plugin.internal.StatePlugin
@@ -190,6 +191,31 @@ internal class MessageListViewModelTest {
     }
 
     @Test
+    fun `Given a poll When casting an answer Should cast poll answer`() = runTest {
+        val messages = listOf(message1, message2)
+        val chatClient = MockChatClientBuilder().build()
+        val pollId = randomString()
+        val answer = randomString()
+
+        val viewModel = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenChannelState(messageState = MessagesState.Result(messages), messages = messages)
+            .givenCastPollAnswer()
+            .get()
+
+        viewModel.onEvent(
+            MessageListViewModel.Event.PollAnswerCast(
+                messageId = message1.id,
+                pollId = pollId,
+                answer = answer,
+            ),
+        )
+
+        verify(chatClient).castPollAnswer(messageId = message1.id, pollId = pollId, answer = answer)
+    }
+
+    @Test
     fun `Given no previous own reactions on a message When leaving a reaction Should leave reaction`() = runTest {
         val messages = listOf(message1, message2)
         val messageState = MessagesState.Result(messages)
@@ -330,6 +356,10 @@ internal class MessageListViewModelTest {
             whenever(chatClient.deleteReaction(any(), any(), any())) doReturn Message().asCall()
         }
 
+        fun givenCastPollAnswer() = apply {
+            whenever(chatClient.castPollAnswer(any(), any(), any())) doReturn randomVote().asCall()
+        }
+
         fun givenChannelState(
             channelData: ChannelData = ChannelData(
                 type = CHANNEL_TYPE,
@@ -381,7 +411,6 @@ internal class MessageListViewModelTest {
                     threadLoadOrderOlderToNewer = false,
                     channelState = MutableStateFlow(channelState),
                 ),
-
             )
         }
     }

--- a/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/PollCommentsViewModelTest.kt
+++ b/stream-chat-android-ui-components/src/test/kotlin/io/getstream/chat/android/ui/viewmodels/messages/PollCommentsViewModelTest.kt
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.viewmodels.messages
+
+import io.getstream.chat.android.client.channel.state.ChannelState
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.randomMessage
+import io.getstream.chat.android.randomPoll
+import io.getstream.chat.android.state.plugin.state.StateRegistry
+import io.getstream.chat.android.test.InstantTaskExecutorExtension
+import io.getstream.chat.android.test.TestCoroutineExtension
+import io.getstream.chat.android.test.observeAll
+import io.getstream.chat.android.ui.viewmodel.messages.PollCommentsViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeEqualTo
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+internal class PollCommentsViewModelTest {
+
+    @Test
+    fun `Given a message hosting a poll When observing Should emit the poll`() = runTest {
+        val poll = randomPoll()
+        val targetMessage = randomMessage(id = TARGET_MESSAGE_ID, poll = poll)
+        val otherMessage = randomMessage(id = "other-message-id", poll = null)
+
+        val viewModel = Fixture()
+            .givenChannelMessages(listOf(otherMessage, targetMessage))
+            .get()
+
+        val emissions = viewModel.poll.observeAll()
+        advanceUntilIdle()
+
+        emissions shouldBeEqualTo listOf(poll)
+    }
+
+    @Test
+    fun `Given the hosting message has no poll When observing Should not emit`() = runTest {
+        val targetMessage = randomMessage(id = TARGET_MESSAGE_ID, poll = null)
+
+        val viewModel = Fixture()
+            .givenChannelMessages(listOf(targetMessage))
+            .get()
+
+        val emissions = viewModel.poll.observeAll()
+        advanceUntilIdle()
+
+        emissions.shouldBeEmpty()
+    }
+
+    @Test
+    fun `Given the poll on the hosting message changes When observing Should emit each distinct poll`() = runTest {
+        val firstPoll = randomPoll()
+        val secondPoll = randomPoll()
+        val fixture = Fixture()
+            .givenChannelMessages(listOf(randomMessage(id = TARGET_MESSAGE_ID, poll = firstPoll)))
+        val viewModel = fixture.get()
+
+        val emissions = viewModel.poll.observeAll()
+        advanceUntilIdle()
+
+        fixture.givenChannelMessages(listOf(randomMessage(id = TARGET_MESSAGE_ID, poll = firstPoll)))
+        advanceUntilIdle()
+
+        fixture.givenChannelMessages(listOf(randomMessage(id = TARGET_MESSAGE_ID, poll = secondPoll)))
+        advanceUntilIdle()
+
+        emissions shouldBeEqualTo listOf(firstPoll, secondPoll)
+    }
+
+    private class Fixture {
+        private val messages = MutableStateFlow<List<Message>>(emptyList())
+        private val channelState: ChannelState = mock {
+            on { messages } doReturn this@Fixture.messages
+        }
+        private val state: StateRegistry = mock {
+            on { channel(any(), any()) } doReturn channelState
+        }
+
+        fun givenChannelMessages(messages: List<Message>) = apply {
+            this.messages.value = messages
+        }
+
+        fun get(): PollCommentsViewModel = PollCommentsViewModel(
+            cid = CID,
+            messageId = TARGET_MESSAGE_ID,
+            state = state,
+        )
+    }
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val testCoroutines = TestCoroutineExtension()
+
+        @JvmField
+        @RegisterExtension
+        val instantExecutor = InstantTaskExecutorExtension()
+
+        private const val CID = "messaging:123"
+        private const val TARGET_MESSAGE_ID = "target-message-id"
+    }
+}


### PR DESCRIPTION
### Goal

Bring the "voters can add comments" poll feature to the XML UI Components, matching what's already available in the Compose UI.

https://linear.app/stream/issue/AND-603/xmlpolls-some-features-are-missing

### Implementation

- `PollView` renders two new entries: "Add a comment" when `poll.allowAnswers` is `true`, the poll is open, and the user hasn't commented yet; and "View N comments" once any answer exists.
- `AddPollCommentDialogFragment` collects the comment text and returns it via the fragment-result API; `MessageListViewModel.bindView` listens for the result and emits `Event.PollAnswerCast(messageId, pollId, answer)`, which the view model forwards to `MessageListController.castAnswer`.
- `PollCommentsDialogFragment` lists comments and shows an "Add a comment" / "Update comment" CTA depending on whether the current user has already answered.
- `PollViewStyle` gains `pollAddCommentTextStyle` and `pollViewCommentsTextStyle` with matching `streamUiPollAddComment*` and `streamUiPollViewComments*` attributes for customization.

### UI Changes

| Poll with comment button | Add comment dialog | Comments list |
|---------------------------|--------------------|---------------|
| <img width="540" height="1200" alt="Screenshot_20260519_122847" src="https://github.com/user-attachments/assets/7589b79e-6ba6-4bfa-8c6c-cca74e3f1dfc" /> | <img width="540" height="1200" alt="Screenshot_20260519_122851" src="https://github.com/user-attachments/assets/5c3ec860-5c95-48a9-b6b9-cf605b1021ad" /> | <img width="540" height="1200" alt="Screenshot_20260519_122903" src="https://github.com/user-attachments/assets/2f0bc607-8ace-4b18-bb8f-ce9674c93888" /> |

### Testing

- Open a channel with a poll that has `allowAnswers = true`: an "Add a comment" entry shows up until the current user posts an answer; afterwards a "View N comments" entry replaces it.
- Tapping "Add a comment" opens the dialog; the Confirm button stays disabled until non-blank text is entered; confirming casts the answer, dismissing does not.
- Tapping "View N comments" opens the bottom-sheet listing all answers; the CTA reads "Add a comment" for users without an answer and "Update comment" for users with one (pre-filling the existing text); closed polls hide the CTA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Poll comments: Users can now add comments to polls and view existing comments from other participants.
  * Customizable poll comment styling through theme attributes for text appearance and color.

* **Tests**
  * Added test coverage for poll comment functionality and poll data fixture helpers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6444?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->