### PR TITLE
Fix `grouped_unread_channels` not parsed in direct `NewMessageEvent` parser

### DIFF
--- a/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/NewMessageEventAdapter.kt
+++ b/stream-chat-android-client/src/main/java/io/getstream/chat/android/client/parser2/direct/NewMessageEventAdapter.kt
@@ -55,6 +55,7 @@ internal class NewMessageEventAdapter(
         var totalUnreadCount: Int = 0
         var unreadChannels: Int = 0
         var channelMessageCount: Int? = null
+        var groupedUnreadChannels: Map<String, Int>? = null
 
         while (reader.hasNext()) {
             when (reader.nextName()) {
@@ -83,6 +84,7 @@ internal class NewMessageEventAdapter(
                 "total_unread_count" -> totalUnreadCount = reader.nextInt()
                 "unread_channels" -> unreadChannels = reader.nextInt()
                 "channel_message_count" -> channelMessageCount = JsonParsingUtils.readNullableInt(reader)
+                "grouped_unread_channels" -> groupedUnreadChannels = JsonParsingUtils.parseIntMap(reader)
                 else -> reader.skipValue()
             }
         }
@@ -149,6 +151,7 @@ internal class NewMessageEventAdapter(
             totalUnreadCount = totalUnreadCount,
             unreadChannels = unreadChannels,
             channelMessageCount = channelMessageCount,
+            groupedUnreadChannels = groupedUnreadChannels,
         )
     }
 

--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/NewMessageEventTestData.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/parser2/testdata/NewMessageEventTestData.kt
@@ -62,7 +62,8 @@ internal object NewMessageEventTestData {
         "watcher_count": 5,
         "total_unread_count": 3,
         "unread_channels": 1,
-        "channel_message_count": 42
+        "channel_message_count": 42,
+        "grouped_unread_channels": {"team": 2, "messaging": 5}
     }"""
 
     @Language("JSON")


### PR DESCRIPTION
### Goal

The hand-written `NewMessageEventAdapter` used when `fastEventParsing` is enabled (registered in `DirectEventParser`) was dropping the `grouped_unread_channels` field delivered on `message.new` events. With the direct path winning over the DTO path, grouped unread counts pushed via `message.new` got silently lost. Counts still recovered from `notification.*` events and `channel.updated`, so it was not a crash, but it was a parser-parity bug.

This is the v6 port of the same fix being applied to `develop` via PR #6516 (review remark from @andremion at https://github.com/GetStream/stream-chat-android/pull/6516#discussion_r3472869399).

### Implementation

- `NewMessageEventAdapter` now reads `grouped_unread_channels` via `JsonParsingUtils.parseIntMap` and forwards it to the `NewMessageEvent` constructor — the DTO and direct paths produce identical events again.
- `NewMessageEventTestData.jsonAllFields` is extended to include the field so the existing parity assertion (`Both paths - all fields populated produce identical events`) actually covers it.

### UI Changes

No UI changes.

### Testing

- `./gradlew :stream-chat-android-client:testDebugUnitTest --tests "io.getstream.chat.android.client.parser2.NewMessageEventParsingTest"` — `BUILD SUCCESSFUL`.
- Without this change, the extended `jsonAllFields` fixture would cause the parity test to fail (DTO path returns the map, direct path returns `null`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved support for message events by recognizing an additional unread-count field when it is included in the response.
  * Unread counts can now be captured more accurately across grouped channels, reducing missing or incomplete badge data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->