### PR TITLE
Fall back to original Giphy URL when sized variant is missing

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -162,7 +162,7 @@ public fun GiphyAttachmentContent(
         "Missing Giphy attachment."
     }
 
-    val previewUrl = attachment.titleLink ?: attachment.ogUrl
+    val previewUrl = attachment.titleLink ?: attachment.thumbUrl ?: attachment.ogUrl
 
     checkNotNull(previewUrl) {
         "Missing preview URL."

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -61,6 +61,7 @@ import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
 import io.getstream.chat.android.ui.common.utils.GiphySizingMode
+import io.getstream.chat.android.ui.common.utils.extensions.giphyFallbackPreviewUrl
 import io.getstream.chat.android.ui.common.utils.giphyInfo
 
 /**
@@ -233,7 +234,7 @@ public fun GiphyAttachmentContent(
             ),
     ) {
         StreamAsyncImage(
-            data = giphyInfo?.url,
+            data = giphyInfo?.url ?: attachment.giphyFallbackPreviewUrl,
             modifier = Modifier.fillMaxSize(),
             contentDescription = null,
             contentScale = contentScale,


### PR DESCRIPTION
### Goal

Resolves: AND-1266

Fix a bug in Compose's `GiphyAttachmentContent` where the Giphy attachment renders as a blank/empty image when the requested sized variant (fixed_height, original, etc.) is unavailable on the attachment. The Compose UI Components and quoted-media variants already use the `giphyFallbackPreviewUrl` extension to handle this case, but `GiphyAttachmentContent` did not.

### Implementation

When `giphyInfo?.url` is `null`, fall back to `attachment.giphyFallbackPreviewUrl` (the same helper used by `MediaAttachmentQuotedContent`, `GiphyViewHolder`, and `GiphyMediaAttachmentView`).

### UI Changes

No UI changes for the happy path. For attachments missing the requested sized variant, the Giphy now renders via the fallback URL instead of showing an empty container.

### Testing

- Send/receive a Giphy whose `giphyInfo` map is missing the requested variant (or whose URL is `null`) and verify the attachment renders in the Compose message list using the fallback URL.
- Verify regular Giphy attachments with a populated sized variant still render unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GIF preview display by showing a fallback image when the primary GIF preview is unavailable.
  * This helps attachments render more reliably instead of appearing blank in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->