### PR TITLE
Enforce poll maxVotesAllowed on the XML voting side

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/ChatClient.kt
@@ -2368,6 +2368,9 @@ internal constructor(
     /**
      * Cast a vote for a poll in a message.
      *
+     * Note: This function does not validate that the vote can be cast (e.g. that the poll is open or that
+     * the user is still within the [Poll.maxVotesAllowed] limit). Callers are responsible for these checks.
+     *
      * @param messageId The message id where the poll is.
      * @param pollId The poll id.
      * @param optionId The id of the option to vote for.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -247,7 +247,6 @@ private fun PollMessageContent(
                 voteCount = voteCount,
                 users = remember(poll.votes, option) { poll.getVotes(option).mapNotNull(Vote::user) },
                 totalVoteCount = poll.voteCountsByOption.values.sum(),
-                checkedCount = poll.ownVotes.size,
                 checked = poll.ownVotes.any { it.optionId == option.id },
                 style = style,
                 onCastVote = { onCastVote.invoke(option) },

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollMoreOptionsDialog.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollMoreOptionsDialog.kt
@@ -201,7 +201,6 @@ private fun PollMoreOptionsItemList(
                 voteCount = voteCount,
                 totalVoteCount = totalVoteCount,
                 users = users,
-                checkedCount = poll.ownVotes.size,
                 checked = isVotedByMine,
                 onCastVote = { onCastVote(option) },
                 onRemoveVote = { poll.votes.find { it.optionId == option.id }?.let(onRemoveVote) },
@@ -218,7 +217,6 @@ private fun PollMoreOptionItem(
     voteCount: Int,
     totalVoteCount: Int,
     users: List<User>,
-    checkedCount: Int,
     checked: Boolean,
     onCastVote: () -> Unit,
     onRemoveVote: () -> Unit,
@@ -231,7 +229,6 @@ private fun PollMoreOptionItem(
         voteCount = voteCount,
         totalVoteCount = totalVoteCount,
         users = users,
-        checkedCount = checkedCount,
         checked = checked,
         style = PollStyle(
             textColor = colors.chatTextIncoming,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/poll/PollOptionVotingRow.kt
@@ -57,6 +57,7 @@ import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.models.VotingVisibility
+import io.getstream.chat.android.ui.common.utils.extensions.canCastVote
 
 /**
  * Renders a single poll option as a voting row: a leading radio / checkbox, the option text, a
@@ -76,8 +77,6 @@ import io.getstream.chat.android.models.VotingVisibility
  * @param voteCount Number of votes the option has received.
  * @param totalVoteCount Total votes across all options, used to compute the progress fill.
  * @param users Subset of users whose avatars are previewed when voting visibility is public.
- * @param checkedCount Number of options the current user has already voted for, used together
- * with [Poll.maxVotesAllowed] to decide whether another vote can be cast.
  * @param checked Whether the current user has voted for this option.
  * @param style Colours used for text, radio outline, progress fill and track.
  * @param onCastVote Invoked when the user casts a vote for this option.
@@ -95,7 +94,6 @@ internal fun PollOptionVotingRow(
     voteCount: Int,
     totalVoteCount: Int,
     users: List<User>,
-    checkedCount: Int,
     checked: Boolean,
     style: PollStyle,
     onCastVote: () -> Unit,
@@ -105,8 +103,7 @@ internal fun PollOptionVotingRow(
 ) {
     val toggleRole = if (poll.maxVotesAllowed == 1) Role.RadioButton else Role.Checkbox
     val onToggle: (Boolean) -> Unit = { enabled ->
-        val canVote = poll.maxVotesAllowed?.let { checkedCount < it } ?: true
-        if (enabled && canVote && !checked) {
+        if (enabled && poll.canCastVote() && !checked) {
             onCastVote()
         } else if (!enabled) {
             onRemoveVote()

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Poll.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/utils/extensions/Poll.kt
@@ -23,6 +23,15 @@ import io.getstream.chat.android.ui.common.R
 import kotlin.math.min
 
 /**
+ * Returns true if the current user can cast another vote on this poll.
+ */
+@InternalStreamChatApi
+public fun Poll.canCastVote(): Boolean {
+    val limit = maxVotesAllowed ?: return true
+    return ownVotes.size < limit
+}
+
+/**
  * Returns the subtitle for the poll based on the maximum number of votes allowed.
  */
 @InternalStreamChatApi

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/utils/extensions/PollExtensionsTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/utils/extensions/PollExtensionsTest.kt
@@ -19,8 +19,11 @@ package io.getstream.chat.android.ui.common.utils.extensions
 import android.content.Context
 import io.getstream.chat.android.randomOption
 import io.getstream.chat.android.randomPoll
+import io.getstream.chat.android.randomVote
 import io.getstream.chat.android.ui.common.R
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -75,5 +78,26 @@ internal class PollExtensionsTest {
         val result = poll.getSubtitle(context)
 
         assertEquals("This poll is closed.", result)
+    }
+
+    @Test
+    fun `canCastVote should return true when maxVotesAllowed is null`() {
+        val poll = randomPoll(maxVotesAllowed = null, ownVotes = List(5) { randomVote() })
+
+        assertTrue(poll.canCastVote())
+    }
+
+    @Test
+    fun `canCastVote should return true when ownVotes size is below maxVotesAllowed`() {
+        val poll = randomPoll(maxVotesAllowed = 3, ownVotes = listOf(randomVote(), randomVote()))
+
+        assertTrue(poll.canCastVote())
+    }
+
+    @Test
+    fun `canCastVote should return false when ownVotes size has reached maxVotesAllowed`() {
+        val poll = randomPoll(maxVotesAllowed = 2, ownVotes = listOf(randomVote(), randomVote()))
+
+        assertFalse(poll.canCastVote())
     }
 }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/PollView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/PollView.kt
@@ -33,6 +33,7 @@ import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.models.Vote
 import io.getstream.chat.android.ui.R
 import io.getstream.chat.android.ui.common.utils.PollsConstants
+import io.getstream.chat.android.ui.common.utils.extensions.canCastVote
 import io.getstream.chat.android.ui.common.utils.extensions.getSubtitle
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollAddCommentBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemPollAnswerBinding
@@ -110,6 +111,7 @@ internal class PollView : RecyclerView {
         )
 
         val winner = poll.getWinner()
+        val canCastVote = poll.canCastVote()
 
         pollItems.addAll(
             poll.options
@@ -123,6 +125,7 @@ internal class PollView : RecyclerView {
                         totalVotes = poll.voteCountsByOption.values.sum(),
                         closed = poll.closed,
                         isWinner = winner == option,
+                        canCastVote = canCastVote,
                     )
                 },
         )
@@ -267,6 +270,7 @@ private sealed class PollItem {
         val totalVotes: Int,
         val closed: Boolean,
         val isWinner: Boolean,
+        val canCastVote: Boolean,
     ) : PollItem()
 
     data object Close : PollItem()
@@ -301,6 +305,7 @@ private class AnswerViewHolder(
         binding.check.isVisible = !pollItem.closed
         if (!pollItem.closed) {
             binding.root.setOnClickListener {
+                if (!pollItem.isVotedByUser && !pollItem.canCastVote) return@setOnClickListener
                 val newVotes = pollItem.voteCount + pollItem.isVotedByUser.invertVoteCount()
                 drawVotes(newVotes, pollItem.totalVotes)
                 binding.check.isEnabled = !binding.check.isEnabled

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AllPollOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AllPollOptionsDialogFragment.kt
@@ -39,6 +39,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.Option
 import io.getstream.chat.android.models.Poll
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.utils.extensions.canCastVote
 import io.getstream.chat.android.ui.databinding.StreamUiFragmentAllPollOptionsBinding
 import io.getstream.chat.android.ui.databinding.StreamUiItemOptionBinding
 import io.getstream.chat.android.ui.utils.extensions.applyEdgeToEdgePadding
@@ -210,12 +211,13 @@ public class AllPollOptionsDialogFragment : AppCompatDialogFragment() {
 
         fun onOptionClick(option: Option) {
             coroutineScope.launch {
-                pollState.value
-                    ?.let { poll ->
-                        poll.ownVotes.firstOrNull { it.optionId == option.id }
-                            ?.let { chatClient.removePollVote(messageId, poll.id, it.id) }
-                            ?: chatClient.castPollVote(messageId, poll.id, option.id)
-                    }?.await()
+                val poll = pollState.value ?: return@launch
+                val existingVote = poll.ownVotes.find { it.optionId == option.id }
+                if (existingVote != null) {
+                    chatClient.removePollVote(messageId, poll.id, existingVote.id).await()
+                } else if (poll.canCastVote()) {
+                    chatClient.castPollVote(messageId, poll.id, option.id).await()
+                }
             }
         }
 

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AllPollOptionsDialogFragment.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/internal/poll/AllPollOptionsDialogFragment.kt
@@ -186,7 +186,12 @@ public class AllPollOptionsDialogFragment : AppCompatDialogFragment() {
         ) : RecyclerView.ViewHolder(binding.root) {
 
             fun bind(result: OptionItem) {
-                binding.root.setOnClickListener { onOptionClick(result.option) }
+                binding.root.isEnabled = !result.readonly
+                if (result.readonly) {
+                    binding.root.setOnClickListener(null)
+                } else {
+                    binding.root.setOnClickListener { onOptionClick(result.option) }
+                }
                 binding.option.text = result.option.text
                 binding.votes.text = result.votes.toString()
                 binding.check.isEnabled = result.isVotedByUser
@@ -211,7 +216,7 @@ public class AllPollOptionsDialogFragment : AppCompatDialogFragment() {
 
         fun onOptionClick(option: Option) {
             coroutineScope.launch {
-                val poll = pollState.value ?: return@launch
+                val poll = pollState.value?.takeUnless(Poll::closed) ?: return@launch
                 val existingVote = poll.ownVotes.find { it.optionId == option.id }
                 if (existingVote != null) {
                     chatClient.removePollVote(messageId, poll.id, existingVote.id).await()


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

The XML UI SDK never checks `Poll.maxVotesAllowed` when the user taps an option to vote. Both the inline poll on the message (`PollView`) and the "see all options" bottom sheet (`AllPollOptionsDialogFragment`) call `ChatClient.castPollVote` unconditionally, so a user can vote past the configured limit.

Closes [AND-1237](https://linear.app/stream/issue/AND-1237/xmlpolls-maxvotesallowed-is-not-enforced-on-the-voting-side)

### Implementation

- New internal `Poll.canCastVote()` extension in `ui-common`.
- XML: both voting sites (`PollView`, `AllPollOptionsDialogFragment`) skip the cast when `canCastVote()` is false. Un-voting always goes through.
- Compose: replaced `PollOptionVotingRow`'s `checkedCount` parameter with a direct `poll.canCastVote()` call. Both callers passed `poll.ownVotes.size`, so no behaviour change.

### Testing

- `PollExtensionsTest`: three new cases cover `canCastVote()` for `maxVotesAllowed = null`, `ownVotes.size < maxVotesAllowed`, and `ownVotes.size == maxVotesAllowed`.
- Manual on the sample app: created polls with `maxVotesAllowed = 1`, `2`, and unlimited in both XML and Compose. Verified that tapping a third option in a 2-vote poll is now a no-op (XML inline + "see all options" sheet, and Compose).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vote casting validation in polls to consistently enforce vote limits across the app.

* **Tests**
  * Added unit tests for poll vote limit validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->