### PR TITLE
Reduce redundant DB writes for users and channel configs

### DIFF
--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channelconfig/internal/DatabaseChannelConfigRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/channelconfig/internal/DatabaseChannelConfigRepository.kt
@@ -48,11 +48,15 @@ internal class DatabaseChannelConfigRepository(
      * Writes many [ChannelConfig]
      */
     override suspend fun insertChannelConfigs(configs: Collection<ChannelConfig>) {
+        // Channel configs are keyed by type, so a page of same-type channels yields many configs
+        // that collapse to one row. Dedup by type to avoid the redundant per-row writes.
+        val configsByType = configs.associateBy(ChannelConfig::type)
+
         // update the local configs
-        channelConfigs += configs.associateBy(ChannelConfig::type)
+        channelConfigs += configsByType
 
         // insert into room db
-        channelConfigDao.insert(configs.map(ChannelConfig::toEntity))
+        channelConfigDao.insert(configsByType.values.map(ChannelConfig::toEntity))
     }
 
     /**

--- a/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
+++ b/stream-chat-android-offline/src/main/java/io/getstream/chat/android/offline/repository/domain/user/internal/DatabaseUserRepository.kt
@@ -59,6 +59,9 @@ internal class DatabaseUserRepository(
     override suspend fun insertUsers(users: Collection<User>) {
         if (users.isEmpty()) return
         val usersToInsert = users
+            // Use associateBy instead of distinctBy to keep the *last* occurrence of each user
+            .associateBy(User::id)
+            .values
             .filter { it != userCache[it.id] }
             .map { it.toEntity() }
         cacheUsers(users)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ChannelConfigRepositoryTest.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/ChannelConfigRepositoryTest.kt
@@ -100,6 +100,25 @@ internal class ChannelConfigRepositoryTest {
     }
 
     @Test
+    fun `When insert configs with duplicate types Should dedup keeping the last per type`() = runTest {
+        val first = randomChannelConfig(type = "messaging", config = randomConfig(name = "first"))
+        val last = randomChannelConfig(type = "messaging", config = randomConfig(name = "last"))
+        val other = randomChannelConfig(type = "livestream", config = randomConfig(name = "other"))
+
+        sut.insertChannelConfigs(listOf(first, other, last))
+
+        verify(dao).insert(
+            argThat<List<ChannelConfigEntity>> {
+                size == 2 &&
+                    single { it.channelConfigInnerEntity.channelType == "messaging" }
+                        .channelConfigInnerEntity.name == "last" &&
+                    single { it.channelConfigInnerEntity.channelType == "livestream" }
+                        .channelConfigInnerEntity.name == "other"
+            },
+        )
+    }
+
+    @Test
     fun `Given config in cache When select Should return config`() = runTest {
         val config = randomChannelConfig(type = "messaging", config = randomConfig(name = "configName"))
         sut.insertChannelConfig(config)

--- a/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
+++ b/stream-chat-android-offline/src/test/java/io/getstream/chat/android/offline/repository/UserRepositoryTests.kt
@@ -52,6 +52,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.times
@@ -131,6 +132,21 @@ internal class UserRepositoryTests {
         sut.insertUsers(emptyList())
 
         verify(userDao, never()).insertMany(any())
+    }
+
+    @Test
+    fun `When insert users with duplicate ids Should insert each user only once keeping the last`() = runTest {
+        val id = randomString()
+        val firstCopy = randomUser(id = id, name = "first")
+        val lastCopy = firstCopy.copy(name = "last")
+        val other = randomUser()
+
+        sut.insertUsers(listOf(firstCopy, other, lastCopy))
+
+        val captor = argumentCaptor<List<UserEntity>>()
+        verify(userDao).insertMany(captor.capture())
+        captor.firstValue.map(UserEntity::id) shouldBeEqualTo listOf(id, other.id)
+        captor.firstValue.first { it.id == id }.name shouldBeEqualTo "last"
     }
 
     @Test


### PR DESCRIPTION
<!-- pr:internal -->

### Goal

Persisting a channel response fans out into redundant SQLite writes: the same user gets inserted once per reference in the payload, and the channel list rewrites each channel's config once per channel. A customer flagged the volume. This dedups before the DB write, with no behaviour change.

Closes [AND-1247](https://linear.app/stream/issue/AND-1247/reduce-redundant-db-writes-for-users-and-channel-configs)

### Implementation

- `insertUsers`: dedup users by id (`Channel.users()` lists the same user once per member/author/watcher/etc.).
- `insertChannelConfigs`: dedup configs by type (one row per type, not per channel).

Both keep the last occurrence, matching the existing `INSERT OR REPLACE` behaviour.

### Testing

- New unit tests in `UserRepositoryTests` and `ChannelConfigRepositoryTest` covering the dedup.
- Manual: Compose sample with SQLite logging, confirmed write counts drop to the distinct counts on chat open and channel list load.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate channel configurations and user records being stored in the database. The system now properly deduplicates these entries, ensuring data consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->