### PR TITLE
Apply option text limit to suggest poll option dialog

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/SuggestPollOptionDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/SuggestPollOptionDialogFragment.kt
@@ -18,11 +18,13 @@ package io.getstream.chat.android.ui.feature.messages.list.internal.poll
 
 import android.app.Dialog
 import android.os.Bundle
+import android.text.InputFilter
 import android.view.WindowManager
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatDialogFragment
 import androidx.core.os.bundleOf
 import androidx.core.widget.doAfterTextChanged
+import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.databinding.StreamUiDialogSuggestPollOptionBinding
 import io.getstream.chat.android.ui.utils.extensions.createStreamThemeWrapper
@@ -42,6 +44,10 @@ public class SuggestPollOptionDialogFragment : AppCompatDialogFragment() {
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
         val binding = StreamUiDialogSuggestPollOptionBinding.inflate(requireContext().streamThemeInflater)
+
+        ChatUI.pollsConfig.optionTextLimit?.takeIf { it > 0 }?.let { limit ->
+            binding.optionInput.filters = arrayOf(InputFilter.LengthFilter(limit))
+        }
 
         val dialog = AlertDialog.Builder(requireContext().createStreamThemeWrapper())
             .setTitle(R.string.stream_ui_poll_suggest_option_dialog_title)


### PR DESCRIPTION
### Goal

Apply `PollsConfig.optionTextLimit` to the "Suggest an option" dialog so the configured character limit is enforced there too, not only inside `CreatePollDialogFragment`.

### Implementation

`SuggestPollOptionDialogFragment` now installs an `InputFilter.LengthFilter` on the option input when `ChatUI.pollsConfig.optionTextLimit` is set and positive.

### Testing

- With `ChatUI.pollsConfig = PollsConfig(optionTextLimit = 10)`, open a poll that allows suggesting options, tap "Suggest an option", and verify the input cannot exceed 10 characters.
- With `ChatUI.pollsConfig` left at its default (`optionTextLimit = null`), verify the input accepts arbitrarily long text as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Poll option input field now enforces a maximum character limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6446?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->