### PR TITLE
Fix reactions modal crash when no reactions can be displayed

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/reactions/user/internal/UserReactionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/reactions/user/internal/UserReactionsView.kt
@@ -100,7 +100,9 @@ public class UserReactionsView : FrameLayout {
             }
         }
 
-        gridLayoutManager.spanCount = userReactionItems.size.coerceAtMost(MAX_COLUMNS_COUNT)
+        gridLayoutManager.spanCount = userReactionItems.size
+            .coerceAtMost(MAX_COLUMNS_COUNT)
+            .coerceAtLeast(1)
         userReactionsAdapter.submitList(userReactionItems)
     }
 


### PR DESCRIPTION
Closes AND-1194

### Goal

Fix the `IllegalArgumentException: Span count should be at least 1. Provided 0` crash from `UserReactionsView.bindReactionList` when the reactions modal opens on a message whose filtered `latestReactions` ends up empty.

### Implementation

`UserReactionsView.bindReactionList` set `gridLayoutManager.spanCount` directly from the size of the filtered reaction list:

```kotlin
gridLayoutManager.spanCount = userReactionItems.size.coerceAtMost(MAX_COLUMNS_COUNT)
```

When `userReactionItems` is empty — every reaction has `user == null`, or `ChatUI.supportedReactions.getReactionDrawable(type) == null`, or `latestReactions` itself is empty while `reactionGroups` is populated — `spanCount = 0` is passed to `GridLayoutManager.setSpanCount`, which rejects it.

Clamp the value to at least 1:

```kotlin
gridLayoutManager.spanCount = userReactionItems.size
    .coerceAtMost(MAX_COLUMNS_COUNT)
    .coerceAtLeast(1)
```

`spanCount = 1` on an empty `RecyclerView` is harmless — the grid has no rows regardless of the span count. The modal opens with its title ("0 reactions") and an empty grid instead of crashing.

`./gradlew apiDump` produced zero `.api` diff, confirming no public surface change.

### Testing

Manual repro needs a small sample-app patch — applied to `ComponentBrowserUserReactionsFragment` and its layout — that adds a tap target which calls `UserReactionsView.setMessage` with `latestReactions = emptyList()`. Apply the patch below, then:

1. Run `stream-chat-android-ui-components-sample`. On the user picker, tap the **SDK Version** label at the bottom to open the Component Browser.
2. Open **UserReactionsView**.
3. Below the four demo cards, tap the **"Tap to repro IllegalArgumentException crash (empty latestReactions)"** label.

- **Before this fix:** crash at `UserReactionsView.kt:103` with the exact stack trace reported by the customer.
- **After this fix:** the modal opens with an empty grid, no crash.

Also verified:
- `./gradlew spotlessApply detekt apiDump` — clean.
- `./gradlew :stream-chat-android-ui-components:testDebugUnitTest` — green.

<details>

<summary>Sample-app patch for manual verification</summary>

```diff
diff --git a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/reactions/ComponentBrowserUserReactionsFragment.kt b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/reactions/ComponentBrowserUserReactionsFragment.kt
index 9bb0c01416..dc4bcde396 100644
--- a/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/reactions/ComponentBrowserUserReactionsFragment.kt
+++ b/stream-chat-android-ui-components-sample/src/main/kotlin/io/getstream/chat/ui/sample/feature/componentbrowser/reactions/ComponentBrowserUserReactionsFragment.kt
@@ -23,6 +23,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.chat.android.models.Reaction
+import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.helper.SupportedReactions.DefaultReactionTypes.LOL
 import io.getstream.chat.android.ui.helper.SupportedReactions.DefaultReactionTypes.LOVE
 import io.getstream.chat.android.ui.helper.SupportedReactions.DefaultReactionTypes.THUMBS_DOWN
@@ -104,6 +105,22 @@ class ComponentBrowserUserReactionsFragment : Fragment() {
                 ),
                 currentUser = currentUser,
             )
+            setupEmptyReactionsCrashRepro(currentUser)
+        }
+    }
+
+    /**
+     * Repro for `IllegalArgumentException("Span count should be at least 1. Provided 0")`
+     * thrown from `UserReactionsView.bindReactionList` (line 103). Triggered when a message
+     * displays a reactions bubble but its `latestReactions` list contains no entries that
+     * survive the supported-reactions / non-null user / non-null drawable filter.
+     */
+    private fun setupEmptyReactionsCrashRepro(currentUser: User) {
+        binding.crashReproLabel.setOnClickListener {
+            binding.userReactionsView5.setMessage(
+                message = randomMessage().copy(latestReactions = mutableListOf()),
+                currentUser = currentUser,
+            )
         }
     }
 }
diff --git a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_user_reactions_view.xml b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_user_reactions_view.xml
index 6f4b2e31be..5299a47ade 100644
--- a/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_user_reactions_view.xml
+++ b/stream-chat-android-ui-components-sample/src/main/res/layout/fragment_component_browser_user_reactions_view.xml
@@ -79,6 +79,26 @@
                 android:layout_marginTop="8dp"
                 />
 
+            <TextView
+                android:id="@+id/crashReproLabel"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:padding="12dp"
+                android:background="?attr/selectableItemBackground"
+                android:textColor="@color/stream_ui_text_color_primary"
+                android:textStyle="bold"
+                android:gravity="center"
+                android:text="Tap to repro IllegalArgumentException crash (empty latestReactions)"
+                />
+
+            <io.getstream.chat.android.ui.feature.messages.list.reactions.user.internal.UserReactionsView
+                android:id="@+id/userReactionsView5"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                />
+
         </LinearLayout>
 
     </ScrollView>
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reaction grid layout calculation to correctly handle all display scenarios. The grid now enforces appropriate column span bounds with both minimum and maximum limits, resolving visual rendering issues that occurred with empty reaction lists. This ensures consistent and reliable presentation regardless of the number of reactions displayed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->