### PR TITLE
Improve poll vote row TalkBack accessibility

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.ButtonDefaults
@@ -50,6 +51,10 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -69,6 +74,7 @@ import io.getstream.chat.android.compose.ui.theme.MessageFailedIconParams
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.MessageStyling.PollStyle
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
+import io.getstream.chat.android.compose.ui.util.applyIf
 import io.getstream.chat.android.compose.ui.util.isErrorOrFailed
 import io.getstream.chat.android.compose.ui.util.passiveRipple
 import io.getstream.chat.android.compose.util.extensions.toSet
@@ -427,23 +433,35 @@ private fun PollOptionItem(
     onRemoveVote: () -> Unit,
 ) {
     val typography = ChatTheme.typography
+    val toggleRole = if (poll.maxVotesAllowed == 1) Role.RadioButton else Role.Checkbox
+    val onToggle: (Boolean) -> Unit = { enabled ->
+        val canVote = poll.maxVotesAllowed?.let { checkedCount < it } ?: true
+        if (enabled && canVote && !checked) {
+            onCastVote.invoke()
+        } else if (!enabled) {
+            onRemoveVote.invoke()
+        }
+    }
 
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .applyIf(!poll.closed) {
+                toggleable(
+                    value = checked,
+                    role = toggleRole,
+                    onValueChange = onToggle,
+                )
+            }
+            .semantics(mergeDescendants = true) {},
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (!poll.closed) {
             RadioCheck(
+                modifier = Modifier.semantics { hideFromAccessibility() },
                 checked = checked,
-                onCheckedChange = { enabled: Boolean ->
-                    val canVote = poll.maxVotesAllowed?.let { checkedCount < it } ?: true
-                    if (enabled && canVote && !checked) {
-                        onCastVote.invoke()
-                    } else if (!enabled) {
-                        onRemoveVote.invoke()
-                    }
-                },
+                onCheckedChange = onToggle,
                 borderColor = style.outlineColor,
             )
         }
@@ -488,7 +506,8 @@ private fun PollOptionItem(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(8.dp)
-                    .clip(RoundedCornerShape(4.dp)),
+                    .clip(RoundedCornerShape(4.dp))
+                    .clearAndSetSemantics {},
                 progress = { progress },
                 color = style.progressColor,
                 trackColor = style.trackColor,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -53,6 +53,7 @@ import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -486,8 +487,15 @@ private fun PollOptionItem(
                     )
                 }
 
+                val voteCountDescription = pluralStringResource(
+                    R.plurals.stream_compose_poll_vote_counts,
+                    voteCount,
+                    voteCount,
+                )
                 Text(
-                    modifier = Modifier.align(Alignment.CenterVertically),
+                    modifier = Modifier
+                        .align(Alignment.CenterVertically)
+                        .semantics { contentDescription = voteCountDescription },
                     text = voteCount.toString(),
                     style = typography.metadataDefault,
                     color = style.textColor,


### PR DESCRIPTION
AND-1180

### Goal

A11y audit of the poll message item (the poll bubble in the message list) surfaced three gaps:

1. **Option rows weren't individually focusable** for TalkBack — the whole poll bubble was a single focus stop, so users had to listen to one long merged announcement (title + every option + every button) instead of navigating option by option.
2. **`LinearProgressIndicator` announced redundant "X percent"** on every option, duplicating the vote-count Text. Two options at 0 votes both announced "0 percent" — flagged repeatedly by Accessibility Scanner.
3. **Vote count Text read as a bare number** ("5") rather than "5 votes", which is ambiguous in the merged row announcement.

This PR addresses all three.

### Implementation

**Row-level focusable + merged content.**

- `PollOptionItem` `Row` gets `Modifier.semantics(mergeDescendants = true) {}` in all cases. The row becomes a single TalkBack focus stop with the option text, vote count, and voter avatars merged into one announcement.
- For open polls (`!poll.closed`), the row also gets `Modifier.toggleable(value = checked, role = toggleRole, onValueChange = onToggle)`. The role is `Role.RadioButton` when `poll.maxVotesAllowed == 1` (mutual-exclusion semantics), `Role.Checkbox` otherwise (multi-vote or unlimited). The previous `onCheckedChange` lambda is extracted into `onToggle` and shared between the row's `toggleable` and the inner `RadioCheck`'s `onCheckedChange`, so sighted taps on either the row or the radio circle fire the same logic.
- `RadioCheck` inside the row gets `Modifier.semantics { hideFromAccessibility() }` since the row now owns the toggle action. The visual RadioCheck still responds to taps for sighted users.
- For closed polls, the row stays non-toggleable (no vote action) but is still a focus stop via `mergeDescendants = true`, so TalkBack users can navigate option by option to read the final tallies.

**Hide redundant progress percentage.**

- `LinearProgressIndicator` modifier gains `.clearAndSetSemantics {}`. Compose Material3 announces the indicator as "X percent" by default; the vote-count Text on the same row already conveys the count more precisely.

**Announce vote count with units.**

- The vote-count `Text` gets a `contentDescription` from the existing `stream_compose_poll_vote_counts` plural (e.g. "5 votes" / "1 vote" / "0 votes"). Visible text stays compact ("5") so the visual layout is unchanged.

### 🎨 UI Changes

No UI changes. All changes are accessibility-tree only.

### Testing

Enable TalkBack on a physical device. Run the Compose sample, create a poll in a 1:1 or group channel.

1. **Open poll.** Open the channel and swipe through the poll bubble with TalkBack:
   - The bubble announces the poll title and subtitle (e.g. "Vote ends 5 Mar").
   - Each option row is its own focus stop. Announces as **"&lt;option text&gt;. N votes. Not selected. Double tap to activate."** (or "Selected" when you've voted for it).
   - "View Results" and "View Comments" buttons are separate focus stops.
2. Double-tap an option row to cast or remove a vote. TalkBack should announce the new selected/not-selected state.
3. **Single-vote vs multi-vote polls.** Create a poll with `maxVotesAllowed = 1` and one with multi-vote (or unlimited). The TalkBack role should be "radio button" for the single-vote poll, "checkbox" for the multi-vote one.
4. **Closed poll.** End the poll. Re-test: each option row is still a separate focus stop (read-only), announces option text + vote count + "Not selected" — no double-tap-to-activate hint.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved poll message accessibility with better semantic descriptions and support for screen readers.
  * Enhanced poll option interaction handling for more reliable voting behavior.

* **Accessibility**
  * Added support for different poll types (single and multiple choice selection modes).
  * Optimized vote count descriptions for assistive technologies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->