### PR TITLE
Open message actions menu on poll option long-press

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -130,6 +130,7 @@ public fun PollMessageContent(
                         },
                         onClosePoll = onClosePoll,
                         onAddPollOption = onAddPollOption,
+                        onLongItemClick = onLongItemClick,
                     )
                 },
             ),
@@ -180,6 +181,7 @@ private fun PollMessageContent(
     onRemoveVote: (Vote) -> Unit,
     onAddPollOption: (poll: Poll, option: String) -> Unit,
     selectPoll: (Message, Poll, PollSelectionType) -> Unit,
+    onLongItemClick: (Message) -> Unit,
 ) {
     val context = LocalContext.current
     val showDialog = remember { mutableStateOf(false) }
@@ -253,6 +255,7 @@ private fun PollMessageContent(
                     poll.ownVotes.firstOrNull { it.optionId == option.id }
                         ?.let(onRemoveVote)
                 },
+                onLongClick = { onLongItemClick(message) },
             )
         }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
@@ -17,6 +17,8 @@
 package io.getstream.chat.android.compose.ui.components.poll
 
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -24,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
@@ -40,12 +41,15 @@ import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.hideFromAccessibility
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.toggleableState
+import androidx.compose.ui.state.ToggleableState
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.components.avatar.UserAvatarStack
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
+import io.getstream.chat.android.compose.ui.messages.list.LocalMessageOnLongClick
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling.PollStyle
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -81,6 +85,7 @@ import io.getstream.chat.android.models.VotingVisibility
  * @param onRemoveVote Invoked when the user removes their vote from this option.
  * @param modifier Modifier applied to the row container.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Suppress("LongParameterList", "LongMethod")
 @Composable
 internal fun PollOptionVotingRow(
@@ -105,18 +110,27 @@ internal fun PollOptionVotingRow(
             onRemoveVote()
         }
     }
+    // Forward long-press up to the message row's actions-menu handler. Without this, the
+    // toggle would consume the long-press as a tap and TalkBack's double-tap-and-hold would
+    // never open the actions menu over a poll option.
+    val onMessageLongClick = LocalMessageOnLongClick.current
 
     Row(
         modifier = modifier
             .fillMaxWidth()
             .applyIf(!poll.closed) {
-                toggleable(
-                    value = checked,
+                combinedClickable(
                     role = toggleRole,
-                    onValueChange = onToggle,
+                    onClick = { onToggle(!checked) },
+                    onLongClick = onMessageLongClick,
                 )
-            }
-            .semantics(mergeDescendants = true) {},
+                    // `combinedClickable` sets the role but not the toggle state — restore the
+                    // "checked" / "not checked" announce that the previous `toggleable` modifier
+                    // contributed so TalkBack still reads the current vote state on each option.
+                    .semantics {
+                        toggleableState = if (checked) ToggleableState.On else ToggleableState.Off
+                    }
+            },
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
@@ -49,7 +49,6 @@ import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.ui.components.avatar.AvatarSize
 import io.getstream.chat.android.compose.ui.components.avatar.UserAvatarStack
 import io.getstream.chat.android.compose.ui.components.common.RadioCheck
-import io.getstream.chat.android.compose.ui.messages.list.LocalMessageOnLongClick
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling.PollStyle
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
@@ -84,6 +83,8 @@ import io.getstream.chat.android.models.VotingVisibility
  * @param onCastVote Invoked when the user casts a vote for this option.
  * @param onRemoveVote Invoked when the user removes their vote from this option.
  * @param modifier Modifier applied to the row container.
+ * @param onLongClick Invoked on long-press to open the message actions menu. `null` when the row
+ * is not hosted in a long-pressable message (e.g. the more-options bottom sheet).
  */
 @OptIn(ExperimentalFoundationApi::class)
 @Suppress("LongParameterList", "LongMethod")
@@ -100,6 +101,7 @@ internal fun PollOptionVotingRow(
     onCastVote: () -> Unit,
     onRemoveVote: () -> Unit,
     modifier: Modifier = Modifier,
+    onLongClick: (() -> Unit)? = null,
 ) {
     val toggleRole = if (poll.maxVotesAllowed == 1) Role.RadioButton else Role.Checkbox
     val onToggle: (Boolean) -> Unit = { enabled ->
@@ -110,19 +112,16 @@ internal fun PollOptionVotingRow(
             onRemoveVote()
         }
     }
-    // Forward long-press up to the message row's actions-menu handler. Without this, the
-    // toggle would consume the long-press as a tap and TalkBack's double-tap-and-hold would
-    // never open the actions menu over a poll option.
-    val onMessageLongClick = LocalMessageOnLongClick.current
-
     Row(
         modifier = modifier
             .fillMaxWidth()
             .applyIf(!poll.closed) {
+                // The toggle's own gesture handling would otherwise consume the long-press as a
+                // tap, so forward it to the message's actions-menu handler.
                 combinedClickable(
                     role = toggleRole,
                     onClick = { onToggle(!checked) },
-                    onLongClick = onMessageLongClick,
+                    onLongClick = onLongClick,
                 )
                     // `combinedClickable` sets the role but not the toggle state — restore the
                     // "checked" / "not checked" announce that the previous `toggleable` modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -41,7 +41,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -49,7 +48,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -121,18 +119,6 @@ import io.getstream.chat.android.ui.common.state.messages.poll.PollSelectionType
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
-
-/**
- * Forwards a long-press from an interactive descendant of the message bubble (poll option,
- * attachment item, etc.) up to the message row's actions-menu handler. Provided by
- * [MessageContainer] when long-press is supported for the current message; `null` otherwise.
- *
- * Compose's nested gesture handling means a child `toggleable` consumes the long-press as a tap
- * before the row's `combinedClickable` can react. Children inside composite content read this
- * local and pass it as `onLongClick` to their own `combinedClickable`, so the long-press routes
- * to the actions menu regardless of which leaf the user holds.
- */
-internal val LocalMessageOnLongClick = staticCompositionLocalOf<(() -> Unit)?> { null }
 
 /**
  * The default message container for a regular message in the Conversation/Messages screen.
@@ -225,15 +211,6 @@ public fun MessageContainer(
         // No click handler on deleted/uploading messages; merge into one TalkBack stop.
         else -> Modifier.semantics(mergeDescendants = true) {}
     }
-    // Provide the row's long-press handler to descendants so an interactive leaf (e.g. a poll
-    // option's combinedClickable) can forward `onLongClick` here and reliably open the actions
-    // menu instead of being intercepted by its own gesture handling. Null when the row isn't
-    // long-pressable so descendants fall back to no-op.
-    val messageOnLongClick: (() -> Unit)? = if (canOpenActions) {
-        { currentOnLongItemClick(currentMessage) }
-    } else {
-        null
-    }
 
     val highlightColor = ChatTheme.colors.backgroundCoreHighlight
     val backgroundColor = when {
@@ -266,88 +243,86 @@ public fun MessageContainer(
         onReply = { onReply(replyMessage) },
         isSwipeable = isSwipeable,
     ) {
-        CompositionLocalProvider(LocalMessageOnLongClick provides messageOnLongClick) {
-            Row(
-                modifier = Modifier
-                    .testTag("Stream_MessageCell")
-                    .fillMaxWidth()
-                    .wrapContentHeight()
-                    .background(color = color)
-                    .then(clickModifier),
-                horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
-                    Arrangement.Start
-                } else {
-                    Arrangement.End
-                },
-            ) {
-                with(ChatTheme.componentFactory) {
-                    when (messageAlignment) {
-                        MessageAlignment.Start -> MessageAuthor(
-                            params = MessageAuthorParams(
-                                messageItem = messageItem,
-                                onUserAvatarClick = onUserAvatarClick,
-                            ),
-                        )
+        Row(
+            modifier = Modifier
+                .testTag("Stream_MessageCell")
+                .fillMaxWidth()
+                .wrapContentHeight()
+                .background(color = color)
+                .then(clickModifier),
+            horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
+                Arrangement.Start
+            } else {
+                Arrangement.End
+            },
+        ) {
+            with(ChatTheme.componentFactory) {
+                when (messageAlignment) {
+                    MessageAlignment.Start -> MessageAuthor(
+                        params = MessageAuthorParams(
+                            messageItem = messageItem,
+                            onUserAvatarClick = onUserAvatarClick,
+                        ),
+                    )
 
-                        MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                    }
+                    MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                }
 
-                    Column(
-                        modifier = Modifier.weight(1f, fill = false),
-                        horizontalAlignment = messageAlignment.contentAlignment,
-                    ) {
-                        MessageTop(
-                            params = MessageTopParams(
-                                messageItem = messageItem,
-                                onThreadClick = onThreadClick,
-                            ),
-                        )
-                        MessageContentWithReactions(
-                            messageAlignment = messageAlignment,
-                            reactions = rememberMessageReactions(message)?.let { reactions ->
-                                {
-                                    MessageReactions(
-                                        params = MessageReactionsParams(
-                                            message = message,
-                                            reactions = reactions,
-                                            onClick = onReactionsClick,
-                                        ),
-                                    )
-                                }
-                            },
-                            content = {
-                                MessageContent(
-                                    params = MessageContentParams(
-                                        messageItem = messageItem,
-                                        onLongItemClick = onLongItemClick,
-                                        onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
-                                        onGiphyActionClick = onGiphyActionClick,
-                                        onQuotedMessageClick = onQuotedMessageClick,
-                                        onLinkClick = onLinkClick,
-                                        onUserMentionClick = onUserMentionClick,
-                                        onPollUpdated = onPollUpdated,
-                                        onCastVote = onCastVote,
-                                        onRemoveVote = onRemoveVote,
-                                        selectPoll = selectPoll,
-                                        onAddAnswer = onAddAnswer,
-                                        onClosePoll = onClosePoll,
-                                        onAddPollOption = onAddPollOption,
+                Column(
+                    modifier = Modifier.weight(1f, fill = false),
+                    horizontalAlignment = messageAlignment.contentAlignment,
+                ) {
+                    MessageTop(
+                        params = MessageTopParams(
+                            messageItem = messageItem,
+                            onThreadClick = onThreadClick,
+                        ),
+                    )
+                    MessageContentWithReactions(
+                        messageAlignment = messageAlignment,
+                        reactions = rememberMessageReactions(message)?.let { reactions ->
+                            {
+                                MessageReactions(
+                                    params = MessageReactionsParams(
+                                        message = message,
+                                        reactions = reactions,
+                                        onClick = onReactionsClick,
                                     ),
                                 )
-                            },
-                        )
-                        MessageBottom(params = MessageBottomParams(messageItem = messageItem))
-                    }
+                            }
+                        },
+                        content = {
+                            MessageContent(
+                                params = MessageContentParams(
+                                    messageItem = messageItem,
+                                    onLongItemClick = onLongItemClick,
+                                    onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
+                                    onGiphyActionClick = onGiphyActionClick,
+                                    onQuotedMessageClick = onQuotedMessageClick,
+                                    onLinkClick = onLinkClick,
+                                    onUserMentionClick = onUserMentionClick,
+                                    onPollUpdated = onPollUpdated,
+                                    onCastVote = onCastVote,
+                                    onRemoveVote = onRemoveVote,
+                                    selectPoll = selectPoll,
+                                    onAddAnswer = onAddAnswer,
+                                    onClosePoll = onClosePoll,
+                                    onAddPollOption = onAddPollOption,
+                                ),
+                            )
+                        },
+                    )
+                    MessageBottom(params = MessageBottomParams(messageItem = messageItem))
+                }
 
-                    when (messageAlignment) {
-                        MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                        MessageAlignment.End -> MessageAuthor(
-                            params = MessageAuthorParams(
-                                messageItem = messageItem,
-                                onUserAvatarClick = onUserAvatarClick,
-                            ),
-                        )
-                    }
+                when (messageAlignment) {
+                    MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                    MessageAlignment.End -> MessageAuthor(
+                        params = MessageAuthorParams(
+                            messageItem = messageItem,
+                            onUserAvatarClick = onUserAvatarClick,
+                        ),
+                    )
                 }
             }
         }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -41,6 +41,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
@@ -48,6 +49,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
@@ -119,6 +121,18 @@ import io.getstream.chat.android.ui.common.state.messages.poll.PollSelectionType
 import kotlinx.coroutines.launch
 import kotlin.math.absoluteValue
 import kotlin.math.roundToInt
+
+/**
+ * Forwards a long-press from an interactive descendant of the message bubble (poll option,
+ * attachment item, etc.) up to the message row's actions-menu handler. Provided by
+ * [MessageContainer] when long-press is supported for the current message; `null` otherwise.
+ *
+ * Compose's nested gesture handling means a child `toggleable` consumes the long-press as a tap
+ * before the row's `combinedClickable` can react. Children inside composite content read this
+ * local and pass it as `onLongClick` to their own `combinedClickable`, so the long-press routes
+ * to the actions menu regardless of which leaf the user holds.
+ */
+internal val LocalMessageOnLongClick = staticCompositionLocalOf<(() -> Unit)?> { null }
 
 /**
  * The default message container for a regular message in the Conversation/Messages screen.
@@ -211,6 +225,15 @@ public fun MessageContainer(
         // No click handler on deleted/uploading messages; merge into one TalkBack stop.
         else -> Modifier.semantics(mergeDescendants = true) {}
     }
+    // Provide the row's long-press handler to descendants so an interactive leaf (e.g. a poll
+    // option's combinedClickable) can forward `onLongClick` here and reliably open the actions
+    // menu instead of being intercepted by its own gesture handling. Null when the row isn't
+    // long-pressable so descendants fall back to no-op.
+    val messageOnLongClick: (() -> Unit)? = if (canOpenActions) {
+        { currentOnLongItemClick(currentMessage) }
+    } else {
+        null
+    }
 
     val highlightColor = ChatTheme.colors.backgroundCoreHighlight
     val backgroundColor = when {
@@ -243,86 +266,88 @@ public fun MessageContainer(
         onReply = { onReply(replyMessage) },
         isSwipeable = isSwipeable,
     ) {
-        Row(
-            modifier = Modifier
-                .testTag("Stream_MessageCell")
-                .fillMaxWidth()
-                .wrapContentHeight()
-                .background(color = color)
-                .then(clickModifier),
-            horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
-                Arrangement.Start
-            } else {
-                Arrangement.End
-            },
-        ) {
-            with(ChatTheme.componentFactory) {
-                when (messageAlignment) {
-                    MessageAlignment.Start -> MessageAuthor(
-                        params = MessageAuthorParams(
-                            messageItem = messageItem,
-                            onUserAvatarClick = onUserAvatarClick,
-                        ),
-                    )
+        CompositionLocalProvider(LocalMessageOnLongClick provides messageOnLongClick) {
+            Row(
+                modifier = Modifier
+                    .testTag("Stream_MessageCell")
+                    .fillMaxWidth()
+                    .wrapContentHeight()
+                    .background(color = color)
+                    .then(clickModifier),
+                horizontalArrangement = if (messageAlignment == MessageAlignment.Start) {
+                    Arrangement.Start
+                } else {
+                    Arrangement.End
+                },
+            ) {
+                with(ChatTheme.componentFactory) {
+                    when (messageAlignment) {
+                        MessageAlignment.Start -> MessageAuthor(
+                            params = MessageAuthorParams(
+                                messageItem = messageItem,
+                                onUserAvatarClick = onUserAvatarClick,
+                            ),
+                        )
 
-                    MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                }
+                        MessageAlignment.End -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                    }
 
-                Column(
-                    modifier = Modifier.weight(1f, fill = false),
-                    horizontalAlignment = messageAlignment.contentAlignment,
-                ) {
-                    MessageTop(
-                        params = MessageTopParams(
-                            messageItem = messageItem,
-                            onThreadClick = onThreadClick,
-                        ),
-                    )
-                    MessageContentWithReactions(
-                        messageAlignment = messageAlignment,
-                        reactions = rememberMessageReactions(message)?.let { reactions ->
-                            {
-                                MessageReactions(
-                                    params = MessageReactionsParams(
-                                        message = message,
-                                        reactions = reactions,
-                                        onClick = onReactionsClick,
+                    Column(
+                        modifier = Modifier.weight(1f, fill = false),
+                        horizontalAlignment = messageAlignment.contentAlignment,
+                    ) {
+                        MessageTop(
+                            params = MessageTopParams(
+                                messageItem = messageItem,
+                                onThreadClick = onThreadClick,
+                            ),
+                        )
+                        MessageContentWithReactions(
+                            messageAlignment = messageAlignment,
+                            reactions = rememberMessageReactions(message)?.let { reactions ->
+                                {
+                                    MessageReactions(
+                                        params = MessageReactionsParams(
+                                            message = message,
+                                            reactions = reactions,
+                                            onClick = onReactionsClick,
+                                        ),
+                                    )
+                                }
+                            },
+                            content = {
+                                MessageContent(
+                                    params = MessageContentParams(
+                                        messageItem = messageItem,
+                                        onLongItemClick = onLongItemClick,
+                                        onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
+                                        onGiphyActionClick = onGiphyActionClick,
+                                        onQuotedMessageClick = onQuotedMessageClick,
+                                        onLinkClick = onLinkClick,
+                                        onUserMentionClick = onUserMentionClick,
+                                        onPollUpdated = onPollUpdated,
+                                        onCastVote = onCastVote,
+                                        onRemoveVote = onRemoveVote,
+                                        selectPoll = selectPoll,
+                                        onAddAnswer = onAddAnswer,
+                                        onClosePoll = onClosePoll,
+                                        onAddPollOption = onAddPollOption,
                                     ),
                                 )
-                            }
-                        },
-                        content = {
-                            MessageContent(
-                                params = MessageContentParams(
-                                    messageItem = messageItem,
-                                    onLongItemClick = onLongItemClick,
-                                    onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
-                                    onGiphyActionClick = onGiphyActionClick,
-                                    onQuotedMessageClick = onQuotedMessageClick,
-                                    onLinkClick = onLinkClick,
-                                    onUserMentionClick = onUserMentionClick,
-                                    onPollUpdated = onPollUpdated,
-                                    onCastVote = onCastVote,
-                                    onRemoveVote = onRemoveVote,
-                                    selectPoll = selectPoll,
-                                    onAddAnswer = onAddAnswer,
-                                    onClosePoll = onClosePoll,
-                                    onAddPollOption = onAddPollOption,
-                                ),
-                            )
-                        },
-                    )
-                    MessageBottom(params = MessageBottomParams(messageItem = messageItem))
-                }
+                            },
+                        )
+                        MessageBottom(params = MessageBottomParams(messageItem = messageItem))
+                    }
 
-                when (messageAlignment) {
-                    MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
-                    MessageAlignment.End -> MessageAuthor(
-                        params = MessageAuthorParams(
-                            messageItem = messageItem,
-                            onUserAvatarClick = onUserAvatarClick,
-                        ),
-                    )
+                    when (messageAlignment) {
+                        MessageAlignment.Start -> MessageSpacer(params = MessageSpacerParams(messageItem))
+                        MessageAlignment.End -> MessageAuthor(
+                            params = MessageAuthorParams(
+                                messageItem = messageItem,
+                                onUserAvatarClick = onUserAvatarClick,
+                            ),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
### Goal

Long-press on a poll option now opens the message actions menu, the same as long-press anywhere else on the message row.

Resolves [AND-1220](https://linear.app/stream/issue/AND-1220).

### Implementation

`MessageContainer` exposes its long-press handler to descendants through a new `LocalMessageOnLongClick` CompositionLocal — provided when the message supports actions, `null` otherwise.

`PollOptionVotingRow` swaps the `toggleable` modifier for `combinedClickable`. The new `onLongClick` reads `LocalMessageOnLongClick.current` so TalkBack's double-tap-and-hold opens the message actions menu instead of being intercepted by the toggle. The `toggleable`'s "checked" / "not checked" announce is restored via an explicit `toggleableState` semantic.

### Testing

With TalkBack enabled:

1. Open a channel containing an open poll with at least one option.
2. Swipe right until focus lands on a poll option.
3. Double-tap to vote — the option toggles and TalkBack announces "checked" / "not checked".
4. Double-tap-and-hold on the same option — the message actions menu opens.
5. Repeat on a closed poll: options are no longer interactive, and long-press on the message bubble still opens the actions menu.

Without TalkBack:

1. Tap a poll option — vote toggles as before.
2. Long-press a poll option — actions menu opens.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced poll voting interactions with long-press support on poll options.

* **Improvements**
  * Improved gesture handling for poll option selection.
  * Better accessibility support for screen readers when voting on polls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->