### PR TITLE
ui-common: Ignore mention suggestions that start with whitespace

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggester.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggester.kt
@@ -58,6 +58,11 @@ internal class TypingSuggester(private val options: TypingSuggestionOptions) {
         }
 
         val suggestionText = text.substring(suggestionStart, caretLocation)
+        // A suggestion cannot start with whitespace: typing a space right after the symbol ends it (e.g. "@ "),
+        // while internal spaces stay allowed so multi-word names like "@John Doe" remain searchable.
+        if (suggestionText.firstOrNull()?.isWhitespace() == true) {
+            return null
+        }
         if (suggestionText.length < options.minimumRequiredCharacters) {
             return null
         }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggesterTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggesterTest.kt
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.feature.messages.composer.typing
+
+import org.amshove.kluent.`should be equal to`
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+
+internal class TypingSuggesterTest {
+
+    private val suggester = TypingSuggester(TypingSuggestionOptions(symbol = "@"))
+
+    @ParameterizedTest(name = "[{index}] text=\"{0}\" -> {1}")
+    @MethodSource("provideCases")
+    fun `typingSuggestion resolves the mention token`(text: String, expected: TypingSuggestion?) {
+        val suggestion = suggester.typingSuggestion(text)
+
+        suggestion `should be equal to` expected
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun provideCases(): List<Arguments> = listOf(
+            Arguments.of("@", TypingSuggestion("", IntRange(1, 0))),
+            Arguments.of("@john", TypingSuggestion("john", 1 until 5)),
+            Arguments.of("Hello @john", TypingSuggestion("john", 7 until 11)),
+            Arguments.of("@John Doe", TypingSuggestion("John Doe", 1 until 9)),
+            Arguments.of("@john ", TypingSuggestion("john ", 1 until 6)),
+            Arguments.of("@ ", null),
+            Arguments.of("@  john", null),
+            Arguments.of("Hello@john", null),
+        )
+    }
+}


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

In the message composer, typing `@` followed by spaces keeps the mention suggestion active with a whitespace-only query, which makes the group/role lookup return everything.

`TypingSuggester.typingSuggestion` lets a suggestion token start with whitespace, so `@ ` produces a `" "` query that is forwarded to the lookup. The fix rejects suggestions that start with whitespace, while still allowing internal spaces so multi-word names (e.g. `@John Doe`) remain searchable.

Closes [AND-1268](https://linear.app/stream/issue/AND-1268/composer-typing-spaces-after-reveals-all-groupsroles)

### Implementation

- `TypingSuggester` now returns no suggestion when the token starts with whitespace. Internal and trailing spaces are still part of the token, so multi-word names keep working.

### Testing

- New `TypingSuggesterTest`: empty token, single-word and mid-text tokens, multi-word and trailing-space tokens, and the leading-whitespace cases that now produce no suggestion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention suggestions so matches are no longer shown when the suggested text starts with whitespace, while still allowing valid internal spacing.
* **Tests**
  * Added coverage for mention suggestion behavior across common typing cases and invalid whitespace patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->