### PR TITLE
Port v6: Fix reactions modal crash when no reactions can be displayed

### DIFF
--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/reactions/user/internal/UserReactionsView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/reactions/user/internal/UserReactionsView.kt
@@ -100,7 +100,9 @@ public class UserReactionsView : FrameLayout {
             }
         }
 
-        gridLayoutManager.spanCount = userReactionItems.size.coerceAtMost(MAX_COLUMNS_COUNT)
+        gridLayoutManager.spanCount = userReactionItems.size
+            .coerceAtMost(MAX_COLUMNS_COUNT)
+            .coerceAtLeast(1)
         userReactionsAdapter.submitList(userReactionItems)
     }
 


### PR DESCRIPTION
Port of #6475 to v7 (develop).

Closes AND-1194.

### Goal

Fix the `IllegalArgumentException: Span count should be at least 1. Provided 0` crash from `UserReactionsView.bindReactionList` when the reactions modal opens on a message whose filtered `latestReactions` ends up empty. The same buggy code is present on every v6 release from 6.35.0 through 6.38.0 and on `develop`.

### Implementation

`UserReactionsView.bindReactionList` set `gridLayoutManager.spanCount` directly from the size of the filtered reaction list:

```kotlin
gridLayoutManager.spanCount = userReactionItems.size.coerceAtMost(MAX_COLUMNS_COUNT)
```

When `userReactionItems` is empty, `spanCount = 0` is passed to `GridLayoutManager.setSpanCount`, which rejects it.

Clamp the value to at least 1:

```kotlin
gridLayoutManager.spanCount = userReactionItems.size
    .coerceAtMost(MAX_COLUMNS_COUNT)
    .coerceAtLeast(1)
```

`./gradlew apiDump` produced zero `.api` diff, confirming no public surface change.

### Testing

See #6475 for the manual repro patch and full testing notes. Also verified on this branch:

- `./gradlew spotlessApply detekt apiDump` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where the reaction layout could fail to display properly when the reaction list was empty, ensuring consistent grid formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/GetStream/stream-chat-android/pull/6476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->