### PR TITLE
ui-common: Show mention suggestions after non-alphanumeric dividers

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggester.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggester.kt
@@ -38,10 +38,11 @@ internal class TypingSuggester(private val options: TypingSuggestionOptions) {
             return null
         }
 
-        // Only show typing suggestions after a space, or at the start of the input
-        // valid examples: "@user", "Hello @user"
-        // invalid examples: "Hello@user"
-        val isValidPosition = firstSymbolBeforeCaret == 0 || text[firstSymbolBeforeCaret - 1].isWhitespace()
+        // The symbol must not be glued to a letter or digit.
+        // valid: "@user", "Hello @user", "@user,@user2"
+        // invalid: "Hello@user"
+        val charBeforeSymbol = text.getOrNull(firstSymbolBeforeCaret - 1)
+        val isValidPosition = charBeforeSymbol?.isLetterOrDigit() != true
         if (!isValidPosition) {
             return null
         }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggesterTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/typing/TypingSuggesterTest.kt
@@ -45,6 +45,10 @@ internal class TypingSuggesterTest {
             Arguments.of("@ ", null),
             Arguments.of("@  john", null),
             Arguments.of("Hello@john", null),
+            Arguments.of("@john,@jane", TypingSuggestion("jane", 7 until 11)),
+            Arguments.of("@john, @jane", TypingSuggestion("jane", 8 until 12)),
+            Arguments.of("(@john", TypingSuggestion("john", 2 until 6)),
+            Arguments.of("john@example.com", null),
         )
     }
 }


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Typing a mention right after a comma (e.g. `@john,@jane`) did not reveal suggestions for the second mention. `TypingSuggester` only accepted the `@` symbol at the start of the input or after whitespace, so any non-whitespace divider in front of it was rejected.

Reported during QA: [Android QA - Mentions](https://www.notion.so/stream-wiki/Android-QA-Mentions-38a6a5d7f9f6801a98e6d1c346f0dd66?source=copy_link)

Closes [AND-1276](https://linear.app/stream/issue/AND-1276/comma-divided-mentions-dont-reveal-suggestions-for-the-second-mention)

### Implementation

- `TypingSuggester` now accepts the symbol unless it is glued directly to a letter or digit. This covers commas and other separators (punctuation, brackets) while still rejecting cases like `Hello@john` and email addresses (`john@example.com`).

### Testing

- New `TypingSuggesterTest` cases: comma-divided mentions (`@john,@jane`), a bracket divider (`(@john`), and an email that must not trigger (`john@example.com`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention detection in the message composer so typing suggestions no longer trigger on email-like text.
  * Mention suggestions now work more reliably around punctuation and when multiple mentions appear in a message.
  * Expanded typing behavior checks to cover additional real-world input patterns, including parentheses and comma-separated mentions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->