### PR TITLE
Accept null file_size in AttachmentDto

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/mapping/DomainMapping.kt
@@ -579,7 +579,7 @@ internal class DomainMapping(
             authorName = author_name,
             authorLink = author_link,
             fallback = fallback,
-            fileSize = file_size,
+            fileSize = file_size ?: 0,
             image = image,
             imageUrl = image_url,
             mimeType = mime_type,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
@@ -33,7 +33,7 @@ internal data class AttachmentDto(
     val author_name: String?,
     val author_link: String?,
     val fallback: String?,
-    val file_size: Int = 0,
+    val file_size: Int? = 0,
     val image: String?,
     val image_url: String?,
     val mime_type: String?,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api2/model/dto/AttachmentDto.kt
@@ -33,7 +33,7 @@ internal data class AttachmentDto(
     val author_name: String?,
     val author_link: String?,
     val fallback: String?,
-    val file_size: Int? = 0,
+    val file_size: Int?,
     val image: String?,
     val image_url: String?,
     val mime_type: String?,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/AttachmentAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/AttachmentAdapter.kt
@@ -54,7 +54,7 @@ internal class AttachmentAdapter : JsonAdapter<Attachment>() {
                 "author_name" -> authorName = JsonParsingUtils.readNullableString(reader)
                 "author_link" -> authorLink = JsonParsingUtils.readNullableString(reader)
                 "fallback" -> fallback = JsonParsingUtils.readNullableString(reader)
-                "file_size" -> fileSize = reader.nextInt()
+                "file_size" -> fileSize = JsonParsingUtils.readNullableInt(reader) ?: 0
                 "image" -> image = JsonParsingUtils.readNullableString(reader)
                 "image_url" -> imageUrl = JsonParsingUtils.readNullableString(reader)
                 "mime_type" -> mimeType = JsonParsingUtils.readNullableString(reader)

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/Mother.kt
@@ -746,7 +746,7 @@ internal object Mother {
         authorName: String? = randomString(),
         authorLink: String? = randomString(),
         fallback: String? = randomString(),
-        fileSize: Int = positiveRandomInt(),
+        fileSize: Int? = positiveRandomInt(),
         image: String? = randomString(),
         imageUrl: String? = randomString(),
         mimeType: String? = randomString(),

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -569,6 +569,16 @@ internal class DomainMappingTest {
     }
 
     @Test
+    fun `AttachmentDto with null file_size falls back to 0`() {
+        val attachmentDto = randomAttachmentDto(fileSize = null)
+        val sut = Fixture().get()
+        val attachment = with(sut) {
+            attachmentDto.toDomain()
+        }
+        assertEquals(0, attachment.fileSize)
+    }
+
+    @Test
     fun `BannedUserResponse is correctly mapped to BannedUser`() {
         val bannedUserResponse = randomBannedUserResponse()
         val sut = Fixture().get()

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/api2/mapping/DomainMappingTest.kt
@@ -550,7 +550,7 @@ internal class DomainMappingTest {
             authorName = attachmentDto.author_name,
             authorLink = attachmentDto.author_link,
             fallback = attachmentDto.fallback,
-            fileSize = attachmentDto.file_size,
+            fileSize = attachmentDto.file_size ?: 0,
             image = attachmentDto.image,
             imageUrl = attachmentDto.image_url,
             mimeType = attachmentDto.mime_type,

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentDtoAdapterTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentDtoAdapterTest.kt
@@ -49,4 +49,10 @@ internal class AttachmentDtoAdapterTest {
         val jsonString = parser.toJson(AttachmentDtoTestData.attachmentWithoutExtraData)
         jsonString.shouldEqualJson(AttachmentDtoTestData.jsonWithoutExtraData)
     }
+
+    @Test
+    fun `Deserialize JSON attachment with null file_size`() {
+        val attachment = parser.fromJson(AttachmentDtoTestData.jsonWithNullFileSize, AttachmentDto::class.java)
+        attachment shouldBeEqualTo AttachmentDtoTestData.attachmentWithNullFileSize
+    }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentParsingTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/AttachmentParsingTest.kt
@@ -16,7 +16,6 @@
 
 package io.getstream.chat.android.client.parser2
 
-import com.squareup.moshi.JsonDataException
 import io.getstream.chat.android.client.api2.mapping.DomainMapping
 import io.getstream.chat.android.client.api2.model.dto.AttachmentDto
 import io.getstream.chat.android.client.parser2.direct.AttachmentAdapter
@@ -26,7 +25,6 @@ import io.getstream.chat.android.models.NoOpMessageTransformer
 import io.getstream.chat.android.models.NoOpUserTransformer
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 
 internal class AttachmentParsingTest {
 
@@ -92,20 +90,19 @@ internal class AttachmentParsingTest {
 
     // endregion
 
-    // region file_size: null (non-nullable Int — both paths must throw)
+    // region file_size: null — coalesces to 0 on both paths
 
     @Test
-    fun `DTO path - throws on file_size null`() {
-        assertThrows<JsonDataException> {
-            parser.fromJson(AttachmentTestData.jsonWithFileSizeNull, AttachmentDto::class.java)
-        }
+    fun `DTO path - file_size null coalesces to 0`() {
+        val dto = parser.fromJson(AttachmentTestData.jsonWithFileSizeNull, AttachmentDto::class.java)
+        val attachment = with(domainMapping) { dto.toDomain() }
+        assertEquals(0, attachment.fileSize)
     }
 
     @Test
-    fun `Direct path - throws on file_size null`() {
-        assertThrows<JsonDataException> {
-            attachmentAdapter.fromJson(AttachmentTestData.jsonWithFileSizeNull)
-        }
+    fun `Direct path - file_size null coalesces to 0`() {
+        val attachment = attachmentAdapter.fromJson(AttachmentTestData.jsonWithFileSizeNull)
+        assertEquals(0, attachment?.fileSize)
     }
 
     // endregion

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/AttachmentDtoTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/AttachmentDtoTestData.kt
@@ -66,6 +66,33 @@ internal object AttachmentDtoTestData {
     )
 
     @Language("JSON")
+    val jsonWithNullFileSize =
+        """{
+          "file_size": null
+        }
+        """.withoutWhitespace()
+    val attachmentWithNullFileSize = AttachmentDto(
+        asset_url = null,
+        author_name = null,
+        author_link = null,
+        fallback = null,
+        file_size = null,
+        image = null,
+        image_url = null,
+        mime_type = null,
+        name = null,
+        og_scrape_url = null,
+        text = null,
+        thumb_url = null,
+        title = null,
+        title_link = null,
+        type = null,
+        original_width = null,
+        original_height = null,
+        extraData = emptyMap(),
+    )
+
+    @Language("JSON")
     val jsonWithoutExtraData =
         """{
           "file_size": 0


### PR DESCRIPTION
### Goal

Backport of #6462 to `v6`.

It seems that backend can return `null` for `file_size` on attachments, but `AttachmentDto.file_size` was non-nullable so explicit nulls in the JSON caused deserialization to fail.

This also aligns with iOS, where `AttachmentFile` decodes a missing or non-decodable `file_size` as `0`.

Closes #6428

### Implementation

- `AttachmentDto.file_size` is now `Int?`, so an explicit `null` from the API deserializes cleanly.
- `DomainMapping` maps `null` to `0` when mapping to the domain `Attachment.fileSize`.

### Testing

- New unit test `Deserialize JSON attachment with null file_size` covers the parser path.
- Existing attachment parser and mapping tests continue to pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of attachments with missing file size information. The system now gracefully defaults file size to 0 when the value is unavailable, enhancing robustness and preventing potential issues during attachment processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6463?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->