### PR TITLE
Fall back to DTO path on direct adapter failure

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/DirectEventParser.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/DirectEventParser.kt
@@ -106,12 +106,17 @@ internal class DirectEventParser(
 
     /**
      * Attempts to parse [raw] JSON into a [ChatEvent] using a direct adapter.
-     * Returns `null` if the event type is not supported by any direct adapter.
+     * Returns `null` if the event type is not supported by any direct adapter,
+     * or if the matching adapter throws — allowing the caller to fall back to the DTO path.
      */
     fun parse(raw: String): ChatEvent? {
         val type = extractType(raw) ?: return null
         val adapter = adapterMap[type] ?: return null
-        return adapter.fromJson(raw)
+        return runCatching { adapter.fromJson(raw) }
+            .onFailure { e ->
+                logger.v { "Direct parse failed for '$type'; falling back to DTO path: ${e.message}" }
+            }
+            .getOrNull()
     }
 
     companion object {

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/NewMessageEventAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/NewMessageEventAdapter.kt
@@ -138,7 +138,7 @@ internal class NewMessageEventAdapter(
 
         return NewMessageEvent(
             type = type,
-            createdAt = createdAt ?: Date(0),
+            createdAt = createdAt,
             rawCreatedAt = rawCreatedAt,
             user = user,
             cid = cid,


### PR DESCRIPTION
### Goal

Harden the opt-in fast event parser so a thrown direct-adapter exception degrades gracefully to the existing DTO path instead of failing the whole event parse. Also clean up a dead `Date(0)` fallback flagged by SonarCloud. Ports two fixes from develop PR #6473 back to V6.

### Implementation

- `DirectEventParser.parse`: wrap `adapter.fromJson(raw)` in `runCatching`. On failure, log at verbose level and return `null` — `MoshiChatParser.parseAndProcessEvent` already checks for `null` and falls through to the DTO path.
- `NewMessageEventAdapter`: drop the `?: Date(0)` elvis on the `createdAt` constructor argument. The explicit `if (createdAt == null) throw JsonDataException(...)` above already guarantees `createdAt` is non-null at that point, so the elvis was dead.

The malformed-`created_at` guards (missing field, explicit JSON null, unparseable string) are preserved unchanged.

### UI Changes

No UI changes.

### Testing

- Existing `DirectEventParserTest`, `NewMessageEventParsingTest`, and other parser2 unit tests continue to pass.
- Fallback behavior can be exercised by feeding a JSON payload that triggers an adapter exception (e.g., malformed nested object on a supported event type) — the parser should return `null` and the DTO path should take over.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced event parsing error handling to gracefully manage malformed data instead of crashing the application. The system now includes improved diagnostic logging and safe fallback mechanisms.
  * Improved message event timestamp accuracy by ensuring proper date initialization instead of using default fallback values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->