### PR TITLE
Fix overly strict cid validation

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/Validation.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/utils/internal/Validation.kt
@@ -19,9 +19,6 @@ package io.getstream.chat.android.client.utils.internal
 import io.getstream.chat.android.core.internal.InternalStreamChatApi
 import io.getstream.result.Error
 import io.getstream.result.Result
-import java.util.regex.Pattern
-
-private val cidPattern = Pattern.compile("^([a-zA-z0-9]|!|-)+:([a-zA-z0-9]|!|-)+$")
 
 /**
  * Validates a cid. Verifies it's not empty and in the format messaging:123.
@@ -33,9 +30,8 @@ private val cidPattern = Pattern.compile("^([a-zA-z0-9]|!|-)+:([a-zA-z0-9]|!|-)+
 @Throws(IllegalArgumentException::class)
 @InternalStreamChatApi
 public fun validateCid(cid: String): String = cid.apply {
-    require(cid.isNotEmpty()) { "cid can not be empty" }
-    require(cid.isNotBlank()) { "cid can not be blank" }
-    require(cidPattern.matcher(cid).matches()) {
+    val parts = cid.split(":")
+    require(parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()) {
         "cid needs to be in the format channelType:channelId. For example, messaging:123"
     }
 }

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/internal/ValidationKtTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/utils/internal/ValidationKtTest.kt
@@ -16,6 +16,9 @@
 
 package io.getstream.chat.android.client.utils.internal
 
+import io.getstream.chat.android.client.utils.internal.ValidationKtTest.Companion.argumentsValidCidResult
+import io.getstream.chat.android.client.utils.internal.ValidationKtTest.Companion.argumentsValidateCid
+import io.getstream.chat.android.client.utils.internal.ValidationKtTest.Companion.argumentsValidateCidError
 import io.getstream.result.Error
 import io.getstream.result.Result
 import org.amshove.kluent.invoking
@@ -85,15 +88,17 @@ internal class ValidationKtTest {
         }
 
         private fun invalidCids(): List<Pair<String, Exception>> = listOf(
-            "" to IllegalArgumentException("cid can not be empty"),
-            "   " to IllegalArgumentException("cid can not be blank"),
+            "" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
+            "   " to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             "messaging 123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             "messaging123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             "messaging::123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             "messaging:" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             ":123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
-            "mess aging:123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
             ":" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
+            "   :   " to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
+            "messaging:   " to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
+            "   :123" to IllegalArgumentException("cid needs to be in the format channelType:channelId. For example, messaging:123"),
         )
 
         private fun validCids() = listOf(
@@ -101,6 +106,9 @@ internal class ValidationKtTest {
             "a:e",
             "messaging:!members-oNJ1lQqt2b9SKG6raDWRTn4wWLakkFkwvqlUn-EsatU",
             "!members-oNJ1lQqt2b9SKG6raDWRTn4wWLakkFkwvqlUn-EsatU:!members-oNJ1lQqt2b9SKG6raDWRTn4wWLakkFkwvqlUn-EsatU",
+            "mess aging:123",
+            "messaging:id_with_underscore",
+            "messaging:id.with.dots",
         )
     }
 }


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Align `validateCid` with iOS so the Android client accepts the same set of cids. The current regex (`^([a-zA-z0-9]|!|-)+:([a-zA-z0-9]|!|-)+$`) over-restricts valid characters (e.g. `_`, `.`) and has a typo: `a-zA-z` (lowercase `z` to uppercase `Z`) accidentally matches `[`, `\`, `]`, `^`, `_`, `` ` ``.

iOS [`ChannelId.init(cid:)`](https://github.com/GetStream/stream-chat-swift/blob/main/Sources/StreamChat/Models/ChannelId.swift#L27-L39) does not use a character-set regex. It splits on `:`, requires exactly 2 parts, and requires each part to be non-empty after stripping whitespace.

Closes [AND-1227](https://linear.app/stream/issue/AND-1227/align-cid-validation-with-ios)

### Implementation

- `Validation.kt`: replaced `cidPattern` with `cid.split(":")` and `parts.size == 2 && parts[0].isNotBlank() && parts[1].isNotBlank()`. The empty/blank pre-checks are no longer needed since they're subsumed by the split check.

### Testing

- `ValidationKtTest`:
  - Moved `"mess aging:123"` to the valid set (matches iOS, which permits internal spaces).
  - Added `"messaging:id_with_underscore"` and `"messaging:id.with.dots"` to the valid set (previously rejected by the regex).
  - Added `"   :   "`, `"messaging:   "`, and `"   :123"` to the invalid set (blank parts).
  - Updated `""` and `"   "` expectations to the unified format error message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced channel ID validation logic to properly handle edge cases with whitespace and blank values, ensuring more reliable validation across all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->