### PR TITLE
Fix input and message text rendering when using RTL keyboard with LTR device locale

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/composer/MessageInput.kt
@@ -28,8 +28,11 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.input.KeyboardCapitalization
@@ -37,6 +40,7 @@ import androidx.compose.ui.text.input.OffsetMapping
 import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ComposerInputFieldTheme
@@ -64,6 +68,7 @@ import io.getstream.chat.android.ui.common.state.messages.composer.MessageCompos
  * @param innerLeadingContent Composable that represents the persistent inner leading content.
  * @param innerTrailingContent Composable that represents the persistent inner trailing content.
  */
+@Suppress("LongMethod")
 @Composable
 public fun MessageInput(
     messageComposerState: MessageComposerState,
@@ -80,6 +85,11 @@ public fun MessageInput(
 ) {
     val (value, attachments, activeAction) = messageComposerState
     val canSendMessage = messageComposerState.canSendMessage()
+
+    val deviceLayoutDirection = LocalLayoutDirection.current
+    val contentLayoutDirection = remember(value, deviceLayoutDirection) {
+        value.contentLayoutDirection(default = deviceLayoutDirection)
+    }
 
     val visualTransformation = MessageInputVisualTransformation(
         inputFieldTheme = ChatTheme.messageComposerTheme.inputField,
@@ -123,21 +133,23 @@ public fun MessageInput(
                     Spacer(modifier = Modifier.size(16.dp))
                 }
 
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    innerLeadingContent()
+                CompositionLocalProvider(LocalLayoutDirection provides contentLayoutDirection) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        innerLeadingContent()
 
-                    Box(modifier = Modifier.weight(1f)) {
-                        innerTextField()
+                        Box(modifier = Modifier.weight(1f)) {
+                            innerTextField()
 
-                        if (value.isEmpty()) {
-                            label(messageComposerState)
+                            if (value.isEmpty()) {
+                                label(messageComposerState)
+                            }
                         }
-                    }
 
-                    innerTrailingContent()
+                        innerTrailingContent()
+                    }
                 }
             }
         },
@@ -183,3 +195,29 @@ private class MessageInputVisualTransformation(
  * this threshold is exceeded.
  */
 private const val DefaultMessageInputMaxLines = 6
+
+/**
+ * Resolves the [LayoutDirection] that matches the first strong directional character in this string.
+ * Falls back to [default] when the string is empty or contains only neutral characters — this keeps
+ * the empty composer aligned with the device locale instead of forcing LTR.
+ */
+private fun String.contentLayoutDirection(default: LayoutDirection): LayoutDirection {
+    for (char in this) {
+        when (Character.getDirectionality(char)) {
+            Character.DIRECTIONALITY_RIGHT_TO_LEFT,
+            Character.DIRECTIONALITY_RIGHT_TO_LEFT_ARABIC,
+            Character.DIRECTIONALITY_RIGHT_TO_LEFT_EMBEDDING,
+            Character.DIRECTIONALITY_RIGHT_TO_LEFT_OVERRIDE,
+            -> return LayoutDirection.Rtl
+
+            Character.DIRECTIONALITY_LEFT_TO_RIGHT,
+            Character.DIRECTIONALITY_LEFT_TO_RIGHT_EMBEDDING,
+            Character.DIRECTIONALITY_LEFT_TO_RIGHT_OVERRIDE,
+            -> return LayoutDirection.Ltr
+            // Neutral / weak character (punctuation, digits, whitespace, etc.) — skip and keep
+            // scanning for the first strong directional character.
+            else -> Unit
+        }
+    }
+    return default
+}

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageTheme.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/MessageTheme.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextDirection
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.ui.theme.messages.attachments.AudioRecordingAttachmentTheme
 import io.getstream.chat.android.compose.ui.theme.messages.attachments.FileAttachmentTheme
@@ -145,6 +146,7 @@ public data class MessageTheme(
                     true -> colors.ownMessageText
                     else -> colors.otherMessageText
                 },
+                textDirection = TextDirection.Content,
             )
             val backgroundColor = when (own) {
                 true -> colors.ownMessagesBackground
@@ -177,6 +179,7 @@ public data class MessageTheme(
                         true -> colors.ownMessageQuotedText
                         else -> colors.otherMessageQuotedText
                     },
+                    textDirection = TextDirection.Content,
                 ),
                 // Deprecated
                 quotedBackgroundColor = when (own) {


### PR DESCRIPTION
### Goal

Fix RTL (right-to-left) keyboard/layout issues in the Compose message composer and message bubbles. When typing in RTL languages (e.g. Arabic, Hebrew) on a device set to an LTR locale — or mixing RTL/LTR text — the composer input field and message text would render with the wrong alignment.

### Implementation

- **`MessageInput.kt`** — The composer now resolves a `LayoutDirection` from the content of the input field by scanning for the first strong directional character (`contentLayoutDirection`). The inner `Row` (leading content + text field + trailing content) is wrapped in a `CompositionLocalProvider` that overrides `LocalLayoutDirection` with the resolved direction. Empty / neutral input falls back to the device locale's layout direction.
- **`MessageTheme.kt`** — `textStyle` and `quotedTextStyle` now set `textDirection = TextDirection.Content`, so message bubbles render in the direction of the text content rather than the locale's default.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Setup</th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
LTR locale
</td>
<td>
<video src="https://github.com/user-attachments/assets/b16d8a68-e1b5-4e58-aa0e-0a4d5e0d28b5" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/fcbf0601-c168-4120-b82a-a9af81df7942" controls="controls" muted="muted" />
</td>
</tr>
<tr>
<td>
RTL locale
</td>
<td>
<video src="https://github.com/user-attachments/assets/f0959e87-c411-42c4-93f6-48a8e89d23c8" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/97117ce9-435e-4605-b2b2-745472a37fc3" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>


### Testing

- Set the device locale to English (LTR).
- Open a channel in the Compose sample app and type Arabic/Hebrew characters in the composer — the input field, cursor, and trailing icons should flip to RTL.
- Clear the field — the composer should return to the device locale's direction.
- Send messages containing RTL, LTR, and mixed content — each bubble should render with the direction of its own text.
- Repeat with the device locale set to Arabic (RTL) to confirm the default fallback still works for empty input.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bidirectional text (RTL/LTR) handling in message input and display. Text direction is now intelligently determined by message content, improving support for mixed-language messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->