### PR TITLE
Fall back to user id when name is empty for user mentions

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -937,7 +937,7 @@ public class MessageComposerController(
         val userMentions = selectedMentions.filterIsInstance<Mention.User>()
         val text = message.lowercase()
         val remainingMentions = userMentions.filter {
-            text.contains("@${it.user.name.lowercase()}")
+            text.contains("@${it.display.lowercase()}")
         }.map { it.user.id }
         this.selectedMentions.clear()
         _state.update { it.copy(selectedMentions = emptySet()) }

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/mention/Mention.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/mention/Mention.kt
@@ -51,7 +51,9 @@ public interface Mention {
     public val type: MentionType
 
     /**
-     * The display text of the mention.
+     * The display text of the mention. Implementations must guarantee a non-empty value so
+     * autocomplete and linkification produce a stable `@token` even when the underlying source
+     * lacks a human-readable name.
      */
     public val display: String
 
@@ -62,6 +64,6 @@ public interface Mention {
      */
     public data class User(public val user: io.getstream.chat.android.models.User) : Mention {
         override val type: MentionType = MentionType.user
-        override val display: String = user.name
+        override val display: String = user.name.ifEmpty { user.id }
     }
 }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -1585,6 +1585,50 @@ internal class MessageComposerControllerTest {
     }
 
     @Test
+    fun `Given nameless mention When user id token present Then mention is kept`() = runTest {
+        // Given
+        val controller = Fixture()
+            .givenAppSettings()
+            .givenAudioPlayer(mock())
+            .givenClientState(User("uid1"))
+            .givenGlobalState()
+            .givenChannelState()
+            .get()
+        val user = User(id = "user1", name = "")
+        controller.setMessageInput("Hello @")
+        controller.selectMention(user)
+        advanceUntilIdle()
+
+        // When
+        val message = controller.buildNewMessage(controller.messageInput.value.text)
+
+        // Then
+        assertEquals(listOf("user1"), message.mentionedUsersIds)
+    }
+
+    @Test
+    fun `Given nameless mention When user id token removed Then mention is dropped`() = runTest {
+        // Given
+        val controller = Fixture()
+            .givenAppSettings()
+            .givenAudioPlayer(mock())
+            .givenClientState(User("uid1"))
+            .givenGlobalState()
+            .givenChannelState()
+            .get()
+        val user = User(id = "user1", name = "")
+        controller.setMessageInput("Hello @")
+        controller.selectMention(user)
+        advanceUntilIdle()
+
+        // When (user erases the mention text but a stray "@" remains)
+        val message = controller.buildNewMessage("Hello @ world")
+
+        // Then
+        assertEquals(emptyList<String>(), message.mentionedUsersIds)
+    }
+
+    @Test
     fun `Given an active command When clearData called Then activeCommand is null`() = runTest {
         // Given
         val command = randomCommand()

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/mention/MentionTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/mention/MentionTest.kt
@@ -34,4 +34,12 @@ internal class MentionTest {
         assertEquals(MentionType.user, mention.type)
         assertEquals("John Doe", mention.display)
     }
+
+    @Test
+    fun `Given User without a name when accessing display then fall back to id`() {
+        val user = io.getstream.chat.android.models.User(id = "user1", name = "")
+        val mention = Mention.User(user)
+
+        assertEquals("user1", mention.display)
+    }
 }


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Make `Mention.User.display` fall back to `user.id` when `user.name` is empty so nameless mentions produce a stable `@<id>` token in the composer. We were already falling back to user id when rendering mentions in [`MessageTextFormatter.kt#L152`](https://github.com/GetStream/stream-chat-android/blob/develop/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageTextFormatter.kt#L152).

Aligns with iOS, which applies the same fallback in [`ChatUser.mentionText`](https://github.com/GetStream/stream-chat-swiftui/blob/main/Sources/StreamChatSwiftUI/ChatChannel/Utils/ChatChannelExtensions.swift#L80-L88) (`stream-chat-swiftui`) and [`ComposerVC.mentionText(for:)`](https://github.com/GetStream/stream-chat-swift/blob/main/Sources/StreamChatUI/Composer/ComposerVC.swift#L1314-L1320) (`stream-chat-swift`).

Closes [AND-1208](https://linear.app/stream/issue/AND-1208/fall-back-to-user-id-when-name-is-empty-in-mentionuserdisplay)

### Implementation

- `Mention.User.display` now returns `user.name.ifEmpty { user.id }`.
- `MessageComposerController.filterMentions` matches against `it.display.lowercase()` instead of `it.user.name.lowercase()`, so the survival check uses the same token that `selectMention` inserted.

### Testing

- New `MentionTest` case asserts the id fallback when `user.name` is empty.
- New `MessageComposerControllerTest` cases cover the round-trip for a nameless mention: kept when the `@<id>` token is present in the input, dropped when the token is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention filtering in the message composer to correctly track mentions using their display text. Users without assigned names now display their user ID, ensuring mentions remain properly preserved in composed messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->