### PR TITLE
Accept null file_size in AttachmentDto

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -585,7 +585,7 @@ internal class DomainMapping(
             authorName = author_name,
             authorLink = author_link,
             fallback = fallback,
-            fileSize = file_size,
+            fileSize = file_size ?: 0,
             image = image,
             imageUrl = image_url,
             mimeType = mime_type,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
@@ -33,7 +33,7 @@ internal data class AttachmentDto(
     val author_name: String?,
     val author_link: String?,
     val fallback: String?,
-    val file_size: Int = 0,
+    val file_size: Int? = 0,
     val image: String?,
     val image_url: String?,
     val mime_type: String?,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
@@ -33,7 +33,7 @@ internal data class AttachmentDto(
     val author_name: String?,
     val author_link: String?,
     val fallback: String?,
-    val file_size: Int? = 0,
+    val file_size: Int?,
     val image: String?,
     val image_url: String?,
     val mime_type: String?,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -750,7 +750,7 @@ internal object Mother {
         authorName: String? = randomString(),
         authorLink: String? = randomString(),
         fallback: String? = randomString(),
-        fileSize: Int = positiveRandomInt(),
+        fileSize: Int? = positiveRandomInt(),
         image: String? = randomString(),
         imageUrl: String? = randomString(),
         mimeType: String? = randomString(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -558,7 +558,7 @@ internal class DomainMappingTest {
             authorName = attachmentDto.author_name,
             authorLink = attachmentDto.author_link,
             fallback = attachmentDto.fallback,
-            fileSize = attachmentDto.file_size,
+            fileSize = attachmentDto.file_size ?: 0,
             image = attachmentDto.image,
             imageUrl = attachmentDto.image_url,
             mimeType = attachmentDto.mime_type,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -577,6 +577,16 @@ internal class DomainMappingTest {
     }
 
     @Test
+    fun `AttachmentDto with null file_size falls back to 0`() {
+        val attachmentDto = randomAttachmentDto(fileSize = null)
+        val sut = Fixture().get()
+        val attachment = with(sut) {
+            attachmentDto.toDomain()
+        }
+        assertEquals(0, attachment.fileSize)
+    }
+
+    @Test
     fun `BannedUserResponse is correctly mapped to BannedUser`() {
         val bannedUserResponse = randomBannedUserResponse()
         val sut = Fixture().get()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentDtoAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentDtoAdapterTest.kt
@@ -49,4 +49,10 @@ internal class AttachmentDtoAdapterTest {
         val jsonString = parser.toJson(AttachmentDtoTestData.attachmentWithoutExtraData)
         jsonString.shouldEqualJson(AttachmentDtoTestData.jsonWithoutExtraData)
     }
+
+    @Test
+    fun `Deserialize JSON attachment with null file_size`() {
+        val attachment = parser.fromJson(AttachmentDtoTestData.jsonWithNullFileSize, AttachmentDto::class.java)
+        attachment shouldBeEqualTo AttachmentDtoTestData.attachmentWithNullFileSize
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/AttachmentDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/AttachmentDtoTestData.kt
@@ -66,6 +66,33 @@ internal object AttachmentDtoTestData {
     )
 
     @Language("JSON")
+    val jsonWithNullFileSize =
+        """{
+          "file_size": null
+        }
+        """.withoutWhitespace()
+    val attachmentWithNullFileSize = AttachmentDto(
+        asset_url = null,
+        author_name = null,
+        author_link = null,
+        fallback = null,
+        file_size = null,
+        image = null,
+        image_url = null,
+        mime_type = null,
+        name = null,
+        og_scrape_url = null,
+        text = null,
+        thumb_url = null,
+        title = null,
+        title_link = null,
+        type = null,
+        original_width = null,
+        original_height = null,
+        extraData = emptyMap(),
+    )
+
+    @Language("JSON")
     val jsonWithoutExtraData =
         """{
           "file_size": 0


### PR DESCRIPTION
### Goal

It seems that backend can return `null` for `file_size` on attachments, but `AttachmentDto.file_size` was non-nullable so explicit nulls in the JSON caused deserialization to fail.

This also aligns [with iOS](https://github.com/GetStream/stream-chat-swift/blob/8c7d807a5f3f6ccf60ada1262e0e1ef0d50f3ab2/Sources/StreamChat/Models/Attachments/AttachmentTypes.swift#L200-L206), where `AttachmentFile` decodes a missing or non-decodable `file_size` as `0`.

Closes #6428

### Implementation

- `AttachmentDto.file_size` is now `Int?`, so an explicit `null` from the API deserializes cleanly.
- `DomainMapping` maps `null` to `0` when mapping to the domain `Attachment.fileSize`.

### Testing

- New unit test `Deserialize JSON attachment with null file_size` covers the parser path.
- Existing attachment parser and mapping tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved attachment data handling by making file size processing null-safe. When file size information is unavailable, the system now defaults to zero instead of propagating null values, ensuring more robust behavior.

* **Tests**
  * Expanded test coverage with new test cases validating correct deserialization and mapping of attachments when file size values are null or missing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6462?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->