### PR TITLE
compose: Improve message view screen-reader focus order

### DIFF
--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobot.kt
@@ -38,6 +38,7 @@ import io.getstream.chat.android.compose.uiautomator.tapOnScreenCenter
 import io.getstream.chat.android.compose.uiautomator.typeText
 import io.getstream.chat.android.compose.uiautomator.wait
 import io.getstream.chat.android.compose.uiautomator.waitToAppear
+import io.getstream.chat.android.compose.uiautomator.waitToAppearBottomUp
 import io.getstream.chat.android.compose.uiautomator.waitToDisappear
 import io.getstream.chat.android.e2e.test.mockserver.AttachmentType
 import io.getstream.chat.android.e2e.test.mockserver.ReactionType
@@ -76,8 +77,7 @@ class UserRobot {
     }
 
     fun openContextMenu(messageCellIndex: Int = 0): UserRobot {
-        MessageList.messages.waitToAppear()
-        val messages = MessageList.messages.findObjects()
+        val messages = MessageList.messages.waitToAppearBottomUp()
         val message = if (messages.size < messageCellIndex + 1) messages.last() else messages[messageCellIndex]
         message.longPress()
         return this
@@ -198,7 +198,7 @@ class UserRobot {
     }
 
     fun tapOnMessage(messageCellIndex: Int = 0): UserRobot {
-        MessageList.messages.waitToAppear(withIndex = messageCellIndex).click()
+        MessageList.messages.waitToAppearBottomUp(withIndex = messageCellIndex).click()
         return this
     }
 
@@ -270,7 +270,7 @@ class UserRobot {
 
     fun swipeMessage(messageCellIndex: Int = 0): UserRobot {
         val percent = 0.5f
-        val message = MessageList.messages.waitToAppear(withIndex = messageCellIndex)
+        val message = MessageList.messages.waitToAppearBottomUp(withIndex = messageCellIndex)
         val rect = message.visibleBounds
         device.swipe(
             rect.left, // startX

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/robots/UserRobotMessageListAsserts.kt
@@ -36,6 +36,7 @@ import io.getstream.chat.android.compose.uiautomator.wait
 import io.getstream.chat.android.compose.uiautomator.waitForCount
 import io.getstream.chat.android.compose.uiautomator.waitForText
 import io.getstream.chat.android.compose.uiautomator.waitToAppear
+import io.getstream.chat.android.compose.uiautomator.waitToAppearBottomUp
 import io.getstream.chat.android.compose.uiautomator.waitToDisappear
 import io.getstream.chat.android.e2e.test.mockserver.MessageDeliveryStatus
 import io.getstream.chat.android.e2e.test.mockserver.ReactionType
@@ -151,15 +152,15 @@ fun UserRobot.assertQuotedMessage(text: String, quote: String = "", isDisplayed:
 }
 
 fun UserRobot.assertMessageSizeChangesAfterEditing(linesCountShouldBeIncreased: Boolean): UserRobot {
-    val cellHeight = MessageListPage.MessageList.messages.waitToAppear(withIndex = 0).height
-    val messageText = Message.text.findObject().text
+    val cellHeight = MessageListPage.MessageList.messages.waitToAppearBottomUp(withIndex = 0).height
+    val messageText = Message.text.waitToAppearBottomUp(withIndex = 0).text
     val newLine = "new line"
     val newText = if (linesCountShouldBeIncreased) "ok\n${messageText}\n$newLine" else newLine
 
     editMessage(newText)
     assertMessage(newText)
 
-    val updatedCellHeight = MessageListPage.MessageList.messages.findObjects().first().height
+    val updatedCellHeight = MessageListPage.MessageList.messages.waitToAppearBottomUp(withIndex = 0).height
     if (linesCountShouldBeIncreased) {
         assertTrue(cellHeight < updatedCellHeight)
     } else {

--- a/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/uiautomator/VisualOrder.kt
+++ b/stream-chat-android-compose-sample/src/androidTestE2eDebug/kotlin/io/getstream/chat/android/compose/uiautomator/VisualOrder.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2014-2026 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-chat-android/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.chat.android.compose.uiautomator
+
+import androidx.test.uiautomator.BySelector
+import androidx.test.uiautomator.UiObject2
+
+/**
+ * Waits for objects matching this selector and returns them sorted by visual position,
+ * bottom-most first. Message cells are enumerated in screen-reader reading order
+ * (oldest-first), so lookups that mean "index 0 = the newest message at the visual bottom"
+ * sort by on-screen position instead of relying on the enumeration order.
+ */
+internal fun BySelector.waitToAppearBottomUp(timeOutMillis: Long = defaultTimeout): List<UiObject2> {
+    wait(timeOutMillis)
+    return device.findObjects(this).sortedByDescending { it.visibleBounds.top }
+}
+
+/**
+ * Waits for objects matching this selector and returns the one at [withIndex], counting
+ * bottom-up (index 0 = the bottom-most object on screen).
+ */
+internal fun BySelector.waitToAppearBottomUp(withIndex: Int, timeOutMillis: Long = defaultTimeout): UiObject2 {
+    val objects = waitToAppearBottomUp(timeOutMillis)
+    return objects.getOrNull(withIndex)
+        ?: error("waitToAppearBottomUp(withIndex=$withIndex): only ${objects.size} objects matched selector: $this")
+}

--- a/stream-chat-android-compose/ACCESSIBILITY.md
+++ b/stream-chat-android-compose/ACCESSIBILITY.md
@@ -1,0 +1,123 @@
+# Accessibility playbook — Compose SDK
+
+This document is a decision tree for adding or changing accessibility semantics inside `stream-chat-android-compose`. It builds on the two principles stated below. Keep it short.
+
+## The two principles to apply
+
+1. **Fix at the leaves; mirror visual order.** Each visual cell (`Icon`, `Text`, badge, button) owns its own `contentDescription` / `text` semantic. Compose's natural merge from clickables already composes them in tree order — which usually matches the visual reading order (top-to-bottom, left-to-right in LTR; mirrored in RTL). When tree order and reading order disagree (reversed lists, `zIndex` overlaps), see the Traversal order section — that disagreement is the root cause, and fixing it beats patching the symptoms.
+
+2. **Trust framework defaults; reach for overrides only when defaults fail at the leaves.** Before adding `clearAndSetSemantics`, a parent `contentDescription`, `mergeDescendants = true`, or any other override, check whether Compose's defaults — perhaps after small leaf fixes — already produce the right result.
+
+## Decision tree
+
+```
+What are you trying to express?
+│
+├─ "This Icon / Text / badge has a non-obvious meaning"
+│      → contentDescription on the LEAF. Done.
+│
+├─ "This decorative leaf should be hidden from TalkBack"
+│      → Modifier.semantics { hideFromAccessibility() } on the leaf.
+│      (Same effect as contentDescription = null for Icons, but explicit.)
+│
+├─ "This element is a heading / section landmark"
+│      → Modifier.semantics { heading() } on the heading composable.
+│
+├─ "Clicking this element triggers an action; TalkBack should announce
+│   what that action does (e.g. 'opens thread', 'opens actions')"
+│      → Pass onClickLabel / onLongClickLabel into clickable / combinedClickable.
+│        Expose as paired onXxxClickLabel parameters on the public composable
+│        with null defaults — the integrator owns the label, the SDK doesn't
+│        ship one.
+│
+├─ "This element has a state TalkBack should announce on top of the role
+│   (selected, checked, on/off, expanded)"
+│      → role + state on the leaf via clickable(role = ...) /
+│        toggleable / Modifier.semantics { toggleableState = ... }.
+│      → For Tab role with selected: clearAndSetSemantics IS appropriate
+│        on the leaf button (Tab semantics are a parent-level a11y concept).
+│
+├─ "Content changes dynamically and TalkBack should announce the change"
+│      → Modifier.semantics { liveRegion = LiveRegionMode.Polite } on the
+│        smallest container that owns the changing text.
+│
+├─ "This is a tappable container (Row) whose children should be read as
+│   one focus stop instead of separate stops"
+│      → If the Row has clickable / combinedClickable, the merge boundary is
+│        IMPLICIT — do not add semantics(mergeDescendants = true) {}.
+│      → If the Row has NO click handler (e.g. an edit-indicator banner),
+│        Modifier.semantics(mergeDescendants = true) {} on the Row is the
+│        right way to force a single focus stop. Add a brief comment
+│        explaining why merging is needed.
+│
+├─ "I need to expose extra actions for TalkBack (move-up, move-down, etc.
+│   that have no visible button)"
+│      → Modifier.semantics { customActions = listOf(...) } on the smallest
+│        container that represents the actionable item.
+│
+├─ "TalkBack reads elements in the wrong order / focus jumps between
+│   elements unpredictably"
+│      → Read the Traversal order section below. The fix is making the
+│        semantics tree order match the reading order, not adding more
+│        traversalIndex values.
+│
+└─ "An interactive descendant (toggle / button) is consuming the long-press
+   so the message row's actions menu never opens"
+      → Thread the message's long-click handler (onLongItemClick) down to the
+        descendant and pass it as onLongClick to its own combinedClickable, so
+        the descendant opens the same actions menu the cell would.
+```
+
+## Traversal order (TalkBack)
+
+Verified against Compose UI 1.9.0 (`SemanticsSort.kt`) and TalkBack 16 sources, plus on-device TalkBack verbose logs.
+
+**How the pipeline actually works.** Compose computes a reading order — a chain of `traversalBefore` links — from geometry plus `traversalIndex`, scoped by `isTraversalGroup`. TalkBack does **not** follow that chain directly. It rebuilds its own traversal tree by physically relocating each link's source node next to its target, and it **silently drops any link whose target is a descendant of its source** — which is exactly what a merged message cell linked before its own inner button produces. The rebuild is only reliable when it has nothing to do.
+
+Rules that follow from this:
+
+1. **The semantics tree order must match the intended reading order.** `traversalIndex` / `isTraversalGroup` should only *confirm* the natural order, never fight it. When they fight it, TalkBack's rebuild strands focusable containers (message cells) and navigation skips or jumps.
+2. **Compose orders sibling semantics nodes by `zIndex`.** When composition order cannot match reading order (a `reverseLayout` lazy list composes newest-first but reads oldest-first), give each sibling a `zIndex` that mirrors its `traversalIndex`. See `Messages.kt` (`itemTraversalOrder`) for the pattern, and mind the draw-order change where siblings overlap.
+3. **Only three kinds of nodes get a slot in Compose's chain**: merging nodes (real `clickable` / `toggleable` / `semantics(mergeDescendants = true)`), unmerged speaking leaves, and traversal groups (non-focusable groups are replaced by their children). A node that TalkBack focuses but Compose never hinted — for example a plain container with `contentDescription` plus `semantics { onClick(...) }` — has no position, and TalkBack degrades navigation around it. If a node should be a focus stop, make it a real `clickable`.
+4. **A focusable container is always read before its focusable descendants**, and backward navigation is the exact reverse. You cannot reorder a parent against its own children with any traversal API.
+
+## Diagnosing traversal issues
+
+Two tools that turn guessing into reading:
+
+- **Compose's computed chain**: an instrumented test can read each node's before-link from `node.extras.getInt("android.view.accessibility.extra.EXTRA_DATA_TEST_TRAVERSALBEFORE_VAL")` and reconstruct the full chain (run with `am instrument --no-hidden-api-checks`; node ids come from the hidden `getSourceNodeId`). Compose only computes the chain while a real accessibility service is enabled — UiAutomation alone does not count, and acquiring UiAutomation without `FLAG_DONT_SUPPRESS_ACCESSIBILITY_SERVICES` kills TalkBack.
+- **TalkBack's decisions**: TalkBack settings → Advanced settings → Developer settings → Log output level → VERBOSE. Logcat then shows every focus verdict with its reason (`shouldFocusNode`) and the navigation pipeline (search, auto-scroll, focus). One real swipe explains a jump precisely. Injected input (UiAutomation, `adb shell input`) never reaches TalkBack's gesture detector, so the swipe must be a real gesture; restore the log level to ERROR afterwards.
+
+## Don't do these
+
+| Anti-pattern                                                                                                                       | Why it breaks                                                                                                                                                                                                      | What to do instead                                                                                                                                  |
+|------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------|
+| `Modifier.semantics(mergeDescendants = true) {}` on a Row that already has `clickable`/`combinedClickable`/`toggleable`            | Redundant. The clickable already creates a merge boundary. The empty block reads like ritual.                                                                                                                      | Delete it.                                                                                                                                          |
+| `Modifier.semantics { contentDescription = "..." }` on a container that wraps `Text` / `Icon` children with their own descriptions | The parent description composes with the children's descriptions, producing a verbose announce that breaks the moment a child is added/removed/swapped. Also breaks consumer overrides via `ChatComponentFactory`. | Let the children own their content. If you need a parent-level label (e.g. role), put it in `stateDescription` or `role`, not `contentDescription`. |
+| `Modifier.clearAndSetSemantics { ... }` to "clean up" a noisy announce                                                             | You re-implement what the leaves already do, and drift the moment a leaf changes. Consumer overrides via the SDK's public extension API stop reaching the announce.                                                | Fix the offending leaf. Reserve `clearAndSetSemantics` for genuine parent-level a11y models (Tab, custom widget).                                   |
+| `Role.Button` on a clickable list/grid item (channel row, message row, attachment tile)                                            | The item isn't visually a button. TalkBack will mis-announce it.                                                                                                                                                   | Don't set a role. Compose's clickable produces a usable focus stop without one.                                                                     |
+| `stateDescription = ...` on a disabled element whose tap already shows a snackbar / dialog / live region with the same info        | TalkBack announces the state on focus, the snackbar announces on tap — the user hears the same string twice.                                                                                                       | Drop the `stateDescription`; trust the existing announce path.                                                                                      |
+| New string resource named `stream_compose_cd_*` for a contentDescription                                                           | Convention was dropped in PRs #6404, #6433. The `_cd_` marker adds no value — a string used in `contentDescription` is still just a localized string.                                                              | Name by feature + intent: `stream_compose_<feature>_<intent>` (e.g. `stream_compose_channel_item_muted`).                                           |
+| `Modifier.semantics { onClick(...) }` on a non-merging container to make it a screen-reader stop                                   | TalkBack focuses it (it is actionable) but Compose's traversal sorter never gives it a position, and TalkBack navigation degrades around the unhinted stop.                                                        | Use a real `clickable` — it makes the node merging, which also earns it a slot in the traversal order.                                              |
+| Stacking `traversalIndex` / `isTraversalGroup` to force an order the semantics tree disagrees with                                 | TalkBack enforces the links by relocating nodes and drops ancestor→descendant links, so a fought-over order breaks in ways the Compose-side APIs cannot fix.                                                       | Align the tree first (composition order, or `zIndex` mirroring the index — see Traversal order), then let the indices confirm it.                   |
+| Shipping a default `onClickLabel` string baked into the SDK for an integrator-defined action                                       | The integrator may swap the click handler; the default label becomes a lie.                                                                                                                                        | Expose an `onXxxClickLabel: String? = null` paired with `onXxxClick: () -> Unit`. Apply only when the integrator provides a label.                  |
+| Manually inventing a formatter that already exists                                                                                 | Drift.                                                                                                                                                                                                             | Reuse: `rememberSpokenDurationFormatter()` (spoken durations), `typingUsersDescription(...)` (typing announce).                                     |
+
+## Verifying changes
+
+For any PR touching a11y:
+
+1. Build and run on a real device.
+2. Enable TalkBack: Settings → Accessibility → TalkBack → On.
+3. Sweep right (next focus) and left (previous focus) through the affected screen — does the order match the visual order?
+4. Double-tap on the focused element — does it activate the right action?
+5. Double-tap-and-hold — does it open the message actions menu (where applicable)?
+6. Check Paparazzi snapshots — semantic changes don't change pixels, so visual snapshots should not regress.
+7. Add a unit test asserting the merged `SemanticsNode` if the announcement is non-trivial.
+
+## When in doubt
+
+- Read the offending leaf first, not the parent — that's almost always where the fix is.
+- If you find yourself re-implementing logic that already lives in a subcomponent, your abstraction is wrong.
+- For ordering problems, check the tree order before reaching for `traversalIndex` — the index can only confirm an order the tree already supports.
+- A `// reason: …` comment next to any rule-bending override is cheap insurance for the next reader.

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/ChannelScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/ChannelScreen.kt
@@ -339,7 +339,8 @@ private const val HeaderTraversalIndex = -1f
 private const val ListTraversalIndex = 0f
 private const val ComposerTraversalIndex = 1f
 
-// Marks the receiver as a screen-reader traversal region at the given reading-order index.
+// The index is deliberately not mirrored as a zIndex (unlike the message list items): that
+// would reorder the Scaffold slot drawing, and TalkBack handles this slot/reading-order divergence.
 private fun Modifier.traversalRegion(index: Float): Modifier =
     semantics {
         isTraversalGroup = true

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/ChannelScreen.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/ChannelScreen.kt
@@ -51,6 +51,9 @@ import androidx.compose.ui.platform.LocalResources
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import io.getstream.chat.android.compose.R
@@ -205,8 +208,17 @@ public fun ChannelScreen(
     ChannelScreenContentBox {
         Scaffold(
             modifier = Modifier.fillMaxSize(),
-            topBar = { topBarContent(backAction) },
-            bottomBar = bottomBarContent,
+            // Order the regions for the screen reader: header, then list, then composer.
+            topBar = {
+                Box(Modifier.traversalRegion(HeaderTraversalIndex)) {
+                    topBarContent(backAction)
+                }
+            },
+            bottomBar = {
+                Box(Modifier.traversalRegion(ComposerTraversalIndex)) {
+                    bottomBarContent()
+                }
+            },
             snackbarHost = { StreamSnackbarHost(snackbarHostState) },
             containerColor = ChatTheme.colors.backgroundCoreApp,
         ) { contentPadding ->
@@ -215,7 +227,8 @@ public fun ChannelScreen(
             MessageList(
                 modifier = Modifier
                     .testTag("Stream_MessagesList")
-                    .fillMaxSize(),
+                    .fillMaxSize()
+                    .traversalRegion(ListTraversalIndex),
                 contentPadding = contentPadding,
                 viewModel = listViewModel,
                 messagesLazyListState = rememberMessageListState(parentMessageId = currentState.parentMessageId),
@@ -320,6 +333,18 @@ private fun ComposerScreenReaderEntryFocus(listViewModel: MessageListViewModel) 
 }
 
 private const val ComposerEntryFocusWindowMs = 2000L
+
+// Screen-reader region order: header first, then the list, then the composer.
+private const val HeaderTraversalIndex = -1f
+private const val ListTraversalIndex = 0f
+private const val ComposerTraversalIndex = 1f
+
+// Marks the receiver as a screen-reader traversal region at the given reading-order index.
+private fun Modifier.traversalRegion(index: Float): Modifier =
+    semantics {
+        isTraversalGroup = true
+        traversalIndex = index
+    }
 
 @Composable
 private fun ChannelScreenContentBox(content: @Composable BoxScope.() -> Unit) {

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/header/ChannelHeader.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
@@ -194,6 +195,8 @@ internal fun DefaultChannelHeaderCenterContent(
 
     Column(
         modifier = modifier
+            // Read the title and subtitle as one ordered unit within the header.
+            .semantics { isTraversalGroup = true }
             .height(IntrinsicSize.Max)
             .ifNotNull(onHeaderTitleClick) { callback ->
                 clickable(

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/MessageContainer.kt
@@ -63,8 +63,10 @@ import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.isTraversalGroup
 import androidx.compose.ui.semantics.onLongClick
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.LayoutDirection
@@ -516,7 +518,18 @@ private fun MessageContentWithReactions(
     Layout(
         modifier = Modifier.zIndex(1f),
         content = {
-            if (reactions != null) reactions()
+            if (reactions != null) {
+                // Pin the reactions bubble to its tree position (drawn last, zIndex 1) so the
+                // traversal order matches the semantics tree order TalkBack needs (see ACCESSIBILITY.md).
+                Box(
+                    modifier = Modifier.semantics {
+                        isTraversalGroup = true
+                        traversalIndex = 1f
+                    },
+                ) {
+                    reactions()
+                }
+            }
             content()
         },
     ) { measurables, constraints ->

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/messages/list/Messages.kt
@@ -46,8 +46,12 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.isTraversalGroup
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.traversalIndex
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import io.getstream.chat.android.compose.handlers.LoadMoreHandler
 import io.getstream.chat.android.compose.ui.components.LoadingIndicator
 import io.getstream.chat.android.compose.ui.theme.ChatTheme
@@ -168,6 +172,10 @@ internal fun Messages(
                 .graphicsLayer { clip = false }
                 .testTag("Stream_Messages")
                 .fillMaxSize()
+                // Scope the screen-reader ordering of the lazy items to the list itself, so the
+                // explicit traversal indices below compete only with each other and not with
+                // overlaid helper content such as the scroll-to-bottom button.
+                .semantics { isTraversalGroup = true }
                 .onSizeChanged {
                     val bottomPadding = contentPadding.calculateBottomPadding()
                     val topPadding = contentPadding.calculateTopPadding()
@@ -191,15 +199,23 @@ internal fun Messages(
             reverseLayout = true,
             contentPadding = contentPadding,
         ) {
+            // reverseLayout composes items bottom-up, which breaks the geometric ordering
+            // heuristic screen readers rely on. Order every lazy item explicitly instead:
+            // message items are read by descending index (index 0 is the newest message at the
+            // visual bottom), and the fixed items around them follow their visual position.
             footerContent?.let { content ->
                 item {
-                    content.invoke()
+                    Box(modifier = Modifier.itemTraversalOrder(FooterTraversalIndex)) {
+                        content.invoke()
+                    }
                 }
             }
 
             if (isLoadingMoreNewMessages && !endOfNewMessages) {
                 item {
-                    loadingMoreContent()
+                    Box(modifier = Modifier.itemTraversalOrder(LoadingNewerTraversalIndex)) {
+                        loadingMoreContent()
+                    }
                 }
             }
 
@@ -217,7 +233,9 @@ internal fun Messages(
                     }
 
                 val itemModifier = itemModifier(index, item)
-                val finalItemModifier = messageItemModifier.then(itemModifier)
+                val finalItemModifier = messageItemModifier
+                    .then(itemModifier)
+                    .itemTraversalOrder(-index.toFloat())
                 Box(modifier = finalItemModifier) {
                     itemContent(item)
                 }
@@ -225,13 +243,17 @@ internal fun Messages(
 
             if (isLoadingMoreOldMessages && !endOfOldMessages) {
                 item {
-                    loadingMoreContent()
+                    Box(modifier = Modifier.itemTraversalOrder(-messages.size.toFloat())) {
+                        loadingMoreContent()
+                    }
                 }
             }
 
             headerContent?.let { content ->
                 item {
-                    content.invoke()
+                    Box(modifier = Modifier.itemTraversalOrder(-messages.size.toFloat() - 1)) {
+                        content.invoke()
+                    }
                 }
             }
         }
@@ -294,6 +316,25 @@ internal fun Messages(
         }
     }
 }
+
+// Screen-reader order for the fixed lazy items, relative to the message items at -index..0:
+// the loading-newer indicator and the footer sit visually below the newest message (index 0).
+private const val LoadingNewerTraversalIndex = 1f
+private const val FooterTraversalIndex = 2f
+
+/**
+ * Positions a lazy item in the screen-reader reading order of the message list.
+ * Grouping keeps the focus stops inside one item contiguous, so traversal never interleaves
+ * the stops of two messages.
+ */
+private fun Modifier.itemTraversalOrder(index: Float): Modifier =
+    // zIndex mirrors traversalIndex so the semantics tree order equals the reading order.
+    // TalkBack needs that agreement to traverse this reversed list (see ACCESSIBILITY.md).
+    zIndex(index)
+        .semantics {
+            isTraversalGroup = true
+            traversalIndex = index
+        }
 
 /**
  * Returns a vertical arrangement for the message list based on the current state,


### PR DESCRIPTION
### Goal

Make the TalkBack focus order in the message view predictable and match the visual reading order, without changing the reversed message list layout that chat relies on. Before this change the reading cursor could enter the header on the subtitle, jump from the composer straight to the header and skip the messages, and, moving backwards from the composer, land inside a reaction or an attachment of a neighbouring message instead of on the message itself.

Resolves AND-1280

### Implementation

- **Header**: group the title and subtitle so the header reads back button, heading, subtitle, avatar.
- **Regions**: mark the header, message list, and composer as ordered traversal regions (header, then list, then composer), because a Scaffold does not reliably sort its scrollable content between the top and bottom bars for screen readers.
- **Message list (the core fix)**: TalkBack rebuilds its own traversal from the Compose semantics tree order and silently drops any ordering hint that points from a node to its own descendant (a message cell hinted before its inner button). A reversed list composes newest-first but reads oldest-first, so those hints were constantly fought and the message cells got stranded, which is what made backward navigation skip messages and jump around. Each lazy item now carries a `zIndex` that mirrors its traversal index, so the semantics tree order equals the reading order and TalkBack has nothing to rearrange. The reactions bubble is pinned to its tree position for the same reason.
- **Docs**: add `stream-chat-android-compose/ACCESSIBILITY.md`, a playbook covering the leaf-first principles, the semantics decision tree, and the traversal-order model with the diagnostics used to verify it.

The interactive parts of a message (open attachment, vote, View Results, reactions) stay individually reachable. They are not collapsed into a single stop, so poll voting and attachment actions remain usable.

No public API changes.

### 🎨 UI Changes

<table>
<thead>
<tr>
<th></th>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>Bottom-up (swipe back from the composer)</td>
<td><video src="https://github.com/user-attachments/assets/74c59343-f449-4ef2-ae9f-9eec95abe835" controls muted /></td>
<td><video src="https://github.com/user-attachments/assets/a30a3fe3-c7cc-4074-a3a1-6df27328b1d3" controls muted /></td>
</tr>
<tr>
<td>Top-down (swipe forward from the header)</td>
<td><video src="https://github.com/user-attachments/assets/427d4c83-5d3f-4b92-ac64-4768844e196d" controls muted /></td>
<td><video src="https://github.com/user-attachments/assets/57ed4c68-36d4-4d61-b0f5-cb8b5c215488" controls muted /></td>
</tr>
</tbody>
</table>

### Testing

Manual, with TalkBack enabled on a device or emulator:

1. Open a channel with a mix of messages (for example a group that has a poll, an image message, and a message with reactions).
2. On entry, focus lands on the composer input (existing behaviour).
3. Sweep through the screen and confirm the order matches the visual order: the header reads back button, heading, subtitle, avatar; the regions read header, then messages, then composer.
4. Swipe left (backwards) from the composer: attachment picker, then the newest message, then older messages in order, and the header only after the oldest loaded message. Focus should not jump between messages or land inside a neighbour's reaction or attachment.
5. On a poll message, focus "View Results" and swipe left: focus lands on the poll message, not on a neighbouring message.
6. Confirm the interactive parts stay reachable and actionable: double-tap a reactions row, a poll option, "View Results", and an attachment.

One Compose platform limitation is out of scope and was accepted with QA: TalkBack speaks a region-name fragment when the reading cursor crosses between the header, list, and composer regions, which cannot be suppressed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved screen-reader navigation across channel screens, message lists, headers, reactions, and the message composer.
  * Refined reading order so content is announced more consistently, including in reversed message lists.
  * Added accessibility guidance and verification notes for future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->