### PR TITLE
Fall back to a video frame when the server thumbnail is not ready

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/channel/attachments/ChannelMediaAttachmentsScreen.kt
@@ -53,6 +53,7 @@ import io.getstream.chat.android.compose.viewmodel.channel.ChannelAttachmentsVie
 import io.getstream.chat.android.compose.viewmodel.channel.ChannelAttachmentsViewModelFactory
 import io.getstream.chat.android.previewdata.PreviewMessageData
 import io.getstream.chat.android.ui.common.feature.channel.attachments.ChannelAttachmentsViewAction
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.state.channel.attachments.ChannelAttachmentsViewState
 import io.getstream.result.Error
 import io.getstream.chat.android.ui.common.R as UiCommonR
@@ -148,8 +149,12 @@ internal fun ChannelMediaAttachmentsItem(
     item: ChannelAttachmentsViewState.Content.Item,
     onClick: () -> Unit,
 ) {
-    val data = item.attachment.upload
-        ?: if (item.attachment.isImage()) item.attachment.imageUrl else item.attachment.thumbUrl
+    val attachment = item.attachment
+    val data = attachment.upload ?: when {
+        attachment.isImage() -> attachment.imageUrl
+        attachment.isVideo() -> attachment.videoThumbnailImageData(attachment.thumbUrl)
+        else -> attachment.thumbUrl
+    }
     val isVideo = item.attachment.isVideo()
     val senderName = item.message.user.name
     val tileDescription = when {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageBodyBuilder.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageBodyBuilder.kt
@@ -35,6 +35,7 @@ import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.models.Message
 import io.getstream.chat.android.models.User
 import io.getstream.chat.android.ui.common.helper.DurationFormatter
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.common.utils.extensions.giphyFallbackPreviewUrl
@@ -221,7 +222,9 @@ internal class QuotedMessageBodyBuilder(
                 type == AttachmentType.VIDEO -> {
                     videoCount++
                     fileCount++
-                    mediaPreviewData = attachment.upload ?: attachment.thumbUrl
+                    val thumbnail = attachment.thumbUrl
+                        ?.applyStreamCdnImageResizingIfEnabled(streamCdnImageResizing)
+                    mediaPreviewData = attachment.videoThumbnailImageData(thumbnail) ?: attachment.upload
                 }
 
                 type == AttachmentType.AUDIO_RECORDING -> {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/extensions/internal/AttachmentExtensions.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/util/extensions/internal/AttachmentExtensions.kt
@@ -22,6 +22,7 @@ import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.common.helper.internal.AttachmentStorageHelper.Companion.EXTRA_SOURCE_URI
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 
 /**
@@ -60,7 +61,9 @@ internal val Attachment.localPreviewData: Any?
  * Otherwise, it returns null.
  *
  * For image attachments, [Attachment.imageUrl] is used.
- * For video attachments when thumbnails are enabled, [Attachment.thumbUrl] is used.
+ * For video attachments when thumbnails are enabled, the server [Attachment.thumbUrl] is used,
+ * falling back to a frame extracted from the [Attachment.assetUrl] video when the thumbnail is
+ * missing or fails to load (see [videoThumbnailImageData]).
  */
 @get:Composable
 internal val Attachment.imagePreviewData: Any?
@@ -70,8 +73,7 @@ internal val Attachment.imagePreviewData: Any?
                 ?.applyStreamCdnImageResizingIfEnabled(ChatTheme.streamCdnImageResizing)
                 ?: upload
         isVideo() && ChatTheme.config.messageList.videoThumbnailsEnabled ->
-            thumbUrl
-                ?.applyStreamCdnImageResizingIfEnabled(ChatTheme.streamCdnImageResizing)
+            videoThumbnailImageData(thumbUrl?.applyStreamCdnImageResizingIfEnabled(ChatTheme.streamCdnImageResizing))
                 ?: upload
         else -> null
     }

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageBodyBuilderTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/components/messages/QuotedMessageBodyBuilderTest.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.randomLocation
 import io.getstream.chat.android.randomPoll
 import io.getstream.chat.android.randomUser
 import io.getstream.chat.android.ui.common.helper.DurationFormatter
+import io.getstream.chat.android.ui.common.images.internal.VideoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.StreamCdnImageResizing.Companion.defaultStreamCdnImageResizing
 import org.amshove.kluent.`should be equal to`
 import org.junit.jupiter.params.ParameterizedTest
@@ -318,7 +319,10 @@ internal class QuotedMessageBodyBuilderTest {
                 QuotedMessageBody(
                     text = "Watch this",
                     iconId = R.drawable.stream_design_ic_video,
-                    videoPreviewData = "https://example.com/thumb.jpg",
+                    videoPreviewData = VideoThumbnailImageData(
+                        thumbnailUrl = "https://example.com/thumb.jpg",
+                        videoUrl = "https://example.com/video.mp4",
+                    ),
                 ),
             ),
             Arguments.of(
@@ -338,7 +342,10 @@ internal class QuotedMessageBodyBuilderTest {
                 QuotedMessageBody(
                     text = "Videos: 1",
                     iconId = R.drawable.stream_design_ic_video,
-                    videoPreviewData = "https://example.com/thumb.jpg",
+                    videoPreviewData = VideoThumbnailImageData(
+                        thumbnailUrl = "https://example.com/thumb.jpg",
+                        videoUrl = "https://example.com/video.mp4",
+                    ),
                 ),
             ),
             Arguments.of(

--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/extensions/internal/AttachmentImagePreviewDataTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/ui/util/extensions/internal/AttachmentImagePreviewDataTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.ui.util.extensions.internal
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.getstream.chat.android.client.test.MockedChatClientTest
+import io.getstream.chat.android.compose.ui.theme.ChatTheme
+import io.getstream.chat.android.compose.ui.theme.ChatUiConfig
+import io.getstream.chat.android.compose.ui.theme.MessageListConfig
+import io.getstream.chat.android.models.Attachment
+import io.getstream.chat.android.models.AttachmentType
+import io.getstream.chat.android.ui.common.images.internal.VideoThumbnailImageData
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.annotation.Config
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+internal class AttachmentImagePreviewDataTest : MockedChatClientTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun `image uses the image url`() {
+        val data = previewDataOf(Attachment(type = AttachmentType.IMAGE, imageUrl = IMAGE_URL))
+
+        assertEquals(IMAGE_URL, data)
+    }
+
+    @Test
+    fun `image without a url falls back to the local upload`() {
+        val upload = File("image")
+        val data = previewDataOf(Attachment(type = AttachmentType.IMAGE, imageUrl = null, upload = upload))
+
+        assertEquals(upload, data)
+    }
+
+    @Test
+    fun `video uses the thumbnail and the asset as fallback`() {
+        val data = previewDataOf(Attachment(type = AttachmentType.VIDEO, thumbUrl = THUMB_URL, assetUrl = VIDEO_URL))
+
+        assertEquals(VideoThumbnailImageData(thumbnailUrl = THUMB_URL, videoUrl = VIDEO_URL), data)
+    }
+
+    @Test
+    fun `video without a thumbnail still uses the asset`() {
+        val data = previewDataOf(Attachment(type = AttachmentType.VIDEO, thumbUrl = null, assetUrl = VIDEO_URL))
+
+        assertEquals(VideoThumbnailImageData(thumbnailUrl = null, videoUrl = VIDEO_URL), data)
+    }
+
+    @Test
+    fun `video without a thumbnail or asset falls back to the local upload`() {
+        val upload = File("video")
+        val data = previewDataOf(
+            Attachment(type = AttachmentType.VIDEO, thumbUrl = null, assetUrl = null, upload = upload),
+        )
+
+        assertEquals(upload, data)
+    }
+
+    @Test
+    fun `video returns null when video thumbnails are disabled`() {
+        val data = previewDataOf(
+            attachment = Attachment(type = AttachmentType.VIDEO, thumbUrl = THUMB_URL, assetUrl = VIDEO_URL),
+            videoThumbnailsEnabled = false,
+        )
+
+        assertNull(data)
+    }
+
+    @Test
+    fun `non-media attachment returns null`() {
+        val data = previewDataOf(Attachment(type = AttachmentType.FILE, assetUrl = VIDEO_URL))
+
+        assertNull(data)
+    }
+
+    private fun previewDataOf(attachment: Attachment, videoThumbnailsEnabled: Boolean = true): Any? {
+        var data: Any? = UNSET
+        val config = ChatUiConfig(messageList = MessageListConfig(videoThumbnailsEnabled = videoThumbnailsEnabled))
+        composeTestRule.setContent {
+            ChatTheme(config = config) {
+                data = attachment.imagePreviewData
+            }
+        }
+        return data
+    }
+
+    private companion object {
+        private val UNSET = Any()
+        private const val IMAGE_URL = "https://cdn.example.com/image.jpg"
+        private const val THUMB_URL = "https://cdn.example.com/thumb.jpg"
+        private const val VIDEO_URL = "https://cdn.example.com/video.mp4"
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactory.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/StreamImageLoaderFactory.kt
@@ -30,6 +30,8 @@ import coil3.request.allowHardware
 import coil3.request.crossfade
 import coil3.video.VideoFrameDecoder
 import io.getstream.chat.android.client.internal.file.StreamFileManager
+import io.getstream.chat.android.ui.common.images.internal.VideoFrameFetcher
+import io.getstream.chat.android.ui.common.images.internal.VideoThumbnailFallbackInterceptor
 import okio.Path.Companion.toOkioPath
 
 private const val DEFAULT_MEMORY_PERCENTAGE = 0.25
@@ -82,7 +84,9 @@ public class StreamImageLoaderFactory(
                     .build()
             }
             .components {
+                add(VideoThumbnailFallbackInterceptor())
                 interceptors.forEach { add(it) }
+                add(VideoFrameFetcher.Factory())
                 add(OkHttpNetworkFetcherFactory())
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
                     add(AnimatedImageDecoder.Factory(enforceMinimumFrameDelay = true))

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoFrameFetcher.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoFrameFetcher.kt
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.images.internal
+
+import android.media.MediaMetadataRetriever
+import android.media.MediaMetadataRetriever.OPTION_CLOSEST_SYNC
+import android.os.Build
+import coil3.Extras
+import coil3.ImageLoader
+import coil3.Uri
+import coil3.asImage
+import coil3.decode.DataSource
+import coil3.fetch.FetchResult
+import coil3.fetch.Fetcher
+import coil3.fetch.ImageFetchResult
+import coil3.getExtra
+import coil3.network.httpHeaders
+import coil3.request.ImageRequest
+import coil3.request.Options
+import coil3.size.pxOrElse
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Offset of the extracted frame, kept slightly above zero so the very first frame
+ * (often black) is skipped.
+ */
+private const val VIDEO_FRAME_MICROS = 100_000L
+
+/**
+ * Marks a request so [VideoFrameFetcher] extracts a preview frame from the video instead of
+ * downloading it through the default network fetcher.
+ */
+internal val videoFramePreviewKey: Extras.Key<Boolean> = Extras.Key(default = false)
+
+/**
+ * Marks this request as a video preview, so the frame is extracted with [MediaMetadataRetriever]
+ * range reads rather than downloading the whole file.
+ */
+internal fun ImageRequest.Builder.videoFramePreview(): ImageRequest.Builder = apply {
+    extras[videoFramePreviewKey] = true
+}
+
+/**
+ * A Coil [Fetcher] that extracts a preview frame from a remote video using [MediaMetadataRetriever].
+ *
+ * Decoding through `VideoFrameDecoder` requires the whole file to be downloaded first.
+ * [MediaMetadataRetriever] instead seeks with HTTP range requests and reads only the bytes needed
+ * for the requested frame, and the full video is never written to the image disk cache. Only
+ * requests marked with [videoFramePreview] are handled; all others fall through to the default
+ * network fetcher.
+ *
+ * The data and headers reaching this fetcher are already resolved by the upstream interceptors
+ * (including CDN signing), so the URL is used as-is.
+ */
+internal class VideoFrameFetcher(
+    private val data: Uri,
+    private val options: Options,
+) : Fetcher {
+
+    override suspend fun fetch(): FetchResult = withContext(Dispatchers.IO) {
+        val retriever = MediaMetadataRetriever()
+        try {
+            retriever.setDataSource(data.toString(), options.requestHeaders())
+            val bitmap = retriever.extractFrame()
+                ?: error("Could not extract a preview frame from the video")
+            ImageFetchResult(
+                image = bitmap.asImage(),
+                isSampled = false,
+                dataSource = DataSource.NETWORK,
+            )
+        } finally {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                retriever.close()
+            } else {
+                @Suppress("DEPRECATION")
+                retriever.release()
+            }
+        }
+    }
+
+    private fun Options.requestHeaders(): Map<String, String> =
+        httpHeaders.asMap().mapNotNull { (name, values) ->
+            values.lastOrNull()?.let { name to it }
+        }.toMap()
+
+    private fun MediaMetadataRetriever.extractFrame(): android.graphics.Bitmap? {
+        val dstWidth = options.size.width.pxOrElse { 0 }
+        val dstHeight = options.size.height.pxOrElse { 0 }
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O_MR1 && dstWidth > 0 && dstHeight > 0) {
+            getScaledFrameAtTime(VIDEO_FRAME_MICROS, OPTION_CLOSEST_SYNC, dstWidth, dstHeight)
+        } else {
+            getFrameAtTime(VIDEO_FRAME_MICROS, OPTION_CLOSEST_SYNC)
+        }
+    }
+
+    class Factory : Fetcher.Factory<Uri> {
+        override fun create(data: Uri, options: Options, imageLoader: ImageLoader): Fetcher? {
+            if (!options.getExtra(videoFramePreviewKey)) return null
+            return VideoFrameFetcher(data, options)
+        }
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailFallbackInterceptor.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailFallbackInterceptor.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.images.internal
+
+import coil3.intercept.Interceptor
+import coil3.request.ImageResult
+import coil3.request.SuccessResult
+
+/**
+ * A Coil [Interceptor] that resolves a [VideoThumbnailImageData] request by loading the server
+ * thumbnail first and, when that is missing or fails, extracting a frame from the video asset.
+ *
+ * Server-side thumbnail generation is asynchronous, so right after a video is sent the thumbnail
+ * URL can return 404 until generation finishes. Without a fallback the preview stays blank until
+ * the item is rendered again.
+ *
+ * The interceptor rewrites the request data to a plain URL before proceeding, so the rest of the
+ * pipeline (CDN signing, network fetching, frame decoding) is reused for both the thumbnail and
+ * the video frame. It must be registered as the outermost interceptor so URL-rewriting
+ * interceptors still apply to the fallback video URL.
+ */
+internal class VideoThumbnailFallbackInterceptor : Interceptor {
+
+    override suspend fun intercept(chain: Interceptor.Chain): ImageResult {
+        val data = chain.request.data as? VideoThumbnailImageData ?: return chain.proceed()
+        val thumbnailUrl = data.thumbnailUrl
+        val videoUrl = data.videoUrl
+
+        if (thumbnailUrl != null) {
+            val thumbnailResult = chain
+                .withRequest(chain.request.newBuilder().data(thumbnailUrl).build())
+                .proceed()
+            if (thumbnailResult is SuccessResult || videoUrl == null) {
+                return thumbnailResult
+            }
+        }
+
+        if (videoUrl != null) {
+            val videoRequest = chain.request.newBuilder()
+                .data(videoUrl)
+                .videoFramePreview()
+                .build()
+            return chain.withRequest(videoRequest).proceed()
+        }
+
+        return chain.proceed()
+    }
+}

--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailImageData.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailImageData.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.images.internal
+
+import io.getstream.chat.android.core.internal.InternalStreamChatApi
+import io.getstream.chat.android.models.Attachment
+
+/**
+ * Image request data for a video preview that should be loaded from the server thumbnail when
+ * available, and fall back to a frame extracted from the video itself when the thumbnail is
+ * missing or fails to load.
+ *
+ * Pass an instance of this as the Coil request data (instead of a raw URL) to opt into the
+ * fallback handled by [VideoThumbnailFallbackInterceptor].
+ *
+ * @param thumbnailUrl The server-provided thumbnail URL, already transformed for CDN resizing if enabled.
+ * @param videoUrl The URL of the video asset, used to extract a preview frame when [thumbnailUrl] fails.
+ */
+@InternalStreamChatApi
+public data class VideoThumbnailImageData(
+    public val thumbnailUrl: String?,
+    public val videoUrl: String?,
+)
+
+/**
+ * Builds the [VideoThumbnailImageData] for a video attachment from the given [thumbnailUrl] and the
+ * attachment's [Attachment.assetUrl], or returns `null` when neither is available.
+ *
+ * @param thumbnailUrl The server thumbnail URL, already transformed for CDN resizing if enabled.
+ */
+@InternalStreamChatApi
+public fun Attachment.videoThumbnailImageData(thumbnailUrl: String?): VideoThumbnailImageData? =
+    if (thumbnailUrl != null || assetUrl != null) {
+        VideoThumbnailImageData(thumbnailUrl = thumbnailUrl, videoUrl = assetUrl)
+    } else {
+        null
+    }

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoFrameFetcherTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoFrameFetcherTest.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.images.internal
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import coil3.BitmapImage
+import coil3.Extras
+import coil3.ImageLoader
+import coil3.fetch.ImageFetchResult
+import coil3.request.Options
+import coil3.size.Size
+import coil3.toUri
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowMediaMetadataRetriever
+import org.robolectric.shadows.util.DataSource
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+internal class VideoFrameFetcherTest {
+
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+    private val factory = VideoFrameFetcher.Factory()
+
+    @After
+    fun tearDown() {
+        ShadowMediaMetadataRetriever.reset()
+    }
+
+    @Test
+    fun `creates a fetcher when the request is marked as a video preview`() {
+        val fetcher = factory.create(VIDEO_URL.toUri(), optionsWith(videoPreview = true), mock<ImageLoader>())
+
+        assertNotNull(fetcher)
+    }
+
+    @Test
+    fun `skips requests that are not marked as a video preview`() {
+        val fetcher = factory.create(VIDEO_URL.toUri(), optionsWith(videoPreview = false), mock<ImageLoader>())
+
+        assertNull(fetcher)
+    }
+
+    @Test
+    fun `extracts a scaled frame when a target size is set`() = runTest {
+        val bitmap = Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
+        ShadowMediaMetadataRetriever.addScaledFrame(
+            DataSource.toDataSource(VIDEO_URL, emptyMap()),
+            FRAME_MICROS,
+            FRAME_SIZE,
+            FRAME_SIZE,
+            bitmap,
+        )
+        val options = Options(context = context, size = Size(FRAME_SIZE, FRAME_SIZE))
+
+        val result = VideoFrameFetcher(VIDEO_URL.toUri(), options).fetch()
+
+        assertTrue(result is ImageFetchResult)
+        assertEquals(bitmap, (result as ImageFetchResult).image.let { (it as BitmapImage).bitmap })
+    }
+
+    @Test
+    fun `extracts an unscaled frame when the size is original`() = runTest {
+        val bitmap = Bitmap.createBitmap(4, 4, Bitmap.Config.ARGB_8888)
+        ShadowMediaMetadataRetriever.addFrame(VIDEO_URL, emptyMap(), FRAME_MICROS, bitmap)
+        val options = Options(context = context, size = Size.ORIGINAL)
+
+        val result = VideoFrameFetcher(VIDEO_URL.toUri(), options).fetch()
+
+        assertTrue(result is ImageFetchResult)
+        assertEquals(bitmap, (result as ImageFetchResult).image.let { (it as BitmapImage).bitmap })
+    }
+
+    @Test
+    fun `throws when no frame can be extracted`() = runTest {
+        val options = Options(context = context, size = Size.ORIGINAL)
+
+        var thrown = false
+        try {
+            VideoFrameFetcher(VIDEO_URL.toUri(), options).fetch()
+        } catch (_: IllegalStateException) {
+            thrown = true
+        }
+
+        assertTrue(thrown)
+    }
+
+    private fun optionsWith(videoPreview: Boolean): Options {
+        val extras = Extras.Builder().set(videoFramePreviewKey, videoPreview).build()
+        return Options(context = context, extras = extras)
+    }
+
+    private companion object {
+        private const val VIDEO_URL = "https://cdn.example.com/video.mp4"
+        private const val FRAME_MICROS = 100_000L
+        private const val FRAME_SIZE = 100
+    }
+}

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailFallbackInterceptorTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/images/internal/VideoThumbnailFallbackInterceptorTest.kt
@@ -1,0 +1,151 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.ui.common.images.internal
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import coil3.getExtra
+import coil3.intercept.Interceptor
+import coil3.request.ErrorResult
+import coil3.request.ImageRequest
+import coil3.request.ImageResult
+import coil3.request.SuccessResult
+import coil3.size.Size
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.kotlin.mock
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+
+@RunWith(AndroidJUnit4::class)
+@Config(sdk = [33])
+internal class VideoThumbnailFallbackInterceptorTest {
+
+    private val context: Context get() = RuntimeEnvironment.getApplication()
+    private val interceptor = VideoThumbnailFallbackInterceptor()
+
+    @Test
+    fun `loads the thumbnail and skips the video when the thumbnail succeeds`() = runTest {
+        val chain = chainFor(
+            VideoThumbnailImageData(thumbnailUrl = THUMB_URL, videoUrl = VIDEO_URL),
+            resultFor = { url -> if (url == THUMB_URL) success else error },
+        )
+
+        val result = interceptor.intercept(chain)
+
+        assertEquals(listOf(THUMB_URL), chain.proceeded)
+        assertTrue(result is SuccessResult)
+    }
+
+    @Test
+    fun `falls back to the video frame when the thumbnail fails`() = runTest {
+        val chain = chainFor(
+            VideoThumbnailImageData(thumbnailUrl = THUMB_URL, videoUrl = VIDEO_URL),
+            resultFor = { url -> if (url == VIDEO_URL) success else error },
+        )
+
+        val result = interceptor.intercept(chain)
+
+        assertEquals(listOf(THUMB_URL, VIDEO_URL), chain.proceeded)
+        assertTrue(result is SuccessResult)
+        // The video fallback request must be marked so VideoFrameFetcher handles it.
+        assertTrue(chain.proceededRequests.last().getExtra(videoFramePreviewKey))
+    }
+
+    @Test
+    fun `loads the video frame directly when there is no thumbnail`() = runTest {
+        val chain = chainFor(
+            VideoThumbnailImageData(thumbnailUrl = null, videoUrl = VIDEO_URL),
+            resultFor = { success },
+        )
+
+        val result = interceptor.intercept(chain)
+
+        assertEquals(listOf(VIDEO_URL), chain.proceeded)
+        assertTrue(result is SuccessResult)
+    }
+
+    @Test
+    fun `returns the thumbnail error when there is no video to fall back to`() = runTest {
+        val chain = chainFor(
+            VideoThumbnailImageData(thumbnailUrl = THUMB_URL, videoUrl = null),
+            resultFor = { error },
+        )
+
+        val result = interceptor.intercept(chain)
+
+        assertEquals(listOf(THUMB_URL), chain.proceeded)
+        assertTrue(result is ErrorResult)
+    }
+
+    @Test
+    fun `proceeds unchanged when there is neither a thumbnail nor a video`() = runTest {
+        val data = VideoThumbnailImageData(thumbnailUrl = null, videoUrl = null)
+        val chain = chainFor(data, resultFor = { success })
+
+        interceptor.intercept(chain)
+
+        assertEquals(listOf(data.toString()), chain.proceeded)
+    }
+
+    @Test
+    fun `passes through requests that are not video thumbnails`() = runTest {
+        val chain = chainFor(THUMB_URL, resultFor = { success })
+
+        interceptor.intercept(chain)
+
+        assertEquals(listOf(THUMB_URL), chain.proceeded)
+    }
+
+    private val success: ImageResult get() = mock<SuccessResult>()
+    private val error: ImageResult get() = mock<ErrorResult>()
+
+    private fun chainFor(data: Any, resultFor: (String?) -> ImageResult): FakeCoilChain {
+        val request = ImageRequest.Builder(context).data(data).build()
+        return FakeCoilChain(request, resultFor)
+    }
+
+    @Suppress("EmptyFunctionBlock")
+    private class FakeCoilChain(
+        override val request: ImageRequest,
+        private val resultFor: (String?) -> ImageResult,
+        val proceeded: MutableList<String?> = mutableListOf(),
+        val proceededRequests: MutableList<ImageRequest> = mutableListOf(),
+    ) : Interceptor.Chain {
+        override val size: Size get() = Size.ORIGINAL
+
+        override suspend fun proceed(): ImageResult {
+            val key = request.data.toString()
+            proceeded.add(key)
+            proceededRequests.add(request)
+            return resultFor(key)
+        }
+
+        override fun withRequest(request: ImageRequest): Interceptor.Chain =
+            FakeCoilChain(request, resultFor, proceeded, proceededRequests)
+
+        override fun withSize(size: Size): Interceptor.Chain = this
+    }
+
+    private companion object {
+        private const val THUMB_URL = "https://cdn.example.com/thumb.jpg"
+        private const val VIDEO_URL = "https://cdn.example.com/video.mp4"
+    }
+}

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/overview/internal/MediaAttachmentAdapter.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/gallery/overview/internal/MediaAttachmentAdapter.kt
@@ -26,6 +26,7 @@ import io.getstream.chat.android.client.utils.attachment.isImage
 import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.ChatUI
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.databinding.StreamUiItemMediaAttachmentBinding
 import io.getstream.chat.android.ui.feature.gallery.AttachmentGalleryItem
@@ -95,10 +96,17 @@ internal class MediaAttachmentAdapter(
 
             val imageData = if (shouldLoadImage) {
                 val attachment = attachmentGalleryItem.attachment
-                val url = if (attachment.isImage()) attachment.imageUrl else attachment.thumbUrl
-                url?.applyStreamCdnImageResizingIfEnabled(
-                    streamCdnImageResizing = ChatUI.streamCdnImageResizing,
-                )
+                if (attachment.isVideo()) {
+                    attachment.videoThumbnailImageData(
+                        thumbnailUrl = attachment.thumbUrl?.applyStreamCdnImageResizingIfEnabled(
+                            streamCdnImageResizing = ChatUI.streamCdnImageResizing,
+                        ),
+                    )
+                } else {
+                    attachment.imageUrl?.applyStreamCdnImageResizingIfEnabled(
+                        streamCdnImageResizing = ChatUI.streamCdnImageResizing,
+                    )
+                }
             } else {
                 null
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/MediaAttachmentView.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/feature/messages/list/adapter/view/internal/MediaAttachmentView.kt
@@ -28,6 +28,7 @@ import io.getstream.chat.android.client.utils.attachment.isVideo
 import io.getstream.chat.android.models.Attachment
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.R
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.databinding.StreamUiMediaAttachmentViewBinding
 import io.getstream.chat.android.ui.feature.messages.list.adapter.view.MediaAttachmentViewStyle
@@ -134,9 +135,10 @@ internal class MediaAttachmentView : ConstraintLayout {
             if (attachment.isImage()) {
                 attachment.imageUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing)
                     ?: attachment.upload ?: return
-            } else if (attachment.isVideo() && ChatUI.videoThumbnailsEnabled && attachment.thumbUrl != null) {
-                attachment.thumbUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing)
-                    ?: return
+            } else if (attachment.isVideo() && ChatUI.videoThumbnailsEnabled) {
+                val thumbnailUrl =
+                    attachment.thumbUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing)
+                attachment.videoThumbnailImageData(thumbnailUrl)
             } else {
                 null
             }

--- a/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/AttachmentUtils.kt
+++ b/stream-chat-android-ui-components/src/main/kotlin/io/getstream/chat/android/ui/utils/AttachmentUtils.kt
@@ -25,6 +25,7 @@ import io.getstream.chat.android.models.AttachmentType
 import io.getstream.chat.android.ui.ChatUI
 import io.getstream.chat.android.ui.common.disposable.Disposable
 import io.getstream.chat.android.ui.common.images.internal.StreamImageLoader.ImageTransformation.RoundedCorners
+import io.getstream.chat.android.ui.common.images.internal.videoThumbnailImageData
 import io.getstream.chat.android.ui.common.images.resizing.applyStreamCdnImageResizingIfEnabled
 import io.getstream.chat.android.ui.common.internal.file.ShareableUriProvider
 import io.getstream.chat.android.ui.common.state.messages.composer.AttachmentMetaData
@@ -36,9 +37,11 @@ private val FILE_THUMB_TRANSFORMATION = RoundedCorners(3.dpToPxPrecise())
 internal fun ImageView.loadAttachmentThumb(attachment: Attachment): Disposable {
     return with(attachment) {
         when {
-            isVideo() && ChatUI.videoThumbnailsEnabled && !thumbUrl.isNullOrBlank() ->
+            isVideo() && ChatUI.videoThumbnailsEnabled && (!thumbUrl.isNullOrBlank() || !assetUrl.isNullOrBlank()) ->
                 load(
-                    data = thumbUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing),
+                    data = videoThumbnailImageData(
+                        thumbnailUrl = thumbUrl?.applyStreamCdnImageResizingIfEnabled(ChatUI.streamCdnImageResizing),
+                    ),
                     transformation = FILE_THUMB_TRANSFORMATION,
                 )
             isImage() && !imageUrl.isNullOrBlank() ->


### PR DESCRIPTION
### Goal

A sent video shows a blank preview in the message list (and in the shared-media grids and quoted previews) until the chat is reopened. The upload-intent response returns a `thumbUrl` before server-side thumbnail generation has finished, so the client requests it, gets a 404, and the preview is blank until the item is rendered again. When the thumbnail fails, we now extract a preview frame from the video itself, matching the iOS behavior.

This is the develop (v7) port of the v6 fix in #6524.

Resolves AND-1271

### Implementation

Core, in `stream-chat-android-ui-common`:

- `VideoThumbnailImageData(thumbnailUrl, videoUrl)` plus the `Attachment.videoThumbnailImageData(...)` builder.
- `VideoThumbnailFallbackInterceptor` loads the server thumbnail first and, when it is missing or fails, falls back to a frame from the video. Registered as the outermost interceptor so CDN signing still applies to the fallback URL.
- `VideoFrameFetcher` extracts the fallback frame with `MediaMetadataRetriever`, which seeks with HTTP range requests and reads only the bytes needed for the frame; the full video is never written to the image disk cache.

Call sites route video previews through the shared extension on both kits: message list (`MediaAttachmentContent`, `MediaAttachmentView`), shared-media grids (`ChannelMediaAttachmentsScreen`, `MediaAttachmentAdapter`), and file/quoted previews (`AttachmentExtensions.imagePreviewData`, `AttachmentUtils`, `QuotedMessageBodyBuilder`).

Notable differences from the v6 PR, due to develop divergence:
- The video-thumbnails flag moved into `ChatTheme.config.messageList.videoThumbnailsEnabled`.
- The quoted preview now goes through `QuotedMessageBodyBuilder` (the old `MediaAttachmentQuotedContent` no longer exists), thumbnail-first.

The new types are `@InternalStreamChatApi`, so there is no public API change.

### 🎨 UI Changes

Message list with a video whose thumbnail is not yet available.

| Before | After |
| --- | --- |
| <img width="1080" height="2400" alt="before-blank-video-preview" src="https://github.com/user-attachments/assets/579fcf3e-9db9-4261-a8dc-5d1447917f1a" /> | <img width="1080" height="2400" alt="after-video-frame-fallback" src="https://github.com/user-attachments/assets/096fc23c-9591-4b97-b133-b5ba934fa5f6" /> |

### Testing

Manual steps (Compose sample):

1. Open the Compose sample and open a channel that has a video message.
2. With a normal thumbnail, the preview shows as usual.
3. To exercise the fallback deterministically, apply the patch below to force the thumbnail load to fail, reinstall, and open the channel. The preview should still render, now from a frame of the video instead of a blank box.

<details>

<summary>Patch to force the thumbnail to fail</summary>

```kotlin
// AttachmentExtensions.kt, imagePreviewData, video branch
isVideo() && ChatTheme.config.messageList.videoThumbnailsEnabled ->
    videoThumbnailImageData("https://invalid.invalid/nonexistent-thumbnail.jpg")
        ?: upload
```

</details>

Verified on the emulator: the frame renders through the fallback, and the full video is not written to the image disk cache.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved video attachment previews across chat, gallery, quoted messages, and message lists.
  * Video thumbnails can now fall back to a frame from the video when a dedicated thumbnail isn’t available.

* **Bug Fixes**
  * Fixed video preview loading when thumbnail URLs are missing or fail to load.
  * Improved consistency for attachment preview images, including better handling for video and image fallback cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->