### PR TITLE
Prevent calling `MarkRead` on the current user's own unsynced last message

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListController.kt
@@ -65,6 +65,7 @@ import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.PollOption
 import io.getstream.chat.android.models.Reaction
+import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.ui.common.feature.messages.translations.MessageOriginalTranslationsStore
@@ -1714,9 +1715,20 @@ public class MessageListController(
         val itemState = messagesState.messageItems.lastOrNull { messageItem ->
             messageItem is HasMessageListItemState
         } as? HasMessageListItemState
-        val messageId = itemState?.message?.id
-        val messageText = itemState?.message?.text
+        val message = itemState?.message
+        val messageId = message?.id
+        val messageText = message?.text
         logger.d { "[markLastMessageRead] cid: $cid, msgId($isInThread): $messageId, msgText: \"$messageText\"" }
+
+        // Skip when our own message is at the bottom and hasn't been confirmed by the server.
+        // Without this, marking read on an empty channel (only an in-flight optimistic message
+        // exists) causes the server to persist last_read_message_id = "" because its view of
+        // the channel is empty.
+        val currentUserId = clientState.user.value?.id
+        if (message != null && message.user.id == currentUserId && message.syncStatus != SyncStatus.COMPLETED) {
+            logger.v { "[markLastMessageRead] cid: $cid; rejected[$isInThread] (own unsynced): $messageId" }
+            return
+        }
 
         val lastSeenMessageId = this.lastSeenMessageId
         if (lastSeenMessageId == messageId) {

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/list/MessageListControllerTests.kt
@@ -40,6 +40,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.MessageType
 import io.getstream.chat.android.models.MessagesState
 import io.getstream.chat.android.models.Reaction
+import io.getstream.chat.android.models.SyncStatus
 import io.getstream.chat.android.models.TypingEvent
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.Vote
@@ -308,9 +309,9 @@ internal class MessageListControllerTests {
     fun `When repetitive markLastMessageRead calls appear only single API call should be sent`() = runTest {
         val chatClient: ChatClient = mock()
         val messages = arrayListOf(
-            randomMessage(id = "1"),
-            randomMessage(id = "2"),
-            randomMessage(id = "3"),
+            randomMessage(id = "1", syncStatus = SyncStatus.COMPLETED),
+            randomMessage(id = "2", syncStatus = SyncStatus.COMPLETED),
+            randomMessage(id = "3", syncStatus = SyncStatus.COMPLETED),
         )
         val messagesState = MutableStateFlow(messages)
         val controller = Fixture(chatClient = chatClient)
@@ -332,6 +333,68 @@ internal class MessageListControllerTests {
         delay(1000)
 
         verify(chatClient, times(1)).markRead(any(), any())
+    }
+
+    @Test
+    fun `When current user's last message is COMPLETED markLastMessageRead should invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.COMPLETED)),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "1"
+    }
+
+    @Test
+    fun `When current user's last message is not COMPLETED markLastMessageRead should not invoke markRead`() = runTest {
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(randomMessage(id = "1", user = user1, syncStatus = SyncStatus.IN_PROGRESS)),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(0)).markRead(any(), any())
+        controller.lastSeenMessageId.shouldBeNull()
+    }
+
+    @Test
+    fun `When peer's last message is not COMPLETED markLastMessageRead should still invoke markRead`() = runTest {
+        // syncStatus is local-only and not on the wire. Peer messages inherit the data
+        // class default — the gate must not block them on that.
+        val chatClient: ChatClient = mock()
+        val messagesState = MutableStateFlow(
+            listOf(randomMessage(id = "1", user = user2, syncStatus = SyncStatus.IN_PROGRESS)),
+        )
+        val controller = Fixture(chatClient = chatClient)
+            .givenCurrentUser()
+            .givenChannelQuery()
+            .givenMarkRead()
+            .givenChannelState(messagesState = messagesState)
+            .get()
+
+        controller.markLastMessageRead()
+        delay(1000)
+
+        verify(chatClient, times(1)).markRead(eq(CHANNEL_TYPE), eq(CHANNEL_ID))
+        controller.lastSeenMessageId `should be equal to` "1"
     }
 
     @Test
@@ -1320,12 +1383,18 @@ internal class MessageListControllerTests {
         @OptIn(ExperimentalCoroutinesApi::class)
         private fun nowDate() = Date(testCoroutines.dispatcher.scheduler.currentTime)
 
-        private fun nowMessage(author: User, type: String, text: String = randomString()): Message {
+        private fun nowMessage(
+            author: User,
+            type: String,
+            text: String = randomString(),
+            syncStatus: SyncStatus = SyncStatus.COMPLETED,
+        ): Message {
             val nowDate = nowDate()
             return randomMessage(
                 user = author,
                 type = type,
                 text = text,
+                syncStatus = syncStatus,
                 createdAt = nowDate,
                 updatedAt = nowDate,
                 deletedAt = null,


### PR DESCRIPTION
### Goal

Ports the v6 fix [#6431](https://github.com/GetStream/stream-chat-android/pull/6431) (commit `536a5255`) to `develop`. Applied as a clean cherry-pick — no conflicts and no manual modifications were required.

[AND-1173](https://linear.app/stream/issue/AND-1173) — In an otherwise-empty channel, sending a message while it is still in-flight (optimistic, `SyncStatus.IN_PROGRESS`) and calling `markLastMessageRead` causes the server to persist `last_read_message_id = ""`. From the server's perspective the channel is empty at that moment, so it has no message to anchor the read state to. This can cause issues in integrations where they expect a valid `last_read_message_id` value.

### Implementation

In `MessageListController.markLastMessageRead()`, gate the `markRead` call on the bottom message: if it is authored by the current user **and** its `syncStatus != COMPLETED`, log and return early instead of issuing the API call. Peer messages are not affected — `syncStatus` is a local-only field and peer messages keep the data-class default, so the gate is intentionally scoped to messages owned by the current user.

### UI Changes

No UI changes.

### Testing

Unit tests added in `MessageListControllerTests`:
- `When current user's last message is COMPLETED markLastMessageRead should invoke markRead` — happy path, `lastSeenMessageId` is updated.
- `When current user's last message is not COMPLETED markLastMessageRead should not invoke markRead` — gated path, no API call, `lastSeenMessageId` stays null.
- `When peer's last message is not COMPLETED markLastMessageRead should still invoke markRead` — guards against the gate over-matching peer messages that carry the default `syncStatus`.

The existing `When repetitive markLastMessageRead calls appear only single API call should be sent` test was updated to seed messages with `SyncStatus.COMPLETED` so it continues to exercise the dedupe path rather than the new gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed a critical message read status issue where unsent or in-flight messages could be incorrectly marked as read before being fully sent to the server. The app now properly waits for all messages to complete syncing before recording their read status, ensuring accurate message state tracking and preventing unnecessary inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6471?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->