### PR TITLE
Clean up TalkBack accessibility semantics

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -171,9 +171,7 @@ public fun MediaAttachmentContent(
                 modifier = Modifier
                     .semantics {
                         this.contentDescription = description
-                        // Keep the grid's tiles together and in order during TalkBack traversal
-                        // so a swipe walks every tile before leaving the grid, instead of letting
-                        // the surrounding list pull focus across rows mid-grid.
+                        // Group the grid so a TalkBack swipe walks every tile before leaving it.
                         isTraversalGroup = true
                     }
                     .padding(MessageStyling.messageSectionPadding),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTag
 import androidx.compose.ui.text.style.TextAlign
@@ -168,7 +169,13 @@ public fun MediaAttachmentContent(
                 stringResource(UiCommonR.string.stream_ui_message_list_semantics_message_attachments, attachments.size)
             Row(
                 modifier = Modifier
-                    .semantics { this.contentDescription = description }
+                    .semantics {
+                        this.contentDescription = description
+                        // Keep the grid's tiles together and in order during TalkBack traversal
+                        // so a swipe walks every tile before leaving the grid, instead of letting
+                        // the surrounding list pull focus across rows mid-grid.
+                        isTraversalGroup = true
+                    }
                     .padding(MessageStyling.messageSectionPadding),
                 horizontalArrangement = Arrangement.spacedBy(gridSpacing),
             ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
@@ -123,10 +123,7 @@ public fun GiphyMessageContent(
                 .applyIf(isTouchExplorationEnabled) {
                     focusRequester(previewFocusRequester).focusable()
                 }
-                // Announce the focused preview as a single TalkBack stop that leads with the
-                // "Giphy preview" label. mergeDescendants prepends it to the children's natural
-                // announcements (the only-visible banner, alt text, Giphy label), keeping their
-                // test tags and any integrator overrides intact.
+                // Lead the preview's merged TalkBack announcement with the "Giphy preview" label.
                 .semantics(mergeDescendants = true) { contentDescription = giphyPreviewLabel },
         ) {
             Row(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
@@ -48,14 +48,13 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import coil3.ColorImage
 import coil3.compose.LocalAsyncImagePreviewHandler
-import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
@@ -98,19 +97,7 @@ public fun GiphyMessageContent(
     val cancelledAnnouncement = stringResource(R.string.stream_compose_message_list_giphy_cancelled)
     val shuffledAnnouncement = stringResource(R.string.stream_compose_message_list_giphy_shuffled)
 
-    // The focused preview is announced as one TalkBack stop. The reading order intentionally leads
-    // with the Giphy context, which differs from the visual top-to-bottom order (the "only visible
-    // to you" banner sits on top). That order spans the banner and the overridable
-    // GiphyAttachmentContent, so no single leaf can own it: compose the description here and clear
-    // the children's semantics below. Alt text is sourced exactly as GiphyAttachmentContent does.
     val giphyPreviewLabel = stringResource(R.string.stream_compose_giphy_preview_label)
-    val onlyVisibleToYou = stringResource(R.string.stream_compose_only_visible_to_you)
-    val giphyAltText = message.attachments
-        .firstOrNull(Attachment::isGiphy)
-        ?.title
-        ?.takeIf(String::isNotBlank)
-    val previewDescription = listOfNotNull(giphyPreviewLabel, giphyAltText, onlyVisibleToYou)
-        .joinToString(separator = ", ")
 
     val isTouchExplorationEnabled = rememberIsTouchExplorationEnabled()
     val previewFocusRequester = remember { FocusRequester() }
@@ -136,7 +123,11 @@ public fun GiphyMessageContent(
                 .applyIf(isTouchExplorationEnabled) {
                     focusRequester(previewFocusRequester).focusable()
                 }
-                .clearAndSetSemantics { contentDescription = previewDescription },
+                // Announce the focused preview as a single TalkBack stop that leads with the
+                // "Giphy preview" label. mergeDescendants prepends it to the children's natural
+                // announcements (the only-visible banner, alt text, Giphy label), keeping their
+                // test tags and any integrator overrides intact.
+                .semantics(mergeDescendants = true) { contentDescription = giphyPreviewLabel },
         ) {
             Row(
                 modifier = Modifier
@@ -152,7 +143,7 @@ public fun GiphyMessageContent(
                     tint = colors.chatTextOutgoing,
                 )
                 Text(
-                    text = onlyVisibleToYou,
+                    text = stringResource(R.string.stream_compose_only_visible_to_you),
                     style = ChatTheme.typography.captionEmphasis,
                     color = colors.chatTextOutgoing,
                 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/GiphyMessageContent.kt
@@ -48,12 +48,14 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.core.content.getSystemService
 import coil3.ColorImage
 import coil3.compose.LocalAsyncImagePreviewHandler
+import io.getstream.chat.android.client.utils.attachment.isGiphy
 import io.getstream.chat.android.compose.R
 import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
 import io.getstream.chat.android.compose.ui.components.button.StreamButtonStyleDefaults
@@ -96,6 +98,20 @@ public fun GiphyMessageContent(
     val cancelledAnnouncement = stringResource(R.string.stream_compose_message_list_giphy_cancelled)
     val shuffledAnnouncement = stringResource(R.string.stream_compose_message_list_giphy_shuffled)
 
+    // The focused preview is announced as one TalkBack stop. The reading order intentionally leads
+    // with the Giphy context, which differs from the visual top-to-bottom order (the "only visible
+    // to you" banner sits on top). That order spans the banner and the overridable
+    // GiphyAttachmentContent, so no single leaf can own it: compose the description here and clear
+    // the children's semantics below. Alt text is sourced exactly as GiphyAttachmentContent does.
+    val giphyPreviewLabel = stringResource(R.string.stream_compose_giphy_preview_label)
+    val onlyVisibleToYou = stringResource(R.string.stream_compose_only_visible_to_you)
+    val giphyAltText = message.attachments
+        .firstOrNull(Attachment::isGiphy)
+        ?.title
+        ?.takeIf(String::isNotBlank)
+    val previewDescription = listOfNotNull(giphyPreviewLabel, giphyAltText, onlyVisibleToYou)
+        .joinToString(separator = ", ")
+
     val isTouchExplorationEnabled = rememberIsTouchExplorationEnabled()
     val previewFocusRequester = remember { FocusRequester() }
     // Track whether the preview has already requested focus so that a LazyColumn dispose +
@@ -120,7 +136,7 @@ public fun GiphyMessageContent(
                 .applyIf(isTouchExplorationEnabled) {
                     focusRequester(previewFocusRequester).focusable()
                 }
-                .semantics(mergeDescendants = true) {},
+                .clearAndSetSemantics { contentDescription = previewDescription },
         ) {
             Row(
                 modifier = Modifier
@@ -136,7 +152,7 @@ public fun GiphyMessageContent(
                     tint = colors.chatTextOutgoing,
                 )
                 Text(
-                    text = stringResource(R.string.stream_compose_only_visible_to_you),
+                    text = onlyVisibleToYou,
                     style = ChatTheme.typography.captionEmphasis,
                     color = colors.chatTextOutgoing,
                 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
@@ -129,7 +129,7 @@ internal fun MessageComposerQuotedMessage(
             message = message,
             currentUser = currentUser,
             replyMessage = null,
-            // No click handler on the composer quoted preview; merge so its sender + text announce as one stop.
+            // No click handler on the composer quoted preview; merge into one TalkBack stop.
             modifier = Modifier.semantics(mergeDescendants = true) {},
         )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessage.kt
@@ -129,6 +129,7 @@ internal fun MessageComposerQuotedMessage(
             message = message,
             currentUser = currentUser,
             replyMessage = null,
+            // No click handler on the composer quoted preview; merge so its sender + text announce as one stop.
             modifier = Modifier.semantics(mergeDescendants = true) {},
         )
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
@@ -178,7 +178,7 @@ internal fun PollAnswersItem(
         verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
     ) {
         Column(
-            // No click handler; merge so the answer text + author row announce as one TalkBack stop.
+            // No click handler; merge into one TalkBack stop.
             modifier = Modifier.semantics(mergeDescendants = true) {},
             verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
         ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollAnswers.kt
@@ -178,6 +178,7 @@ internal fun PollAnswersItem(
         verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
     ) {
         Column(
+            // No click handler; merge so the answer text + author row announce as one TalkBack stop.
             modifier = Modifier.semantics(mergeDescendants = true) {},
             verticalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
         ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
@@ -164,7 +164,7 @@ private fun Content(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
-                            // No click handler; merge so the winner badge + vote count announce as one stop.
+                            // No click handler; merge into one TalkBack stop.
                             .semantics(mergeDescendants = true) {},
                         horizontalArrangement = Arrangement.End,
                     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotesDialog.kt
@@ -164,6 +164,7 @@ private fun Content(
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
+                            // No click handler; merge so the winner badge + vote count announce as one stop.
                             .semantics(mergeDescendants = true) {},
                         horizontalArrangement = Arrangement.End,
                     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollVoteItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollVoteItem.kt
@@ -44,6 +44,7 @@ internal fun PollVoteItem(
     val borderSize = 2.dp
 
     Row(
+        // No click handler; merge so the voter avatar + name announce as one TalkBack stop.
         modifier = modifier.semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollVoteItem.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollVoteItem.kt
@@ -44,7 +44,7 @@ internal fun PollVoteItem(
     val borderSize = 2.dp
 
     Row(
-        // No click handler; merge so the voter avatar + name announce as one TalkBack stop.
+        // No click handler; merge into one TalkBack stop.
         modifier = modifier.semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingSm),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/attachments/poll/PollSwitchList.kt
@@ -179,8 +179,7 @@ private fun PollSwitchHeader(
                 value = enabled,
                 role = Role.Switch,
                 onValueChange = onCheckedChange,
-            )
-            .semantics(mergeDescendants = true) {},
+            ),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Column(
@@ -230,8 +229,7 @@ private fun LimitVotesPerPerson(
                     value = enabled,
                     role = Role.Switch,
                     onValueChange = onCheckedChange,
-                )
-                .semantics(mergeDescendants = true) {},
+                ),
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingContent.kt
@@ -196,13 +196,17 @@ internal fun MessageComposerAudioRecordingLockedContent(
             modifier = RecordingBarModifier
                 .focusRequester(rowFocusRequester)
                 .focusable()
-                .semantics(mergeDescendants = true) { contentDescription = rowLabel },
+                // Merge the row into a single TalkBack stop. The label is owned by the leading icon
+                // leaf (below) rather than set here, so children announce in visual order
+                // (label, duration, progress) and a new child appends in its slot instead of
+                // silently shifting a parent-level description.
+                .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Box(modifier = Modifier.size(48.dp), contentAlignment = Alignment.Center) {
                 Icon(
                     painter = painterResource(id = R.drawable.stream_design_ic_voice),
-                    contentDescription = null,
+                    contentDescription = rowLabel,
                     tint = ChatTheme.colors.accentError,
                 )
             }
@@ -314,7 +318,10 @@ private fun RowScope.OverviewPlaybackRow(
             .fillMaxHeight()
             .focusRequester(focusRequester)
             .focusable()
-            .semantics(mergeDescendants = true) { contentDescription = rowLabel },
+            // Merge the row into a single TalkBack stop. The label is owned by the waveform leaf
+            // (below) rather than set here, so the announce is composed from the children instead
+            // of a parent description that would concatenate with any future child.
+            .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
     ) {
         val playbackInMs = (currentProgress * state.durationInMs).toInt()
@@ -330,6 +337,7 @@ private fun RowScope.OverviewPlaybackRow(
         StaticWaveformSlider(
             modifier = Modifier
                 .fillMaxSize()
+                .semantics { contentDescription = rowLabel }
                 .padding(start = StreamTokens.spacingMd, top = 8.dp, bottom = 8.dp),
             waveformData = state.waveform,
             progress = currentProgress,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingContent.kt
@@ -196,10 +196,7 @@ internal fun MessageComposerAudioRecordingLockedContent(
             modifier = RecordingBarModifier
                 .focusRequester(rowFocusRequester)
                 .focusable()
-                // Merge the row into a single TalkBack stop. The label is owned by the leading icon
-                // leaf (below) rather than set here, so children announce in visual order
-                // (label, duration, progress) and a new child appends in its slot instead of
-                // silently shifting a parent-level description.
+                // Merge the row into one TalkBack stop; the leading icon owns the row label.
                 .semantics(mergeDescendants = true) {},
             verticalAlignment = Alignment.CenterVertically,
         ) {
@@ -318,9 +315,7 @@ private fun RowScope.OverviewPlaybackRow(
             .fillMaxHeight()
             .focusRequester(focusRequester)
             .focusable()
-            // Merge the row into a single TalkBack stop. The label is owned by the waveform leaf
-            // (below) rather than set here, so the announce is composed from the children instead
-            // of a parent description that would concatenate with any future child.
+            // Merge the row into one TalkBack stop; the waveform owns the row label.
             .semantics(mergeDescendants = true) {},
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
@@ -85,6 +85,7 @@ private fun EditIndicatorCard(body: QuotedMessageBody) {
             )
             .padding(StreamTokens.spacingXs)
             .height(IntrinsicSize.Min)
+            // No click handler here; merge so the divider + quoted-message text announce as one stop.
             .semantics(mergeDescendants = true) {},
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/MessageComposerEditIndicator.kt
@@ -85,7 +85,7 @@ private fun EditIndicatorCard(body: QuotedMessageBody) {
             )
             .padding(StreamTokens.spacingXs)
             .height(IntrinsicSize.Min)
-            // No click handler here; merge so the divider + quoted-message text announce as one stop.
+            // No click handler; merge into one TalkBack stop.
             .semantics(mergeDescendants = true) {},
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacingXs),
     ) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
@@ -200,7 +200,6 @@ internal fun DefaultChannelHeaderCenterContent(
                     onClickLabel = onHeaderTitleClickLabel,
                     role = Role.Button,
                 ) { callback(channel) }
-                    .semantics(mergeDescendants = true) {}
             },
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -208,6 +208,8 @@ public fun MessageContainer(
                         true
                     }
                 }
+        // Deleted/uploading messages have no click handler; merge so the row's children
+        // (avatar, text, footer) announce as one TalkBack stop instead of separate ones.
         else -> Modifier.semantics(mergeDescendants = true) {}
     }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -208,8 +208,7 @@ public fun MessageContainer(
                         true
                     }
                 }
-        // Deleted/uploading messages have no click handler; merge so the row's children
-        // (avatar, text, footer) announce as one TalkBack stop instead of separate ones.
+        // No click handler on deleted/uploading messages; merge into one TalkBack stop.
         else -> Modifier.semantics(mergeDescendants = true) {}
     }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -1105,11 +1105,6 @@ public interface ChatComponentFactory {
     /**
      * The default Giphy message content.
      *
-     * For TalkBack, the focused preview is announced as a single merged node whose description is
-     * composed and owned here ("Giphy preview", alt text, "Only visible to you"). This clears the
-     * semantics of the inner [GiphyAttachmentContent], so to customize the preview's accessibility
-     * announcement, override this function rather than [GiphyAttachmentContent].
-     *
      * @param params Parameters for this component.
      */
     @Composable

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/theme/ChatComponentFactory.kt
@@ -1105,6 +1105,11 @@ public interface ChatComponentFactory {
     /**
      * The default Giphy message content.
      *
+     * For TalkBack, the focused preview is announced as a single merged node whose description is
+     * composed and owned here ("Giphy preview", alt text, "Only visible to you"). This clears the
+     * semantics of the inner [GiphyAttachmentContent], so to customize the preview's accessibility
+     * announcement, override this function rather than [GiphyAttachmentContent].
+     *
      * @param params Parameters for this component.
      */
     @Composable

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -92,6 +92,7 @@
   <string name="stream_compose_flag_message_title">"Marcar mensaje"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Vista previa de Giphy"</string>
   <string name="stream_compose_image_options">"Opciones de imagen"</string>
   <string name="stream_compose_image_order">"%1$d de %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"Cancelar compartir"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -92,6 +92,7 @@
   <string name="stream_compose_flag_message_title">"Signaler le message"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Aperçu Giphy"</string>
   <string name="stream_compose_image_options">"Options de l\'image"</string>
   <string name="stream_compose_image_order">"%1$d sur %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"Annuler le partage"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -152,6 +152,7 @@
   <string name="stream_compose_flag_message_title">"मैसेज चिह्नित करें"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Giphy पूर्वावलोकन"</string>
   <string name="stream_compose_image_options">"इमेज के विकल्प"</string>
   <string name="stream_compose_image_order">"%2$d में से %1$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"शेयरिंग रद्द करें"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -92,6 +92,7 @@
   <string name="stream_compose_flag_message_title">"Tandai Pesan"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Pratinjau Giphy"</string>
   <string name="stream_compose_image_options">"Opsi gambar"</string>
   <string name="stream_compose_image_order">"%1$d dari %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"Batalkan Berbagi"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -152,6 +152,7 @@
   <string name="stream_compose_flag_message_title">"Segnala messaggio"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Anteprima Giphy"</string>
   <string name="stream_compose_image_options">"Opzioni immagine"</string>
   <string name="stream_compose_image_order">"%1$d di %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"Annulla condivisione"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -102,6 +102,7 @@
   <string name="stream_compose_flag_message_title">"メッセージを報告"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Giphyプレビュー"</string>
   <string name="stream_compose_image_options">"画像オプション"</string>
   <string name="stream_compose_image_order">"%1$d / %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"共有をキャンセル"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -102,6 +102,7 @@
   <string name="stream_compose_flag_message_title">"메시지 신고"</string>
   <string name="stream_compose_giphy_label">"GIPHY"</string>
   <string name="stream_compose_giphy_preview">"Giphy"</string>
+  <string name="stream_compose_giphy_preview_label">"Giphy 미리보기"</string>
   <string name="stream_compose_image_options">"이미지 옵션"</string>
   <string name="stream_compose_image_order">"%1$d / %2$d"</string>
   <string name="stream_compose_image_preview_cancel_sharing">"공유 취소"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -211,6 +211,7 @@
     <string name="stream_compose_video_preview">Video</string>
     <string name="stream_compose_file_preview">File</string>
     <string name="stream_compose_giphy_preview">Giphy</string>
+    <string name="stream_compose_giphy_preview_label">Giphy preview</string>
     <string name="stream_compose_link_preview">Link</string>
     <string name="stream_compose_message_deleted_preview">Message deleted</string>
     <string name="stream_compose_no_messages_yet">No messages yet</string>


### PR DESCRIPTION
### Goal

The TalkBack sweep (AND-1180) left the Compose SDK's accessibility code uneven: a few parent-level overrides re-derive what their children already announce, and some empty merge-semantics blocks add noise. This consolidates the remaining cleanup into one pass, and folds in the verified media-grid traversal change and the QA reorder feedback on the Giphy preview, so we stop opening a PR per finding.

### Implementation

Four independent changes, one per commit:

- **AudioRecordingContent** (locked + overview rows): the parent `contentDescription` under `mergeDescendants` concatenated with the child descriptions (duration, progress), so any new child silently shifted the announce. The label now lives on a child leaf (the leading icon, the waveform) and the merge stays only as the single TalkBack focus stop.
- **Empty merge-semantics blocks**: removed the empty `Modifier.semantics(mergeDescendants = true) {}` on Rows that already have a `clickable` or `toggleable` (the merge boundary is implicit there), and kept plus commented the load-bearing ones (containers with no click handler, such as the deleted-message fallback).
- **Giphy preview**: the focused ephemeral preview announced "Only visible to you, [alt text], Giphy". It now announces as one node leading with "Giphy preview", then the alt text, then "Only visible to you" (composed via `clearAndSetSemantics`). Added the `stream_compose_giphy_preview_label` string in all supported locales.
- **Media attachment grid**: added `isTraversalGroup` so a TalkBack swipe walks every tile in order before leaving the grid.

No public API change (`apiCheck` passes). The changes are semantics and string only.

### Testing

Manual TalkBack testing on a device or emulator:

1. **Giphy preview**: open a channel and send a `/giphy <query>` command. With TalkBack on, focus the rendered preview. It should read as a single stop: "Giphy preview, [search query / alt text], Only visible to you" (leading with "Giphy preview"). Verified on-device: the merged accessibility node exposes `contentDescription="Giphy preview, <query>, Only visible to you"`.
2. **Voice recording**: start a voice recording in the composer and lock it, then stop to reach the overview. With TalkBack, the locked and overview rows each read as a single stop with the recording label plus duration (plus progress for the locked state).
3. **Media grid**: open a message with multiple image attachments. With TalkBack, once focus enters the grid, swiping walks every tile in order before moving past the grid.
4. **Poll switches, poll dialogs, quoted reply, deleted message**: confirm each still reads as a single focus stop (no regression from the merge-block cleanup).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced accessibility for media attachments, Giphy previews, polls, and audio recording with improved TalkBack descriptions and traversal behavior.

* **Localization**
  * Added Giphy preview label translations across Spanish, French, Hindi, Indonesian, Italian, Japanese, and Korean locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->