### PR TITLE
compose: Reset mention suggestion list to top when suggestions change

### DIFF
--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/suggestions/UserSuggestionList.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/composer/internal/suggestions/UserSuggestionList.kt
@@ -20,7 +20,9 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.tooling.preview.Preview
@@ -39,7 +41,12 @@ internal fun MentionSuggestionList(
     onUserSelected: (User) -> Unit = {},
     onMentionSelected: (Mention) -> Unit = {},
 ) {
+    val listState = rememberLazyListState()
+    LaunchedEffect(mentions) {
+        listState.scrollToItem(0)
+    }
     LazyColumn(
+        state = listState,
         modifier = Modifier
             .fillMaxWidth()
             .testTag("Stream_MentionSuggestionList"),


### PR DESCRIPTION
<!-- pr:bug -->

### Goal

In the Compose composer, changing the mention filter (e.g. deleting characters to widen it) sometimes leaves the suggestion list scrolled down instead of starting at the top, hiding one or more of the topmost suggestions.

The mention `LazyColumn` keys its items, so when the suggestions are re-sorted and new entries land above the previously visible top row, Compose re-anchors on that old row's key and keeps the list scrolled past everything inserted above it.

Reported during QA: [Android QA - Mentions](https://www.notion.so/stream-wiki/Android-QA-Mentions-38a6a5d7f9f6801a98e6d1c346f0dd66?source=copy_link)

Closes [AND-1278](https://linear.app/stream/issue/AND-1278/mention-suggestion-list-stays-scrolled-when-the-suggestions-change)

### Implementation

- `MentionSuggestionList` now holds a `rememberLazyListState` and scrolls back to the top whenever the `mentions` list changes.

### Testing

- Open the composer, type `@` plus a couple of letters to narrow the suggestions, then delete characters to widen them again. The list now resets to the top instead of staying scrolled down.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mention suggestions so the list now resets to the top when the available suggestions change.
  * This makes it easier to find the most relevant user when typing a mention, especially after the suggestion list updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->