### PR TITLE
Improve message actions menu TalkBack accessibility

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1087,7 +1087,7 @@ public final class io/getstream/chat/android/compose/ui/components/ComposableSin
 public final class io/getstream/chat/android/compose/ui/components/ComposableSingletons$StreamModalBottomSheetKt {
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/ComposableSingletons$StreamModalBottomSheetKt;
 	public fun <init> ()V
-	public final fun getLambda$42975036$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$932570128$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
 public final class io/getstream/chat/android/compose/ui/components/ComposerCancelIconKt {
@@ -1718,12 +1718,6 @@ public final class io/getstream/chat/android/compose/ui/components/reactionoptio
 	public final fun getLambda$857155321$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
-public final class io/getstream/chat/android/compose/ui/components/reactionpicker/ComposableSingletons$ReactionsPickerKt {
-	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactionpicker/ComposableSingletons$ReactionsPickerKt;
-	public fun <init> ()V
-	public final fun getLambda$1237548717$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-}
-
 public final class io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPickerKt {
 	public static final fun ReactionsPicker (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ReactionsPickerContent (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
@@ -1870,7 +1864,7 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/Com
 	public final fun getLambda$-2013272462$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-2042605497$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$12639049$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$1654106807$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$2047105752$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentTypePickerKt {

--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -1084,6 +1084,12 @@ public final class io/getstream/chat/android/compose/ui/components/ComposableSin
 	public final fun getLambda$2132906032$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
+public final class io/getstream/chat/android/compose/ui/components/ComposableSingletons$StreamModalBottomSheetKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/ComposableSingletons$StreamModalBottomSheetKt;
+	public fun <init> ()V
+	public final fun getLambda$42975036$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class io/getstream/chat/android/compose/ui/components/ComposerCancelIconKt {
 	public static final fun ComposerCancelIcon (Landroidx/compose/ui/Modifier;Ljava/lang/String;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 }
@@ -1712,6 +1718,12 @@ public final class io/getstream/chat/android/compose/ui/components/reactionoptio
 	public final fun getLambda$857155321$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 }
 
+public final class io/getstream/chat/android/compose/ui/components/reactionpicker/ComposableSingletons$ReactionsPickerKt {
+	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/components/reactionpicker/ComposableSingletons$ReactionsPickerKt;
+	public fun <init> ()V
+	public final fun getLambda$1237548717$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+}
+
 public final class io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPickerKt {
 	public static final fun ReactionsPicker (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)V
 	public static final fun ReactionsPickerContent (Lio/getstream/chat/android/models/Message;Lkotlin/jvm/functions/Function1;Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;II)V
@@ -1858,7 +1870,7 @@ public final class io/getstream/chat/android/compose/ui/messages/attachments/Com
 	public final fun getLambda$-2013272462$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$-2042605497$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$12639049$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$2047105752$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
+	public final fun getLambda$1654106807$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/attachments/ComposableSingletons$AttachmentTypePickerKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/StreamModalBottomSheet.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/StreamModalBottomSheet.kt
@@ -19,6 +19,7 @@ package io.getstream.chat.android.compose.ui.components
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.shape.CornerSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetState
@@ -53,6 +54,7 @@ import io.getstream.chat.android.compose.ui.theme.StreamTokens
  * @param onDismissRequest Invoked when the user dismisses the sheet.
  * @param modifier Modifier applied to the sheet container.
  * @param sheetState State controlling the sheet's visibility and target value.
+ * @param dragHandle Composable rendered as the sheet's drag handle. Defaults to the M3 default.
  * @param content Sheet body, laid out vertically in a [ColumnScope].
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -61,6 +63,7 @@ internal fun StreamCardBottomSheet(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberStreamSheetState(initialValueInInspection = SheetValue.PartiallyExpanded),
+    dragHandle: @Composable () -> Unit = { BottomSheetDefaults.DragHandle() },
     content: @Composable ColumnScope.() -> Unit,
 ) {
     ModalBottomSheet(
@@ -70,6 +73,7 @@ internal fun StreamCardBottomSheet(
         shape = StreamCardSheetShape,
         containerColor = ChatTheme.colors.backgroundCoreElevation1,
         scrimColor = ChatTheme.colors.backgroundCoreScrim,
+        dragHandle = dragHandle,
         content = content,
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/StreamModalBottomSheet.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/StreamModalBottomSheet.kt
@@ -31,6 +31,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.Dp
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -39,7 +41,8 @@ import io.getstream.chat.android.compose.ui.theme.StreamTokens
  * Card-style Stream modal bottom sheet.
  *
  * Bakes the design-system tokens for a card sitting above the app:
- * 32dp top corners, elevated surface color, heavier scrim, and the M3 default drag handle.
+ * 32dp top corners, elevated surface color, heavier scrim, and the M3 default drag handle
+ * (hidden from the accessibility tree).
  * Use for menus and option pickers that appear on top of the underlying screen
  * (e.g. reactions, channel info member modal, attachment command picker).
  *
@@ -54,7 +57,6 @@ import io.getstream.chat.android.compose.ui.theme.StreamTokens
  * @param onDismissRequest Invoked when the user dismisses the sheet.
  * @param modifier Modifier applied to the sheet container.
  * @param sheetState State controlling the sheet's visibility and target value.
- * @param dragHandle Composable rendered as the sheet's drag handle. Defaults to the M3 default.
  * @param content Sheet body, laid out vertically in a [ColumnScope].
  */
 @OptIn(ExperimentalMaterial3Api::class)
@@ -63,7 +65,6 @@ internal fun StreamCardBottomSheet(
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
     sheetState: SheetState = rememberStreamSheetState(initialValueInInspection = SheetValue.PartiallyExpanded),
-    dragHandle: @Composable () -> Unit = { BottomSheetDefaults.DragHandle() },
     content: @Composable ColumnScope.() -> Unit,
 ) {
     ModalBottomSheet(
@@ -73,7 +74,11 @@ internal fun StreamCardBottomSheet(
         shape = StreamCardSheetShape,
         containerColor = ChatTheme.colors.backgroundCoreElevation1,
         scrimColor = ChatTheme.colors.backgroundCoreScrim,
-        dragHandle = dragHandle,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                modifier = Modifier.semantics { hideFromAccessibility() },
+            )
+        },
         content = content,
     )
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageactions/MessageActions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messageactions/MessageActions.kt
@@ -49,6 +49,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.layout.positionInWindow
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.paneTitle
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
 import androidx.compose.ui.tooling.preview.Preview
@@ -59,6 +61,7 @@ import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import androidx.compose.ui.window.DialogWindowProvider
 import androidx.compose.ui.zIndex
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messageoptions.MessageOptionItemState
 import io.getstream.chat.android.compose.state.messages.MessageAlignment
 import io.getstream.chat.android.compose.ui.components.messageoptions.defaultMessageOptionsState
@@ -175,9 +178,13 @@ public fun MessageActions(
             if (isInspection) animation.snapIn() else animation.animateIn()
         }
 
+        val menuPaneTitle = stringResource(R.string.stream_compose_message_actions_menu_title)
         Column(
             modifier = modifier
-                .semantics { testTagsAsResourceId = true }
+                .semantics {
+                    testTagsAsResourceId = true
+                    paneTitle = menuPaneTitle
+                }
                 .fillMaxSize()
                 .clickable(onClick = animatedDismiss, indication = null, interactionSource = null)
                 .systemBarsPadding()

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPicker.kt
@@ -17,9 +17,16 @@
 package io.getstream.chat.android.compose.ui.components.reactionpicker
 
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.hideFromAccessibility
+import androidx.compose.ui.semantics.semantics
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.StreamCardBottomSheet
 import io.getstream.chat.android.compose.ui.components.reactionoptions.ExtendedReactionsOptions
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -45,9 +52,20 @@ public fun ReactionsPicker(
     modifier: Modifier = Modifier,
     onDismiss: () -> Unit = {},
 ) {
+    val view = LocalView.current
+    val emojiPickerTitle = stringResource(R.string.stream_compose_emoji_picker_title)
+    // ModalBottomSheet swallows the standard `paneTitle` window-state-changed event, so
+    // announce the title programmatically. See PollDialogHeader for the same workaround.
+    LaunchedEffect(emojiPickerTitle) { view.announceForAccessibility(emojiPickerTitle) }
+
     StreamCardBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                modifier = Modifier.semantics { hideFromAccessibility() },
+            )
+        },
     ) {
         ChatTheme.componentFactory.MessageReactionsPickerContent(
             params = MessageReactionsPickerContentParams(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPicker.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactionpicker/ReactionsPicker.kt
@@ -17,15 +17,12 @@
 package io.getstream.chat.android.compose.ui.components.reactionpicker
 
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.hideFromAccessibility
-import androidx.compose.ui.semantics.semantics
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.StreamCardBottomSheet
 import io.getstream.chat.android.compose.ui.components.reactionoptions.ExtendedReactionsOptions
@@ -61,11 +58,6 @@ public fun ReactionsPicker(
     StreamCardBottomSheet(
         onDismissRequest = onDismiss,
         modifier = modifier,
-        dragHandle = {
-            BottomSheetDefaults.DragHandle(
-                modifier = Modifier.semantics { hideFromAccessibility() },
-            )
-        },
     ) {
         ChatTheme.componentFactory.MessageReactionsPickerContent(
             params = MessageReactionsPickerContentParams(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -70,8 +70,8 @@ internal fun ReactionToggle(
         val notSelectedStateDescription = stringResource(R.string.stream_compose_reactions_state_not_selected)
         val selectActionLabel = stringResource(R.string.stream_compose_reactions_action_select)
         val unselectActionLabel = stringResource(R.string.stream_compose_reactions_action_unselect)
-        val addedAnnouncement = stringResource(R.string.stream_compose_reactions_added, emoji)
-        val removedAnnouncement = stringResource(R.string.stream_compose_reactions_removed, emoji)
+        val selectedAnnouncement = stringResource(R.string.stream_compose_reactions_selected, emoji)
+        val unselectedAnnouncement = stringResource(R.string.stream_compose_reactions_unselected, emoji)
         val view = LocalView.current
         ChatTheme.componentFactory.ReactionIcon(
             params = ReactionIconParams(
@@ -85,7 +85,7 @@ internal fun ReactionToggle(
                     .ifNotNull(onCheckedChange) { onChange ->
                         val toggleAndAnnounce: (Boolean) -> Unit = { newChecked ->
                             view.announceForAccessibility(
-                                if (newChecked) addedAnnouncement else removedAnnouncement,
+                                if (newChecked) selectedAnnouncement else unselectedAnnouncement,
                             )
                             onChange(newChecked)
                         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -29,10 +29,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ReactionIconParams
 import io.getstream.chat.android.compose.ui.util.ReactionResolver
@@ -60,6 +65,10 @@ internal fun ReactionToggle(
 ) {
     emoji?.let {
         val containerSize = size.toContainerSize()
+        val selectedStateDescription = stringResource(R.string.stream_compose_reactions_state_selected)
+        val notSelectedStateDescription = stringResource(R.string.stream_compose_reactions_state_not_selected)
+        val selectActionLabel = stringResource(R.string.stream_compose_reactions_action_select)
+        val unselectActionLabel = stringResource(R.string.stream_compose_reactions_action_unselect)
         ChatTheme.componentFactory.ReactionIcon(
             params = ReactionIconParams(
                 type = type,
@@ -70,11 +79,25 @@ internal fun ReactionToggle(
                         background(ChatTheme.colors.backgroundUtilitySelected, CircleShape)
                     }
                     .ifNotNull(onCheckedChange) { onChange ->
-                        clip(CircleShape).toggleable(
-                            value = checked,
-                            role = Role.Checkbox,
-                            onValueChange = onChange,
-                        )
+                        clip(CircleShape)
+                            .toggleable(
+                                value = checked,
+                                role = Role.Button,
+                                onValueChange = onChange,
+                            )
+                            .semantics {
+                                stateDescription = if (checked) {
+                                    selectedStateDescription
+                                } else {
+                                    notSelectedStateDescription
+                                }
+                                onClick(
+                                    label = if (checked) unselectActionLabel else selectActionLabel,
+                                ) {
+                                    onChange(!checked)
+                                    true
+                                }
+                            }
                     }
                     .defaultMinSize(minWidth = containerSize, minHeight = containerSize)
                     .wrapContentSize(),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/reactions/ReactionToggle.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.onClick
@@ -69,6 +70,9 @@ internal fun ReactionToggle(
         val notSelectedStateDescription = stringResource(R.string.stream_compose_reactions_state_not_selected)
         val selectActionLabel = stringResource(R.string.stream_compose_reactions_action_select)
         val unselectActionLabel = stringResource(R.string.stream_compose_reactions_action_unselect)
+        val addedAnnouncement = stringResource(R.string.stream_compose_reactions_added, emoji)
+        val removedAnnouncement = stringResource(R.string.stream_compose_reactions_removed, emoji)
+        val view = LocalView.current
         ChatTheme.componentFactory.ReactionIcon(
             params = ReactionIconParams(
                 type = type,
@@ -79,11 +83,17 @@ internal fun ReactionToggle(
                         background(ChatTheme.colors.backgroundUtilitySelected, CircleShape)
                     }
                     .ifNotNull(onCheckedChange) { onChange ->
+                        val toggleAndAnnounce: (Boolean) -> Unit = { newChecked ->
+                            view.announceForAccessibility(
+                                if (newChecked) addedAnnouncement else removedAnnouncement,
+                            )
+                            onChange(newChecked)
+                        }
                         clip(CircleShape)
                             .toggleable(
                                 value = checked,
                                 role = Role.Button,
-                                onValueChange = onChange,
+                                onValueChange = toggleAndAnnounce,
                             )
                             .semantics {
                                 stateDescription = if (checked) {
@@ -94,7 +104,7 @@ internal fun ReactionToggle(
                                 onClick(
                                     label = if (checked) unselectActionLabel else selectActionLabel,
                                 ) {
-                                    onChange(!checked)
+                                    toggleAndAnnounce(!checked)
                                     true
                                 }
                             }

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -230,9 +230,9 @@
   <string name="stream_compose_reactions_action_select">"Seleccionar"</string>
   <string name="stream_compose_reactions_action_unselect">"Deseleccionar"</string>
   <string name="stream_compose_reactions_add">"Añadir reacción"</string>
-  <string name="stream_compose_reactions_added">"Reacción %1$s añadida"</string>
   <string name="stream_compose_reactions_remove">"Toca para eliminar"</string>
-  <string name="stream_compose_reactions_removed">"Reacción %1$s eliminada"</string>
+  <string name="stream_compose_reactions_selected">"Reacción %1$s seleccionada"</string>
+  <string name="stream_compose_reactions_unselected">"Reacción %1$s deseleccionada"</string>
   <string name="stream_compose_reactions_state_not_selected">"No seleccionado"</string>
   <string name="stream_compose_reactions_state_selected">"Seleccionado"</string>
   <string name="stream_compose_reactions_you">"Tú"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -228,7 +228,9 @@
   <string name="stream_compose_reactions_action_select">"Seleccionar"</string>
   <string name="stream_compose_reactions_action_unselect">"Deseleccionar"</string>
   <string name="stream_compose_reactions_add">"Añadir reacción"</string>
+  <string name="stream_compose_reactions_added">"Reacción %1$s añadida"</string>
   <string name="stream_compose_reactions_remove">"Toca para eliminar"</string>
+  <string name="stream_compose_reactions_removed">"Reacción %1$s eliminada"</string>
   <string name="stream_compose_reactions_state_not_selected">"No seleccionado"</string>
   <string name="stream_compose_reactions_state_selected">"Seleccionado"</string>
   <string name="stream_compose_reactions_you">"Tú"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -135,6 +135,7 @@
   <string name="stream_compose_message_composer_attachments_open">"Abrir archivos adjuntos"</string>
   <string name="stream_compose_message_deleted">"Mensaje eliminado"</string>
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
+  <string name="stream_compose_message_actions_menu_title">"Acciones del mensaje"</string>
   <string name="stream_compose_message_item_open_thread">"Abrir hilo"</string>
   <string name="stream_compose_message_item_options">"Mostrar opciones del mensaje"</string>
   <string name="stream_compose_message_attachment_open">"Abrir archivo adjunto"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -225,8 +225,12 @@
   <string name="stream_compose_quoted_message_reply_to">"Responder a %s"</string>
   <string name="stream_compose_quoted_message_reply_to_you">"Responder a ti"</string>
   <string name="stream_compose_quoted_message_you">"Tú"</string>
+  <string name="stream_compose_reactions_action_select">"Seleccionar"</string>
+  <string name="stream_compose_reactions_action_unselect">"Deseleccionar"</string>
   <string name="stream_compose_reactions_add">"Añadir reacción"</string>
   <string name="stream_compose_reactions_remove">"Toca para eliminar"</string>
+  <string name="stream_compose_reactions_state_not_selected">"No seleccionado"</string>
+  <string name="stream_compose_reactions_state_selected">"Seleccionado"</string>
   <string name="stream_compose_reactions_you">"Tú"</string>
   <string name="stream_compose_recent_files">"Archivos recientes"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -85,6 +85,7 @@
   <string name="stream_compose_dismiss">"Descartar"</string>
   <string name="stream_compose_edit_answer">"Actualizar tu comentario"</string>
   <string name="stream_compose_edit_message">"Editar mensaje"</string>
+  <string name="stream_compose_emoji_picker_title">"Selector de emojis"</string>
   <string name="stream_compose_file_preview">"Archivo"</string>
   <string name="stream_compose_flag_message">"Marcar mensaje"</string>
   <string name="stream_compose_flag_message_text">"¿Quieres enviar una copia de este mensaje a un moderador para una investigación más detallada?"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -85,6 +85,7 @@
   <string name="stream_compose_dismiss">"Ignorer"</string>
   <string name="stream_compose_edit_answer">"Mettre à jour votre commentaire"</string>
   <string name="stream_compose_edit_message">"Modifier le message"</string>
+  <string name="stream_compose_emoji_picker_title">"Sélecteur d’emojis"</string>
   <string name="stream_compose_file_preview">"Fichier"</string>
   <string name="stream_compose_flag_message">"Signaler le message"</string>
   <string name="stream_compose_flag_message_text">"Voulez-vous envoyer une copie de ce message à un modérateur pour une enquête plus approfondie ?"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -225,8 +225,12 @@
   <string name="stream_compose_quoted_message_reply_to">"Répondre à %s"</string>
   <string name="stream_compose_quoted_message_reply_to_you">"Répondre à vous-même"</string>
   <string name="stream_compose_quoted_message_you">"Vous"</string>
+  <string name="stream_compose_reactions_action_select">"Sélectionner"</string>
+  <string name="stream_compose_reactions_action_unselect">"Désélectionner"</string>
   <string name="stream_compose_reactions_add">"Ajouter une réaction"</string>
   <string name="stream_compose_reactions_remove">"Appuyez pour supprimer"</string>
+  <string name="stream_compose_reactions_state_not_selected">"Non sélectionné"</string>
+  <string name="stream_compose_reactions_state_selected">"Sélectionné"</string>
   <string name="stream_compose_reactions_you">"Vous"</string>
   <string name="stream_compose_recent_files">"Fichiers récents"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -230,9 +230,9 @@
   <string name="stream_compose_reactions_action_select">"Sélectionner"</string>
   <string name="stream_compose_reactions_action_unselect">"Désélectionner"</string>
   <string name="stream_compose_reactions_add">"Ajouter une réaction"</string>
-  <string name="stream_compose_reactions_added">"Réaction %1$s ajoutée"</string>
   <string name="stream_compose_reactions_remove">"Appuyez pour supprimer"</string>
-  <string name="stream_compose_reactions_removed">"Réaction %1$s supprimée"</string>
+  <string name="stream_compose_reactions_selected">"Réaction %1$s sélectionnée"</string>
+  <string name="stream_compose_reactions_unselected">"Réaction %1$s désélectionnée"</string>
   <string name="stream_compose_reactions_state_not_selected">"Non sélectionné"</string>
   <string name="stream_compose_reactions_state_selected">"Sélectionné"</string>
   <string name="stream_compose_reactions_you">"Vous"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -135,6 +135,7 @@
   <string name="stream_compose_message_composer_attachments_open">"Ouvrir les pièces jointes"</string>
   <string name="stream_compose_message_deleted">"Message supprimé"</string>
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
+  <string name="stream_compose_message_actions_menu_title">"Actions du message"</string>
   <string name="stream_compose_message_item_open_thread">"Ouvrir le fil"</string>
   <string name="stream_compose_message_item_options">"Afficher les options du message"</string>
   <string name="stream_compose_message_attachment_open">"Ouvrir la pièce jointe"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -228,7 +228,9 @@
   <string name="stream_compose_reactions_action_select">"Sélectionner"</string>
   <string name="stream_compose_reactions_action_unselect">"Désélectionner"</string>
   <string name="stream_compose_reactions_add">"Ajouter une réaction"</string>
+  <string name="stream_compose_reactions_added">"Réaction %1$s ajoutée"</string>
   <string name="stream_compose_reactions_remove">"Appuyez pour supprimer"</string>
+  <string name="stream_compose_reactions_removed">"Réaction %1$s supprimée"</string>
   <string name="stream_compose_reactions_state_not_selected">"Non sélectionné"</string>
   <string name="stream_compose_reactions_state_selected">"Sélectionné"</string>
   <string name="stream_compose_reactions_you">"Vous"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -288,7 +288,9 @@
   <string name="stream_compose_reactions_action_select">"चुनें"</string>
   <string name="stream_compose_reactions_action_unselect">"अचयन करें"</string>
   <string name="stream_compose_reactions_add">"प्रतिक्रिया जोड़ें"</string>
+  <string name="stream_compose_reactions_added">"%1$s प्रतिक्रिया जोड़ी गई"</string>
   <string name="stream_compose_reactions_remove">"हटाने के लिए टैप करें"</string>
+  <string name="stream_compose_reactions_removed">"%1$s प्रतिक्रिया हटाई गई"</string>
   <string name="stream_compose_reactions_state_not_selected">"चयनित नहीं"</string>
   <string name="stream_compose_reactions_state_selected">"चयनित"</string>
   <string name="stream_compose_reactions_you">"आप"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -285,8 +285,12 @@
   <string name="stream_compose_quoted_message_reply_to">"%s को जवाब"</string>
   <string name="stream_compose_quoted_message_reply_to_you">"स्वयं को जवाब"</string>
   <string name="stream_compose_quoted_message_you">"आप"</string>
+  <string name="stream_compose_reactions_action_select">"चुनें"</string>
+  <string name="stream_compose_reactions_action_unselect">"अचयन करें"</string>
   <string name="stream_compose_reactions_add">"प्रतिक्रिया जोड़ें"</string>
   <string name="stream_compose_reactions_remove">"हटाने के लिए टैप करें"</string>
+  <string name="stream_compose_reactions_state_not_selected">"चयनित नहीं"</string>
+  <string name="stream_compose_reactions_state_selected">"चयनित"</string>
   <string name="stream_compose_reactions_you">"आप"</string>
   <string name="stream_compose_recent_files">"हाल ही की फाइलें"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -145,6 +145,7 @@
   <string name="stream_compose_dismiss">"खारिज करें"</string>
   <string name="stream_compose_edit_answer">"अपनी टिप्पणी अपडेट करें"</string>
   <string name="stream_compose_edit_message">"मैसेज एडिट करें"</string>
+  <string name="stream_compose_emoji_picker_title">"इमोजी चयनकर्ता"</string>
   <string name="stream_compose_file_preview">"फ़ाइल"</string>
   <string name="stream_compose_flag_message">"मैसेज चिह्नित करें"</string>
   <string name="stream_compose_flag_message_text">"क्या आप आगे की जांच के लिए इस संदेश की एक कॉपी मॉडरेटर को भेजना चाहते हैं?"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -195,6 +195,7 @@
   <string name="stream_compose_message_composer_attachments_open">"अटैचमेंट खोलें"</string>
   <string name="stream_compose_message_deleted">"मैसेज मिटाया गया"</string>
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
+  <string name="stream_compose_message_actions_menu_title">"संदेश की क्रियाएँ"</string>
   <string name="stream_compose_message_item_open_thread">"थ्रेड खोलें"</string>
   <string name="stream_compose_message_item_options">"संदेश के विकल्प दिखाएँ"</string>
   <string name="stream_compose_message_attachment_open">"अटैचमेंट खोलें"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -290,9 +290,9 @@
   <string name="stream_compose_reactions_action_select">"चुनें"</string>
   <string name="stream_compose_reactions_action_unselect">"अचयन करें"</string>
   <string name="stream_compose_reactions_add">"प्रतिक्रिया जोड़ें"</string>
-  <string name="stream_compose_reactions_added">"%1$s प्रतिक्रिया जोड़ी गई"</string>
   <string name="stream_compose_reactions_remove">"हटाने के लिए टैप करें"</string>
-  <string name="stream_compose_reactions_removed">"%1$s प्रतिक्रिया हटाई गई"</string>
+  <string name="stream_compose_reactions_selected">"%1$s प्रतिक्रिया चुनी गई"</string>
+  <string name="stream_compose_reactions_unselected">"%1$s प्रतिक्रिया का चयन हटाया गया"</string>
   <string name="stream_compose_reactions_state_not_selected">"चयनित नहीं"</string>
   <string name="stream_compose_reactions_state_selected">"चयनित"</string>
   <string name="stream_compose_reactions_you">"आप"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -85,6 +85,7 @@
   <string name="stream_compose_dismiss">"Tutup"</string>
   <string name="stream_compose_edit_answer">"Perbarui Komentar Anda"</string>
   <string name="stream_compose_edit_message">"Edit Pesan"</string>
+  <string name="stream_compose_emoji_picker_title">"Pemilih emoji"</string>
   <string name="stream_compose_file_preview">"File"</string>
   <string name="stream_compose_flag_message">"Tandai Pesan"</string>
   <string name="stream_compose_flag_message_text">"Apakah Anda ingin mengirim salinan pesan ini ke moderator untuk investigasi lebih lanjut?"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -225,8 +225,12 @@
   <string name="stream_compose_quoted_message_reply_to">"Balas ke %s"</string>
   <string name="stream_compose_quoted_message_reply_to_you">"Balas ke diri sendiri"</string>
   <string name="stream_compose_quoted_message_you">"Anda"</string>
+  <string name="stream_compose_reactions_action_select">"Pilih"</string>
+  <string name="stream_compose_reactions_action_unselect">"Batalkan pilihan"</string>
   <string name="stream_compose_reactions_add">"Tambahkan reaksi"</string>
   <string name="stream_compose_reactions_remove">"Ketuk untuk menghapus"</string>
+  <string name="stream_compose_reactions_state_not_selected">"Tidak dipilih"</string>
+  <string name="stream_compose_reactions_state_selected">"Dipilih"</string>
   <string name="stream_compose_reactions_you">"Anda"</string>
   <string name="stream_compose_recent_files">"File Terbaru"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -135,6 +135,7 @@
   <string name="stream_compose_message_composer_attachments_open">"Buka lampiran"</string>
   <string name="stream_compose_message_deleted">"Pesan dihapus"</string>
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
+  <string name="stream_compose_message_actions_menu_title">"Tindakan pesan"</string>
   <string name="stream_compose_message_item_open_thread">"Buka utas"</string>
   <string name="stream_compose_message_item_options">"Tampilkan opsi pesan"</string>
   <string name="stream_compose_message_attachment_open">"Buka lampiran"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -228,7 +228,9 @@
   <string name="stream_compose_reactions_action_select">"Pilih"</string>
   <string name="stream_compose_reactions_action_unselect">"Batalkan pilihan"</string>
   <string name="stream_compose_reactions_add">"Tambahkan reaksi"</string>
+  <string name="stream_compose_reactions_added">"Reaksi %1$s ditambahkan"</string>
   <string name="stream_compose_reactions_remove">"Ketuk untuk menghapus"</string>
+  <string name="stream_compose_reactions_removed">"Reaksi %1$s dihapus"</string>
   <string name="stream_compose_reactions_state_not_selected">"Tidak dipilih"</string>
   <string name="stream_compose_reactions_state_selected">"Dipilih"</string>
   <string name="stream_compose_reactions_you">"Anda"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -230,9 +230,9 @@
   <string name="stream_compose_reactions_action_select">"Pilih"</string>
   <string name="stream_compose_reactions_action_unselect">"Batalkan pilihan"</string>
   <string name="stream_compose_reactions_add">"Tambahkan reaksi"</string>
-  <string name="stream_compose_reactions_added">"Reaksi %1$s ditambahkan"</string>
   <string name="stream_compose_reactions_remove">"Ketuk untuk menghapus"</string>
-  <string name="stream_compose_reactions_removed">"Reaksi %1$s dihapus"</string>
+  <string name="stream_compose_reactions_selected">"Reaksi %1$s dipilih"</string>
+  <string name="stream_compose_reactions_unselected">"Reaksi %1$s tidak dipilih"</string>
   <string name="stream_compose_reactions_state_not_selected">"Tidak dipilih"</string>
   <string name="stream_compose_reactions_state_selected">"Dipilih"</string>
   <string name="stream_compose_reactions_you">"Anda"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -285,8 +285,12 @@
   <string name="stream_compose_quoted_message_reply_to">"Rispondi a %s"</string>
   <string name="stream_compose_quoted_message_reply_to_you">"Rispondi a te stesso"</string>
   <string name="stream_compose_quoted_message_you">"Tu"</string>
+  <string name="stream_compose_reactions_action_select">"Seleziona"</string>
+  <string name="stream_compose_reactions_action_unselect">"Deseleziona"</string>
   <string name="stream_compose_reactions_add">"Aggiungi reazione"</string>
   <string name="stream_compose_reactions_remove">"Tocca per rimuovere"</string>
+  <string name="stream_compose_reactions_state_not_selected">"Non selezionato"</string>
+  <string name="stream_compose_reactions_state_selected">"Selezionato"</string>
   <string name="stream_compose_reactions_you">"Tu"</string>
   <string name="stream_compose_recent_files">"File recenti"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -288,7 +288,9 @@
   <string name="stream_compose_reactions_action_select">"Seleziona"</string>
   <string name="stream_compose_reactions_action_unselect">"Deseleziona"</string>
   <string name="stream_compose_reactions_add">"Aggiungi reazione"</string>
+  <string name="stream_compose_reactions_added">"Reazione %1$s aggiunta"</string>
   <string name="stream_compose_reactions_remove">"Tocca per rimuovere"</string>
+  <string name="stream_compose_reactions_removed">"Reazione %1$s rimossa"</string>
   <string name="stream_compose_reactions_state_not_selected">"Non selezionato"</string>
   <string name="stream_compose_reactions_state_selected">"Selezionato"</string>
   <string name="stream_compose_reactions_you">"Tu"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -145,6 +145,7 @@
   <string name="stream_compose_dismiss">"Chiudi"</string>
   <string name="stream_compose_edit_answer">"Aggiorna il tuo commento"</string>
   <string name="stream_compose_edit_message">"Modifica messaggio"</string>
+  <string name="stream_compose_emoji_picker_title">"Selettore emoji"</string>
   <string name="stream_compose_file_preview">"File"</string>
   <string name="stream_compose_flag_message">"Segnala messaggio"</string>
   <string name="stream_compose_flag_message_text">"Vuoi mandare una copia di questo messaggio ad un moderatore?"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -195,6 +195,7 @@
   <string name="stream_compose_message_composer_attachments_open">"Apri allegati"</string>
   <string name="stream_compose_message_deleted">"Messaggio cancellato"</string>
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
+  <string name="stream_compose_message_actions_menu_title">"Azioni del messaggio"</string>
   <string name="stream_compose_message_item_open_thread">"Apri thread"</string>
   <string name="stream_compose_message_item_options">"Mostra opzioni messaggio"</string>
   <string name="stream_compose_message_attachment_open">"Apri allegato"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -290,9 +290,9 @@
   <string name="stream_compose_reactions_action_select">"Seleziona"</string>
   <string name="stream_compose_reactions_action_unselect">"Deseleziona"</string>
   <string name="stream_compose_reactions_add">"Aggiungi reazione"</string>
-  <string name="stream_compose_reactions_added">"Reazione %1$s aggiunta"</string>
   <string name="stream_compose_reactions_remove">"Tocca per rimuovere"</string>
-  <string name="stream_compose_reactions_removed">"Reazione %1$s rimossa"</string>
+  <string name="stream_compose_reactions_selected">"Reazione %1$s selezionata"</string>
+  <string name="stream_compose_reactions_unselected">"Reazione %1$s deselezionata"</string>
   <string name="stream_compose_reactions_state_not_selected">"Non selezionato"</string>
   <string name="stream_compose_reactions_state_selected">"Selezionato"</string>
   <string name="stream_compose_reactions_you">"Tu"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -266,9 +266,9 @@
   <string name="stream_compose_reactions_action_select">"選択"</string>
   <string name="stream_compose_reactions_action_unselect">"選択解除"</string>
   <string name="stream_compose_reactions_add">"リアクションを追加"</string>
-  <string name="stream_compose_reactions_added">"%1$s リアクションを追加しました"</string>
   <string name="stream_compose_reactions_remove">"タップして削除"</string>
-  <string name="stream_compose_reactions_removed">"%1$s リアクションを削除しました"</string>
+  <string name="stream_compose_reactions_selected">"%1$s リアクションを選択しました"</string>
+  <string name="stream_compose_reactions_unselected">"%1$s リアクションの選択を解除しました"</string>
   <string name="stream_compose_reactions_state_not_selected">"選択されていません"</string>
   <string name="stream_compose_reactions_state_selected">"選択されています"</string>
   <string name="stream_compose_reactions_you">"あなた"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -261,8 +261,12 @@
     <item quantity="other">"%d本の動画"</item>
   </plurals>
   <string name="stream_compose_quoted_message_you">"あなた"</string>
+  <string name="stream_compose_reactions_action_select">"選択"</string>
+  <string name="stream_compose_reactions_action_unselect">"選択解除"</string>
   <string name="stream_compose_reactions_add">"リアクションを追加"</string>
   <string name="stream_compose_reactions_remove">"タップして削除"</string>
+  <string name="stream_compose_reactions_state_not_selected">"選択されていません"</string>
+  <string name="stream_compose_reactions_state_selected">"選択されています"</string>
   <string name="stream_compose_reactions_you">"あなた"</string>
   <string name="stream_compose_recent_files">"最近のファイル"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -264,7 +264,9 @@
   <string name="stream_compose_reactions_action_select">"選択"</string>
   <string name="stream_compose_reactions_action_unselect">"選択解除"</string>
   <string name="stream_compose_reactions_add">"リアクションを追加"</string>
+  <string name="stream_compose_reactions_added">"%1$s リアクションを追加しました"</string>
   <string name="stream_compose_reactions_remove">"タップして削除"</string>
+  <string name="stream_compose_reactions_removed">"%1$s リアクションを削除しました"</string>
   <string name="stream_compose_reactions_state_not_selected">"選択されていません"</string>
   <string name="stream_compose_reactions_state_selected">"選択されています"</string>
   <string name="stream_compose_reactions_you">"あなた"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -147,6 +147,7 @@
   <string name="stream_compose_message_composer_attachments_open">"添付ファイルを開く"</string>
   <string name="stream_compose_message_deleted">"メッセージは削除されました"</string>
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
+  <string name="stream_compose_message_actions_menu_title">"メッセージのアクション"</string>
   <string name="stream_compose_message_item_open_thread">"スレッドを開く"</string>
   <string name="stream_compose_message_item_options">"メッセージのオプションを表示"</string>
   <string name="stream_compose_message_attachment_open">"添付ファイルを開く"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -92,6 +92,7 @@
   <string name="stream_compose_dismiss">"閉じる"</string>
   <string name="stream_compose_edit_answer">"コメントを更新"</string>
   <string name="stream_compose_edit_message">"メッセージを編集"</string>
+  <string name="stream_compose_emoji_picker_title">"絵文字ピッカー"</string>
   <string name="stream_compose_file_preview">"ファイル"</string>
   <plurals name="stream_compose_files_preview">
     <item quantity="other">"%dファイル"</item>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -147,6 +147,7 @@
   <string name="stream_compose_message_composer_attachments_open">"첨부파일 열기"</string>
   <string name="stream_compose_message_deleted">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
+  <string name="stream_compose_message_actions_menu_title">"메시지 작업"</string>
   <string name="stream_compose_message_item_open_thread">"스레드 열기"</string>
   <string name="stream_compose_message_item_options">"메시지 옵션 표시"</string>
   <string name="stream_compose_message_attachment_open">"첨부파일 열기"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -92,6 +92,7 @@
   <string name="stream_compose_dismiss">"닫기"</string>
   <string name="stream_compose_edit_answer">"댓글 수정"</string>
   <string name="stream_compose_edit_message">"메시지 수정"</string>
+  <string name="stream_compose_emoji_picker_title">"이모지 선택기"</string>
   <string name="stream_compose_file_preview">"파일"</string>
   <plurals name="stream_compose_files_preview">
     <item quantity="other">"%d개의 파일"</item>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -261,8 +261,12 @@
     <item quantity="other">"%d개의 동영상"</item>
   </plurals>
   <string name="stream_compose_quoted_message_you">"나"</string>
+  <string name="stream_compose_reactions_action_select">"선택"</string>
+  <string name="stream_compose_reactions_action_unselect">"선택 해제"</string>
   <string name="stream_compose_reactions_add">"리액션 추가"</string>
   <string name="stream_compose_reactions_remove">"탭하여 삭제"</string>
+  <string name="stream_compose_reactions_state_not_selected">"선택되지 않음"</string>
+  <string name="stream_compose_reactions_state_selected">"선택됨"</string>
   <string name="stream_compose_reactions_you">"나"</string>
   <string name="stream_compose_recent_files">"최근 파일"</string>
   <string name="stream_compose_remaining_media_attachments_count">"+%1$d"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -264,7 +264,9 @@
   <string name="stream_compose_reactions_action_select">"선택"</string>
   <string name="stream_compose_reactions_action_unselect">"선택 해제"</string>
   <string name="stream_compose_reactions_add">"리액션 추가"</string>
+  <string name="stream_compose_reactions_added">"%1$s 리액션 추가됨"</string>
   <string name="stream_compose_reactions_remove">"탭하여 삭제"</string>
+  <string name="stream_compose_reactions_removed">"%1$s 리액션 제거됨"</string>
   <string name="stream_compose_reactions_state_not_selected">"선택되지 않음"</string>
   <string name="stream_compose_reactions_state_selected">"선택됨"</string>
   <string name="stream_compose_reactions_you">"나"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -266,9 +266,9 @@
   <string name="stream_compose_reactions_action_select">"선택"</string>
   <string name="stream_compose_reactions_action_unselect">"선택 해제"</string>
   <string name="stream_compose_reactions_add">"리액션 추가"</string>
-  <string name="stream_compose_reactions_added">"%1$s 리액션 추가됨"</string>
   <string name="stream_compose_reactions_remove">"탭하여 삭제"</string>
-  <string name="stream_compose_reactions_removed">"%1$s 리액션 제거됨"</string>
+  <string name="stream_compose_reactions_selected">"%1$s 리액션 선택됨"</string>
+  <string name="stream_compose_reactions_unselected">"%1$s 리액션 선택 해제됨"</string>
   <string name="stream_compose_reactions_state_not_selected">"선택되지 않음"</string>
   <string name="stream_compose_reactions_state_selected">"선택됨"</string>
   <string name="stream_compose_reactions_you">"나"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -111,6 +111,7 @@
     <string name="stream_compose_message_item_options">Show message options</string>
     <string name="stream_compose_message_reactions_show">Show reactions</string>
     <string name="stream_compose_message_attachment_open">Open attachment</string>
+    <string name="stream_compose_message_actions_menu_title">Message actions</string>
 
     <!--  Quoted Message  -->
     <string name="stream_compose_quoted_message_audio_recording">Voice message (%s)</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -160,8 +160,8 @@
     <string name="stream_compose_reactions_state_not_selected">Not selected</string>
     <string name="stream_compose_reactions_action_select">Select</string>
     <string name="stream_compose_reactions_action_unselect">Unselect</string>
-    <string name="stream_compose_reactions_added">%1$s reaction added</string>
-    <string name="stream_compose_reactions_removed">%1$s reaction removed</string>
+    <string name="stream_compose_reactions_selected">%1$s reaction selected</string>
+    <string name="stream_compose_reactions_unselected">%1$s reaction unselected</string>
 
     <!-- Reactions Picker -->
     <string name="stream_compose_show_more_reactions">Show more reactions</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -155,6 +155,10 @@
     <string name="stream_compose_reactions_add">Add reaction</string>
     <string name="stream_compose_reactions_you">You</string>
     <string name="stream_compose_reactions_remove">Tap to remove</string>
+    <string name="stream_compose_reactions_state_selected">Selected</string>
+    <string name="stream_compose_reactions_state_not_selected">Not selected</string>
+    <string name="stream_compose_reactions_action_select">Select</string>
+    <string name="stream_compose_reactions_action_unselect">Unselect</string>
 
     <!-- Reactions Picker -->
     <string name="stream_compose_show_more_reactions">Show more reactions</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -165,6 +165,7 @@
 
     <!-- Reactions Picker -->
     <string name="stream_compose_show_more_reactions">Show more reactions</string>
+    <string name="stream_compose_emoji_picker_title">Emoji picker</string>
 
     <!-- Message Action Prompts -->
     <string name="stream_compose_delete_message_title">Delete message</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -159,6 +159,8 @@
     <string name="stream_compose_reactions_state_not_selected">Not selected</string>
     <string name="stream_compose_reactions_action_select">Select</string>
     <string name="stream_compose_reactions_action_unselect">Unselect</string>
+    <string name="stream_compose_reactions_added">%1$s reaction added</string>
+    <string name="stream_compose_reactions_removed">%1$s reaction removed</string>
 
     <!-- Reactions Picker -->
     <string name="stream_compose_show_more_reactions">Show more reactions</string>


### PR DESCRIPTION
AND-1180

### Goal

The long-press message actions menu and the emoji reactions surfaces had four screen-reader gaps:

1. **Reactions announced as checkboxes.** `ReactionToggle` used `Modifier.toggleable(role = Role.Checkbox)`, so TalkBack read "[emoji] sign, checkbox, not checked, double tap to toggle". The Figma a11y principle calls this out explicitly as the *Don't* case; reactions are toggle buttons (tap to add / tap to remove), not checkboxes.
2. **No status confirmation on toggle.** Tapping a reaction emitted no screen-reader signal that the toggle state changed.
3. **Menu opening leaked host activity label.** Opening the long-press actions menu announced the host activity's `android:label` ("Chat Sample Compose") before the focused element, with no signal of the new surface.
4. **Emoji picker sheet focused the drag handle.** Opening the picker via "+" in the reactions bar landed TalkBack on the drag handle, with no signal that the picker surface had appeared.

### Implementation

Four feature-scoped commits.

**1. Expose reactions as toggle buttons to TalkBack.**

In `ReactionToggle`, switch the toggleable role from `Role.Checkbox` to `Role.Button` and attach an explicit `stateDescription` of "Pressed" / "Not pressed". TalkBack now reads "[emoji], button, pressed / not pressed, double tap to toggle" — the canonical Android toggle-button pattern, since Compose has no `Role.ToggleButton`. Internal composable; no public API change. This overrides #6440's deliberate `Role.Checkbox` decision in favour of the design source-of-truth.

**2. Announce reaction add and remove.**

Wrap `ReactionToggle.onValueChange` to fire `view.announceForAccessibility("[emoji] reaction added" / "removed")` before forwarding the new state. Both the long-press reactions bar and the full emoji picker grid benefit automatically because the picker's `ReactionMenuOptionItem` factory delegates to the same `ReactionToggle`. The string carries the emoji character as `%1$s`; TalkBack reads the character with its locale-native name, so the announce reads naturally as "Thumbs up sign reaction added" without maintaining a per-reaction name table.

**3. Announce the message actions menu pane title.**

Declare `Modifier.semantics { paneTitle = "Message actions" }` on the inner `Column` inside the `Dialog`. TalkBack treats `paneTitle` changes as a window-state event and announces the title on dialog entry, replacing the previously-leaked host activity label.

**4. Announce the emoji picker sheet.**

`ModalBottomSheet` swallows the standard `paneTitle` window-state event (verified in #6466 / `PollDialogHeader`), so fall back to programmatic announce via `view.announceForAccessibility` in a `LaunchedEffect`. Hide the sheet's drag handle from the accessibility tree via `Modifier.semantics { hideFromAccessibility() }` — the handle stays visually present and remains draggable for sighted users; TalkBack focus skips it and lands on the first emoji in the picker grid.

Migrated `ReactionsPicker` to the `StreamCardBottomSheet` wrapper introduced in #6480 so the emoji picker matches the rest of the SDK's card sheets (32dp top corners, `backgroundCoreElevation1` container, Stream scrim). Added an optional `dragHandle` parameter to `StreamCardBottomSheet` (internal API; defaults to `BottomSheetDefaults.DragHandle()`) so the emoji picker can pass its accessibility-hidden handle. All other callers of `StreamCardBottomSheet` keep the default and are unaffected.

New strings translated across the 7 supported locales:
- `stream_compose_reactions_pressed`, `stream_compose_reactions_not_pressed`
- `stream_compose_reactions_added`, `stream_compose_reactions_removed`
- `stream_compose_message_actions_menu_title`
- `stream_compose_emoji_picker_title`

No public API changes.

### Testing

Enable TalkBack on a physical device. Run the Compose sample.

1. Long-press a message in the chat. Expected: TalkBack announces "Message actions" on dialog open, then reads the focused reaction as "[emoji], button, not pressed, double tap to toggle".
2. Double-tap a reaction in the reactions bar. Expected: TalkBack announces "[emoji] reaction added" (live region). Double-tap again to remove: "[emoji] reaction removed".
3. From the reactions bar, double-tap the "+" button to open the full emoji picker sheet. Expected: TalkBack announces "Emoji picker" then bottom sheet context. Focus does **not** land on the drag handle. Swipe to navigate the grid; tap an emoji to fire the same add/remove announce as step 2.
4. Disable TalkBack and re-test all three surfaces to confirm visible behaviour is unchanged (the drag handle is still visible and draggable).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for the message actions menu with proper semantic labeling.
  * Improved reactions picker with better screen reader support and accessibility announcements.
  * Added accessible state descriptions for reaction buttons to better communicate interaction states.

* **Localization**
  * Added new UI text strings across 8+ languages (Spanish, French, Hindi, Indonesian, Italian, Japanese, Korean, and English) for emoji picker, message actions menu, and reaction states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
