### PR TITLE
Replace reflection-based resolveDependency with typed variants

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -135,7 +135,6 @@ import io.getstream.chat.android.client.persistance.repository.factory.Repositor
 import io.getstream.chat.android.client.persistance.repository.noop.NoOpRepositoryFactory
 import io.getstream.chat.android.client.persistence.db.ChatClientDatabase
 import io.getstream.chat.android.client.persistence.repository.ChatClientRepository
-import io.getstream.chat.android.client.plugin.DependencyResolver
 import io.getstream.chat.android.client.plugin.MessageDeliveredPluginFactory
 import io.getstream.chat.android.client.plugin.Plugin
 import io.getstream.chat.android.client.plugin.factory.PluginFactory
@@ -261,7 +260,6 @@ import java.util.Calendar
 import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
-import kotlin.reflect.full.isSubclassOf
 import kotlin.time.Duration.Companion.days
 
 /**
@@ -366,30 +364,14 @@ internal constructor(
     public var plugins: List<Plugin> = emptyList()
 
     /**
-     * Resolves dependency [T] within the provided plugin [DR].
-     * This method can't be called before user is connected because plugins are added only after user
-     * connection is completed.
+     * Resolves dependency [T] from the [PluginFactory] of type [F].
      *
-     * @see [Plugin]
-     * @throws IllegalStateException if plugin was not added or dependency is not found.
+     * @throws IllegalStateException if the factory was not added or the dependency is not found.
      */
     @InternalStreamChatApi
     @Throws(IllegalStateException::class)
     @Suppress("ThrowsCount")
-    public inline fun <reified DR : DependencyResolver, reified T : Any> resolveDependency(): T {
-        StreamLog.d(TAG) { "[resolveDependency] DR: ${DR::class.simpleName}, T: ${T::class.simpleName}" }
-        return when {
-            DR::class.isSubclassOf(PluginFactory::class) -> resolveFactoryDependency<DR, T>()
-            DR::class.isSubclassOf(Plugin::class) -> resolvePluginDependency<DR, T>()
-            else -> error("Unsupported dependency resolver: ${DR::class}")
-        }
-    }
-
-    @PublishedApi
-    @InternalStreamChatApi
-    @Throws(IllegalStateException::class)
-    @Suppress("ThrowsCount")
-    internal inline fun <reified F : DependencyResolver, reified T : Any> resolveFactoryDependency(): T {
+    public inline fun <reified F : PluginFactory, reified T : Any> resolveFactoryDependency(): T {
         StreamLog.v(TAG) { "[resolveFactoryDependency] F: ${F::class.simpleName}, T: ${T::class.simpleName}" }
         val resolver = pluginFactories.find { plugin ->
             plugin is F
@@ -402,11 +384,17 @@ internal constructor(
             )
     }
 
-    @PublishedApi
+    /**
+     * Resolves dependency [T] from the [Plugin] of type [P].
+     * This method can't be called before user is connected because plugins are added only after user
+     * connection is completed.
+     *
+     * @throws IllegalStateException if the plugin was not added or the dependency is not found.
+     */
     @InternalStreamChatApi
     @Throws(IllegalStateException::class)
     @Suppress("ThrowsCount")
-    internal inline fun <reified P : DependencyResolver, reified T : Any> resolvePluginDependency(): T {
+    public inline fun <reified P : Plugin, reified T : Any> resolvePluginDependency(): T {
         StreamLog.v(TAG) { "[resolvePluginDependency] P: ${P::class.simpleName}, T: ${T::class.simpleName}" }
         // Snapshot plugins BEFORE checking initializationState to avoid a race with disconnect().
         // disconnect() sets initializationState to NOT_INITIALIZED before clearing plugins,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -368,10 +368,9 @@ internal constructor(
      *
      * @throws IllegalStateException if the factory was not added or the dependency is not found.
      */
-    @InternalStreamChatApi
     @Throws(IllegalStateException::class)
     @Suppress("ThrowsCount")
-    public inline fun <reified F : PluginFactory, reified T : Any> resolveFactoryDependency(): T {
+    internal inline fun <reified F : PluginFactory, reified T : Any> resolveFactoryDependency(): T {
         StreamLog.v(TAG) { "[resolveFactoryDependency] F: ${F::class.simpleName}, T: ${T::class.simpleName}" }
         val resolver = pluginFactories.find { plugin ->
             plugin is F
@@ -391,10 +390,9 @@ internal constructor(
      *
      * @throws IllegalStateException if the plugin was not added or the dependency is not found.
      */
-    @InternalStreamChatApi
     @Throws(IllegalStateException::class)
     @Suppress("ThrowsCount")
-    public inline fun <reified P : Plugin, reified T : Any> resolvePluginDependency(): T {
+    internal inline fun <reified P : Plugin, reified T : Any> resolvePluginDependency(): T {
         StreamLog.v(TAG) { "[resolvePluginDependency] P: ${P::class.simpleName}, T: ${T::class.simpleName}" }
         // Snapshot plugins BEFORE checking initializationState to avoid a race with disconnect().
         // disconnect() sets initializationState to NOT_INITIALIZED before clearing plugins,

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/state/ChatClientStateExtensions.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/api/state/ChatClientStateExtensions.kt
@@ -78,7 +78,7 @@ private const val TAG = "Chat:Client-StatePlugin"
  */
 public val ChatClient.state: StateRegistry
     @Throws(IllegalArgumentException::class)
-    get() = resolveDependency<StatePlugin, StateRegistry>()
+    get() = resolvePluginDependency<StatePlugin, StateRegistry>()
 
 /**
  * [GlobalState] instance that contains information about the current user, unreads, etc.
@@ -87,7 +87,7 @@ public val ChatClient.state: StateRegistry
  */
 public val ChatClient.globalState: GlobalState
     @Throws(IllegalArgumentException::class)
-    get() = resolveDependency<StatePlugin, GlobalState>()
+    get() = resolvePluginDependency<StatePlugin, GlobalState>()
 
 /**
  * Retrieves a [Flow] holding the [GlobalState] object, which emits only if the user is connected, and the [ChatClient]
@@ -109,7 +109,7 @@ public val ChatClient.globalStateFlow: Flow<GlobalState>
  * @throws IllegalArgumentException If the [ChatClientConfig] was not initialized yet.
  */
 private val ChatClient.chatClientConfig: ChatClientConfig
-    get() = resolveDependency<StreamStatePluginFactory, ChatClientConfig>()
+    get() = resolveFactoryDependency<StreamStatePluginFactory, ChatClientConfig>()
 
 /**
  * Performs [ChatClient.queryChannels] under the hood and returns [QueryChannelsState] associated with the query.

--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/extensions/internal/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/internal/state/extensions/internal/ChatClient.kt
@@ -26,7 +26,7 @@ import kotlinx.coroutines.CoroutineScope
  * [LogicRegistry] instance that contains all objects responsible for handling logic in offline plugin.
  */
 internal val ChatClient.logic: LogicRegistry
-    get() = resolveDependency<StatePlugin, LogicRegistry>()
+    get() = resolvePluginDependency<StatePlugin, LogicRegistry>()
 
 /**
  * Intermediate class to request ChatClient class as states

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/DependencyResolverTest.kt
@@ -59,13 +59,13 @@ public class DependencyResolverTest {
             .get()
 
         invoking {
-            client.resolveDependency<PluginDependency, SomeDependency>()
+            client.resolvePluginDependency<PluginDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("Plugin 'io.getstream.chat.android.client.DependencyResolverTest.PluginDependency' was not found. Did you init it within ChatClient?")
 
         invoking {
-            client.resolveDependency<FactoryDependency, SomeDependency>()
+            client.resolveFactoryDependency<FactoryDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("Factory 'io.getstream.chat.android.client.DependencyResolverTest.FactoryDependency' was not found. Did you init it within ChatClient?")
@@ -80,13 +80,13 @@ public class DependencyResolverTest {
             .get()
 
         invoking {
-            client.resolveDependency<PluginDependency, SomeDependency>()
+            client.resolvePluginDependency<PluginDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("Dependency 'io.getstream.chat.android.client.DependencyResolverTest.SomeDependency' was not resolved by plugin 'io.getstream.chat.android.client.DependencyResolverTest.PluginDependency'")
 
         invoking {
-            client.resolveDependency<FactoryDependency, SomeDependency>()
+            client.resolveFactoryDependency<FactoryDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("Dependency 'io.getstream.chat.android.client.DependencyResolverTest.SomeDependency' was not resolved by factory 'io.getstream.chat.android.client.DependencyResolverTest.FactoryDependency'")
@@ -105,13 +105,13 @@ public class DependencyResolverTest {
             .get()
 
         invoking {
-            client.resolveDependency<PluginDependency, SomeDependency>()
+            client.resolvePluginDependency<PluginDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("ChatClient::connectUser() must be called before resolving any dependency")
 
         invoking {
-            client.resolveDependency<FactoryDependency, SomeDependency>()
+            client.resolveFactoryDependency<FactoryDependency, SomeDependency>()
         }
             .`should throw`(IllegalStateException::class)
             .`with message`("Dependency 'io.getstream.chat.android.client.DependencyResolverTest.SomeDependency' was not resolved by factory 'io.getstream.chat.android.client.DependencyResolverTest.FactoryDependency'")
@@ -126,8 +126,8 @@ public class DependencyResolverTest {
             .with(FactoryDependency(mapOf(SomeDependency::class to expectedDependency)))
             .get()
 
-        val pResult = client.resolveDependency<PluginDependency, SomeDependency>()
-        val fResult = client.resolveDependency<FactoryDependency, SomeDependency>()
+        val pResult = client.resolvePluginDependency<PluginDependency, SomeDependency>()
+        val fResult = client.resolveFactoryDependency<FactoryDependency, SomeDependency>()
 
         pResult `should be` expectedDependency
         fResult `should be` expectedDependency
@@ -144,7 +144,7 @@ public class DependencyResolverTest {
         val racingFlow = DisconnectSimulatingStateFlow(client)
         whenever(fixture.mutableClientState.initializationState).thenReturn(racingFlow)
 
-        val result = client.resolveDependency<PluginDependency, SomeDependency>()
+        val result = client.resolvePluginDependency<PluginDependency, SomeDependency>()
 
         result `should be` expectedDependency
     }


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Remove the reflection-based dispatcher from `ChatClient.resolveDependency` now that `StatePlugin` and `OfflinePlugin` live in `stream-chat-android-client`. The call site already statically knows whether it wants a `Plugin` or a `PluginFactory`, so the runtime `isSubclassOf` branch was dead weight.

Closes [AND-1003](https://linear.app/stream/issue/AND-1003/remove-reflection-based-instantiation-from-plugins)

### Implementation

- Deleted the `ChatClient.resolveDependency<DR, T>()` dispatcher and the `kotlin.reflect.full.isSubclassOf` call it relied on.
- Promoted the two underlying helpers to `public inline` with tighter type bounds: `resolvePluginDependency<P : Plugin, T>()` and `resolveFactoryDependency<F : PluginFactory, T>()`. Wrong-side calls now fail at compile time instead of at the old `error("Unsupported...")`.
- Updated the four call sites in `ChatClientStateExtensions.kt` and `internal/state/extensions/internal/ChatClient.kt` to pick the matching helper.

Note: `kotlin-reflect` is still needed by `NotificationHandlerFactory.primaryConstructor` so we can't remove it yet.

### Testing

- `DependencyResolverTest` updated to call the typed helpers; all existing cases (plugin not found, factory not found, dependency not resolved, init-state guard, plugin-cleared-during-resolution race) still pass.
- `:stream-chat-android-client:apiCheck`, `spotlessKotlinCheck`, `detekt` all green.
- Manual: exercise channel list, channel details, message list pagination, reply, and Giphy cancel in the sample app to confirm `state`, `globalState`, `chatClientConfig`, and `logic` all still resolve.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Simplified dependency resolution by replacing the generic method with two specific, type-safe helpers for plugin factories and plugin dependencies.

* **Tests**
  * Updated tests to reflect new dependency resolution APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->