### PR TITLE
compose: Align bottom bar nav items with the Nav Bar spec

### DIFF
--- a/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/component/AppBottomBar.kt
+++ b/stream-chat-android-compose-sample/src/main/java/io/getstream/chat/android/compose/sample/ui/component/AppBottomBar.kt
@@ -25,10 +25,11 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -37,8 +38,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.getstream.chat.android.compose.sample.R
@@ -66,7 +70,8 @@ fun AppBottomBar(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .background(ChatTheme.colors.backgroundCoreElevation1),
+                .background(ChatTheme.colors.backgroundCoreElevation1)
+                .padding(4.dp),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.SpaceEvenly,
         ) {
@@ -76,10 +81,10 @@ fun AppBottomBar(
                 text = R.string.app_bottom_bar_chats,
                 isSelected = selectedOption == AppBottomBarOption.CHATS,
                 onClick = { onOptionSelected(AppBottomBarOption.CHATS) },
-                decorationBadge = {
-                    if (unreadChannelsCount > 0) {
-                        UnreadCountIndicator(unreadChannelsCount)
-                    }
+                decorationBadge = if (unreadChannelsCount > 0) {
+                    { NavBarBadge(unreadChannelsCount) }
+                } else {
+                    null
                 },
             )
             AppBottomBarOptionTile(
@@ -88,10 +93,10 @@ fun AppBottomBar(
                 text = R.string.app_bottom_bar_threads,
                 isSelected = selectedOption == AppBottomBarOption.THREADS,
                 onClick = { onOptionSelected(AppBottomBarOption.THREADS) },
-                decorationBadge = {
-                    if (unreadThreadsCount > 0) {
-                        UnreadCountIndicator(unreadThreadsCount)
-                    }
+                decorationBadge = if (unreadThreadsCount > 0) {
+                    { NavBarBadge(unreadThreadsCount) }
+                } else {
+                    null
                 },
             )
         }
@@ -116,39 +121,82 @@ private fun AppBottomBarOptionTile(
     decorationBadge: (@Composable () -> Unit)? = null,
 ) {
     val contentColor by animateColorAsState(
-        targetValue = if (isSelected) ChatTheme.colors.textPrimary else ChatTheme.colors.textSecondary,
+        targetValue = if (isSelected) ChatTheme.colors.textPrimary else ChatTheme.colors.textTertiary,
     )
-    Box(
+    Column(
         modifier = Modifier
+            .clip(CircleShape)
             .clickable(
-                indication = ripple(bounded = false),
+                indication = ripple(),
                 interactionSource = null,
                 onClick = onClick,
             )
-            .padding(4.dp),
+            .defaultMinSize(minHeight = 56.dp, minWidth = 72.dp)
+            .padding(horizontal = 12.dp, vertical = 8.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(4.dp, Alignment.CenterVertically),
     ) {
-        // Content
-        Column(
-            modifier = Modifier.padding(4.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
+        Box {
             Icon(
                 painter = painterResource(if (isSelected) selectedIcon else unselectedIcon),
                 contentDescription = null,
                 tint = contentColor,
             )
-            Spacer(modifier = Modifier.height(4.dp))
-            Text(
-                text = stringResource(text),
-                fontSize = 12.sp,
-                color = contentColor,
-            )
-        }
-        // Decoration badge
-        decorationBadge?.let {
-            Box(modifier = Modifier.align(Alignment.TopEnd)) {
-                decorationBadge()
+            decorationBadge?.let {
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopEnd)
+                        .offset(x = 10.dp, y = (-6).dp),
+                ) {
+                    it()
+                }
             }
         }
+        Text(
+            text = stringResource(text),
+            fontSize = 12.sp,
+            fontWeight = FontWeight.SemiBold,
+            color = contentColor,
+        )
+    }
+}
+
+@Composable
+private fun NavBarBadge(count: Int) {
+    Box(
+        modifier = Modifier
+            .background(color = ChatTheme.colors.borderCoreOnInverse, shape = CircleShape)
+            .padding(2.dp),
+    ) {
+        UnreadCountIndicator(
+            modifier = Modifier.defaultMinSize(minHeight = 16.dp, minWidth = 16.dp),
+            unreadCount = count,
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AppBottomBarChatsSelectedPreview() {
+    ChatTheme {
+        AppBottomBar(
+            unreadChannelsCount = 100,
+            unreadThreadsCount = 4,
+            selectedOption = AppBottomBarOption.CHATS,
+            onOptionSelected = {},
+        )
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun AppBottomBarThreadsSelectedPreview() {
+    ChatTheme {
+        AppBottomBar(
+            unreadChannelsCount = 0,
+            unreadThreadsCount = 0,
+            selectedOption = AppBottomBarOption.THREADS,
+            onOptionSelected = {},
+        )
     }
 }


### PR DESCRIPTION
### Goal

The unread count badge on the demo app's bottom bar (Chats / Threads) was mispositioned: it sat too low and too far left, overlapping the icon body. This change fixes the badge position and aligns the bottom bar nav items with the Nav Bar design spec. Demo app only, no SDK change.

Resolves AND-1262

### Implementation

All changes are in `AppBottomBar.kt` (Compose sample):

- Anchor the unread badge to the icon's top-right corner (centered on the icon's right edge, raised above the top edge), instead of the top-right of the whole tile (icon plus label). The previous anchoring put the badge over the icon because the label is wider than the icon.
- Add the white cutout border around the badge, using `borderCoreOnInverse` so it adapts to light and dark themes.
- Match the item metrics to the spec: 56dp min height, 12dp horizontal / 8dp vertical padding, 4dp icon-to-label gap.
- Make the label semibold, and use `textTertiary` for the unselected state (`textPrimary` for selected).
- Use a pill-shaped bounded ripple for the pressed state.
- Add Compose previews for the bottom bar.

The icon size is not set explicitly: the drawables already have a 20dp intrinsic size, which Material `Icon` honours, so it stays overridable.

### 🎨 UI Changes

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="Screenshot_20260625_092713" src="https://github.com/user-attachments/assets/bcce8734-bf86-4acb-adf2-2bdae5d14351" /> | <img width="1080" height="2400" alt="Screenshot_20260625_111315" src="https://github.com/user-attachments/assets/d82770f4-a44f-4caf-8207-8135b37ee069" /> |

### Testing

1. Run the Compose sample (`demoDebug`) and log in with a user that has unread channels and unread threads.
2. Open the Chats screen and look at the bottom bar.
3. The unread badge sits at the top-right corner of each icon, with a white border, clearing the glyph with only minor overlap.
4. Switch between Chats and Threads: the selected item shows the filled icon and dark label, the unselected item shows the outline icon and grey label.
5. Press an item: the ripple fills a pill shape covering the item.

You can also use the `@Preview`s in `AppBottomBar.kt` (`AppBottomBarChatsSelectedPreview`, `AppBottomBarThreadsSelectedPreview`) to verify without running the app.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the bottom navigation tiles with a cleaner layout, improved spacing, and a more polished tap interaction.
  * Refined the selected state styling for better readability.
  * Adjusted unread-count badge placement so badges appear more consistently on tab items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->