### PR TITLE
compose: Remove @JvmOverloads from MediaPreviewActivity.getIntent

### DIFF
--- a/stream-chat-android-compose/api/stream-chat-android-compose.api
+++ b/stream-chat-android-compose/api/stream-chat-android-compose.api
@@ -976,7 +976,6 @@ public final class io/getstream/chat/android/compose/ui/attachments/preview/Medi
 }
 
 public final class io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity$Companion {
-	public final fun getIntent (Landroid/content/Context;Ljava/lang/String;)Landroid/content/Intent;
 	public final fun getIntent (Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;)Landroid/content/Intent;
 	public static synthetic fun getIntent$default (Lio/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity$Companion;Landroid/content/Context;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Landroid/content/Intent;
 }

--- a/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
+++ b/stream-chat-android-compose/src/main/java/io/getstream/chat/android/compose/ui/attachments/preview/MediaPreviewActivity.kt
@@ -184,7 +184,6 @@ public class MediaPreviewActivity : AppCompatActivity() {
          * @param url The URL of the media file.
          * @param title The name of the media file.
          */
-        @JvmOverloads
         public fun getIntent(
             context: Context,
             url: String,


### PR DESCRIPTION
### Goal

Revert an accidentally committed `@JvmOverloads` annotation on `MediaPreviewActivity.getIntent`. The annotation was added by mistake and has not been released, so removing it has no external impact.

### Implementation

Dropped the `@JvmOverloads` annotation on the companion-object `getIntent(context, url, title = null)` factory. No other changes.

### UI Changes

No UI changes.

### Testing

Existing tests in `MediaPreviewActivityTest` continue to cover intent creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the media preview launch interface to accept an additional value when opening a preview.
  * Simplified the available overloads for this action, so any custom integrations may need to be adjusted to match the new call format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->