### PR TITLE
Fall back to original Giphy URL when sized variant is missing

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/content/GiphyAttachmentContent.kt
@@ -71,6 +71,7 @@ import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.ui.common.utils.GiphyInfo
 import io.getstream.chat.android.ui.common.utils.GiphyInfoType
 import io.getstream.chat.android.ui.common.utils.GiphySizingMode
+import io.getstream.chat.android.ui.common.utils.extensions.giphyFallbackPreviewUrl
 import io.getstream.chat.android.ui.common.utils.giphyInfo
 
 /**
@@ -111,7 +112,7 @@ public fun GiphyAttachmentContent(
         "Missing Giphy attachment."
     }
 
-    val previewUrl = attachment.titleLink ?: attachment.ogUrl
+    val previewUrl = attachment.titleLink ?: attachment.thumbUrl ?: attachment.ogUrl
 
     checkNotNull(previewUrl) {
         "Missing preview URL."
@@ -170,7 +171,7 @@ public fun GiphyAttachmentContent(
                 },
         ) {
             StreamAsyncImage(
-                data = giphyInfo?.url,
+                data = giphyInfo?.url ?: attachment.giphyFallbackPreviewUrl,
                 modifier = Modifier.fillMaxSize(),
                 contentDescription = giphyTitle,
                 contentScale = contentScale,


### PR DESCRIPTION
### Goal

Resolves:  AND-1266

Ports V6 [PR #6522](https://github.com/GetStream/stream-chat-android/pull/6522) (commit `51f561bd87a24d257a2170712fba3ff145e33aef`) to `develop`.

When Stream's backend doesn't return a sized variant URL for the requested `GiphyInfoType`, the Compose `GiphyAttachmentContent` previously rendered nothing because `giphyInfo?.url` was `null`. The same regression also affected the click `previewUrl`, which only considered `titleLink` and `ogUrl`.

### Implementation

- Fall back to `attachment.giphyFallbackPreviewUrl` (the existing `thumbUrl ?: titleLink ?: ogUrl` chain in `stream-chat-android-ui-common`) when `giphyInfo?.url` is `null`, so the GIF still renders.
- Add a `thumbUrl` fallback to the click `previewUrl` selection (`titleLink ?: thumbUrl ?: ogUrl`).

This was a manual port. The V6 cherry-pick did not apply cleanly because `develop` has since rewritten the surrounding `Box`/`combinedClickable` block for accessibility (nested wrapper Box, `applyIf(interactive)`, `contentDescription = giphyTitle`). The resolution kept `develop`'s structure intact and applied only the V6 fix to the `data = giphyInfo?.url` line. The `previewUrl` line and the new import auto-merged cleanly.

### UI Changes

No UI changes when sized variants are present. When the backend omits a sized variant URL, the GIF now renders via the fallback URL instead of an empty container.

### Testing

Verified locally:

- `./gradlew :stream-chat-android-compose:detekt` — pass
- `./gradlew :stream-chat-android-compose:spotlessApply` — no reformatting
- `./gradlew :stream-chat-android-compose:apiDump` — no API surface change
- `./gradlew :stream-chat-android-ui-common:testReleaseUnitTest --tests "io.getstream.chat.android.ui.common.utils.extensions.AttachmentExtensionsTest"` — pass (covers `giphyFallbackPreviewUrl`)
- `./gradlew :stream-chat-android-compose:verifyPaparazziDebug --tests "io.getstream.chat.android.compose.ui.attachments.content.AttachmentsContentTest"` — pass (`GiphyAttachmentContent` snapshots)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GIF attachment preview handling so images are more likely to display correctly.
  * Added extra fallback sources for preview URLs, helping prevent missing previews when one source is unavailable.
  * Made GIF rendering more resilient by using a backup image source when primary GIF data isn’t present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->