### PR TITLE
Improve compose TalkBack screen-entry announcements

### DIFF
--- a/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
+++ b/stream-chat-android-compose-sample/src/main/AndroidManifest.xml
@@ -66,54 +66,71 @@
         <activity
             android:name=".ui.login.UserLoginActivity"
             android:exported="false"
+            android:label="@string/user_login_screen_title"
             />
         <activity
             android:name=".ui.login.CustomLoginActivity"
             android:exported="false"
+            android:label="@string/user_login_advanced_options"
             android:windowSoftInputMode="adjustResize"
             />
         <activity
             android:name=".ui.chats.ChatsActivity"
             android:exported="false"
+            android:label="@string/app_bottom_bar_chats"
             />
         <activity
             android:name=".feature.channel.list.ChannelsActivity"
             android:exported="false"
+            android:label="@string/app_bottom_bar_chats"
             />
         <activity
             android:name=".ui.channel.ChannelActivity"
             android:exported="false"
+            android:label="@string/channel_title"
             android:windowSoftInputMode="adjustResize"
             />
         <activity
             android:name=".ui.channel.DirectChannelInfoActivity"
             android:exported="false"
+            android:label="@string/stream_ui_channel_info_contact_title"
             />
         <activity
             android:name=".ui.channel.GroupChannelInfoActivity"
             android:exported="false"
+            android:label="@string/stream_ui_channel_info_group_title"
             />
         <activity
             android:name=".ui.pinned.PinnedMessagesActivity"
             android:exported="false"
+            android:label="@string/pinned_messages_title"
             />
         <activity
             android:name=".feature.channel.add.AddChannelActivity"
             android:exported="false"
+            android:label="@string/add_channel_title"
             android:windowSoftInputMode="adjustResize"
             />
         <activity
             android:name=".feature.channel.add.group.AddGroupChannelActivity"
             android:exported="false"
+            android:label="@string/add_group_channel_members_title"
             android:windowSoftInputMode="adjustResize"
             />
         <activity
             android:name=".feature.channel.draft.DraftChannelActivity"
             android:exported="false"
+            android:label="@string/stream_compose_channel_list_header_new_chat"
             android:windowSoftInputMode="adjustResize"
             />
-        <activity android:name=".feature.reminders.MessageRemindersActivity" />
-        <activity android:name=".ui.profile.UserProfileActivity" />
+        <activity
+            android:name=".feature.reminders.MessageRemindersActivity"
+            android:label="@string/reminders_title"
+            />
+        <activity
+            android:name=".ui.profile.UserProfileActivity"
+            android:label="@string/user_profile_title"
+            />
         <activity
             android:name=".ui.channel.attachments.ChannelFilesAttachmentsActivity"
             android:label="@string/stream_ui_channel_attachments_files_title"

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -128,6 +128,10 @@
     <string name="channel_attachments_files_loading_more_error">Failed to load more files attachments</string>
 
     <!-- Channel -->
+    <string name="channel_title">Channel</string>
     <string name="channel_open_info">Open channel info</string>
+
+    <!-- User Profile -->
+    <string name="user_profile_title">Profile</string>
 
 </resources>

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/AddMembersScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/AddMembersScreen.kt
@@ -40,6 +40,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -101,11 +103,13 @@ internal fun AddMembersScreen(
     onDismiss: () -> Unit,
     onConfirm: () -> Unit,
 ) {
+    val paneTitleText = stringResource(id = R.string.stream_compose_add_members_title)
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(ChatTheme.colors.backgroundCoreApp)
-            .systemBarsPadding(),
+            .systemBarsPadding()
+            .semantics { paneTitle = paneTitleText },
     ) {
         AddMembersHeader(
             hasSelection = state.selectedUserIds.isNotEmpty(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/DirectChannelInfoScreen.kt
@@ -42,6 +42,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -113,8 +115,9 @@ private fun DirectChannelInfoScaffold(
     onViewAction: (action: ChannelInfoViewAction) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
+    val paneTitleText = stringResource(id = UiCommonR.string.stream_ui_channel_info_contact_title)
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.semantics { paneTitle = paneTitleText },
         topBar = {
             ChatTheme.componentFactory.DirectChannelInfoTopBar(
                 params = DirectChannelInfoTopBarParams(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelEditScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelEditScreen.kt
@@ -54,6 +54,8 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.text.style.TextOverflow
@@ -206,7 +208,9 @@ private fun GroupChannelEditContent(
     onSaveActionClick: () -> Unit = {},
     onUploadPictureClick: () -> Unit = {},
 ) {
+    val paneTitleText = stringResource(id = UiCommonR.string.stream_ui_channel_info_edit_title)
     Scaffold(
+        modifier = Modifier.semantics { paneTitle = paneTitleText },
         topBar = {
             GroupChannelEditTopBar(
                 isBusy = isBusy,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/info/GroupChannelInfoScreen.kt
@@ -50,6 +50,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -174,8 +176,9 @@ private fun GroupChannelInfoScaffold(
     onViewAction: (action: ChannelInfoViewAction) -> Unit = {},
 ) {
     val listState = rememberLazyListState()
+    val paneTitleText = stringResource(id = UiCommonR.string.stream_ui_channel_info_group_title)
     Scaffold(
-        modifier = modifier,
+        modifier = modifier.semantics { paneTitle = paneTitleText },
         topBar = {
             ChatTheme.componentFactory.GroupChannelInfoTopBar(
                 params = GroupChannelInfoTopBarParams(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
@@ -69,7 +69,8 @@ import io.getstream.chat.android.ui.common.state.channels.actions.ViewInfo
  * You can use the default implementation by not passing in an instance yourself, or you
  * can customize the behavior using its parameters.
  * @param viewModelKey Key to differentiate between instances of [ChannelListViewModel].
- * @param title Header title.
+ * @param title Header title. Also drives the screen's `paneTitle` semantic, announced by TalkBack
+ * when the screen appears as a pane (e.g. an adaptive-layout pane or a Compose Navigation route).
  * @param isShowingHeader If we show the header or hide it.
  * @param searchMode The search mode for the screen.
  * @param onHeaderActionClick Handler for the default header action.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channels/ChannelsScreen.kt
@@ -41,6 +41,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.getstream.chat.android.compose.state.channels.list.SearchQuery
@@ -123,7 +125,9 @@ public fun ChannelsScreen(
             .testTag("Stream_ChannelsScreen"),
     ) {
         Scaffold(
-            modifier = Modifier.fillMaxSize(),
+            modifier = Modifier
+                .fillMaxSize()
+                .semantics { paneTitle = title },
             topBar = {
                 if (isShowingHeader) {
                     ChatTheme.componentFactory.ChannelListHeader(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
@@ -108,6 +108,8 @@ import kotlin.math.abs
  * When the initial [ChannelViewModelFactory] is requested (before a channel is selected),
  * `channelId`, `messageId`, and `parentMessageId` are `null`.
  * @param title The title displayed in the list pane top bar. Default is `"Stream Chat"`.
+ * Also drives the list pane's `paneTitle` semantic, announced by TalkBack when the list pane
+ * appears or becomes active (e.g. switching between panes in the adaptive layout).
  * @param searchMode The current search mode. Default is [SearchMode.None].
  * @param listContentMode The mode for displaying the list content. Default is [ChatListContentMode.Channels].
  * @param onBackPress Callback invoked when the user presses the back button.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/chats/ChatsScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.IntSize
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -179,10 +181,12 @@ public fun ChatsScreen(
         onDispose { navigator.popUpTo(ThreePaneRole.List) }
     }
 
-    val listPane = remember(listContentMode) {
+    val listPane = remember(listContentMode, title) {
         movableContentOf { modifier: Modifier ->
             Scaffold(
-                modifier = modifier.safeDrawingPadding(),
+                modifier = modifier
+                    .safeDrawingPadding()
+                    .semantics { paneTitle = title },
                 containerColor = ChatTheme.colors.backgroundCoreApp,
                 topBar = { listTopBarContent() },
                 bottomBar = { listBottomBarContent() },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadsScreen.kt
@@ -40,7 +40,8 @@ import io.getstream.chat.android.models.Thread
  * It can be used without most parameters for default behavior, that can be tweaked if necessary.
  *
  * @param viewModelFactory The factory used to build the [ThreadListViewModel].
- * @param title Header title.
+ * @param title Header title. Also drives the screen's `paneTitle` semantic, announced by TalkBack
+ * when the screen appears as a pane (e.g. an adaptive-layout pane or a Compose Navigation route).
  * @param onHeaderAvatarClick Handle for when the user clicks on the header avatar.
  * @param onThreadClick Handler for Thread item clicks.
  */

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/threads/ThreadsScreen.kt
@@ -23,6 +23,8 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
+import androidx.compose.ui.semantics.semantics
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.getstream.chat.android.client.api.models.QueryThreadsRequest
 import io.getstream.chat.android.compose.R
@@ -54,7 +56,7 @@ public fun ThreadsScreen(
     val user by listViewModel.user.collectAsState()
     val connectionState by listViewModel.connectionState.collectAsState()
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().semantics { paneTitle = title }) {
         ChatTheme.componentFactory.ThreadListHeader(
             params = ThreadListHeaderParams(
                 title = title,

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/threads/ThreadsScreenTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/threads/ThreadsScreenTest.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.getstream.chat.android.compose.ui.chats
+package io.getstream.chat.android.compose.ui.threads
 
 import androidx.annotation.UiThread
 import androidx.compose.ui.test.junit4.createComposeRule
@@ -22,7 +22,6 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import io.getstream.chat.android.client.test.MockedChatClientTest
-import io.getstream.chat.android.compose.ui.channels.SearchMode
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.ConnectionState
 import io.getstream.chat.android.randomUser
@@ -37,56 +36,28 @@ import org.robolectric.annotation.Config
 
 @RunWith(AndroidJUnit4::class)
 @Config(sdk = [33])
-internal class ChatsScreenTest : MockedChatClientTest {
+internal class ThreadsScreenTest : MockedChatClientTest {
 
     @get:Rule
     val composeTestRule = createComposeRule()
 
     @Before
     fun prepare() {
-        val user = randomUser()
-        whenever(mockChatClient.getCurrentUser()) doReturn user
-        whenever(mockClientState.user) doReturn MutableStateFlow(user)
+        whenever(mockClientState.user) doReturn MutableStateFlow(randomUser())
         whenever(mockClientState.connectionState) doReturn MutableStateFlow(ConnectionState.Connected)
     }
 
     @Test
     @UiThread
-    fun `with search mode none`() {
+    fun `with default title`() {
         composeTestRule.setContent {
             ChatTheme {
-                ChatsScreen()
+                ThreadsScreen()
             }
         }
 
-        composeTestRule.onNodeWithText("Stream Chat").assertExists()
-        composeTestRule.onNodeWithTag("Stream_ChannelListLoading").assertExists()
-    }
-
-    @Test
-    @UiThread
-    fun `with search mode messages`() {
-        composeTestRule.setContent {
-            ChatTheme {
-                ChatsScreen(searchMode = SearchMode.Messages)
-            }
-        }
-
-        composeTestRule.onNodeWithText("Search").assertExists()
-        composeTestRule.onNodeWithTag("Stream_ChannelListLoading").assertExists()
-    }
-
-    @Test
-    @UiThread
-    fun `with list content mode threads`() {
-        composeTestRule.setContent {
-            ChatTheme {
-                ChatsScreen(listContentMode = ChatListContentMode.Threads)
-            }
-        }
-
-        composeTestRule.onNodeWithTag("Stream_ThreadListLoading")
-            .assertExists()
+        composeTestRule.onNodeWithText("Threads").assertExists()
+        composeTestRule.onNodeWithTag("Stream_ThreadListLoading").assertExists()
     }
 
     @Test
@@ -94,10 +65,10 @@ internal class ChatsScreenTest : MockedChatClientTest {
     fun `with custom title`() {
         composeTestRule.setContent {
             ChatTheme {
-                ChatsScreen(title = "My Chats")
+                ThreadsScreen(title = "My Threads")
             }
         }
 
-        composeTestRule.onNodeWithText("My Chats").assertExists()
+        composeTestRule.onNodeWithText("My Threads").assertExists()
     }
 }


### PR DESCRIPTION
AND-1180

### Goal

TalkBack was reading the wrong thing whenever a user navigated between screens in the Compose sample, and was silent when sub-screens appeared inside an existing Activity:

- In the sample app, every Activity entry announced "Chat Sample Compose" (the application label) because most activities had no per-activity `android:label`. The user couldn't tell which screen they had just landed on.
- In the Compose SDK, screens shown via `FullscreenDialog` (e.g. `AddMembersScreen`, `GroupChannelEditScreen` reached from `GroupChannelInfoScreen`) had no `Modifier.semantics { paneTitle = ... }`, so TalkBack made no pane-change announcement on dialog open. The user heard only the back-button focus, with no indication of which dialog had appeared.
- Top-level Screen composables (`ChannelsScreen`, `ChatsScreen`, `ThreadsScreen`, `DirectChannelInfoScreen`, `GroupChannelInfoScreen`) had no `paneTitle` either. When used as a pane in an adaptive layout or shown via a Compose Navigation route inside an existing Activity, pane changes were silent.

The two mechanisms are independent and not interchangeable. `android:label` is the only thing TalkBack announces on Activity entry. `paneTitle` is the only thing TalkBack announces on in-Activity pane / dialog changes. Empirically verified: removing `android:label` while setting `paneTitle` alone on `PinnedMessagesActivity` produced "Chat Sample Compose, Back, button…" — `paneTitle` does not fire on initial Activity entry. Confirmed by the [official Compose semantics docs](https://developer.android.com/develop/ui/compose/accessibility/semantics): "Window-like custom components, similar to `ModalBottomSheet`, need additional signals to differentiate them from surrounding content. For this, you can use `paneTitle` semantics, so that any relevant window or pane changes may be represented appropriately by the accessibility services."

### Implementation

**Compose sample app — per-Activity `android:label`**

Added `android:label` to 13 activities in `stream-chat-android-compose-sample/src/main/AndroidManifest.xml` that previously had none (two attachment activities — Files, Media — already carried a label). `StartupActivity` is deliberately skipped because it routes to another Activity in `onCreate` and never gains stable focus. Labels reuse existing sample strings (`pinned_messages_title`, `reminders_title`, `add_channel_title`, etc.) or SDK ui-common strings (`stream_ui_channel_info_contact_title`, `stream_ui_channel_info_group_title`) where they fit. Only two net-new sample strings were needed (`channel_title`, `user_profile_title`) for screens whose top bar is dynamic or empty.

**Compose SDK — `paneTitle` on Screen composables**

Added `Modifier.semantics { paneTitle = ... }` to seven SDK Screen composables. All reuse existing strings or the screen's existing `title` parameter — no new public API:

| Screen                    | `paneTitle` source                                             |
|---------------------------|----------------------------------------------------------------|
| `AddMembersScreen`        | `R.string.stream_compose_add_members_title`                    |
| `GroupChannelEditScreen`  | `UiCommonR.string.stream_ui_channel_info_edit_title`           |
| `DirectChannelInfoScreen` | `UiCommonR.string.stream_ui_channel_info_contact_title`        |
| `GroupChannelInfoScreen`  | `UiCommonR.string.stream_ui_channel_info_group_title`          |
| `ChannelsScreen`          | existing `title` parameter                                     |
| `ChatsScreen`             | existing `title` parameter (applied on the list-pane Scaffold) |
| `ThreadsScreen`           | existing `title` parameter                                     |

`ChannelScreen` (dynamic channel-name title) and `MediaGalleryPreviewScreen` (complex dual-overload structure) are deferred to follow-up PRs — each needs its own design decision.

`ChannelsScreen`, `ChatsScreen`, and `ThreadsScreen` also have their `@param title` KDoc updated to state that the value drives the `paneTitle` semantic.

No visual changes; only accessibility semantics and manifest labels.

### Testing

1. Enable TalkBack.
2. **Compose sample — Activity labels**. Launch the sample app and navigate through each screen, listening to the announcement on entry:
   - Welcome / login → "Welcome to Stream Chat" / "Advanced options".
   - Channel list → "Chats".
   - Open a channel → "Channel".
   - From the channel header, open channel info → "Contact Info" (DM) or "Group Info" (group).
   - From channel info → Pinned Messages → "Pinned Messages".
   - From the navigation drawer → New chat → "New Chat"; New group chat → "Add group members"; Reminders → "Message Reminders"; Profile → "Profile".
   - From a message → media gallery → existing labels ("Photos & Videos" / "Files").
   - On each, confirm the announced label matches the table above and that "Chat Sample Compose" is no longer heard.
3. **Compose SDK — `paneTitle` for FullscreenDialog content**. Open a group channel's info screen, tap **Add Members** → TalkBack should announce "Add Members" when the dialog appears. From the same screen, tap the edit action → TalkBack should announce "Edit".
4. **Compose SDK — Adaptive layout**. In the sample app, enable the "Adaptive layout (Experimental)" toggle in Custom settings and log in. As you navigate between the list and detail panes, the active pane should be announced ("Stream Chat" / channel name).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Added proper activity titles throughout the app for clearer navigation and task switching.
  * Enhanced accessibility support with improved screen reader annotations across messaging and channel management screens.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->