### PR TITLE
ui-common: Restore mention state when editing a message

### DIFF
--- a/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
+++ b/stream-chat-android-ui-common/src/main/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerController.kt
@@ -489,8 +489,22 @@ public class MessageComposerController(
         setMessageInputInternal(message.text, MessageInput.Source.Edit)
         _editModeMessage.value = fullMessage
         _editModeAttachments.value = attachments
+        restoreSelectedMentions(fullMessage)
         _messageActions.update { it + Edit(fullMessage) }
         syncAttachments()
+    }
+
+    private fun restoreSelectedMentions(message: Message) {
+        val mentions = mutableSetOf<Mention>()
+        if (message.mentionedChannel) mentions += Mention.Channel
+        if (message.mentionedHere) mentions += Mention.Here
+        message.mentionedUsers.mapTo(mentions, Mention::User)
+        message.mentionedRoles.mapTo(mentions, Mention::Role)
+        message.mentionedGroups.mapTo(mentions, Mention::Group)
+
+        selectedMentions.clear()
+        selectedMentions += mentions
+        _state.update { it.copy(selectedMentions = selectedMentions.toSet()) }
     }
 
     /**
@@ -639,6 +653,7 @@ public class MessageComposerController(
                 setMessageInputInternal(messageAction.message.text, MessageInput.Source.Edit)
                 _editModeMessage.value = messageAction.message
                 _editModeAttachments.value = messageAction.message.attachments
+                restoreSelectedMentions(messageAction.message)
                 _messageActions.update { it + messageAction }
                 syncAttachments()
             }
@@ -655,6 +670,8 @@ public class MessageComposerController(
             setMessageInputInternal("", MessageInput.Source.Default)
             _editModeMessage.value = null
             _editModeAttachments.value = emptyList()
+            selectedMentions.clear()
+            _state.update { it.copy(selectedMentions = emptySet()) }
             syncAttachments()
         }
 

--- a/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
+++ b/stream-chat-android-ui-common/src/test/kotlin/io/getstream/chat/android/ui/common/feature/messages/composer/MessageComposerControllerTest.kt
@@ -1736,6 +1736,96 @@ internal class MessageComposerControllerTest {
     }
 
     @Test
+    fun `Given edit mode for message with multiple mentions When one mention is removed Then the others are preserved`() = runTest {
+        // Given
+        val controller = Fixture()
+            .givenAppSettings(mock())
+            .givenAudioPlayer(mock())
+            .givenClientState(randomUser())
+            .givenGlobalState()
+            .givenChannelState()
+            .get()
+        val alice = User(id = "u1", name = "Alice")
+        val bob = User(id = "u2", name = "Bob")
+        val editedMessage = randomMessage(
+            cid = CID,
+            text = "Hey @Alice and @Bob",
+            mentionedUsers = listOf(alice, bob),
+            mentionedChannel = false,
+            mentionedHere = false,
+        )
+        controller.performMessageAction(Edit(editedMessage))
+
+        // When — only @Bob remains in the edited text
+        val message = controller.buildNewMessage("Hey there and @Bob")
+
+        // Then
+        assertEquals(listOf("u2"), message.mentionedUsersIds)
+    }
+
+    @Test
+    fun `Given edit mode for message with mentions of every type When text unchanged Then all mentions are preserved`() = runTest {
+        // Given
+        val controller = Fixture()
+            .givenAppSettings(mock())
+            .givenAudioPlayer(mock())
+            .givenClientState(randomUser())
+            .givenGlobalState()
+            .givenChannelState()
+            .get()
+        val user = User(id = "u1", name = "Alice")
+        val group = UserGroup(id = "g1", name = "platform")
+        val editedMessage = randomMessage(
+            cid = CID,
+            text = "@Alice @channel @here @admin @platform hi",
+            mentionedUsers = listOf(user),
+            mentionedChannel = true,
+            mentionedHere = true,
+            mentionedRoles = listOf("admin"),
+            mentionedGroups = listOf(group),
+        )
+        controller.performMessageAction(Edit(editedMessage))
+
+        // When
+        val message = controller.buildNewMessage("@Alice @channel @here @admin @platform hi")
+
+        // Then
+        assertEquals(listOf("u1"), message.mentionedUsersIds)
+        assertTrue(message.mentionedChannel)
+        assertTrue(message.mentionedHere)
+        assertEquals(listOf("admin"), message.mentionedRoles)
+        assertEquals(listOf(group), message.mentionedGroups)
+    }
+
+    @Test
+    fun `Given edit mode mentions When edit dismissed Then mentions do not leak into next message`() = runTest {
+        // Given
+        val controller = Fixture()
+            .givenAppSettings(mock())
+            .givenAudioPlayer(mock())
+            .givenClientState(randomUser())
+            .givenGlobalState()
+            .givenChannelState()
+            .get()
+        val alice = User(id = "u1", name = "Alice")
+        val editedMessage = randomMessage(
+            cid = CID,
+            text = "Hey @Alice",
+            mentionedUsers = listOf(alice),
+            mentionedChannel = false,
+            mentionedHere = false,
+        )
+        controller.performMessageAction(Edit(editedMessage))
+
+        // When
+        controller.dismissMessageActions()
+        val message = controller.buildNewMessage("Hey @Alice")
+
+        // Then — the dismissed edit must not carry mentions into a fresh message
+        assertTrue(message.mentionedUsersIds.isEmpty())
+    }
+
+    @Test
     fun `Given an active command When clearData called Then activeCommand is null`() = runTest {
         // Given
         val command = randomCommand()


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

Editing one mention in a message that has multiple mentions strips all of them. Entering edit mode never restored the composer's mention state, so `selectedMentions` was empty and `filterMentions` dropped every mention still present in the text on save.

Reported during QA: [Android QA - Mentions](https://www.notion.so/stream-wiki/Android-QA-Mentions-38a6a5d7f9f6801a98e6d1c346f0dd66?source=copy_link)

Closes [AND-1277](https://linear.app/stream/issue/AND-1277/editing-one-mention-in-a-message-with-multiple-mentions-strips-all)

### Implementation

- `MessageComposerController` now rebuilds `selectedMentions` from the message's `mentionedUsers`/`mentionedChannel`/`mentionedHere`/`mentionedRoles`/`mentionedGroups` when entering edit mode (both the action and the restored-session paths).
- Dismissing an edit clears `selectedMentions` so restored mentions don't leak into the next message.

### Testing

- New `MessageComposerControllerTest` cases: removing one mention while editing keeps the others, an unchanged edit preserves mentions of every type, and dismissing an edit doesn't carry mentions into a fresh message.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mention selections are now restored correctly when editing a message, so edited messages keep the right mentions.
  * Dismissing edit mode now clears any leftover mention selections, preventing them from carrying into the next message.
  * Editing a message with mentions now better preserves mention data across users, channels, roles, groups, and “here” mentions.

* **Tests**
  * Added coverage for mention handling while editing messages and when leaving edit mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
