### PR TITLE
client: Fix flaky event subscription tests by ensuring distinct event classes

### DIFF
--- a/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
+++ b/stream-chat-android-client/src/test/java/io/getstream/chat/android/client/ChatClientTest.kt
@@ -76,9 +76,17 @@ internal class ChatClientTest {
         val createdAt = Date()
         val rawCreatedAt = StreamDateFormatter().format(createdAt)
 
-        val eventA = EventArguments.randomEvent()
-        val eventB = EventArguments.randomEvent()
-        val eventC = EventArguments.randomEvent()
+        val eventA: ChatEvent
+        val eventB: ChatEvent
+        val eventC: ChatEvent
+
+        init {
+            val distinctEvents = generateSequence(EventArguments::randomEvent)
+                .distinctBy { it::class }.take(3).toList()
+            eventA = distinctEvents[0]
+            eventB = distinctEvents[1]
+            eventC = distinctEvents[2]
+        }
 
         val eventD = UnknownEvent("d", createdAt, rawCreatedAt, null, emptyMap<Any, Any>())
         val eventE = UnknownEvent("e", createdAt, rawCreatedAt, null, mapOf<Any, Any>("cid" to "myCid"))


### PR DESCRIPTION
<!-- pr:test -->

### Goal

`ChatClientTest.Subscribe for Java Class event types` and `Subscribe for KClass event types` fail intermittently when the full suite runs (they pass in isolation and vary run-to-run).

Both tests subscribe with `eventA::class` and `eventC::class`, emit `eventA`/`eventB`/`eventC`, and assert the collector receives exactly `[eventA, eventC]`. The companion object draws all three events with independent `EventArguments.randomEvent()` calls, so when `eventB` happens to draw the same class as `eventA` or `eventC`, the class filter matches it too and the assertion fails. The seed is fixed per JVM launch, which is why it varies across runs.

Closes [AND-1286](https://linear.app/stream/issue/AND-1286/fix-flaky-event-subscription-tests-in-chatclienttest)

### Implementation

- `eventA`, `eventB`, and `eventC` are now drawn so their classes are distinct (`generateSequence(EventArguments::randomEvent).distinctBy { it::class }.take(3)`), so no stray event can slip through the `::class` filter.

### Testing

- Ran `:stream-chat-android-client:testDebugUnitTest` repeatedly with `--rerun-tasks`; the two tests pass consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test setup for chat event handling by selecting three distinct random events, reducing accidental duplicates.
  * Adjusted test event initialization to use a more consistent event type setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->