### PR TITLE
compose: Animate the audio recording hint from above the composer

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -2083,11 +2083,11 @@ public final class io/getstream/chat/android/compose/ui/messages/composer/intern
 	public static final field INSTANCE Lio/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$AudioRecordingButtonKt;
 	public fun <init> ()V
 	public final fun getLambda$-585591518$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
-	public final fun getLambda$-958526642$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
-	public final fun getLambda$-989564617$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$146509517$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$1828592956$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 	public final fun getLambda$266592135$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
 	public final fun getLambda$79147160$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function2;
+	public final fun getLambda$921498771$stream_chat_android_compose_release ()Lkotlin/jvm/functions/Function3;
 }
 
 public final class io/getstream/chat/android/compose/ui/messages/composer/internal/ComposableSingletons$AudioRecordingContentKt {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/AudioRecordingButton.kt
@@ -372,22 +372,26 @@ private fun RecordingSnackbars(
     hintHostState: SnackbarHostState,
     rationaleHostState: SnackbarHostState,
 ) {
-    SnackbarPopup(
-        hostState = hintHostState,
-        snackbar = {
-            ChatTheme.componentFactory.MessageComposerAudioRecordingHint(
-                params = MessageComposerAudioRecordingHintParams(it),
-            )
-        },
-    )
-    SnackbarPopup(
-        hostState = rationaleHostState,
-        snackbar = {
-            ChatTheme.componentFactory.MessageComposerAudioRecordingPermissionRationale(
-                params = MessageComposerAudioRecordingPermissionRationaleParams(it),
-            )
-        },
-    )
+    if (hintHostState.currentSnackbarData != null) {
+        SnackbarPopup(
+            hostState = hintHostState,
+            snackbar = {
+                ChatTheme.componentFactory.MessageComposerAudioRecordingHint(
+                    params = MessageComposerAudioRecordingHintParams(it),
+                )
+            },
+        )
+    }
+    if (rationaleHostState.currentSnackbarData != null) {
+        SnackbarPopup(
+            hostState = rationaleHostState,
+            snackbar = {
+                ChatTheme.componentFactory.MessageComposerAudioRecordingPermissionRationale(
+                    params = MessageComposerAudioRecordingPermissionRationaleParams(it),
+                )
+            },
+        )
+    }
 }
 
 /** Emits press/release interactions on [interactionSource] while [isPressed] is true. */


### PR DESCRIPTION
### Goal

The audio recording hint ("Hold to record. Release to save.") and the audio recording permission rationale snackbar animated in from the mic button at the lower right. They should animate from above the composer, centered, matching the design and the composer's own snackbar.

Resolves AND-1264

### Implementation

Both snackbars are shown through `SnackbarPopup`, which positions itself above its anchor based on its content size. They were composed unconditionally, so while no snackbar was visible the popup content measured zero and the position provider placed it at the screen center at composer level. The toast then animated out from that wrong starting point.

`RecordingSnackbars` now guards both with a `currentSnackbarData != null` check, the same way the composer already shows its own snackbar. The popup only enters composition when there is data, so it appears centered above the composer. No animation code was added.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<video src="https://github.com/user-attachments/assets/e3b2767e-ac9b-40ca-9e44-0364406492c0" controls="controls" muted="muted" />
</td>
<td>
<video src="https://github.com/user-attachments/assets/1b814d8f-7154-4d88-8aff-114b66aebd4c" controls="controls" muted="muted" />
</td>
</tr>
</tbody>
</table>

### Testing

1. Open any channel in the Compose sample.
2. Tap the mic button quickly, do not hold.
3. The "Hold to record. Release to save." hint should animate from above the composer, centered, and dismiss on its own after a few seconds.
4. Optional: set "Animator duration scale" to 10x in Developer options to watch the entrance slowly.

For the permission rationale: revoke the microphone permission, then tap the mic. The rationale snackbar should appear the same way.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snackbar hints and permission messages now appear only when there’s actually content to show, preventing unnecessary popup rendering.
  * Improved the audio recording UI’s behavior when snackbar data is unavailable, making the experience more stable and predictable.

* **Chores**
  * Updated the public API surface for the audio recording button to reflect internal implementation changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->