### PR TITLE
compose: Announce message sender to screen readers

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -317,15 +317,17 @@ public abstract interface class io/getstream/chat/android/compose/state/messages
 
 public final class io/getstream/chat/android/compose/state/messages/attachments/AttachmentState {
 	public static final field $stable I
-	public fun <init> (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)V
-	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)V
+	public synthetic fun <init> (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lio/getstream/chat/android/models/Message;
 	public final fun component2 ()Z
 	public final fun component3 ()Lkotlin/jvm/functions/Function1;
 	public final fun component4 ()Lkotlin/jvm/functions/Function1;
-	public final fun copy (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
-	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
+	public final fun component5 ()Z
+	public final fun copy (Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Z)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
+	public static synthetic fun copy$default (Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;Lio/getstream/chat/android/models/Message;ZLkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;ZILjava/lang/Object;)Lio/getstream/chat/android/compose/state/messages/attachments/AttachmentState;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAnnounceSender ()Z
 	public final fun getMessage ()Lio/getstream/chat/android/models/Message;
 	public final fun getOnLongItemClick ()Lkotlin/jvm/functions/Function1;
 	public final fun getOnMediaGalleryPreviewResult ()Lkotlin/jvm/functions/Function1;

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/attachments/AttachmentState.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/state/messages/attachments/AttachmentState.kt
@@ -27,10 +27,14 @@ import io.getstream.chat.android.models.Message
  * @param onLongItemClick Handler for a long click on the message item.
  * @param onMediaGalleryPreviewResult Handler used when the user selects an action to perform from
  * [io.getstream.chat.android.compose.ui.attachments.preview.MediaGalleryPreviewActivity].
+ * @param announceSender Whether this attachment should prefix its accessibility label with the
+ * sender. Set for the first attachment of a message that has no text, so screen readers attribute
+ * attachment-only messages without announcing the sender more than once.
  */
 public data class AttachmentState(
     val message: Message,
     val isMine: Boolean = false,
     val onLongItemClick: (Message) -> Unit = {},
     val onMediaGalleryPreviewResult: (MediaGalleryPreviewResult?) -> Unit = {},
+    val announceSender: Boolean = false,
 )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/AudioRecordAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/AudioRecordAttachmentContent.kt
@@ -18,6 +18,7 @@ package io.getstream.chat.android.compose.ui.attachments.content
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -41,6 +42,9 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
@@ -66,6 +70,7 @@ import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.applyIf
+import io.getstream.chat.android.compose.ui.util.senderAwareDescription
 import io.getstream.chat.android.compose.ui.util.shouldBeDisplayedAsFullSizeAttachment
 import io.getstream.chat.android.compose.viewmodel.messages.AudioPlayerViewModel
 import io.getstream.chat.android.compose.viewmodel.messages.AudioPlayerViewModelFactory
@@ -99,26 +104,38 @@ public fun AudioRecordAttachmentContent(
     val playerState by viewModel.state.collectAsStateWithLifecycle()
 
     val shouldBeFullSize = attachmentState.message.shouldBeDisplayedAsFullSizeAttachment()
-    Column(
-        modifier = modifier.applyIf(!shouldBeFullSize) { padding(MessageStyling.messageSectionPadding) },
-        verticalArrangement = Arrangement.spacedBy(MessageStyling.sectionsDistance),
+    // Mirror the multi-attachment grid: a non-clickable wrapper carries the "Voice message" label
+    // (and the sender when this is the sender-bearing attachment) so the message row announces it,
+    // while the playback controls stay individually focusable.
+    val voiceMessageLabel = stringResource(R.string.stream_compose_audio_recording_preview)
+    val rowDescription = attachmentState.senderAwareDescription(voiceMessageLabel)
+    Box(
+        modifier = Modifier.semantics {
+            contentDescription = rowDescription
+            isTraversalGroup = true
+        },
     ) {
-        audioRecordings.forEach { audioRecording ->
-            AudioRecordAttachmentContentItem(
-                modifier = Modifier.applyIf(!shouldBeFullSize) {
-                    background(
-                        MessageStyling.attachmentBackgroundColor(attachmentState.isMine),
-                        RoundedCornerShape(StreamTokens.radiusLg),
-                    )
-                },
-                attachment = audioRecording,
-                playerState = playerState,
-                isMine = attachmentState.isMine,
-                onPlayToggleClick = viewModel::playOrPause,
-                onPlaySpeedClick = viewModel::changeSpeed,
-                onThumbDragStart = viewModel::startSeek,
-                onThumbDragStop = viewModel::seekTo,
-            )
+        Column(
+            modifier = modifier.applyIf(!shouldBeFullSize) { padding(MessageStyling.messageSectionPadding) },
+            verticalArrangement = Arrangement.spacedBy(MessageStyling.sectionsDistance),
+        ) {
+            audioRecordings.forEach { audioRecording ->
+                AudioRecordAttachmentContentItem(
+                    modifier = Modifier.applyIf(!shouldBeFullSize) {
+                        background(
+                            MessageStyling.attachmentBackgroundColor(attachmentState.isMine),
+                            RoundedCornerShape(StreamTokens.radiusLg),
+                        )
+                    },
+                    attachment = audioRecording,
+                    playerState = playerState,
+                    isMine = attachmentState.isMine,
+                    onPlayToggleClick = viewModel::playOrPause,
+                    onPlaySpeedClick = viewModel::changeSpeed,
+                    onThumbDragStart = viewModel::startSeek,
+                    onThumbDragStop = viewModel::seekTo,
+                )
+            }
         }
     }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/FileAttachmentContent.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -38,6 +39,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -59,6 +63,7 @@ import io.getstream.chat.android.compose.ui.util.MimeTypeIconProvider
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
 import io.getstream.chat.android.compose.ui.util.applyIf
 import io.getstream.chat.android.compose.ui.util.extensions.internal.imagePreviewData
+import io.getstream.chat.android.compose.ui.util.senderAwareDescription
 import io.getstream.chat.android.compose.ui.util.shouldBeDisplayedAsFullSizeAttachment
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.Attachment.UploadState
@@ -67,6 +72,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.model.MimeType
 import io.getstream.chat.android.ui.common.utils.MediaStringUtil
 import io.getstream.chat.android.ui.common.utils.extensions.getDisplayableName
+import io.getstream.chat.android.ui.common.R as UiCommonR
 
 /**
  * Builds a file attachment message which shows a list of files.
@@ -92,40 +98,57 @@ public fun FileAttachmentContent(
 
     val shouldBeFullSize = message.shouldBeDisplayedAsFullSizeAttachment()
 
-    Column(
-        modifier = modifier
-            .combinedClickable(
-                indication = null,
-                interactionSource = remember { MutableInteractionSource() },
-                onClick = {},
-                onLongClick = { attachmentState.onLongItemClick(message) },
-            )
-            .testTag("Stream_MultipleFileAttachmentsColumn"),
+    val fileAttachments = message.attachments.filter { it.isFile() || it.isAudio() }
+    // Mirror the multi-attachment grid: a non-clickable wrapper carries the sender so the message
+    // row announces it, while the clickable file rows stay individually focusable.
+    val fileLabel = if (fileAttachments.size == 1) {
+        fileAttachments.first().getDisplayableName().orEmpty()
+    } else {
+        stringResource(UiCommonR.string.stream_ui_message_list_semantics_message_attachments, fileAttachments.size)
+    }
+    val rowDescription = attachmentState.senderAwareDescription(fileLabel)
+
+    Box(
+        modifier = Modifier.semantics {
+            contentDescription = rowDescription
+            isTraversalGroup = true
+        },
     ) {
-        val openAttachmentLabel = stringResource(R.string.stream_compose_message_attachment_open)
-        for (attachment in message.attachments) {
-            if (attachment.isFile() || attachment.isAudio()) {
-                ChatTheme.componentFactory.FileAttachmentItem(
-                    params = FileAttachmentItemParams(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .applyIf(!shouldBeFullSize) {
-                                val color = MessageStyling.attachmentBackgroundColor(attachmentState.isMine)
-                                padding(MessageStyling.messageSectionPadding)
-                                    .background(color, fileAttachmentShape)
-                            }
-                            .combinedClickable(
-                                indication = ripple(),
-                                interactionSource = remember { MutableInteractionSource() },
-                                onClickLabel = openAttachmentLabel,
-                                onClick = { onItemClick(previewHandlers, attachment) },
-                                onLongClick = { attachmentState.onLongItemClick(message) },
-                            ),
-                        attachment = attachment,
-                        isMine = attachmentState.isMine,
-                        showFileSize = showFileSize,
-                    ),
+        Column(
+            modifier = modifier
+                .combinedClickable(
+                    indication = null,
+                    interactionSource = remember { MutableInteractionSource() },
+                    onClick = {},
+                    onLongClick = { attachmentState.onLongItemClick(message) },
                 )
+                .testTag("Stream_MultipleFileAttachmentsColumn"),
+        ) {
+            val openAttachmentLabel = stringResource(R.string.stream_compose_message_attachment_open)
+            for (attachment in message.attachments) {
+                if (attachment.isFile() || attachment.isAudio()) {
+                    ChatTheme.componentFactory.FileAttachmentItem(
+                        params = FileAttachmentItemParams(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .applyIf(!shouldBeFullSize) {
+                                    val color = MessageStyling.attachmentBackgroundColor(attachmentState.isMine)
+                                    padding(MessageStyling.messageSectionPadding)
+                                        .background(color, fileAttachmentShape)
+                                }
+                                .combinedClickable(
+                                    indication = ripple(),
+                                    interactionSource = remember { MutableInteractionSource() },
+                                    onClickLabel = openAttachmentLabel,
+                                    onClick = { onItemClick(previewHandlers, attachment) },
+                                    onLongClick = { attachmentState.onLongItemClick(message) },
+                                ),
+                            attachment = attachment,
+                            isMine = attachmentState.isMine,
+                            showFileSize = showFileSize,
+                        ),
+                    )
+                }
             }
         }
     }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -45,6 +45,9 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.DpSize
@@ -60,6 +63,7 @@ import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.AsyncImagePreviewHandler
 import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
 import io.getstream.chat.android.compose.ui.util.applyIf
+import io.getstream.chat.android.compose.ui.util.senderAwareDescription
 import io.getstream.chat.android.compose.ui.util.shouldBeDisplayedAsFullSizeAttachment
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
@@ -118,51 +122,66 @@ public fun GiphyAttachmentContent(
     val giphyDimensions: DpSize = calculateSize(giphyInfo, giphySizingMode)
 
     val shouldBeFullSize = message.shouldBeDisplayedAsFullSizeAttachment()
+    val giphyTitle = attachment.title?.takeIf(String::isNotBlank)
+    // Mirror the card's announcement (title + the Giphy badge) so the row identifies it as a giphy.
+    val giphyContent = listOfNotNull(giphyTitle, stringResource(R.string.stream_compose_giphy_label))
+        .joinToString(separator = ", ")
+    val giphyRowDescription = state.senderAwareDescription(giphyContent)
     val interactionSource = remember { MutableInteractionSource() }
+    // Mirror the multi-attachment grid: a non-clickable wrapper carries the content (and the sender
+    // when this is the sender-bearing attachment) so the message row announces it, while the
+    // clickable giphy stays individually focusable.
     Box(
-        modifier = modifier
-            .testTag("Stream_GiphyContent")
-            .size(giphyDimensions)
-            .applyIf(!shouldBeFullSize) {
-                padding(MessageStyling.messageSectionPadding)
-                    .clip(RoundedCornerShape(StreamTokens.radiusLg))
-            }
-            // Workaround: `interactive` gates `combinedClickable` so the ephemeral preview path
-            // can disable the clickable (its inner click and long-click are no-ops there) and let
-            // the surrounding bubble announce as a single TalkBack focus. The proper fix is to
-            // make `onItemClick` (and `AttachmentState.onLongItemClick`) nullable and gate on
-            // `!= null`, but that is a binary-breaking type change on a published API. Revisit in
-            // v8 and drop `interactive` once the handlers are nullable.
-            .applyIf(interactive) {
-                combinedClickable(
-                    indication = ripple(),
-                    interactionSource = interactionSource,
-                    onClick = {
-                        onItemClick(
-                            GiphyAttachmentClickData(
-                                context = context,
-                                url = previewUrl,
-                                attachment = attachment,
-                                message = message,
-                            ),
-                        )
-                    },
-                    onLongClick = { state.onLongItemClick(message) },
-                )
-            },
+        modifier = modifier.semantics {
+            contentDescription = giphyRowDescription
+            isTraversalGroup = true
+        },
     ) {
-        StreamAsyncImage(
-            data = giphyInfo?.url,
-            modifier = Modifier.fillMaxSize(),
-            contentDescription = attachment.title?.takeIf(String::isNotBlank),
-            contentScale = contentScale,
-        )
+        Box(
+            modifier = Modifier
+                .testTag("Stream_GiphyContent")
+                .size(giphyDimensions)
+                .applyIf(!shouldBeFullSize) {
+                    padding(MessageStyling.messageSectionPadding)
+                        .clip(RoundedCornerShape(StreamTokens.radiusLg))
+                }
+                // Workaround: `interactive` gates `combinedClickable` so the ephemeral preview path
+                // can disable the clickable (its inner click and long-click are no-ops there) and
+                // let the surrounding bubble announce as a single TalkBack focus. The proper fix is
+                // to make `onItemClick` (and `AttachmentState.onLongItemClick`) nullable and gate on
+                // `!= null`, but that is a binary-breaking type change on a published API. Revisit
+                // in v8 and drop `interactive` once the handlers are nullable.
+                .applyIf(interactive) {
+                    combinedClickable(
+                        indication = ripple(),
+                        interactionSource = interactionSource,
+                        onClick = {
+                            onItemClick(
+                                GiphyAttachmentClickData(
+                                    context = context,
+                                    url = previewUrl,
+                                    attachment = attachment,
+                                    message = message,
+                                ),
+                            )
+                        },
+                        onLongClick = { state.onLongItemClick(message) },
+                    )
+                },
+        ) {
+            StreamAsyncImage(
+                data = giphyInfo?.url,
+                modifier = Modifier.fillMaxSize(),
+                contentDescription = giphyTitle,
+                contentScale = contentScale,
+            )
 
-        GiphyLabel(
-            Modifier
-                .align(Alignment.BottomStart)
-                .padding(StreamTokens.spacingXs),
-        )
+            GiphyLabel(
+                Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(StreamTokens.spacingXs),
+            )
+        }
     }
 }
 

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/MediaAttachmentContent.kt
@@ -93,6 +93,7 @@ import io.getstream.chat.android.compose.ui.util.StreamAsyncImage
 import io.getstream.chat.android.compose.ui.util.applyIf
 import io.getstream.chat.android.compose.ui.util.extensions.internal.imagePreviewData
 import io.getstream.chat.android.compose.ui.util.ifNotNull
+import io.getstream.chat.android.compose.ui.util.senderAwareDescription
 import io.getstream.chat.android.compose.ui.util.shouldBeDisplayedAsFullSizeAttachment
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.models.AttachmentType
@@ -117,6 +118,7 @@ import io.getstream.chat.android.ui.common.R as UiCommonR
  * By default it is used to display a play button over video previews.
  */
 @OptIn(ExperimentalFoundationApi::class)
+@Suppress("LongMethod")
 @Composable
 public fun MediaAttachmentContent(
     state: AttachmentState,
@@ -153,20 +155,39 @@ public fun MediaAttachmentContent(
 
     Box(modifier = modifier) {
         if (attachments.size == 1) {
-            SingleMediaAttachment(
-                attachment = attachments.first(),
-                message = message,
-                modifier = Modifier,
-                onMediaGalleryPreviewResult = state.onMediaGalleryPreviewResult,
-                onLongItemClick = state.onLongItemClick,
-                skipEnrichUrl = skipEnrichUrl,
-                onContentItemClick = onItemClick,
-                overlayContent = itemOverlayContent,
+            val singleAttachment = attachments.first()
+            // Mirror the multi-attachment grid: a non-clickable wrapper carries the sender so the
+            // message row announces it, while the clickable preview stays individually focusable.
+            val singleLabel = stringResource(
+                if (singleAttachment.isVideo()) {
+                    UiCommonR.string.stream_ui_message_list_semantics_message_attachment_video
+                } else {
+                    UiCommonR.string.stream_ui_message_list_semantics_message_attachment_image
+                },
             )
+            val rowDescription = state.senderAwareDescription(singleLabel)
+            Box(
+                modifier = Modifier.semantics {
+                    contentDescription = rowDescription
+                    isTraversalGroup = true
+                },
+            ) {
+                SingleMediaAttachment(
+                    attachment = singleAttachment,
+                    message = message,
+                    modifier = Modifier,
+                    onMediaGalleryPreviewResult = state.onMediaGalleryPreviewResult,
+                    onLongItemClick = state.onLongItemClick,
+                    skipEnrichUrl = skipEnrichUrl,
+                    onContentItemClick = onItemClick,
+                    overlayContent = itemOverlayContent,
+                )
+            }
         } else {
             val gridSpacing = StreamTokens.spacing2xs
-            val description =
+            val attachmentsLabel =
                 stringResource(UiCommonR.string.stream_ui_message_list_semantics_message_attachments, attachments.size)
+            val description = state.senderAwareDescription(attachmentsLabel)
             Row(
                 modifier = Modifier
                     .semantics {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
@@ -148,8 +148,13 @@ internal fun DefaultMessageDeletedContent(
     val isMine = currentUser?.id == message.user.id
     val contentColor = MessageStyling.textColor(outgoing = isMine)
     val deletedText = stringResource(id = R.string.stream_compose_message_deleted)
-    // Attribute the sender on deleted messages too, so every message announces who sent it (DS-035).
-    val deletedDescription = senderAwareContentDescription(isMine, message.user.name, deletedText)
+    // Attribute the sender on deleted messages too, so every message announces who sent it.
+    val deletedDescription = senderAwareContentDescription(
+        isMine = isMine,
+        senderName = message.user.name,
+        content = deletedText,
+        isReply = message.replyTo != null,
+    )
     Row(
         modifier = modifier.padding(MessageStyling.contentPadding),
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing2xs),

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageContent.kt
@@ -37,6 +37,8 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.client.utils.attachment.isAudio
 import io.getstream.chat.android.client.utils.attachment.isAudioRecording
@@ -65,6 +67,7 @@ import io.getstream.chat.android.compose.ui.theme.MessageStyling
 import io.getstream.chat.android.compose.ui.theme.MessageTextContentParams
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.passiveRipple
+import io.getstream.chat.android.compose.ui.util.senderAwareContentDescription
 import io.getstream.chat.android.compose.ui.util.shouldBeDisplayedAsFullSizeAttachment
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
@@ -142,7 +145,11 @@ internal fun DefaultMessageDeletedContent(
     currentUser: User?,
     modifier: Modifier,
 ) {
-    val contentColor = MessageStyling.textColor(outgoing = currentUser?.id == message.user.id)
+    val isMine = currentUser?.id == message.user.id
+    val contentColor = MessageStyling.textColor(outgoing = isMine)
+    val deletedText = stringResource(id = R.string.stream_compose_message_deleted)
+    // Attribute the sender on deleted messages too, so every message announces who sent it (DS-035).
+    val deletedDescription = senderAwareContentDescription(isMine, message.user.name, deletedText)
     Row(
         modifier = modifier.padding(MessageStyling.contentPadding),
         horizontalArrangement = Arrangement.spacedBy(StreamTokens.spacing2xs),
@@ -155,8 +162,10 @@ internal fun DefaultMessageDeletedContent(
             modifier = Modifier.size(16.dp),
         )
         Text(
-            modifier = Modifier.testTag("Stream_MessageDeleted"),
-            text = stringResource(id = R.string.stream_compose_message_deleted),
+            modifier = Modifier
+                .testTag("Stream_MessageDeleted")
+                .semantics { contentDescription = deletedDescription },
+            text = deletedText,
             color = contentColor,
             style = ChatTheme.typography.bodyDefault,
         )
@@ -217,11 +226,21 @@ internal fun DefaultMessageRegularContent(
             onMediaGalleryPreviewResult = onMediaGalleryPreviewResult,
         )
         val info = message.rememberMessageInfo()
+        // A text-less message announces its sender on the first attachment; messages with text
+        // carry it on the text leaf instead, so the sender is announced exactly once.
+        val senderAttachment = when {
+            message.text.isNotEmpty() -> null
+            info.hasMedia -> SenderAttachment.Media
+            info.hasGiphys -> SenderAttachment.Giphy
+            info.hasFiles -> SenderAttachment.File
+            info.hasRecordings -> SenderAttachment.Audio
+            else -> null
+        }
 
         if (info.hasMedia) {
             componentFactory.MediaAttachmentContent(
                 params = MediaAttachmentContentParams(
-                    state = attachmentState,
+                    state = attachmentState.copy(announceSender = senderAttachment == SenderAttachment.Media),
                 ),
             )
         }
@@ -229,7 +248,7 @@ internal fun DefaultMessageRegularContent(
         if (info.hasGiphys) {
             componentFactory.GiphyAttachmentContent(
                 params = GiphyAttachmentContentParams(
-                    state = attachmentState,
+                    state = attachmentState.copy(announceSender = senderAttachment == SenderAttachment.Giphy),
                 ),
             )
         }
@@ -245,7 +264,7 @@ internal fun DefaultMessageRegularContent(
         if (info.hasFiles) {
             componentFactory.FileAttachmentContent(
                 params = FileAttachmentContentParams(
-                    state = attachmentState,
+                    state = attachmentState.copy(announceSender = senderAttachment == SenderAttachment.File),
                 ),
             )
         }
@@ -253,7 +272,7 @@ internal fun DefaultMessageRegularContent(
         if (info.hasRecordings) {
             componentFactory.AudioRecordAttachmentContent(
                 params = AudioRecordAttachmentContentParams(
-                    state = attachmentState,
+                    state = attachmentState.copy(announceSender = senderAttachment == SenderAttachment.Audio),
                 ),
             )
         }
@@ -317,6 +336,8 @@ private fun Message.rememberMessageInfo(): MessageContentInfo {
         )
     }
 }
+
+private enum class SenderAttachment { Media, Giphy, File, Audio }
 
 private data class MessageContentInfo(
     val hasFiles: Boolean,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -36,6 +36,8 @@ import androidx.compose.ui.input.pointer.PointerInputChange
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
@@ -56,6 +58,7 @@ import io.getstream.chat.android.compose.ui.util.AnnotationTagUrl
 import io.getstream.chat.android.compose.ui.util.AnnotationTagUserMention
 import io.getstream.chat.android.compose.ui.util.isFewEmoji
 import io.getstream.chat.android.compose.ui.util.isSingleEmoji
+import io.getstream.chat.android.compose.ui.util.senderAwareContentDescription
 import io.getstream.chat.android.compose.ui.util.showOriginalTextAsState
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
@@ -114,11 +117,19 @@ public fun MessageText(
     val annotations = remember(styledText) {
         styledText.getStringAnnotations(0, styledText.length)
     }
+    // Announce the sender as part of the text so screen readers attribute every message (DS-035).
+    val senderAwareText = senderAwareContentDescription(
+        isMine = message.isMine(currentUser),
+        senderName = message.user.name,
+        content = styledText.text,
+        isReply = message.replyTo != null,
+    )
     if (annotations.fastAny(AnnotatedString.Range<String>::isInteractiveTag)) {
         ClickableText(
             modifier = modifier
                 .padding(MessageStyling.textPadding)
-                .testTag("Stream_MessageClickableText"),
+                .testTag("Stream_MessageClickableText")
+                .semantics { contentDescription = senderAwareText },
             text = styledText,
             style = style,
             onLongPress = { onLongItemClick(message) },
@@ -141,7 +152,8 @@ public fun MessageText(
             modifier = modifier
                 .padding(MessageStyling.textPadding)
                 .clipToBounds()
-                .testTag("Stream_MessageText"),
+                .testTag("Stream_MessageText")
+                .semantics { contentDescription = senderAwareText },
             text = styledText,
             style = style,
         )

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/MessageText.kt
@@ -117,7 +117,7 @@ public fun MessageText(
     val annotations = remember(styledText) {
         styledText.getStringAnnotations(0, styledText.length)
     }
-    // Announce the sender as part of the text so screen readers attribute every message (DS-035).
+    // Announce the sender as part of the text so screen readers attribute every message.
     val senderAwareText = senderAwareContentDescription(
         isMine = message.isMine(currentUser),
         senderName = message.user.name,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -218,11 +218,12 @@ private fun PollMessageContent(
         )
     }
 
-    // Announce the sender on the poll name so screen readers attribute every message (DS-035).
+    // Announce the sender on the poll name so screen readers attribute every message.
     val senderAwareName = senderAwareContentDescription(
         isMine = isMine,
         senderName = message.user.name,
         content = poll.name,
+        isReply = message.replyTo != null,
     )
     Column(
         modifier = Modifier

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/PollMessageContent.kt
@@ -41,6 +41,8 @@ import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import io.getstream.chat.android.compose.R
@@ -59,6 +61,7 @@ import io.getstream.chat.android.compose.ui.theme.MessageStyling.PollStyle
 import io.getstream.chat.android.compose.ui.theme.StreamTokens
 import io.getstream.chat.android.compose.ui.util.isErrorOrFailed
 import io.getstream.chat.android.compose.ui.util.passiveRipple
+import io.getstream.chat.android.compose.ui.util.senderAwareContentDescription
 import io.getstream.chat.android.compose.util.extensions.toSet
 import io.getstream.chat.android.models.ChannelCapabilities
 import io.getstream.chat.android.models.Message
@@ -215,12 +218,19 @@ private fun PollMessageContent(
         )
     }
 
+    // Announce the sender on the poll name so screen readers attribute every message (DS-035).
+    val senderAwareName = senderAwareContentDescription(
+        isMine = isMine,
+        senderName = message.user.name,
+        content = poll.name,
+    )
     Column(
         modifier = Modifier
             .passiveRipple()
             .padding(StreamTokens.spacingMd),
     ) {
         Text(
+            modifier = Modifier.semantics { contentDescription = senderAwareName },
             text = poll.name,
             style = typography.bodyEmphasis,
             color = style.textColor,

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageSenderDescription.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/MessageSenderDescription.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import io.getstream.chat.android.compose.R
+import io.getstream.chat.android.compose.state.messages.attachments.AttachmentState
+
+/**
+ * Prefixes [content] with the message sender so screen readers announce who sent the message.
+ * Applied to a single content leaf per message, so the sender is announced once regardless of the
+ * visual grouping that hides the author name on consecutive messages from the same user. When
+ * [isReply] is set, the prefix uses "replied" instead of "said" so the message announces that it is
+ * a reply.
+ *
+ * @param isMine Whether the message belongs to the current user.
+ * @param senderName Display name of the sender, used for incoming messages.
+ * @param content The content already announced for this leaf (message text, poll name, etc.).
+ * @param isReply Whether the message is a reply to another message.
+ */
+@Composable
+internal fun senderAwareContentDescription(
+    isMine: Boolean,
+    senderName: String,
+    content: String,
+    isReply: Boolean = false,
+): String = when {
+    isMine && isReply -> stringResource(R.string.stream_compose_message_sender_self_reply, content)
+    isMine -> stringResource(R.string.stream_compose_message_sender_self, content)
+    isReply -> stringResource(R.string.stream_compose_message_sender_other_reply, senderName, content)
+    else -> stringResource(R.string.stream_compose_message_sender_other, senderName, content)
+}
+
+/**
+ * Returns [label] prefixed with the sender when this attachment is the one designated to announce
+ * the sender ([AttachmentState.announceSender]); otherwise returns [label] unchanged. Centralizes
+ * the sender gate shared by the attachment content components.
+ *
+ * @param label The content already announced for this attachment (e.g. "Image attachment").
+ */
+@Composable
+internal fun AttachmentState.senderAwareDescription(label: String): String =
+    if (announceSender) {
+        senderAwareContentDescription(isMine, message.user.name, label, isReply = message.replyTo != null)
+    } else {
+        label
+    }

--- a/stream-chat-android-compose/src/main/res/values-es/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-es/strings.xml
@@ -150,6 +150,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"expandido"</string>
   <string name="stream_compose_message_composer_attachments_open">"Abrir archivos adjuntos"</string>
   <string name="stream_compose_message_deleted">"Mensaje eliminado"</string>
+  <string name="stream_compose_message_sender_self">"Tú dijiste, %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s dijo, %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"Tú respondiste, %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s respondió, %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"Mensaje eliminado"</string>
   <string name="stream_compose_message_actions_menu_title">"Acciones del mensaje"</string>
   <string name="stream_compose_message_item_open_thread">"Abrir hilo"</string>

--- a/stream-chat-android-compose/src/main/res/values-fr/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-fr/strings.xml
@@ -150,6 +150,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"développé"</string>
   <string name="stream_compose_message_composer_attachments_open">"Ouvrir les pièces jointes"</string>
   <string name="stream_compose_message_deleted">"Message supprimé"</string>
+  <string name="stream_compose_message_sender_self">"Vous avez dit, %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s a dit, %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"Vous avez répondu, %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s a répondu, %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"Message supprimé"</string>
   <string name="stream_compose_message_actions_menu_title">"Actions du message"</string>
   <string name="stream_compose_message_item_open_thread">"Ouvrir le fil"</string>

--- a/stream-chat-android-compose/src/main/res/values-hi/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-hi/strings.xml
@@ -210,6 +210,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"विस्तृत"</string>
   <string name="stream_compose_message_composer_attachments_open">"अटैचमेंट खोलें"</string>
   <string name="stream_compose_message_deleted">"मैसेज मिटाया गया"</string>
+  <string name="stream_compose_message_sender_self">"आपने कहा, %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s ने कहा, %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"आपने जवाब दिया, %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s ने जवाब दिया, %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"मैसेज हटा दिया गया"</string>
   <string name="stream_compose_message_actions_menu_title">"संदेश की क्रियाएँ"</string>
   <string name="stream_compose_message_item_open_thread">"थ्रेड खोलें"</string>

--- a/stream-chat-android-compose/src/main/res/values-in/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-in/strings.xml
@@ -150,6 +150,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"diperluas"</string>
   <string name="stream_compose_message_composer_attachments_open">"Buka lampiran"</string>
   <string name="stream_compose_message_deleted">"Pesan dihapus"</string>
+  <string name="stream_compose_message_sender_self">"Anda berkata, %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s berkata, %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"Anda membalas, %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s membalas, %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"Pesan dihapus"</string>
   <string name="stream_compose_message_actions_menu_title">"Tindakan pesan"</string>
   <string name="stream_compose_message_item_open_thread">"Buka utas"</string>

--- a/stream-chat-android-compose/src/main/res/values-it/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-it/strings.xml
@@ -210,6 +210,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"espanso"</string>
   <string name="stream_compose_message_composer_attachments_open">"Apri allegati"</string>
   <string name="stream_compose_message_deleted">"Messaggio cancellato"</string>
+  <string name="stream_compose_message_sender_self">"Hai detto, %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s ha detto, %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"Hai risposto, %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s ha risposto, %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"Messaggio cancellato"</string>
   <string name="stream_compose_message_actions_menu_title">"Azioni del messaggio"</string>
   <string name="stream_compose_message_item_open_thread">"Apri thread"</string>

--- a/stream-chat-android-compose/src/main/res/values-ja/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ja/strings.xml
@@ -162,6 +162,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"展開"</string>
   <string name="stream_compose_message_composer_attachments_open">"添付ファイルを開く"</string>
   <string name="stream_compose_message_deleted">"メッセージは削除されました"</string>
+  <string name="stream_compose_message_sender_self">"あなたのメッセージ: %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$sさんのメッセージ: %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"あなたの返信: %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$sさんの返信: %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"メッセージは削除されました"</string>
   <string name="stream_compose_message_actions_menu_title">"メッセージのアクション"</string>
   <string name="stream_compose_message_item_open_thread">"スレッドを開く"</string>

--- a/stream-chat-android-compose/src/main/res/values-ko/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values-ko/strings.xml
@@ -162,6 +162,10 @@
   <string name="stream_compose_message_composer_attachments_expanded">"확장됨"</string>
   <string name="stream_compose_message_composer_attachments_open">"첨부파일 열기"</string>
   <string name="stream_compose_message_deleted">"메시지가 삭제되었습니다"</string>
+  <string name="stream_compose_message_sender_self">"내 메시지: %1$s"</string>
+  <string name="stream_compose_message_sender_other">"%1$s님의 메시지: %2$s"</string>
+  <string name="stream_compose_message_sender_self_reply">"내 답장: %1$s"</string>
+  <string name="stream_compose_message_sender_other_reply">"%1$s님의 답장: %2$s"</string>
   <string name="stream_compose_message_deleted_preview">"메시지가 삭제되었습니다"</string>
   <string name="stream_compose_message_actions_menu_title">"메시지 작업"</string>
   <string name="stream_compose_message_item_open_thread">"스레드 열기"</string>

--- a/stream-chat-android-compose/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose/src/main/res/values/strings.xml
@@ -126,6 +126,10 @@
     <string name="stream_compose_message_list_show_translation">Show translation</string>
     <string name="stream_compose_message_item_open_thread">Open thread</string>
     <string name="stream_compose_message_item_options">Show message options</string>
+    <string name="stream_compose_message_sender_self">You said, %1$s</string>
+    <string name="stream_compose_message_sender_other">%1$s said, %2$s</string>
+    <string name="stream_compose_message_sender_self_reply">You replied, %1$s</string>
+    <string name="stream_compose_message_sender_other_reply">%1$s replied, %2$s</string>
     <string name="stream_compose_message_reactions_show">Show reactions</string>
     <string name="stream_compose_message_attachment_open">Open attachment</string>
     <string name="stream_compose_message_actions_menu_title">Message actions</string>

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/list/MessageContainerSenderAttributionTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/messages/list/MessageContainerSenderAttributionTest.kt
@@ -1,0 +1,240 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.messages.list
+
+import androidx.compose.ui.test.assertContentDescriptionContains
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.test.MockedChatClientTest
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.util.extensions.toSet
+import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.ChannelCapabilities
+import io.getstream.chat.android.models.ConnectionState
+import io.getstream.chat.android.models.Message
+import io.getstream.chat.android.models.User
+import io.getstream.chat.android.randomUser
+import io.getstream.chat.android.ui.common.state.messages.list.MessageItemState
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.robolectric.annotation.Config
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+internal class MessageContainerSenderAttributionTest : MockedChatClientTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Before
+    fun prepare() {
+        whenever(mockClientState.user) doReturn MutableStateFlow(randomUser())
+        whenever(mockClientState.connectionState) doReturn MutableStateFlow(ConnectionState.Connected)
+    }
+
+    @Test
+    fun `outgoing message is announced as sent by the current user`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(id = "m1", text = "Hello", user = User(id = "me")),
+                isMine = true,
+                currentUser = User(id = "me"),
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        // Assert on the merged tree to prove the label joins the message cell's single
+        // TalkBack announcement, not just that the leaf node exists.
+        composeTestRule
+            .onNodeWithContentDescription("You said, Hello")
+            .assertExists()
+    }
+
+    @Test
+    fun `incoming message is announced with the sender name`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(id = "m2", text = "Hi", user = User(id = "u2", name = "Petar Velikov")),
+                isMine = false,
+                currentUser = User(id = "me"),
+                showMessageFooter = true,
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("Petar Velikov said, Hi")
+            .assertExists()
+    }
+
+    @Test
+    fun `single image attachment without text announces the sender`() {
+        setMessageContent(
+            ownAttachmentMessage(Attachment(type = "image", imageUrl = "https://example.com/i.png")),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("You said, Image attachment")
+            .assertExists()
+    }
+
+    @Test
+    fun `multiple image attachments without text announce the sender once`() {
+        setMessageContent(
+            ownAttachmentMessage(
+                Attachment(type = "image", imageUrl = "https://example.com/1.png"),
+                Attachment(type = "image", imageUrl = "https://example.com/2.png"),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("You said, 2 attachments")
+            .assertExists()
+    }
+
+    @Test
+    fun `file attachment without text announces the sender`() {
+        setMessageContent(
+            ownAttachmentMessage(
+                Attachment(type = "file", title = "report.pdf", assetUrl = "https://example.com/report.pdf"),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("You said, report.pdf")
+            .assertExists()
+    }
+
+    @Test
+    fun `giphy attachment without text announces the sender`() {
+        setMessageContent(
+            ownAttachmentMessage(
+                Attachment(type = "giphy", title = "cat", titleLink = "https://giphy.com/cat.gif"),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("You said, cat, GIPHY")
+            .assertExists()
+    }
+
+    @Test
+    fun `message with text and an attachment announces both`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(
+                    id = "m",
+                    text = "Hello",
+                    attachments = listOf(Attachment(type = "image", imageUrl = "https://example.com/i.png")),
+                    user = User(id = "me"),
+                ),
+                isMine = true,
+                currentUser = User(id = "me"),
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        // The text leaf carries the sender; the attachment still announces its content on the row.
+        composeTestRule.onNodeWithTag("Stream_MessageCell")
+            .assertContentDescriptionContains("You said, Hello")
+        composeTestRule.onNodeWithTag("Stream_MessageCell")
+            .assertContentDescriptionContains("Image attachment")
+    }
+
+    @Test
+    fun `text reply announces that it is a reply`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(
+                    id = "m",
+                    text = "Hi",
+                    user = User(id = "me"),
+                    replyTo = Message(id = "q", text = "Original", user = User(id = "u2")),
+                ),
+                isMine = true,
+                currentUser = User(id = "me"),
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        composeTestRule.onNodeWithTag("Stream_MessageCell")
+            .assertContentDescriptionContains("You replied, Hi")
+    }
+
+    @Test
+    fun `attachment-only reply announces that it is a reply`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(
+                    id = "m",
+                    text = "",
+                    attachments = listOf(Attachment(type = "image", imageUrl = "https://example.com/i.png")),
+                    user = User(id = "me"),
+                    replyTo = Message(id = "q", text = "Original", user = User(id = "u2")),
+                ),
+                isMine = true,
+                currentUser = User(id = "me"),
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        composeTestRule.onNodeWithTag("Stream_MessageCell")
+            .assertContentDescriptionContains("You replied, Image attachment")
+    }
+
+    @Test
+    fun `deleted message announces the sender`() {
+        setMessageContent(
+            MessageItemState(
+                message = Message(id = "m", user = User(id = "me"), deletedAt = Date()),
+                isMine = true,
+                currentUser = User(id = "me"),
+                ownCapabilities = ChannelCapabilities.toSet(),
+            ),
+        )
+
+        composeTestRule
+            .onNodeWithContentDescription("You said, Message deleted")
+            .assertExists()
+    }
+
+    private fun ownAttachmentMessage(vararg attachments: Attachment) = MessageItemState(
+        message = Message(id = "m", text = "", attachments = attachments.toList(), user = User(id = "me")),
+        isMine = true,
+        currentUser = User(id = "me"),
+        ownCapabilities = ChannelCapabilities.toSet(),
+    )
+
+    private fun setMessageContent(messageItem: MessageItemState) {
+        composeTestRule.setContent {
+            ChatTheme {
+                MessageContainer(
+                    messageItem = messageItem,
+                    onLongItemClick = {},
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Goal

TalkBack does not announce who sent a message, so screen reader users cannot tell the author. The author name is shown only visually, and the visual grouping that hides it on consecutive messages from the same user is a sighted-only concept. This change announces the sender on every message for screen readers.

Resolves https://linear.app/stream/issue/AND-1239

### Implementation

The sender is announced once per message, on a single content leaf, independent of the visual grouping:

- Text, emoji, and poll messages prefix the content: "[sender] said, [content]".
- Attachment messages (single image/video, multiple media, file, voice message, sent giphy) carry the sender on a non-clickable wrapper around the content, so the message row announces "[sender] said, [content]" while the attachment card stays individually focusable.
- Deleted messages are attributed too.
- Reply messages announce "replied" instead of "said".

Outgoing messages announce "You said"; incoming messages name the sender. A shared `senderAwareContentDescription` helper builds the label, and an additive `AttachmentState.announceSender` flag marks the single attachment that carries the sender. The new strings are translated in all supported locales.

Custom and unsupported attachments are intentionally left to the integrator, since their content is integrator-defined.

### Testing

No visual changes (accessibility semantics only). Covered by unit tests in `MessageContainerSenderAttributionTest`.

Manual: enable TalkBack, open a channel, and focus the message rows:

1. Outgoing text -> "You said, [text]".
2. Incoming text -> "[sender] said, [text]".
3. Single image / video -> "[sender] said, Image attachment / Video attachment".
4. Multiple images -> "[sender] said, N attachments"; swipe into the grid to focus each tile.
5. File -> "[sender] said, [filename]".
6. Voice message -> "[sender] said, Voice message".
7. Sent giphy -> "[sender] said, [title], GIPHY".
8. Text + attachment -> both the attachment label and "[sender] said, [text]" are announced.
9. Poll -> "[sender] said, [poll question]".
10. Deleted message -> "[sender] said, Message deleted".
11. Reply -> "[sender] replied, [text]"; the quoted preview stays a separate, tappable stop.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
- Enhanced screen reader support with sender attribution for messages and attachments.
- Improved accessibility labels for audio, file, Giphy, and media attachments.
- Better announcement of deleted messages and replies for screen readers.
- Added multilingual accessibility strings in Spanish, French, Hindi, Indonesian, Italian, Japanese, and Korean.

**Tests**
- Added comprehensive accessibility tests for message sender attribution across various attachment types and scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
