### PR TITLE
compose: Fix flakiness of MediaAttachmentPreviewHandlerTest

### DIFF
--- a/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/MediaAttachmentPreviewHandlerTest.kt
+++ b/stream-chat-android-compose/src/test/kotlin/io/getstream/chat/android/compose/MediaAttachmentPreviewHandlerTest.kt
@@ -46,9 +46,11 @@ internal class MediaAttachmentPreviewHandlerTest {
         fun generateAttachmentsInput() = listOf(
             Arguments.of(Attachment(), false),
             Arguments.of(Attachment(assetUrl = randomString()), false),
-            Arguments.of(Attachment(assetUrl = randomString(), type = randomString()), false),
+            // Non-media type/mimeType must use fixed values, not randomString(): a random string can
+            // contain a media token (e.g. "wav", "mp3", "video") and flip canHandle() to true.
+            Arguments.of(Attachment(assetUrl = randomString(), type = AttachmentType.FILE), false),
             Arguments.of(
-                Attachment(assetUrl = randomString(), type = randomString(), mimeType = randomString()),
+                Attachment(assetUrl = randomString(), type = AttachmentType.FILE, mimeType = "text/plain"),
                 false,
             ),
             Arguments.of(


### PR DESCRIPTION
### Goal

`MediaAttachmentPreviewHandlerTest` is flaky on CI. The negative cases (expecting `canHandle` to return `false`) built attachments with `randomString()` for the `type` and `mimeType`. `MediaAttachmentPreviewHandler.canHandle()` matches media types by substring, so when a random value happened to contain a token like `wav`, `mp3`, `mp4`, `aac`, `ogg`, or `video`, `canHandle()` returned `true` and the expected-`false` assertion failed. It was seen failing on [this CI run](https://github.com/GetStream/stream-chat-android/actions/runs/28655583103/job/84997384800) with a random `mimeType` of `6wavzXYsJQwQWl1viewX`, which contains `wav`.

Resolves AND-1290

### Implementation

The two negative cases now use fixed non-media values (`AttachmentType.FILE` for the type and `"text/plain"` for the mimeType) instead of `randomString()`, so they are deterministic. A comment documents why random values must not be used there. The positive cases are unchanged.

### Testing

Run `./gradlew :stream-chat-android-compose:testDebugUnitTest --tests "*MediaAttachmentPreviewHandlerTest*"`. All cases pass, and the negative cases are now deterministic (no dependency on the random draw).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved negative test coverage for media attachment handling by using fixed non-media values instead of randomized inputs.
  * This makes the tests more reliable and reduces the chance of false positives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
