### PR TITLE
compose: Restore location sharing in the sample behind a feature flag

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/CustomSettings.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/data/CustomSettings.kt
@@ -37,6 +37,7 @@ class CustomSettings(private val context: Context) {
     var isComposerLinkPreviewEnabled: Boolean by booleanPref(ComposerLinkPreview)
     var isComposerFloatingStyleEnabled: Boolean by booleanPref(ComposerFloatingStyle)
     var isSystemAttachmentPickerEnabled: Boolean by booleanPref(SystemAttachmentPicker)
+    var isLocationSharingEnabled: Boolean by booleanPref(LocationSharing)
 
     private fun booleanPref(key: String, default: Boolean = false) =
         object : ReadWriteProperty<Any?, Boolean> {
@@ -53,5 +54,6 @@ private const val ChannelPinning = "channel_pinning"
 private const val ComposerLinkPreview = "composer_link_preview"
 private const val ComposerFloatingStyle = "composer_floating_style"
 private const val SystemAttachmentPicker = "system_attachment_picker"
+private const val LocationSharing = "location_sharing"
 
 fun Context.customSettings(): CustomSettings = CustomSettings(this)

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/SampleChatTheme.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/SampleChatTheme.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.testTagsAsResourceId
+import io.getstream.chat.android.compose.ui.theme.ChatComponentFactory
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 
@@ -33,11 +34,13 @@ import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 @Composable
 internal fun SampleChatTheme(
     config: ChatUiConfig = ChatUiConfig(),
+    componentFactory: ChatComponentFactory = object : ChatComponentFactory {},
     content: @Composable () -> Unit,
 ) {
     Box(modifier = Modifier.semantics { testTagsAsResourceId = true }) {
         ChatTheme(
             config = config,
+            componentFactory = componentFactory,
             content = content,
         )
     }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelActivity.kt
@@ -23,13 +23,17 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.res.stringResource
 import io.getstream.chat.android.compose.sample.R
 import io.getstream.chat.android.compose.sample.data.customSettings
 import io.getstream.chat.android.compose.sample.feature.channel.isGroupChannel
 import io.getstream.chat.android.compose.sample.ui.SampleChatTheme
+import io.getstream.chat.android.compose.sample.ui.location.LocationComponentFactory
+import io.getstream.chat.android.compose.sample.vm.SharedLocationViewModelFactory
 import io.getstream.chat.android.compose.ui.messages.ChannelScreen
 import io.getstream.chat.android.compose.ui.theme.AttachmentPickerConfig
+import io.getstream.chat.android.compose.ui.theme.ChatComponentFactory
 import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
 import io.getstream.chat.android.compose.ui.theme.ComposerConfig
 import io.getstream.chat.android.compose.viewmodel.messages.ChannelViewModelFactory
@@ -72,6 +76,13 @@ class ChannelActivity : ComponentActivity() {
 
     @Composable
     private fun SetupChatTheme() {
+        val componentFactory = remember(cid) {
+            if (settings.isLocationSharingEnabled) {
+                LocationComponentFactory(locationViewModelFactory = SharedLocationViewModelFactory(cid))
+            } else {
+                object : ChatComponentFactory {}
+            }
+        }
         SampleChatTheme(
             config = ChatUiConfig(
                 composer = ComposerConfig(
@@ -80,6 +91,7 @@ class ChannelActivity : ComponentActivity() {
                 ),
                 attachmentPicker = AttachmentPickerConfig(useSystemPicker = settings.isSystemAttachmentPickerEnabled),
             ),
+            componentFactory = componentFactory,
         ) {
             SetupContent()
         }

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/channel/ChannelActivity.kt
@@ -76,7 +76,7 @@ class ChannelActivity : ComponentActivity() {
 
     @Composable
     private fun SetupChatTheme() {
-        val componentFactory = remember(cid) {
+        val componentFactory = remember {
             if (settings.isLocationSharingEnabled) {
                 LocationComponentFactory(locationViewModelFactory = SharedLocationViewModelFactory(cid))
             } else {

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
@@ -138,6 +138,9 @@ class CustomLoginActivity : AppCompatActivity() {
                     var isSystemAttachmentPickerEnabled by remember {
                         mutableStateOf(settings.isSystemAttachmentPickerEnabled)
                     }
+                    var isLocationSharingEnabled by remember {
+                        mutableStateOf(settings.isLocationSharingEnabled)
+                    }
 
                     val isLoginButtonEnabled = apiKeyText.isNotEmpty() &&
                         userIdText.isNotEmpty() &&
@@ -193,6 +196,15 @@ class CustomLoginActivity : AppCompatActivity() {
                             onValueChange = {
                                 isSystemAttachmentPickerEnabled = it
                                 settings.isSystemAttachmentPickerEnabled = it
+                            },
+                        ),
+                        FeatureFlag(
+                            label = stringResource(R.string.custom_login_flag_location_sharing_label),
+                            description = stringResource(R.string.custom_login_flag_location_sharing_description),
+                            value = isLocationSharingEnabled,
+                            onValueChange = {
+                                isLocationSharingEnabled = it
+                                settings.isLocationSharingEnabled = it
                             },
                         ),
                     )

--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/login/CustomLoginActivity.kt
@@ -287,7 +287,7 @@ class CustomLoginActivity : AppCompatActivity() {
                     Icon(
                         painter = painterResource(id = ComposeR.drawable.stream_design_ic_arrow_left),
                         contentDescription = null,
-                        tint = Color.Black,
+                        tint = ChatTheme.colors.textPrimary,
                     )
                 }
             },
@@ -376,10 +376,12 @@ class CustomLoginActivity : AppCompatActivity() {
                 Text(
                     text = label,
                     style = ChatTheme.typography.headingMedium,
+                    color = ChatTheme.colors.textPrimary,
                 )
                 Text(
                     text = description,
                     style = ChatTheme.typography.metadataDefault,
+                    color = ChatTheme.colors.textSecondary,
                 )
             }
         }

--- a/stream-chat-android-compose-sample/src/main/res/values/strings.xml
+++ b/stream-chat-android-compose-sample/src/main/res/values/strings.xml
@@ -41,6 +41,8 @@
     <string name="custom_login_flag_composer_link_preview_description">Show link previews in the message composer</string>
     <string name="custom_login_flag_system_attachment_picker_label">System attachment picker</string>
     <string name="custom_login_flag_system_attachment_picker_description">Use the system\'s native file/media picker</string>
+    <string name="custom_login_flag_location_sharing_label">Location sharing</string>
+    <string name="custom_login_flag_location_sharing_description">Add a Location option to the attachment picker for sharing static and live locations</string>
     <string name="custom_login_flag_channel_pinning_label">Channel pinning</string>
     <string name="custom_login_flag_channel_pinning_description">Show the Pin/Unpin Chat action in the channel options menu</string>
 


### PR DESCRIPTION
<!-- pr:demo-app -->

### Goal

While working on the OpenAPI migration, I realized the demo location sharing feature was still unused (we removed it while testing the v7 redesign). I'm readding it behind a flag so it's easier to test location (which is what I needed to do for testing the app with generated DTOs).

Closes [AND-1259](https://linear.app/stream/issue/AND-1259/restore-location-sharing-in-the-compose-sample-behind-a-feature-flag)

### Implementation

- Added an `isLocationSharingEnabled` flag to `CustomSettings` (SharedPreferences, defaults to `false`) and a toggle for it on the login/settings screen.
- `ChannelActivity` now passes `LocationComponentFactory` when the flag is on, and a no-op factory otherwise.

### Testing

- Manual: with the flag off, the attachment picker is unchanged; with it on, a Location option appears and sharing static/live locations works. Required location permissions are already declared in the sample manifest.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new location sharing option in the sample app’s login settings.
  * Channel screens now adapt to the location sharing setting and can enable location-related chat components.
  * Theme customization now supports supplying a component factory for chat UI extensions.

* **Bug Fixes**
  * Improved toolbar and feature flag text styling to better match the app theme.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->